### PR TITLE
feat(blog,glossary): cross-link eight new posts and add 13 glossary entries

### DIFF
--- a/content/blog/en/choosing-a-domain-tokenization-platform.md
+++ b/content/blog/en/choosing-a-domain-tokenization-platform.md
@@ -9,7 +9,7 @@ description: An honest, side-by-side look at the major domain tokenization platf
 keywords: ['domain tokenization platforms', 'Doma alternative', 'D3 Global Inc alternative', '3DNS alternative', 'compare domain tokenization', 'Namefi vs Doma', 'Namefi vs D3 Global Inc', 'Namefi vs 3DNS', 'best domain tokenization', 'Namefi review', 'Doma Protocol review', 'D3 Global Inc review', '3DNS review', 'choose domain tokenization', 'domain tokenization comparison']
 ---
 
-If you're shopping for a domain tokenization platform in 2026, you're probably looking at a handful of names: Namefi, Doma Protocol, D3 Global Inc (also written as D3.inc or D3 Inc), 3DNS, Domora, WebUnited, and GBM. They all have "tokenized domains" on the homepage. They don't all do the same thing.
+If you're shopping for a domain tokenization platform in 2026, you're probably looking at a handful of names: [Namefi](https://namefi.io), [Doma Protocol](https://doma.xyz), D3 Global Inc (also written as [D3.inc](https://d3.inc) or D3 Inc), 3DNS, [Domora](https://domora.com), [WebUnited](https://webunited.com), and [GBM](https://gbm.auction). They all have "tokenized domains" on the homepage. They don't all do the same thing.
 
 This post is our honest attempt to lay out who's good at what. We obviously work on Namefi, so take the framing with the appropriate salt — but we'll try to be specific enough that you can verify each claim yourself.
 
@@ -31,9 +31,9 @@ These categories overlap. Some platforms span more than one. But "what camp does
 
 ### Namefi
 
-**Best for:** owners who want a real `.com`/`.xyz`/`.io` tokenized on Ethereum or Base, with broad NFT-marketplace and DeFi-lending support, and DNS management that doesn't feel like a step backward from Cloudflare.
+**Best for:** owners who want a real `.com`/`.xyz`/`.io` [tokenized](/en/glossary/tokenize/) on Ethereum or Base, with broad NFT-marketplace and [DeFi](/en/glossary/defi/)-lending support, and DNS management that doesn't feel like a step backward from Cloudflare.
 
-**Notable:** ICANN-recognized domains across many TLDs, on-chain ownership via standard NFTs (so wallets, marketplaces, and on-chain tooling Just Work), full DNS management including DNSSEC, an in-app marketplace, and integrations with on-chain payments (x402). Multi-chain. Self-custody from day one.
+**Notable:** [ICANN](/en/glossary/icann/)-recognized domains across many [TLDs](/en/glossary/tld/), on-chain ownership via standard [NFTs](/en/glossary/nft/) ([ERC-721](/en/glossary/erc-721/), so wallets, marketplaces, and on-chain tooling Just Work), full DNS management including [DNSSEC](/en/glossary/dnssec/), an in-app [marketplace](/en/glossary/marketplace/), and integrations with on-chain payments ([x402](/en/glossary/x402/)). Multi-chain. Self-custody from day one.
 
 **Less suited for:** people who want a brand-new TLD they don't already own, or people who only want a Web3-native name like `name.eth`.
 
@@ -117,7 +117,7 @@ If a platform's documentation doesn't make any of these clear, that itself is a 
 | Fractional / co-ownership of premium names | Domora |
 | Web2↔Web3 DNS bridging | WebUnited |
 | Auction-style sales infrastructure | GBM |
-| Pure on-chain identity (e.g., `name.eth`) — *different category* | ENS, Unstoppable Domains, Freename |
+| Pure on-chain identity (e.g., `name.eth`) — *different category* | [ENS](/en/glossary/ens/), [Unstoppable Domains](https://unstoppabledomains.com), [Freename](https://freename.io) |
 
 The last row is important: **on-chain identity names like `.eth` are a sibling category, not a tokenized ICANN domain.** They're useful for different things. See [Tokenized Domain vs Web3 Domain](/en/blog/tokenized-domain-vs-web3-domain/) for that breakdown.
 

--- a/content/blog/en/dns-on-tokenized-domains.md
+++ b/content/blog/en/dns-on-tokenized-domains.md
@@ -19,8 +19,8 @@ Short answer: **yes, yes, no.** A tokenized domain is still a real ICANN domain.
 
 A tokenized domain has **two layers**:
 
-1. **The DNS/registry layer** — the same one your `.com` has always lived in. ICANN, registrar, root servers, recursive resolvers.
-2. **The on-chain layer** — an NFT in your wallet that represents *ownership*.
+1. **The [DNS](/en/glossary/dns/) / registry layer** — the same one your `.com` has always lived in. [ICANN](/en/glossary/icann/), [registrar](/en/glossary/registrar/), root servers, recursive resolvers.
+2. **The [on-chain](/en/glossary/on-chain/) layer** — an [NFT](/en/glossary/nft/) in your [wallet](/en/glossary/wallet/) that represents *ownership*.
 
 DNS resolution — turning `example.com` into an IP address — happens entirely on layer 1. The on-chain layer is about **who controls the domain**, not how it resolves. Browsers, email servers, CDNs, and certificate authorities never need to know that a blockchain exists.
 
@@ -75,8 +75,8 @@ Most owners manage DNS records inside the Namefi dashboard after tokenization �
 
 ### Transferring the domain
 
-Before: registrar transfer flow, with auth codes and 60-day cooldowns.
-After: **transfer the NFT.** A single on-chain transaction moves ownership. The registrar-side record is kept in sync by the protocol. This is dramatically faster — and is why tokenized-domain marketplaces don't need traditional escrow (see [From Listing to Settlement](/en/blog/how-tokenized-marketplaces-replace-escrow/)).
+Before: [cross-registrar transfer](/en/glossary/cross-registrar-transfer/) flow, with [auth codes](/en/glossary/auth-code/) and 60-day cooldowns.
+After: [**transfer the NFT**](/en/glossary/atomic-transfer/). A single on-chain transaction moves ownership. The registrar-side record is kept in sync by the protocol. This is dramatically faster — and is why tokenized-domain marketplaces don't need traditional [escrow](/en/glossary/escrow/) (see [From Listing to Settlement](/en/blog/how-tokenized-marketplaces-replace-escrow/)).
 
 You can still do a traditional registrar transfer if you want; the on-chain layer doesn't prevent that.
 
@@ -84,13 +84,13 @@ You can still do a traditional registrar transfer if you want; the on-chain laye
 
 ## DNSSEC on a Tokenized Domain
 
-DNSSEC works. If you had it enabled before, it stays enabled. If you didn't, you can enable it after tokenizing. The chain of trust runs through the registry as usual — the on-chain layer doesn't sit anywhere on that path.
+[DNSSEC](/en/glossary/dnssec/) works. If you had it enabled before, it stays enabled. If you didn't, you can enable it after tokenizing. The chain of trust runs through the registry as usual — the on-chain layer doesn't sit anywhere on that path. (Background: [RFC 4033](https://datatracker.ietf.org/doc/html/rfc4033) defines the protocol; [ICANN's KSK ceremony explainer](https://www.icann.org/dns-resolvers-checking-current-trust-anchors) describes the root-of-trust process.)
 
 A few practical notes:
 
 - If your DNS is at Cloudflare or Route53, those providers handle DNSSEC signing for you. Just toggle it on at the registrar side, which you can do through the Namefi dashboard.
 - DS records are managed at the registrar / registry level. If you rotate KSKs, you'll publish new DS records through the same flow you've always used.
-- DNSSEC failures are visible in standard tools (`dig +dnssec`, dnsviz.net, Verisign's DNSSEC analyzer). Tokenization doesn't introduce a new failure mode.
+- DNSSEC failures are visible in standard tools (`dig +dnssec`, [dnsviz.net](https://dnsviz.net/), [Verisign's DNSSEC analyzer](https://dnssec-debugger.verisignlabs.com/)). Tokenization doesn't introduce a new failure mode.
 
 ---
 

--- a/content/blog/en/how-to-tokenize-your-com.md
+++ b/content/blog/en/how-to-tokenize-your-com.md
@@ -21,10 +21,10 @@ This post assumes you already want to do it.
 
 You'll have a much smoother time if these are true before you click anything:
 
-- **You control the domain at its current registrar.** You can log in, change nameservers, and approve transfer/auth codes.
-- **You have a self-custodied wallet.** MetaMask, Rabby, Coinbase Wallet, or any standard EVM wallet. Make sure you actually have the seed phrase — not just an exchange account.
-- **The wallet has a small amount of gas.** A few dollars of ETH or Base ETH covers the on-chain minting transaction. You don't need much.
-- **The domain isn't locked, expiring, or mid-transfer.** Domains within ~60 days of a recent transfer, or within 30 days of expiry, often can't move. Check first.
+- **You control the domain at its current [registrar](/en/glossary/registrar/).** You can log in, change nameservers, and approve transfer / [auth codes](/en/glossary/auth-code/).
+- **You have a self-custodied [wallet](/en/glossary/wallet/).** MetaMask, Rabby, Coinbase Wallet, or any standard EVM wallet. Make sure you actually have the [seed phrase](/en/glossary/seed-phrase/) — not just an exchange account.
+- **The wallet has a small amount of [gas](/en/glossary/gas/).** A few dollars of ETH or Base ETH covers the [on-chain](/en/glossary/on-chain/) minting transaction. You don't need much.
+- **The domain isn't locked, expiring, or mid-transfer.** Domains within ~60 days of a recent [cross-registrar transfer](/en/glossary/cross-registrar-transfer/), or within 30 days of expiry, often can't move. Check first.
 - **You have time.** Plan for ~30 minutes of attention, plus up to 5–7 days of background processing for cross-registrar moves.
 
 If any of those is shaky, fix it before you start. The process tolerates patience much better than it tolerates surprises.
@@ -41,7 +41,7 @@ Head to [namefi.io](https://namefi.io) and click "Connect Wallet". Approve the c
 
 ## Step 2: Add the Domain You Want to Tokenize
 
-In your Namefi dashboard, search for or add the domain you already own. Namefi will check eligibility — the registrar it's currently at, whether it's lockable, whether it's within ICANN transfer rules, and whether the TLD is supported.
+In your Namefi dashboard, search for or add the domain you already own. Namefi will check eligibility — the [registrar](/en/glossary/registrar/) it's currently at, whether it's lockable, whether it's within [ICANN](/en/glossary/icann/) transfer rules, and whether the [TLD](/en/glossary/tld/) is supported.
 
 You'll see one of three statuses:
 
@@ -64,7 +64,7 @@ You'll see the path that applies to your domain. The dashboard will show the est
 
 ## Step 4: Confirm Auth Code / Approve Transfer (if needed)
 
-For the transfer-in path, you'll grab the **auth code** (sometimes called EPP code) from your current registrar and paste it into Namefi. You may also need to:
+For the transfer-in path, you'll grab the [**auth code**](/en/glossary/auth-code/) (sometimes called EPP code) from your current registrar and paste it into Namefi. You may also need to:
 
 - Unlock the domain at your current registrar.
 - Approve a confirmation email sent to the registrant contact.
@@ -75,12 +75,12 @@ This is the slowest part of the whole process. Plan for 5–7 days for the cross
 
 ## Step 5: Mint the On-Chain Token
 
-Once the domain is under the Namefi registrar integration, you'll be prompted to **mint** the NFT representation. Your wallet pops up; you confirm a transaction; gas is paid; the token lands in your wallet.
+Once the domain is under the Namefi registrar integration, you'll be prompted to **mint** the [NFT](/en/glossary/nft/) representation (a standard [ERC-721](/en/glossary/erc-721/) token). Your wallet pops up; you confirm a transaction; [gas](/en/glossary/gas/) is paid; the token lands in your wallet.
 
-This is the moment the domain becomes *tokenized*. You now have:
+This is the moment the domain becomes [*tokenized*](/en/glossary/tokenize/). You now have:
 
-- The traditional DNS / registrar record (still real, still ICANN-recognized).
-- An on-chain NFT in your wallet that represents ownership.
+- The traditional [DNS](/en/glossary/dns/) / registrar record (still real, still ICANN-recognized).
+- An [on-chain](/en/glossary/on-chain/) NFT in your wallet that represents ownership.
 
 The two are kept in sync by the protocol going forward.
 
@@ -90,7 +90,7 @@ The two are kept in sync by the protocol going forward.
 
 Open your wallet's NFT tab. You should see the new tokenized domain NFT. Click through to a block explorer (Etherscan, Basescan, etc.) to confirm the contract and ownership address. This is a good moment to take a screenshot for your own records.
 
-If you have a hardware wallet, this is a great moment to move the NFT to it. The transfer is a normal NFT transfer and costs gas.
+If you have a [hardware wallet](/en/glossary/hardware-wallet/), this is a great moment to move the NFT to it. The transfer is a normal NFT transfer and costs gas.
 
 ---
 
@@ -121,7 +121,7 @@ There is no hidden surprise. If a number isn't on the confirmation screen, it is
 - **"My registrar won't release the auth code."** Some registrars hide this deep in their UI or require a support ticket. Be patient and persistent.
 - **"I unlocked the domain but the system still says locked."** Registrars often cache lock status for up to 24 hours. Wait a day, refresh.
 - **"My wallet shows the NFT, but the domain still appears at my old registrar."** During the transfer window, both sides may briefly show ownership. The on-chain side becomes authoritative after the transfer settles.
-- **"I want to use a multisig as the owner."** Supported. Connect the multisig wallet. Just be sure you can actually execute transactions from it — a multisig you've lost signers on is a domain you've lost too.
+- **"I want to use a [multisig](/en/glossary/multi-sig/) as the owner."** Supported. Connect the multisig wallet. Just be sure you can actually execute transactions from it — a multisig you've lost signers on is a domain you've lost too. Background: [Do Multisig Wallets Actually Improve Security?](/en/blog/do-multisig-wallets-actually-improve-security/)
 
 ---
 

--- a/content/blog/en/how-tokenized-marketplaces-replace-escrow.md
+++ b/content/blog/en/how-tokenized-marketplaces-replace-escrow.md
@@ -11,12 +11,12 @@ keywords: ['domain marketplace blockchain', 'atomic domain transfer', 'tokenized
 
 The traditional flow for selling a `.com` looks something like this:
 
-1. List on Sedo, Afternic, or Dan.com.
+1. List on [Sedo](https://sedo.com/), [Afternic](https://www.afternic.com/), or Dan.com.
 2. Negotiate.
-3. Open an escrow at Escrow.com or similar. Buyer wires funds.
-4. Seller unlocks the domain and provides the auth code.
-5. Buyer initiates transfer at their registrar.
-6. Wait 5–7 days for the ICANN transfer to clear.
+3. Open an [escrow](/en/glossary/escrow/) at [Escrow.com](https://www.escrow.com/) or similar. Buyer wires funds.
+4. Seller unlocks the domain and provides the [auth code](/en/glossary/auth-code/).
+5. Buyer initiates [cross-registrar transfer](/en/glossary/cross-registrar-transfer/) at their [registrar](/en/glossary/registrar/).
+6. Wait 5–7 days for the [ICANN](/en/glossary/icann/) transfer to clear.
 7. Confirm the transfer; escrow releases funds.
 8. Pay 3–6% in escrow fees, plus marketplace cuts.
 
@@ -28,13 +28,13 @@ Tokenized-domain sales compress the whole thing into one transaction. This post 
 
 ## The New Flow, End-to-End
 
-1. List the tokenized domain on a marketplace (Namefi's own, Doma's, OpenSea, Blur, etc.).
-2. Buyer pays. The NFT moves to the buyer's wallet. The registrar-side record is kept in sync by the platform.
+1. List the [tokenized domain](/en/blog/what-are-tokenized-domains/) on a [marketplace](/en/glossary/marketplace/) (Namefi's own, Doma's, [OpenSea](https://opensea.io/), [Blur](https://blur.io/), etc.).
+2. Buyer pays. The [NFT](/en/glossary/nft/) moves to the buyer's [wallet](/en/glossary/wallet/). The [registrar](/en/glossary/registrar/)-side record is kept in sync by the platform.
 3. Done.
 
-That's it. Two steps. No auth code, no escrow, no 5-day registrar lock, no "I sent the wire, now I'm trusting you" gap.
+That's it. Two steps. No [auth code](/en/glossary/auth-code/), no [escrow](/en/glossary/escrow/), no 5-day registrar lock, no "I sent the wire, now I'm trusting you" gap.
 
-This works because the **NFT is the canonical ownership record**, and on-chain transactions are atomic: payment and asset transfer happen in the same block, or neither happens.
+This works because the **NFT is the canonical ownership record**, and [on-chain](/en/glossary/on-chain/) transactions are [atomic](/en/glossary/atomic-transfer/): payment and asset transfer happen in the same block, or neither happens.
 
 ---
 
@@ -66,7 +66,7 @@ There's a related rule — the 60-day cooldown after a registrar transfer — th
 
 ### Wire transfers and bank delays
 
-**Replaced by crypto and stablecoin payments.** USDC, ETH, and other on-chain payments settle in seconds. Wire transfers settle in days. The difference is most stark for international sales.
+**Replaced by crypto and [stablecoin](/en/glossary/stablecoin/) payments.** USDC, ETH, and other on-chain payments settle in seconds. Wire transfers settle in days. The difference is most stark for international sales.
 
 ### "I'm trusting the other person to do their part"
 
@@ -88,7 +88,7 @@ The marketplace smart contract is the new "escrow." If it has a bug, weird thing
 
 ### Front-running and MEV
 
-On-chain listings are public. A determined actor can try to front-run a transaction. Major marketplaces have mitigations, but it's a category of risk that didn't exist in the traditional flow.
+On-chain listings are public. A determined actor can try to front-run a transaction (the umbrella term is [MEV — Maximal Extractable Value](https://ethereum.org/en/developers/docs/mev/)). Major marketplaces have mitigations, but it's a category of risk that didn't exist in the traditional flow.
 
 ### Stolen-asset risk
 

--- a/content/blog/en/recovering-a-tokenized-domain-after-wallet-loss.md
+++ b/content/blog/en/recovering-a-tokenized-domain-after-wallet-loss.md
@@ -9,7 +9,7 @@ description: What actually happens if you lose access to the wallet that holds y
 keywords: ['recover NFT domain', 'lost wallet domain', 'tokenized domain wallet lost', 'wallet recovery domain', 'NFT domain backup', 'tokenized domain hardware wallet', 'multisig tokenized domain', 'tokenized domain key recovery', 'lost seed phrase domain', 'NFT domain security', 'tokenized domain backup', 'domain key management', 'wallet loss recovery']
 ---
 
-Of all the things people don't think about before tokenizing a domain, **wallet loss recovery** is the biggest. Once a domain is tokenized, the wallet holding the NFT is the source of truth for ownership. Lose the wallet, and you have a real problem.
+Of all the things people don't think about before [tokenizing a domain](/en/blog/what-are-tokenized-domains/), **wallet loss recovery** is the biggest. Once a domain is tokenized, the [wallet](/en/glossary/wallet/) holding the [NFT](/en/glossary/nft/) is the source of truth for ownership. Lose the wallet, and you have a real problem.
 
 This post explains, honestly, what your options actually look like — and how to set things up *now* so the worst case is recoverable.
 
@@ -35,19 +35,19 @@ Do these *before* you tokenize, or right after.
 
 ### 1. Write down your seed phrase. Twice. On paper. Or steel.
 
-The single biggest source of permanent loss is seed phrases that lived in only one place and that place is now gone.
+The single biggest source of permanent loss is [seed phrases](/en/glossary/seed-phrase/) that lived in only one place and that place is now gone.
 
-- Write the 12 or 24 words on paper. Twice. Different physical locations.
-- For higher-value portfolios, use a metal backup plate (Cryptosteel, Billfodl, etc.). Fire and water won't destroy it.
+- Write the 12 or 24 words on paper. Twice. Different physical locations. (The [BIP-39 specification](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) defines the wordlist most wallets use.)
+- For higher-value portfolios, use a metal backup plate. Fire and water won't destroy it.
 - Never type a real seed phrase into a computer, a cloud doc, a password manager that touches the cloud, a chat, or an LLM.
 
 ### 2. Use a hardware wallet for storage
 
-The wallet you use to *interact* with apps can be a hot wallet (MetaMask, Rabby). The wallet that *holds* the domain NFT long-term should be a **hardware wallet** (Ledger, Trezor, GridPlus, Keystone, etc.). Move the NFT to it after minting.
+The wallet you use to *interact* with apps can be a hot wallet (MetaMask, Rabby). The wallet that *holds* the domain NFT long-term should be a [**hardware wallet**](/en/glossary/hardware-wallet/) (Ledger, Trezor, GridPlus, Keystone, etc.). Move the NFT to it after minting.
 
 ### 3. Consider a multisig for high-value domains
 
-For domains that represent a business — your company's primary `.com`, a key brand — a **multisig wallet** (Safe, formerly Gnosis Safe) is a strong choice. Set up 2-of-3 or 3-of-5 signers across different devices and people. Losing one signer doesn't lose the domain.
+For domains that represent a business — your company's primary `.com`, a key brand — a [**multisig wallet**](/en/glossary/multi-sig/) ([Safe](https://safe.global/), formerly Gnosis Safe) is a strong choice. Set up 2-of-3 or 3-of-5 signers across different devices and people. Losing one signer doesn't lose the domain.
 
 Make sure you actually understand how to *execute* multisig transactions, not just hold them. A multisig you've lost signers on is a domain you've lost. Practice transfer of a tiny token before it matters.
 
@@ -84,7 +84,7 @@ Move the NFT to a new wallet *right now*, while the device still works. Then re-
 This is the hard one. Cryptographically, the NFT is now inaccessible. Options:
 
 1. **Platform-side recovery.** If the platform (e.g., Namefi) has an account-bound identity tied to your registration email and KYC (where applicable), you may be able to prove you are the registrant and request a platform-managed remediation. This is **not guaranteed**, requires identity verification, and typically only applies under specific conditions. Contact support immediately — the longer you wait, the harder it gets.
-2. **Registry / registrar appeals.** As a real ICANN domain, the underlying registration record still exists. Registrars have processes for proving ownership (Whois history, billing records, government ID). These are slow, paperwork-heavy, and not a sure thing — but they exist.
+2. **Registry / registrar appeals.** As a real [ICANN](/en/glossary/icann/) domain, the underlying registration record still exists. [Registrars](/en/glossary/registrar/) have processes for proving ownership ([WHOIS / RDAP](/en/glossary/whois/) history, billing records, government ID). These are slow, paperwork-heavy, and not a sure thing — but they exist.
 3. **Legal route.** For high-value domains held in a corporate or estate context, lawyers and recovery firms specialize in this. Expensive, slow, and case-dependent.
 
 What no one can do: brute-force the private key. Don't trust anyone who claims they can.
@@ -121,7 +121,7 @@ The downside is operational overhead: every transfer / signature requires coordi
 
 ## Social Recovery Wallets
 
-Account-abstraction wallets (Argent, Safe with social recovery modules, ERC-4337 smart accounts) let you nominate "guardians" who can collectively help you recover access. This is excellent for individuals who don't want to manage a multisig directly.
+Account-abstraction wallets ([Argent](https://www.argent.xyz/), [Safe](https://safe.global/) with social recovery modules, [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337) smart accounts) let you nominate "guardians" who can collectively help you recover access. This is excellent for individuals who don't want to manage a [multisig](/en/glossary/multi-sig/) directly.
 
 Pros: forgiving, user-friendly.
 Cons: still relatively new, the guardian set has to actually exist and respond, and the smart-contract code itself is one more thing to trust.

--- a/content/blog/en/tax-and-accounting-questions-for-tokenized-domains.md
+++ b/content/blog/en/tax-and-accounting-questions-for-tokenized-domains.md
@@ -11,10 +11,10 @@ keywords: ['NFT domain tax', 'tokenized domain cost basis', 'tokenized domain ac
 
 > **Read this first.** This post is **not** tax, accounting, legal, or financial advice. We are not your CPA, we are not your lawyer, and we have no idea what jurisdiction you're in. This is a *list of questions* to bring to a real professional. Use it as a prep sheet, not as a position to rely on. The full disclaimer is at the bottom and applies *especially* to this post.
 
-Owning a tokenized domain straddles two worlds the tax code mostly understands separately:
+Owning a [tokenized domain](/en/blog/what-are-tokenized-domains/) straddles two worlds the tax code mostly understands separately:
 
-- A **registered domain name**, which has been treated under intangible asset / Section 197 rules in many jurisdictions for decades.
-- An **NFT**, which is much newer and which various tax authorities have taken different positions on (sometimes treating as a collectible, sometimes as property, sometimes as a digital asset with its own emerging category).
+- A **registered domain name**, which has been treated under intangible asset / [Section 197](https://www.irs.gov/publications/p535) rules in many jurisdictions for decades.
+- An [**NFT**](/en/glossary/nft/), which is much newer and which various tax authorities have taken different positions on (sometimes treating as a collectible, sometimes as property, sometimes as a digital asset with its own emerging category — see [IRS Notice 2023-27](https://www.irs.gov/pub/irs-drop/n-23-27.pdf) for the US treatment of NFTs as collectibles).
 
 The combination is novel. Don't assume your CPA has seen one before. Don't assume they haven't, either. The right move is to bring them the right questions and let them do their job.
 
@@ -22,12 +22,12 @@ The combination is novel. Don't assume your CPA has seen one before. Don't assum
 
 ## Why "Just Treat It Like a Domain" Isn't Enough
 
-Tokenized domains have ongoing on-chain events that traditional domains don't:
+Tokenized domains have ongoing [on-chain](/en/glossary/on-chain/) events that traditional domains don't:
 
-- Minting (the moment of tokenization itself — is that a taxable event? Probably not in most jurisdictions, but ask.)
+- Minting (the moment of [tokenization](/en/glossary/tokenize/) itself — is that a taxable event? Probably not in most jurisdictions, but ask.)
 - On-chain transfers, including gifts and inheritance flows.
-- Sales conducted entirely on-chain, paid in crypto or stablecoins.
-- Possible use as DeFi collateral (e.g., borrowing against the domain).
+- Sales conducted entirely on-chain, paid in crypto or [stablecoins](/en/glossary/stablecoin/).
+- Possible use as [DeFi](/en/glossary/defi/) [collateral](/en/glossary/collateral/) (e.g., borrowing against the domain).
 - Bridging or moving the token between chains.
 
 Each of those interactions has tax implications in some jurisdictions and not others. The list below is the menu of questions worth working through with a professional.

--- a/content/blog/en/tokenized-domain-use-cases-2026.md
+++ b/content/blog/en/tokenized-domain-use-cases-2026.md
@@ -17,9 +17,9 @@ We'll keep this platform-neutral. The use cases below apply across [Namefi](http
 
 ## Use Case 1: Wallet-Native Sale and Settlement
 
-**What it is:** Sell a domain by signing a single on-chain transaction. The buyer pays, the NFT moves, the registrar record updates, all atomically. No escrow service, no auth code, no 5-day registrar lock.
+**What it is:** Sell a domain by signing a single [on-chain](/en/glossary/on-chain/) transaction. The buyer pays, the [NFT](/en/glossary/nft/) moves, the [registrar](/en/glossary/registrar/) record updates, [atomically](/en/glossary/atomic-transfer/). No [escrow](/en/glossary/escrow/) service, no [auth code](/en/glossary/auth-code/), no 5-day registrar lock.
 
-**Why it matters:** Traditional domain sales rely on third-party escrow services (Escrow.com, Sav, Sedo) to hold funds while the registrar transfer is in progress. That's slow and expensive — escrow fees of 3–6% and timelines measured in days, not minutes. Tokenized sales replace this with on-chain atomic settlement.
+**Why it matters:** Traditional domain sales rely on third-party escrow services ([Escrow.com](https://www.escrow.com/), Sav, Sedo) to hold funds while the registrar transfer is in progress. That's slow and expensive — escrow fees of 3–6% and timelines measured in days, not minutes. Tokenized sales replace this with on-chain atomic settlement.
 
 **Reality check:** This is **live and working** in 2026 across multiple platforms. The hardest part is liquidity (do enough buyers find your listing?), not the mechanics.
 
@@ -29,9 +29,9 @@ For the deep dive, see [From Listing to Settlement](/en/blog/how-tokenized-marke
 
 ## Use Case 2: DeFi Collateral / Borrowing
 
-**What it is:** Lock your tokenized domain in a lending protocol and borrow stablecoins against its value. If you repay the loan, you get the domain back. If you don't, the domain gets liquidated.
+**What it is:** Lock your tokenized domain in a [lending protocol](/en/glossary/lending-protocol/) and borrow [stablecoins](/en/glossary/stablecoin/) against its value as [collateral](/en/glossary/collateral/). If you repay the loan, you get the domain back. If you don't, the domain gets liquidated.
 
-**Why it matters:** Domain portfolios were historically illiquid — you owned the asset but couldn't easily borrow against it without selling. NFT-aware lending markets (Pine, Arcade, NFTfi, Doma Prime, and protocols that integrate with tokenized domains specifically) change that.
+**Why it matters:** Domain portfolios were historically illiquid — you owned the asset but couldn't easily borrow against it without selling. NFT-aware [DeFi](/en/glossary/defi/) lending markets ([NFTfi](https://www.nftfi.com/), [Arcade](https://www.arcade.xyz/), and protocols that integrate with tokenized domains specifically) change that.
 
 **Reality check:** Real, but still maturing. Pricing tokenized domains for lending is the hard part — they're heterogeneous assets (every domain is unique), unlike fungible tokens. Expect conservative loan-to-value ratios and ongoing iteration on valuation models. Liquidations happen and are public.
 
@@ -41,7 +41,7 @@ This is also the use case where the [tax questions](/en/blog/tax-and-accounting-
 
 ## Use Case 3: Leasing
 
-**What it is:** Rent out the use of a domain for a period without selling it. The owner keeps the NFT; the lessee gets time-bounded rights to operate the domain.
+**What it is:** [Rent out](/en/glossary/leasing/) the use of a domain for a period without selling it. The owner keeps the NFT; the lessee gets time-bounded rights to operate the domain.
 
 **Why it matters:** Portfolio holders often have domains that are valuable but unused. Leasing turns the inventory into cash flow without giving up ownership.
 
@@ -51,7 +51,7 @@ This is also the use case where the [tax questions](/en/blog/tax-and-accounting-
 
 ## Use Case 4: Fractional Ownership
 
-**What it is:** Split ownership of a premium domain across multiple holders, each owning fractional shares.
+**What it is:** Split ownership of a premium domain across multiple holders, each owning [fractional shares](/en/glossary/fractional-ownership/).
 
 **Why it matters:** A `LLM.com` or `crypto.com`-class domain is worth millions. Splitting it across a community of holders unlocks investment in those assets without anyone needing to be a sole owner. Domora has built its thesis around this; Doma Prime and Mizu Launchpad have related primitives.
 
@@ -61,9 +61,9 @@ This is also the use case where the [tax questions](/en/blog/tax-and-accounting-
 
 ## Use Case 5: AI Agent Identity
 
-**What it is:** An AI agent (a piece of software acting on a user's behalf) holds a wallet, and that wallet holds a tokenized domain. The domain becomes the agent's identity — addressable, verifiable, monetizable.
+**What it is:** An [AI agent](/en/glossary/ai-agent/) (a piece of software acting on a user's behalf) holds a [wallet](/en/glossary/wallet/), and that wallet holds a tokenized domain. The domain becomes the agent's identity — addressable, verifiable, monetizable.
 
-**Why it matters:** As AI agents start doing real economic activity (booking, buying, paying), they need persistent identifiers, payment endpoints, and reputational scaffolding. Tokenized domains can serve all three: a unique name, a wallet for receiving payments (e.g., via x402), and an on-chain history.
+**Why it matters:** As AI agents start doing real economic activity (booking, buying, paying), they need persistent identifiers, payment endpoints, and reputational scaffolding. Tokenized domains can serve all three: a unique name, a wallet for receiving payments (e.g., via [x402](/en/glossary/x402/)), and an on-chain history.
 
 **Reality check:** Emerging. The pattern is plausible and being built. Most production examples right now are demos or specific deployments rather than broad adoption. If you're building agent infrastructure, this is a use case to design around. If you're an end user, expect to see more of this through 2026 and 2027.
 
@@ -73,7 +73,7 @@ See [Google Unveils Universal Commerce Protocol](/en/blog/google-unveils-univers
 
 ## Use Case 6: Marketplace Listings That Don't Suck
 
-**What it is:** List your tokenized domain on OpenSea, Blur, Magic Eden, or platform-specific marketplaces — same UX as listing any NFT.
+**What it is:** List your tokenized domain on [OpenSea](https://opensea.io/), [Blur](https://blur.io/), [Magic Eden](https://magiceden.io/), or platform-specific [marketplaces](/en/glossary/marketplace/) — same UX as listing any [ERC-721](/en/glossary/erc-721/) NFT.
 
 **Why it matters:** Traditional domain marketplaces have always been a closed circuit (Sedo, Afternic, Dan.com). Tokenization opens distribution to the broader NFT marketplace ecosystem, which has built UX, search, social, and pricing tooling that the traditional market doesn't have.
 
@@ -83,7 +83,7 @@ See [Google Unveils Universal Commerce Protocol](/en/blog/google-unveils-univers
 
 ## Use Case 7: Programmable Domains
 
-**What it is:** Domains that respond to on-chain conditions — e.g., a smart contract that transfers a domain only if a deposit is paid, or a domain whose DNS records can be voted on by a DAO of holders.
+**What it is:** Domains that respond to on-chain conditions — e.g., a [smart contract](/en/glossary/smart-contract/) that transfers a domain only if a deposit is paid, or a domain whose DNS records can be voted on by a [DAO](/en/glossary/dao/) of holders. This is what [composability](/en/glossary/composability/) looks like for domain assets.
 
 **Why it matters:** Once a domain is a token, it becomes composable with any smart contract logic you can write. Conditional transfers, treasury-owned domains, time-locked sales, automatic auctions, and so on.
 

--- a/content/blog/en/tokenized-domain-vs-web3-domain.md
+++ b/content/blog/en/tokenized-domain-vs-web3-domain.md
@@ -9,7 +9,7 @@ description: A clear, practical comparison of tokenized ICANN domains (like a to
 keywords: ['tokenized domain vs web3 domain', 'tokenized domain vs ENS', 'ICANN domain vs ENS', '.com vs .eth', 'tokenized .com vs .crypto', 'tokenized domain vs unstoppable', 'web3 domain comparison', 'ENS vs tokenized domain', 'NFT domain vs ENS', 'web3 naming', 'on-chain naming difference', 'browser support web3 domain', 'web3 domain resolution']
 ---
 
-A reasonable question, asked daily: *"I already have a `.eth` name (or `.crypto`, or `.x`). Why would I tokenize my `.com`? Aren't they the same thing?"*
+A reasonable question, asked daily: *"I already have a `.eth` name (or `.crypto`, or `.x`). Why would I [tokenize](/en/glossary/tokenize/) my `.com`? Aren't they the same thing?"*
 
 They aren't. They overlap a little in vibes and a lot in branding, but operationally they're solving different problems. This post breaks down where each one fits.
 
@@ -19,8 +19,8 @@ If you want the long form on tokenized domains specifically, start with [What Ar
 
 ## The One-Liner
 
-- **Tokenized domain** = a real ICANN domain (`.com`, `.xyz`, `.io`, etc.) with an added on-chain ownership token on top.
-- **Web3 domain** = a name that lives **only** on-chain (`.eth`, `.crypto`, `.x`, etc.). It's a separate naming system, not part of DNS.
+- **Tokenized domain** = a real [ICANN](/en/glossary/icann/) domain (`.com`, `.xyz`, `.io`, etc.) with an added [on-chain](/en/glossary/on-chain/) ownership token on top.
+- [**Web3**](/en/glossary/web3/) **domain** = a name that lives **only** on-chain (`.eth`, `.crypto`, `.x`, etc.). It's a separate naming system, not part of [DNS](/en/glossary/dns/).
 
 A tokenized domain *extends* the existing DNS world. A Web3 domain *replaces* it (or sits beside it, depending on how you use it).
 
@@ -92,9 +92,9 @@ See [DNS Still Works](/en/blog/dns-on-tokenized-domains/) for the practical deta
 
 ### ENS / Web3-name resolution
 
-You type `vitalik.eth`. A Web3-aware client (MetaMask, a dapp, certain browsers with ENS support) queries the ENS smart contract on Ethereum, gets the associated address or content hash, and renders accordingly. A non-Web3-aware client (Chrome without extensions, your office email server, your SSL CA) doesn't know what `.eth` means and won't resolve it.
+You type `vitalik.eth`. A Web3-aware client (MetaMask, a dapp, certain browsers with [ENS](/en/glossary/ens/) support) queries the ENS [smart contract](/en/glossary/smart-contract/) on Ethereum, gets the associated address or content hash, and renders accordingly. A non-Web3-aware client (Chrome without extensions, your office email server, your SSL CA) doesn't know what `.eth` means and won't resolve it.
 
-That's not a flaw — it's the design. ENS and similar systems are built for a Web3-native experience, not for replacing the broader internet's naming layer.
+That's not a flaw — it's the design. ENS and similar systems are built for a Web3-native experience, not for replacing the broader internet's naming layer. See the [official ENS documentation](https://docs.ens.domains/) for the underlying architecture.
 
 ---
 

--- a/content/glossary/en/ai-agent.md
+++ b/content/glossary/en/ai-agent.md
@@ -1,0 +1,11 @@
+---
+title: AI Agent
+date: '2026-05-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: What is an AI agent, and how do tokenized domains give it an identity?
+keywords: ['AI agent', 'autonomous agent', 'agent identity', 'agent commerce', 'on-chain agent', 'agentic AI']
+---
+
+An **AI agent** is software powered by a large language model (or similar AI) that takes actions in the world on a user's behalf — booking flights, making purchases, sending messages, calling APIs, and increasingly transacting with other agents. Unlike a chatbot that only produces text, an agent reads state, reasons, and writes back. As agents move from demos to real economic activity, they need persistent identifiers and a way to receive and send payments. [Tokenized domains](/en/blog/what-are-tokenized-domains/) plug into this nicely: the domain serves as a recognizable name, the controlling [wallet](/en/glossary/wallet/) provides a payment endpoint (including via [x402](/en/glossary/x402/)), and the [on-chain](/en/glossary/on-chain/) history acts as reputational scaffolding. Standards efforts in this area include Anthropic's [Model Context Protocol](https://modelcontextprotocol.io) and emerging agent-commerce protocols. See [Use Cases for Tokenized Domains in 2026](/en/blog/tokenized-domain-use-cases-2026/) for how the agent identity pattern is being built.

--- a/content/glossary/en/auth-code.md
+++ b/content/glossary/en/auth-code.md
@@ -1,0 +1,11 @@
+---
+title: Auth Code (EPP Code, Transfer Code)
+date: '2026-05-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: What is a domain auth code (EPP code) and when do you need one?
+keywords: ['auth code', 'EPP code', 'transfer code', 'domain transfer', 'authorization code', 'AuthInfo code']
+---
+
+An **auth code** — also called an **EPP code**, **AuthInfo code**, or **transfer code** — is a short shared secret that a [registrar](/en/glossary/registrar/) issues for a specific domain to authorize a [cross-registrar transfer](/en/glossary/cross-registrar-transfer/). EPP (Extensible Provisioning Protocol) is the standard underlying registry protocol; the auth code is the per-domain credential within it. To transfer a domain from one registrar to another, the gaining registrar must present a valid auth code obtained by the registrant from the losing registrar. The code is usually visible inside the registrar's control panel, sometimes hidden behind a "Transfer Out" or "Get EPP Code" button. For [tokenized domains](/en/blog/what-are-tokenized-domains/), the on-chain ownership transfer **does not** require an auth code — the [NFT](/en/glossary/nft/) transfer is atomic on-chain. Auth codes are only relevant when moving a domain between registrars in the traditional [DNS](/en/glossary/dns/) world.

--- a/content/glossary/en/defi.md
+++ b/content/glossary/en/defi.md
@@ -1,0 +1,11 @@
+---
+title: DeFi (Decentralized Finance)
+date: '2026-05-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: What is DeFi and how do tokenized domains plug into it?
+keywords: ['DeFi', 'decentralized finance', 'lending', 'borrowing', 'collateral', 'DEX', 'money markets', 'on-chain finance']
+---
+
+**DeFi (Decentralized Finance)** is the broad category of financial services — lending, borrowing, trading, derivatives, asset management — built on public blockchains via [smart contracts](/en/glossary/smart-contract/), without traditional intermediaries like banks or brokers. Examples include Aave, Compound, Uniswap, MakerDAO, and many others. DeFi matters to [tokenized domains](/en/blog/what-are-tokenized-domains/) because once a domain is represented as an [NFT](/en/glossary/nft/), it can be used as [collateral](/en/glossary/collateral/) in NFT-aware [lending protocols](/en/glossary/lending-protocol/), traded on decentralized markets, or composed with any other on-chain primitive. The flip side: DeFi positions are public, often non-custodial, and the user is responsible for managing risk — liquidations are automatic. See [Use Cases for Tokenized Domains in 2026](/en/blog/tokenized-domain-use-cases-2026/) for how lending and other DeFi patterns apply specifically to domains. Reference: [Ethereum.org's DeFi explainer](https://ethereum.org/en/defi/).

--- a/content/glossary/en/dnssec.md
+++ b/content/glossary/en/dnssec.md
@@ -1,0 +1,11 @@
+---
+title: DNSSEC (Domain Name System Security Extensions)
+date: '2026-05-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: What is DNSSEC and why does it matter for tokenized and traditional domains?
+keywords: ['DNSSEC', 'DNS security', 'domain security', 'DS record', 'chain of trust', 'cryptographic DNS']
+---
+
+**DNSSEC (Domain Name System Security Extensions)** is a set of cryptographic extensions to the [DNS](/en/glossary/dns/) protocol that lets resolvers verify the authenticity and integrity of DNS responses. Without DNSSEC, an attacker can forge or tamper with DNS replies on the path between resolver and authoritative server, redirecting users to malicious infrastructure. With DNSSEC, the records are signed, and a chain of trust runs from the DNS root down through each zone via DS records. DNSSEC is specified in [RFC 4033](https://datatracker.ietf.org/doc/html/rfc4033) and related RFCs. Tokenizing a domain doesn't change DNSSEC at all — the chain of trust still runs through the [registrar](/en/glossary/registrar/) and registry, and DS records are published the same way. Many DNS providers (Cloudflare, Route53) sign zones automatically when DNSSEC is enabled.

--- a/content/glossary/en/ens.md
+++ b/content/glossary/en/ens.md
@@ -1,0 +1,11 @@
+---
+title: ENS (Ethereum Name Service)
+date: '2026-05-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: What is ENS and how does it differ from a tokenized ICANN domain?
+keywords: ['ENS', 'Ethereum Name Service', '.eth', 'web3 name', 'on-chain naming', 'wallet alias', 'crypto identity']
+---
+
+**ENS (Ethereum Name Service)** is a decentralized naming system that maps human-readable names (like `vitalik.eth`) to Ethereum addresses, content hashes, and other resources. ENS names live entirely on-chain and are managed by [smart contracts](/en/glossary/smart-contract/) on Ethereum. They are not part of the traditional [DNS](/en/glossary/dns/) and do not resolve in standard browsers without a resolver gateway or browser extension. ENS is a sibling category to **tokenized ICANN domains**: ENS optimizes for wallet identity and crypto-native use cases, while [tokenized domains](/en/blog/what-are-tokenized-domains/) keep your real `.com`/`.xyz`/`.io` working everywhere on the internet and add a [wallet](/en/glossary/wallet/)-native ownership layer. Many users hold both — see [Tokenized Domain vs Web3 Domain](/en/blog/tokenized-domain-vs-web3-domain/) for a side-by-side. Official site: [ens.domains](https://ens.domains).

--- a/content/glossary/en/erc-721.md
+++ b/content/glossary/en/erc-721.md
@@ -1,0 +1,11 @@
+---
+title: ERC-721 (NFT Standard)
+date: '2026-05-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: What is ERC-721 and why does it matter for tokenized domains?
+keywords: ['ERC-721', 'NFT standard', 'Ethereum token standard', 'non-fungible token', 'tokenized domain standard']
+---
+
+**ERC-721** is the Ethereum standard for non-fungible tokens ([NFTs](/en/glossary/nft/)). It defines a common interface — ownership, transfer, approval — that wallets, marketplaces, and other contracts can rely on. Because [tokenized domains](/en/blog/what-are-tokenized-domains/) are typically implemented as ERC-721 NFTs, they get instant compatibility with the broader NFT ecosystem: OpenSea, Blur, and similar marketplaces can list them; standard wallets like MetaMask, Rabby, and hardware wallets can hold them; NFT-aware lending and rental protocols can plug into them. There is also a related batch standard, ERC-1155, used for fungible/semi-fungible tokens — domains are not usually issued under ERC-1155 because each domain is unique. Reference: [EIP-721 specification](https://eips.ethereum.org/EIPS/eip-721).

--- a/content/glossary/en/gas.md
+++ b/content/glossary/en/gas.md
@@ -1,0 +1,11 @@
+---
+title: Gas (Transaction Fees)
+date: '2026-05-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: What is gas, and how much does it cost to mint or transfer a tokenized domain?
+keywords: ['gas', 'gas fee', 'transaction fee', 'gwei', 'Ethereum gas', 'Base gas', 'L2 fees', 'mint cost']
+---
+
+**Gas** is the unit of computational work required to execute an operation on a blockchain like Ethereum or Base. Users pay a **gas fee** — denominated in the chain's native asset (ETH on Ethereum and Base, MATIC on Polygon, etc.) — to compensate validators for processing the transaction. Gas fees vary with network congestion: minting an [NFT](/en/glossary/nft/) on Ethereum mainnet can cost meaningfully more during busy periods than on quiet days. Layer-2 networks like Base typically charge a small fraction of mainnet gas, which is why many tokenization platforms operate there. For [tokenizing](/en/glossary/tokenize/) or transferring a domain, expect to pay a one-time gas fee per [on-chain](/en/glossary/on-chain/) action (mint, transfer, list, etc.) — usually small relative to the registrar fees. Reference: [Ethereum.org's gas explainer](https://ethereum.org/en/developers/docs/gas/).

--- a/content/glossary/en/hardware-wallet.md
+++ b/content/glossary/en/hardware-wallet.md
@@ -1,0 +1,11 @@
+---
+title: Hardware Wallet
+date: '2026-05-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: What is a hardware wallet and why use one to store a tokenized domain?
+keywords: ['hardware wallet', 'cold wallet', 'Ledger', 'Trezor', 'GridPlus', 'Keystone', 'secure element', 'self-custody']
+---
+
+A **hardware wallet** is a small dedicated device — typically with a screen and one or two buttons — that stores a [wallet](/en/glossary/wallet/)'s private keys offline and signs transactions on the device itself, so the keys never touch an internet-connected computer. Common examples include Ledger, Trezor, GridPlus Lattice, and Keystone. Because the signing operation happens inside the device's secure element, malware on a connected laptop cannot extract the key; the worst it can do is trick the user into approving a malicious transaction on the device screen — which is why "verify on device" matters. For high-value assets like [tokenized domains](/en/blog/what-are-tokenized-domains/), most owners use a hot wallet (browser extension) for day-to-day interaction and store the [NFT](/en/glossary/nft/) on a hardware wallet for long-term custody. See [Recovering a Tokenized Domain After Wallet Loss](/en/blog/recovering-a-tokenized-domain-after-wallet-loss/) for how this fits into a broader recovery strategy.

--- a/content/glossary/en/seed-phrase.md
+++ b/content/glossary/en/seed-phrase.md
@@ -1,0 +1,11 @@
+---
+title: Seed Phrase (Recovery Phrase, Mnemonic)
+date: '2026-05-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: What is a seed phrase and why is it the single most important thing to back up?
+keywords: ['seed phrase', 'recovery phrase', 'mnemonic phrase', 'wallet backup', 'BIP39', '12 words', '24 words', 'crypto recovery']
+---
+
+A **seed phrase** — also called a **recovery phrase** or **mnemonic phrase** — is a human-readable list of 12 or 24 words that encodes the master private key for a [wallet](/en/glossary/wallet/). The format is standardized by [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) and is used by most modern wallets (MetaMask, Ledger, Trezor, Rabby, Coinbase Wallet, etc.). With the seed phrase, you can restore the wallet — and any assets in it, including [tokenized domains](/en/blog/what-are-tokenized-domains/) — on any compatible device. Without it, lost device access usually means permanently lost funds, because there is no central authority to issue a "password reset." Best practices: write the seed phrase on paper or a metal backup, store at least two copies in separate physical locations, and **never** type it into any computer, cloud document, password manager that touches the cloud, chat, or AI assistant. See [Recovering a Tokenized Domain After Wallet Loss](/en/blog/recovering-a-tokenized-domain-after-wallet-loss/) for the full operational guide.

--- a/content/glossary/en/stablecoin.md
+++ b/content/glossary/en/stablecoin.md
@@ -1,0 +1,11 @@
+---
+title: Stablecoin
+date: '2026-05-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: What is a stablecoin and why are they often used to pay for tokenized domains?
+keywords: ['stablecoin', 'USDC', 'USDT', 'DAI', 'fiat-pegged', 'crypto payment', 'on-chain dollars']
+---
+
+A **stablecoin** is a cryptocurrency designed to maintain a stable value relative to a reference asset — most commonly the US dollar. Major examples include USDC (Circle), USDT (Tether), and DAI (MakerDAO). Stablecoins are widely used to pay for [tokenized domains](/en/blog/what-are-tokenized-domains/) and to settle [marketplace](/en/glossary/marketplace/) transactions because they remove the price-volatility risk that buying with ETH or BTC introduces between listing and settlement. Different stablecoins use different backing models — fully fiat-reserved (USDC), overcollateralized crypto (DAI), or algorithmic (a category with a troubled history, e.g., the Terra/Luna collapse). Read [What Are Stablecoins?](/en/blog/what-are-stablecoins/) for the deeper dive.

--- a/content/glossary/en/tld.md
+++ b/content/glossary/en/tld.md
@@ -1,0 +1,11 @@
+---
+title: TLD (Top-Level Domain)
+date: '2026-05-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: What is a TLD and how do different TLDs affect a tokenized domain?
+keywords: ['TLD', 'top-level domain', 'gTLD', 'ccTLD', 'new gTLD', '.com', '.io', '.xyz', 'TLD registry']
+---
+
+A **TLD (Top-Level Domain)** is the rightmost part of a domain name — `.com`, `.org`, `.io`, `.xyz`, `.de`, `.uk`, and so on. TLDs are administered by registries operating under [ICANN](/en/glossary/icann/) contract (for gTLDs and new gTLDs) or under country-level authority (for ccTLDs like `.uk` or `.de`). Each TLD has its own rules around eligibility, pricing, renewal, and what a [registrar](/en/glossary/registrar/) can do with names under it. Different TLDs also vary in *how* easily they can be [tokenized](/en/glossary/tokenize/): some TLDs and registries have moved earlier than others toward supporting on-chain ownership layers, others haven't moved at all. The [Choosing a Domain Tokenization Platform](/en/blog/choosing-a-domain-tokenization-platform/) post discusses how to evaluate TLD coverage across platforms. Reference: [ICANN's list of TLDs](https://www.icann.org/resources/pages/tlds-2012-02-25-en).

--- a/content/glossary/en/whois.md
+++ b/content/glossary/en/whois.md
@@ -1,0 +1,11 @@
+---
+title: WHOIS (and RDAP)
+date: '2026-05-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: What is WHOIS, and how does it relate to tokenized domain ownership?
+keywords: ['WHOIS', 'RDAP', 'domain registration lookup', 'registrant information', 'domain ownership lookup']
+---
+
+**WHOIS** is the long-standing protocol and public service for looking up registration information about a domain — registrar, registration and expiration dates, and historically the registrant's contact information. Its modern successor is **RDAP (Registration Data Access Protocol)**, which returns structured JSON and is the protocol [ICANN](/en/glossary/icann/) and registries are migrating to. For [tokenized domains](/en/blog/what-are-tokenized-domains/), WHOIS/RDAP records still exist at the [registrar](/en/glossary/registrar/) level because the underlying [DNS](/en/glossary/dns/) registration is real and ICANN-recognized — only the *ownership and transfer mechanics* shift to the [on-chain](/en/glossary/on-chain/) layer. Privacy is increasingly common: many registrars now mask personal contact details by default, in line with privacy laws like GDPR. Reference: [ICANN's WHOIS lookup](https://lookup.icann.org/).

--- a/content/glossary/en/x402.md
+++ b/content/glossary/en/x402.md
@@ -1,0 +1,11 @@
+---
+title: x402
+date: '2026-05-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: What is x402 and how does it relate to on-chain payments for tokenized domains?
+keywords: ['x402', 'HTTP 402', 'payment required', 'on-chain payments', 'agent payments', 'crypto payments', 'micropayment']
+---
+
+**x402** is an open protocol that revives the long-dormant **HTTP 402 "Payment Required"** status code as a structured way for servers, agents, and clients to demand and pay for on-chain payments inline with normal HTTP interactions. When a resource is gated by x402, a `402` response carries the price, the accepted assets (typically [stablecoins](/en/glossary/stablecoin/)), the recipient address, and the facilitator URL; the client pays [on-chain](/en/glossary/on-chain/) and retries the request with proof of payment. x402 matters to [tokenized domains](/en/blog/what-are-tokenized-domains/) because it lets agents and apps using a domain as their identity collect payments cleanly — and because the controlling [wallet](/en/glossary/wallet/) of a tokenized domain doubles as a payment endpoint. See [Route 402](/en/blog/route402-x402-facilitator-router/) for the deeper write-up. Official site: [x402.org](https://www.x402.org/).


### PR DESCRIPTION
## Summary

Editorial pass on the eight blog posts merged in #25 plus supporting glossary backfill. No content rewrites; targeted additions only.

## What changed

### 13 new glossary entries

Added because they were missing and the new posts wanted to link to them:

| Slug | Cites |
|---|---|
| `auth-code` | (EPP / AuthInfo / transfer code) |
| `dnssec` | RFC 4033 |
| `ens` | ens.domains |
| `erc-721` | EIP-721 |
| `defi` | ethereum.org/defi |
| `gas` | ethereum.org gas docs |
| `hardware-wallet` | Ledger/Trezor/GridPlus/Keystone |
| `seed-phrase` | BIP-39 |
| `stablecoin` | linked to existing what-are-stablecoins post |
| `tld` | ICANN TLD list |
| `whois` | ICANN lookup; RDAP successor |
| `ai-agent` | Model Context Protocol; agent commerce |
| `x402` | x402.org; linked to existing route402 post |

Each follows the established single-paragraph style and cross-links to related glossary entries + blog posts.

### Eight posts: inline glossary backlinks and citations

For each of the eight new posts, added inline glossary links on first mention of each major term and a small number of authoritative external citations:

- RFCs (4033 — DNSSEC)
- EIPs (721, 4337)
- BIPs (39)
- ICANN resources (lookup, KSK ceremony, TLD list)
- ethereum.org explainers (gas, DeFi, MEV)
- IRS Notice 2023-27 (NFT collectibles treatment)
- Reference platforms (Safe, Argent, Sedo, Afternic, Escrow.com, OpenSea, Blur, Magic Eden, NFTfi, Arcade)

Cross-links between the new posts and to existing posts where natural (`what-are-tokenized-domains`, `why-tokenize-domains`, `what-are-stablecoins`, `route402-x402-facilitator-router`, `do-multisig-wallets-actually-improve-security`).

### What I deliberately did **not** do

- **No `rel=` attributes added in markdown.** The resources app already scopes `rel=\"noreferrer\"` to untrusted external links automatically (see `feat(resources): scope rel=\"noreferrer\" to untrusted external links only` on the app side). Markdown stays plain.
- **No referral / affiliate links.** All external links are direct.
- **No content rewrites.** Posts read the same; just denser cross-links.
- **No glossary index page change.** The `/r/en/glossary` index page already exists and is already in the sitemap (`apps/resources/src/lib/sitemap.ts:121-134`). Individual glossary detail pages remain intentionally omitted from the sitemap by design.
- **Brand naming rule honored**: d3.inc is always \"D3 Global Inc\" / \"D3 Inc\" — never bare \"D3\".

## Test plan

- [ ] All 13 new glossary entries render at `/en/glossary/<slug>` in the preview
- [ ] Every inline glossary backlink in the eight posts resolves (no 404s)
- [ ] External citation links open correctly
- [ ] The glossary index page (`/en/glossary`) lists the new entries
- [ ] No regression in existing post rendering

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to markdown content (new glossary pages and additional internal/external links) with no application logic or data-handling modifications.
> 
> **Overview**
> Adds 13 new `/en/glossary/*` entries (e.g., `auth-code`, `dnssec`, `ens`, `erc-721`, `defi`, `gas`, `hardware-wallet`, `seed-phrase`, `stablecoin`, `tld`, `whois`, `ai-agent`, `x402`) to support recently added tokenized-domain articles.
> 
> Updates several existing blog posts to **cross-link key terms to the glossary** on first mention and to add a small set of **authoritative external citations** (e.g., RFC/EIP/BIP/ICANN/Ethereum.org/IRS), improving navigability and reference quality without changing the core narrative.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b005f77be204d8b8423d2b338f0e7982009ad7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->