### PR TITLE
chore(seo): change base from /b to /r

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,10 @@
     "allow": [
       "Bash(mkdir:*)",
       "Bash(python3:*)",
-      "Bash(find:*)"
+      "Bash(find:*)",
+      "Bash(ls:*)",
+      "Bash(rg:*)",
+      "Bash(gt:*)"
     ],
     "deny": []
   }

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -51,6 +51,6 @@ export default async function (eleventyConfig) {
     },
     markdownTemplateEngine: 'njk',
     htmlTemplateEngine: 'njk',
-    pathPrefix: '/b/'
+    pathPrefix: '/r/'
   };
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This is an Eleventy-based internationalized blog website supporting multiple lan
 ```bash
 npm start
 ```
-Starts development server on `http://localhost:8080` with live reload. Note: Redirects only work on the server, so manually navigate to language-specific URLs like `http://localhost:8080/en/`. Uses `--pathprefix=/b/` for correct asset paths.
+Starts development server on `http://localhost:8080` with live reload. Note: Redirects only work on the server, so manually navigate to language-specific URLs like `http://localhost:8080/en/`. Uses `--pathprefix=/r/` for correct asset paths.
 
 ### Build for production
 ```bash
@@ -35,7 +35,7 @@ Generates Open Graph images for all blog posts using Puppeteer. Creates PNG and 
 - **Content Structure**: Each language has its own directory in `src/` (e.g., `src/en/`, `src/de/`)
 
 ### Key Files and Directories
-- `.eleventy.js`: Main Eleventy configuration with I18n plugin setup and path prefix `/b/`
+- `.eleventy.js`: Main Eleventy configuration with I18n plugin setup and path prefix `/r/`
 - `src/_data/`: Global data files including language strings, navigation, and metadata
 - `src/_includes/`: Nunjucks templates (base.njk, header.njk, footer.njk)
 - `src/{lang}/`: Language-specific content directories

--- a/docs/prd/glossary-auto-linker.md
+++ b/docs/prd/glossary-auto-linker.md
@@ -28,7 +28,7 @@
 
 **链接格式要求：**
 - 统一使用 `[term]({{ '/en/blog/glossary/term/' | url }})` 格式
-- 确保baseURL="/b"配置正确应用
+- 确保baseURL="/r"配置正确应用
 - 保持原文的markdown结构
 
 **链接策略：**
@@ -242,7 +242,7 @@ npm run glossary:link -- --help
 
 ### 链接格式验证
 所有链接均使用格式：`[term]({{ '/en/blog/glossary/term/' | url }})`
-确保与Eleventy配置的baseURL="/b"兼容。
+确保与Eleventy配置的baseURL="/r"兼容。
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": ">=18.x.x"
   },
   "scripts": {
-    "start": "eleventy --serve --watch --pathprefix=/b/",
+    "start": "eleventy --serve --watch --pathprefix=/r/",
     "gen:og": "node scripts/prebuild-og-images.mjs",
     "build": "eleventy"
   },

--- a/src/sitemap.xml.njk
+++ b/src/sitemap.xml.njk
@@ -8,7 +8,7 @@ layout: false
 {%- for post in collections.all %}
   {%- if post.data.permalink != '/sitemap.xml' and post.url and not post.data.draft %}
   <url>
-    <loc>{{ meta.url }}/b{{ post.url }}</loc>
+    <loc>{{ meta.url }}/r{{ post.url }}</loc>
     {%- if post.data.date %}
     {%- set postDate = post.data.date %}
     {%- if postDate.toISOString %}

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "rewrites": [
     {
-      "source": "/b/:path*",
+      "source": "/r/:path*",
       "destination": "/:path*"
     }
   ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the set of allowed Bash commands to include `ls`, `rg`, and `gt`.

* **Bug Fixes**
  * Updated all references to the path prefix from `/b/` to `/r/` across the site, including configuration, documentation, sitemap, and URL rewrite rules.

* **Documentation**
  * Revised documentation to accurately reflect the new `/r/` path prefix and baseURL settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->