### PR TITLE
feat(career): add legal/compliance section and industry blog links

### DIFF
--- a/content/careers/_shared/about-namefi.md
+++ b/content/careers/_shared/about-namefi.md
@@ -1,3 +1,13 @@
 ## About Namefi
 
 Namefi is an ICANN-accredited registrar tokenizing internet domain names for trading, DeFi, and the future of the Internet. We are backed by leading investors including Orange DAO, Google Cloud, AWS, and more. Our engineering is accelerated by AI agents and the latest generative tooling across every layer of the stack.
+
+### Learn about our industry
+
+- [What is a Domain?](/r/en/blog/what-is-domain)
+- [What are Tokenized Domains?](/r/en/blog/what-are-tokenized-domains)
+- [Why Tokenize Domains?](/r/en/blog/why-tokenize-domains)
+- [DNS on Tokenized Domains](/r/en/blog/dns-on-tokenized-domains)
+- [DNS is the Control Plane](/r/en/blog/dns-is-the-control-plane)
+- [How to Tokenize Your .com](/r/en/blog/how-to-tokenize-your-com)
+- [Tokenized Domain vs Web3 Domain](/r/en/blog/tokenized-domain-vs-web3-domain)

--- a/content/careers/en/how-we-hire.md
+++ b/content/careers/en/how-we-hire.md
@@ -67,9 +67,7 @@ We look at your trajectory — past growth, recent leaps, appetite for learning.
 
 We do not hire based on your gender, sex, age, race, ability or physical challenge, or where you come from — and many other factors (see [Know Your Rights: Workplace Discrimination is Illegal](https://www.eeoc.gov/poster)). Not only because it is right, but because hiring the best means selecting from the widest possible talent pool and judging purely on merit.
 
-We do not restrict schools or prior career paths. We take candidates from non-traditional backgrounds, career switchers, self-taught builders, and anyone who can demonstrate they have what it takes.
-
-We highly value the quality of your past work: code repos, portfolios, papers, deals closed, funds raised, customers served — much more than line items, titles, schools, or companies on your resume. Those matter too, but much less.
+We do not restrict schools or prior career paths. We take candidates from non-traditional backgrounds, career switchers, self-taught builders, and anyone who can demonstrate they have what it takes. We highly value the quality of your past work — code repos, portfolios, papers, deals closed, funds raised, customers served — much more than line items, titles, schools, or companies on your resume. Those matter too, but much less.
 
 ## Legal and Compliance
 

--- a/content/careers/en/how-we-hire.md
+++ b/content/careers/en/how-we-hire.md
@@ -65,7 +65,7 @@ We look at your trajectory — past growth, recent leaps, appetite for learning.
 
 ## Equal Opportunity
 
-We do not hire based on your gender, age, race, ability or physical challenge, or where you come from. Period.
+We do not hire based on your gender, sex, age, race, ability or physical challenge, or where you come from — and many other factors (see [Know Your Rights: Workplace Discrimination is Illegal](https://www.eeoc.gov/poster)). Period.
 
 We do not restrict schools or prior career paths. We take candidates from non-traditional backgrounds, career switchers, self-taught builders, and anyone who can demonstrate they have what it takes.
 

--- a/content/careers/en/how-we-hire.md
+++ b/content/careers/en/how-we-hire.md
@@ -69,6 +69,10 @@ We do not hire based on your gender, age, race, ability or physical challenge, o
 
 We do not restrict schools or prior career paths. We take candidates from non-traditional backgrounds, career switchers, self-taught builders, and anyone who can demonstrate they have what it takes.
 
+## Legal and Compliance
+
+Namefi is a Delaware-incorporated company. All hiring is conducted in accordance with US federal and Delaware state law. We hire globally — we do not care where you are located, so long as your engagement is compliant with applicable regulations.
+
 ---
 
 ## Language

--- a/content/careers/en/how-we-hire.md
+++ b/content/careers/en/how-we-hire.md
@@ -65,7 +65,7 @@ We look at your trajectory — past growth, recent leaps, appetite for learning.
 
 ## Equal Opportunity
 
-We do not hire based on your gender, sex, age, race, ability or physical challenge, or where you come from — and many other factors (see [Know Your Rights: Workplace Discrimination is Illegal](https://www.eeoc.gov/poster)). Period.
+We do not hire based on your gender, sex, age, race, ability or physical challenge, or where you come from — and many other factors (see [Know Your Rights: Workplace Discrimination is Illegal](https://www.eeoc.gov/poster)). Not only because it is right, but because hiring the best means selecting from the widest possible talent pool and judging purely on merit.
 
 We do not restrict schools or prior career paths. We take candidates from non-traditional backgrounds, career switchers, self-taught builders, and anyone who can demonstrate they have what it takes.
 

--- a/content/careers/en/how-we-hire.md
+++ b/content/careers/en/how-we-hire.md
@@ -69,6 +69,8 @@ We do not hire based on your gender, sex, age, race, ability or physical challen
 
 We do not restrict schools or prior career paths. We take candidates from non-traditional backgrounds, career switchers, self-taught builders, and anyone who can demonstrate they have what it takes.
 
+We highly value the quality of your past work: code repos, portfolios, papers, deals closed, funds raised, customers served — much more than line items, titles, schools, or companies on your resume. Those matter too, but much less.
+
 ## Legal and Compliance
 
 Namefi is a Delaware-incorporated company. All hiring is conducted in accordance with US federal and Delaware state law. We hire globally — we do not care where you are located, so long as your engagement is compliant with applicable regulations.


### PR DESCRIPTION
## Summary

- Add Legal and Compliance section to how-we-hire: Delaware-incorporated, US federal/state law, hire globally so long as compliant
- Add industry FAQ blog post links to about-namefi shared partial

Companion PR: d3servelabs/namefi-astra#4281

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to careers markdown with no application logic, auth, or data handling impact.
> 
> **Overview**
> Careers documentation is updated in two places. The shared **About Namefi** partial gains a **Learn about our industry** section with seven curated blog links (domains, tokenization, DNS) using `/r/en/blog/...` routes.
> 
> On **How we hire**, the **Equal Opportunity** copy is expanded: explicit **sex** alongside gender, an EEOC poster link, a merit/widest-talent-pool rationale, and stronger emphasis on past work (repos, portfolios, outcomes) over resume line items. A new **Legal and Compliance** block states Delaware incorporation, US federal/Delaware hiring law, and global hiring subject to applicable regulations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af5f8a065de642bf5d8ae4ba56ad5baa75e63494. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced "Learn about our industry" section to careers content, featuring curated links to blog articles on domains, tokenization, and related topics
  * Refreshed hiring policy page with expanded Equal Opportunity statement aligned with EEOC requirements and added Legal and Compliance section clarifying corporate incorporation and global hiring compliance framework

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d3servelabs/namefi-resources/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->