### PR TITLE
feat(career): add 10 remaining job posts

### DIFF
--- a/content/careers/_shared/about-namefi.md
+++ b/content/careers/_shared/about-namefi.md
@@ -1,3 +1,13 @@
 ## About Namefi
 
 Namefi is an ICANN-accredited registrar tokenizing internet domain names for trading, DeFi, and the future of the Internet. We are backed by leading investors including Orange DAO, Google Cloud, AWS, and more. Our engineering is accelerated by AI agents and the latest generative tooling across every layer of the stack.
+
+### Learn about our industry
+
+- [What is a Domain?](/r/en/blog/what-is-domain)
+- [What are Tokenized Domains?](/r/en/blog/what-are-tokenized-domains)
+- [Why Tokenize Domains?](/r/en/blog/why-tokenize-domains)
+- [DNS on Tokenized Domains](/r/en/blog/dns-on-tokenized-domains)
+- [DNS is the Control Plane](/r/en/blog/dns-is-the-control-plane)
+- [How to Tokenize Your .com](/r/en/blog/how-to-tokenize-your-com)
+- [Tokenized Domain vs Web3 Domain](/r/en/blog/tokenized-domain-vs-web3-domain)

--- a/content/careers/en/build-design-2026-05.md
+++ b/content/careers/en/build-design-2026-05.md
@@ -1,0 +1,37 @@
+---
+title: 'AI Empowered Builder: Non-Engineer (PM / Product Designer / UXUI Designer)'
+date: '2026-05-27'
+language: en
+tags: ['product', 'design', 'ai']
+authors: ['namefiteam']
+draft: false
+type: job
+description: Drive product decisions, user experience, and design quality with AI agents as core collaborators in your daily workflow.
+employmentType: FULL_TIME
+validThrough: '2026-08-31'
+team: Product
+location: Remote (Worldwide)
+compensation: Competitive pay with equity
+---
+
+## What You Will Do
+
+- Shape product direction: define problems worth solving, prioritize ruthlessly, and translate user needs into clear requirements — using AI agents to accelerate research and analysis.
+- Design intuitive interfaces for a complex domain (domain management, tokenization, DNS, trading) that make powerful features feel simple.
+- Create wireframes, prototypes, and high-fidelity designs; iterate rapidly based on user feedback and data.
+- Collaborate closely with engineers to ship features end-to-end — from concept through production, not just handoff.
+- Use AI-powered design and prototyping tools to move faster and explore more design space.
+
+## What We Look For
+
+- Proven ability to ship products people use — show us what you have built, not just what you have mocked up.
+- Strong design intuition: you can simplify complex workflows, create clear information hierarchies, and make good default choices.
+- Comfort with ambiguity: you can define the problem when the brief is vague and make decisions with incomplete information.
+- Hands-on experience with AI tools in your workflow — using AI for research, copywriting, prototyping, or design generation.
+- Professional fluency in English. A second language is a plus; one that no existing teammate speaks is a big plus.
+
+## Nice to Have
+
+- Experience designing for technical or developer-facing products.
+- Familiarity with Web3 concepts, domain industry, or DNS.
+- Background in both product management and design (hybrid roles welcome).

--- a/content/careers/en/build-dns-2026-05.md
+++ b/content/careers/en/build-dns-2026-05.md
@@ -1,0 +1,37 @@
+---
+title: 'AI Empowered Builder: Engineer with Specialty in DNS and EPP'
+date: '2026-05-27'
+language: en
+tags: ['engineering', 'dns', 'ai']
+authors: ['namefiteam']
+draft: false
+type: job
+description: Lead technical depth in DNS and EPP domains while contributing broadly as a full-stack engineer, amplified by AI-assisted development workflows.
+employmentType: FULL_TIME
+validThrough: '2026-08-31'
+team: Engineering
+location: Remote (Worldwide)
+compensation: Competitive pay with equity
+---
+
+## What You Will Do
+
+- Own and evolve our DNS and domain registration infrastructure — protocol implementations, registrar integrations, and domain lifecycle management — using AI agents to accelerate development.
+- Design and maintain systems for DNSSEC, nameserver management, zone file handling, and domain transfer workflows.
+- Contribute broadly as a full-stack engineer beyond your specialty: ship features, fix bugs, and improve architecture across the product.
+- Evaluate and integrate the latest AI/LLM tools and agents into development workflows and DNS-related product features.
+- Collaborate with the team on systems design, code review, and production operations.
+
+## What We Look For
+
+- Deep understanding of DNS protocols, record types, resolution, caching, DNSSEC, and related internet infrastructure.
+- Familiarity with EPP (Extensible Provisioning Protocol) or willingness to learn it quickly.
+- Strong software engineering fundamentals: systems design, data modeling, testing strategies, and clean code practices.
+- Hands-on experience with AI-assisted development — using AI coding agents in your daily workflow.
+- Professional fluency in English. A second language is a plus; one that no existing teammate speaks is a big plus.
+
+## Nice to Have
+
+- Experience operating or integrating with domain registrars or registry systems.
+- Background in network protocols, distributed systems, or internet standards (RFCs).
+- Track record of building and shipping personal projects or open source contributions.

--- a/content/careers/en/build-nontraditional-2026-05.md
+++ b/content/careers/en/build-nontraditional-2026-05.md
@@ -1,0 +1,43 @@
+---
+title: 'AI Empowered Builder: Without Traditional Product Experience'
+date: '2026-05-27'
+language: en
+tags: ['engineering', 'product', 'ai']
+authors: ['namefiteam']
+draft: false
+type: job
+description: Turn high AI and agent fluency into real product output — no conventional background required, just the ability to deliver with cutting-edge tools.
+employmentType: FULL_TIME
+validThrough: '2026-08-31'
+team: Engineering
+location: Remote (Worldwide)
+compensation: Competitive pay with equity
+---
+
+## What You Will Do
+
+- Build and ship real product features using AI agents and the latest generative tooling as your primary development environment.
+- Learn fast on the job: pick up whatever skills, tools, or domain knowledge are needed to deliver — we will support you, but you drive.
+- Collaborate with experienced engineers, designers, and product people — contributing meaningfully from day one.
+- Take ownership of features or projects end-to-end: from understanding the problem through shipping and iterating.
+- Help us discover what is possible when AI-native builders tackle problems without the constraints of conventional workflows.
+
+## What You Will Not Need
+
+- A traditional CS degree, bootcamp certificate, or years of industry experience.
+- A resume full of well-known company names or specific job titles.
+- Deep expertise in any one technology — we care about your ability to learn and deliver, not what you already know.
+
+## What We Look For
+
+- Exceptional fluency with AI tools and agents — you use them naturally and productively, not as a novelty.
+- A portfolio of things you have actually built and shipped: projects, tools, automations, content, businesses — anything that shows you can turn ideas into output.
+- Rapid learning ability: you have picked up hard things fast before, and you can demonstrate it.
+- Resourcefulness and self-direction: you figure things out without waiting to be told how.
+- Professional fluency in English. A second language is a plus; one that no existing teammate speaks is a big plus.
+
+## Nice to Have
+
+- Published work of any kind: code, writing, art, products, research.
+- Experience in a non-traditional field that gives you a unique perspective on building products.
+- Contributions to open source, community projects, or public-facing tools.

--- a/content/careers/en/build-security-2026-05.md
+++ b/content/careers/en/build-security-2026-05.md
@@ -1,0 +1,37 @@
+---
+title: 'AI Empowered Builder: Engineer with Specialty in Cyber Security'
+date: '2026-05-27'
+language: en
+tags: ['engineering', 'security', 'ai']
+authors: ['namefiteam']
+draft: false
+type: job
+description: Apply security-first thinking across everything we ship while contributing as a hands-on engineer, amplified by AI-augmented tooling.
+employmentType: FULL_TIME
+validThrough: '2026-08-31'
+team: Engineering
+location: Remote (Worldwide)
+compensation: Competitive pay with equity
+---
+
+## What You Will Do
+
+- Lead security practices across our web, blockchain, and DNS infrastructure — threat modeling, vulnerability assessment, penetration testing, and incident response — using AI agents to augment your workflow.
+- Harden APIs, authentication flows, and data handling across the product surface.
+- Design and implement security monitoring, alerting, and audit logging systems.
+- Contribute broadly as a full-stack engineer beyond your specialty: ship features, review code, and improve architecture across the product.
+- Evaluate and integrate the latest AI/LLM tools and agents into security testing, code review, and threat detection workflows.
+
+## What We Look For
+
+- Strong understanding of application security: OWASP Top 10, authentication/authorization patterns, cryptography fundamentals, and secure coding practices.
+- Experience with security across multiple domains: web applications, APIs, blockchain, and infrastructure.
+- Solid software engineering fundamentals: systems design, testing strategies, and clean code practices.
+- Hands-on experience with AI-assisted development — using AI coding agents in your daily workflow.
+- Professional fluency in English. A second language is a plus; one that no existing teammate speaks is a big plus.
+
+## Nice to Have
+
+- Experience with smart contract security, DNS security (DNSSEC, DNS hijacking prevention), or cloud infrastructure hardening.
+- Background in CTF competitions, bug bounty programs, or security research.
+- Relevant certifications or published security research.

--- a/content/careers/en/build-web3-2026-05.md
+++ b/content/careers/en/build-web3-2026-05.md
@@ -1,0 +1,37 @@
+---
+title: 'AI Empowered Builder: Engineer with Specialty in Smart Contract and Web3'
+date: '2026-05-27'
+language: en
+tags: ['engineering', 'web3', 'ai']
+authors: ['namefiteam']
+draft: false
+type: job
+description: Bring deep Web3 and smart contract expertise across the full product surface, using AI agents to accelerate on-chain and off-chain delivery.
+employmentType: FULL_TIME
+validThrough: '2026-08-31'
+team: Engineering
+location: Remote (Worldwide)
+compensation: Competitive pay with equity
+---
+
+## What You Will Do
+
+- Design, develop, and audit smart contracts powering NFT-based domain ownership, token economies, and on-chain governance — using AI agents to accelerate development and review.
+- Build and maintain the bridge between on-chain state and off-chain systems: indexers, event listeners, and synchronization logic.
+- Contribute broadly as a full-stack engineer beyond your specialty: ship features across the product, from backend services to frontend interfaces.
+- Evaluate and integrate the latest AI/LLM tools and agents into smart contract development, auditing, and testing workflows.
+- Collaborate on systems design, security reviews, and production operations.
+
+## What We Look For
+
+- Strong understanding of blockchain fundamentals: consensus, state machines, transaction lifecycle, and gas optimization.
+- Experience writing, testing, and deploying smart contracts in a production environment.
+- Solid software engineering fundamentals: data structures, algorithms, testing strategies, and security-first thinking.
+- Hands-on experience with AI-assisted development — using AI coding agents in your daily workflow.
+- Professional fluency in English. A second language is a plus; one that no existing teammate speaks is a big plus.
+
+## Nice to Have
+
+- Experience with token standards, DeFi protocols, or NFT marketplaces.
+- Background in formal verification, fuzzing, or smart contract auditing.
+- Track record of building and shipping personal projects or open source contributions in the Web3 space.

--- a/content/careers/en/conn-bd-2026-05.md
+++ b/content/careers/en/conn-bd-2026-05.md
@@ -1,0 +1,37 @@
+---
+title: 'AI Empowered Connector: Business Development'
+date: '2026-05-27'
+language: en
+tags: ['business', 'partnerships', 'ai']
+authors: ['namefiteam']
+draft: false
+type: job
+description: Build relationships, identify opportunities, and expand our reach across industries and ecosystems, powered by AI-driven research and outreach workflows.
+employmentType: FULL_TIME
+validThrough: '2026-08-31'
+team: Business
+location: Remote (Worldwide)
+compensation: Competitive pay with equity
+---
+
+## What You Will Do
+
+- Identify, pursue, and close strategic partnerships that expand Namefi's reach across the domain, Web3, and internet infrastructure ecosystems — using AI agents for research, outreach, and deal pipeline management.
+- Build and maintain relationships with registrars, registries, Web3 protocols, DeFi platforms, and enterprise partners.
+- Develop go-to-market strategies for new markets, geographies, and customer segments.
+- Represent Namefi at industry events, conferences, and community gatherings.
+- Collaborate with product and engineering to translate partner needs into product opportunities.
+
+## What We Look For
+
+- Track record of closing deals, building partnerships, or growing business relationships — show us what you have accomplished.
+- Strong understanding of at least one of: the domain industry, Web3/crypto ecosystem, or internet infrastructure market.
+- Ability to use AI tools for research, prospecting, communication drafting, and workflow automation.
+- Excellent communication: you can pitch, negotiate, and build trust across cultures and time zones.
+- Professional fluency in English. A second language is a plus; one that no existing teammate speaks is a big plus.
+
+## Nice to Have
+
+- Existing network in the domain industry, Web3 space, or internet infrastructure community.
+- Experience with partnership models: affiliate, reseller, API integrations, co-marketing.
+- Background in startups or early-stage companies where you wore multiple hats.

--- a/content/careers/en/conn-community-2026-05.md
+++ b/content/careers/en/conn-community-2026-05.md
@@ -1,0 +1,37 @@
+---
+title: 'AI Empowered Connector: Community Manager'
+date: '2026-05-27'
+language: en
+tags: ['community', 'engagement', 'ai']
+authors: ['namefiteam']
+draft: false
+type: job
+description: Grow and nurture our community with meaningful engagement, using AI agents to stay responsive and surface insights at scale.
+employmentType: FULL_TIME
+validThrough: '2026-08-31'
+team: Community
+location: Remote (Worldwide)
+compensation: Competitive pay with equity
+---
+
+## What You Will Do
+
+- Build, grow, and nurture Namefi's community across Discord, Telegram, Twitter/X, and other platforms — using AI agents to stay responsive and surface insights at scale.
+- Be the bridge between users and the team: gather feedback, surface pain points, celebrate wins, and keep the community informed.
+- Create and moderate community programs: AMAs, campaigns, contests, governance discussions, and educational content.
+- Develop community strategies that drive engagement, retention, and organic growth.
+- Monitor sentiment, identify emerging issues, and escalate appropriately — using AI tools for monitoring and analysis.
+
+## What We Look For
+
+- Experience building or managing online communities — show us communities you have grown or contributed to meaningfully.
+- Genuine passion for engaging with people: you enjoy answering questions, resolving conflicts, and celebrating community members.
+- Comfort with AI tools for community management: moderation, sentiment analysis, content scheduling, and response drafting.
+- Strong written communication: clear, empathetic, and able to represent the team's voice authentically.
+- Professional fluency in English. A second language is a plus; one that no existing teammate speaks is a big plus.
+
+## Nice to Have
+
+- Experience in Web3, domain industry, or developer-facing communities.
+- Background in content creation, social media management, or growth marketing.
+- Familiarity with community platforms, bots, and automation tools.

--- a/content/careers/en/conn-creative-2026-05.md
+++ b/content/careers/en/conn-creative-2026-05.md
@@ -1,0 +1,37 @@
+---
+title: 'AI Empowered Connector: Creative Creator'
+date: '2026-05-27'
+language: en
+tags: ['content', 'creative', 'ai']
+authors: ['namefiteam']
+draft: false
+type: job
+description: Create content and media that amplify our brand across every channel, using the latest AI and generative tools to move at creative speed.
+employmentType: FULL_TIME
+validThrough: '2026-08-31'
+team: Marketing
+location: Remote (Worldwide)
+compensation: Competitive pay with equity
+---
+
+## What You Will Do
+
+- Produce compelling content across formats: blog posts, social media, video, graphics, podcasts, newsletters — using AI generative tools to move fast and experiment widely.
+- Tell Namefi's story in ways that resonate with different audiences: domain investors, Web3 builders, developers, and mainstream internet users.
+- Build and maintain our brand voice, visual identity, and content calendar across all channels.
+- Experiment with emerging AI content tools — image generation, video creation, audio synthesis — to stay ahead of what is possible.
+- Measure what works, iterate on what does not, and grow our audience.
+
+## What We Look For
+
+- A portfolio of content you have created and published — any format, any platform. Show us your best work.
+- Strong writing and visual storytelling ability: you can explain complex ideas simply and make dry topics interesting.
+- Comfort with AI creative tools: you already use them to generate, edit, or augment your creative output.
+- Self-direction: you can identify what content to create, not just execute briefs handed to you.
+- Professional fluency in English. A second language is a plus; one that no existing teammate speaks is a big plus.
+
+## Nice to Have
+
+- Experience creating content for technical, Web3, or developer-facing audiences.
+- Video production or podcast experience.
+- Background in growth marketing, SEO, or audience building.

--- a/content/careers/en/how-we-hire.md
+++ b/content/careers/en/how-we-hire.md
@@ -67,9 +67,7 @@ We look at your trajectory — past growth, recent leaps, appetite for learning.
 
 We do not hire based on your gender, sex, age, race, ability or physical challenge, or where you come from — and many other factors (see [Know Your Rights: Workplace Discrimination is Illegal](https://www.eeoc.gov/poster)). Not only because it is right, but because hiring the best means selecting from the widest possible talent pool and judging purely on merit.
 
-We do not restrict schools or prior career paths. We take candidates from non-traditional backgrounds, career switchers, self-taught builders, and anyone who can demonstrate they have what it takes.
-
-We highly value the quality of your past work: code repos, portfolios, papers, deals closed, funds raised, customers served — much more than line items, titles, schools, or companies on your resume. Those matter too, but much less.
+We do not restrict schools or prior career paths. We take candidates from non-traditional backgrounds, career switchers, self-taught builders, and anyone who can demonstrate they have what it takes. We highly value the quality of your past work — code repos, portfolios, papers, deals closed, funds raised, customers served — much more than line items, titles, schools, or companies on your resume. Those matter too, but much less.
 
 ## Legal and Compliance
 

--- a/content/careers/en/how-we-hire.md
+++ b/content/careers/en/how-we-hire.md
@@ -65,7 +65,7 @@ We look at your trajectory — past growth, recent leaps, appetite for learning.
 
 ## Equal Opportunity
 
-We do not hire based on your gender, age, race, ability or physical challenge, or where you come from. Period.
+We do not hire based on your gender, sex, age, race, ability or physical challenge, or where you come from — and many other factors (see [Know Your Rights: Workplace Discrimination is Illegal](https://www.eeoc.gov/poster)). Period.
 
 We do not restrict schools or prior career paths. We take candidates from non-traditional backgrounds, career switchers, self-taught builders, and anyone who can demonstrate they have what it takes.
 

--- a/content/careers/en/how-we-hire.md
+++ b/content/careers/en/how-we-hire.md
@@ -69,6 +69,10 @@ We do not hire based on your gender, age, race, ability or physical challenge, o
 
 We do not restrict schools or prior career paths. We take candidates from non-traditional backgrounds, career switchers, self-taught builders, and anyone who can demonstrate they have what it takes.
 
+## Legal and Compliance
+
+Namefi is a Delaware-incorporated company. All hiring is conducted in accordance with US federal and Delaware state law. We hire globally — we do not care where you are located, so long as your engagement is compliant with applicable regulations.
+
 ---
 
 ## Language

--- a/content/careers/en/how-we-hire.md
+++ b/content/careers/en/how-we-hire.md
@@ -65,7 +65,7 @@ We look at your trajectory — past growth, recent leaps, appetite for learning.
 
 ## Equal Opportunity
 
-We do not hire based on your gender, sex, age, race, ability or physical challenge, or where you come from — and many other factors (see [Know Your Rights: Workplace Discrimination is Illegal](https://www.eeoc.gov/poster)). Period.
+We do not hire based on your gender, sex, age, race, ability or physical challenge, or where you come from — and many other factors (see [Know Your Rights: Workplace Discrimination is Illegal](https://www.eeoc.gov/poster)). Not only because it is right, but because hiring the best means selecting from the widest possible talent pool and judging purely on merit.
 
 We do not restrict schools or prior career paths. We take candidates from non-traditional backgrounds, career switchers, self-taught builders, and anyone who can demonstrate they have what it takes.
 

--- a/content/careers/en/how-we-hire.md
+++ b/content/careers/en/how-we-hire.md
@@ -69,6 +69,8 @@ We do not hire based on your gender, sex, age, race, ability or physical challen
 
 We do not restrict schools or prior career paths. We take candidates from non-traditional backgrounds, career switchers, self-taught builders, and anyone who can demonstrate they have what it takes.
 
+We highly value the quality of your past work: code repos, portfolios, papers, deals closed, funds raised, customers served — much more than line items, titles, schools, or companies on your resume. Those matter too, but much less.
+
 ## Legal and Compliance
 
 Namefi is a Delaware-incorporated company. All hiring is conducted in accordance with US federal and Delaware state law. We hire globally — we do not care where you are located, so long as your engagement is compliant with applicable regulations.

--- a/content/careers/en/intern-builder-2026-05.md
+++ b/content/careers/en/intern-builder-2026-05.md
@@ -1,0 +1,37 @@
+---
+title: 'Intern: AI Empowered Builder'
+date: '2026-05-27'
+language: en
+tags: ['intern', 'engineering', 'ai']
+authors: ['namefiteam']
+draft: false
+type: job
+description: Contribute to real product work from day one, learning fast with AI agents and the latest development tools alongside experienced builders.
+employmentType: INTERN
+validThrough: '2026-08-31'
+team: Engineering
+location: Remote (Worldwide)
+compensation: Generally unpaid with exceptions
+---
+
+## What You Will Do
+
+- Work on real product features alongside experienced engineers — not busywork, not a toy project.
+- Use AI coding agents and the latest development tools as your primary workflow — we will help you get set up and productive fast.
+- Learn by shipping: write code, get code reviews, fix bugs, and see your work in production.
+- Participate in team meetings, design discussions, and code reviews to build your engineering judgment.
+- Complete a meaningful project or set of contributions by the end of your internship.
+
+## What We Look For
+
+- Genuine excitement about building software and learning new things fast.
+- Some programming experience — personal projects, coursework, bootcamps, self-taught, anything that shows you can write code.
+- Comfort with or curiosity about AI-assisted development tools.
+- Initiative and self-direction: you ask questions, seek feedback, and do not wait to be told what to do next.
+- Professional fluency in English. A second language is a plus; one that no existing teammate speaks is a big plus.
+
+## Nice to Have
+
+- Published projects: GitHub repos, apps, websites, bots — anything you have built and can show.
+- Familiarity with version control, testing, or any software engineering best practices.
+- Interest in domains, DNS, Web3, or internet infrastructure.

--- a/content/careers/en/intern-connector-2026-05.md
+++ b/content/careers/en/intern-connector-2026-05.md
@@ -1,0 +1,37 @@
+---
+title: 'Intern: AI Empowered Connector'
+date: '2026-05-27'
+language: en
+tags: ['intern', 'content', 'community', 'ai']
+authors: ['namefiteam']
+draft: false
+type: job
+description: Get hands-on experience in content, partnerships, or community while developing AI-agent-powered communication and outreach skills.
+employmentType: INTERN
+validThrough: '2026-08-31'
+team: Marketing
+location: Remote (Worldwide)
+compensation: Generally unpaid with exceptions
+---
+
+## What You Will Do
+
+- Support content creation, community engagement, or business development efforts — depending on your strengths and interests.
+- Use AI tools for research, writing, outreach, design, and workflow automation as a core part of how you work.
+- Learn how a startup communicates, builds community, and grows its audience from the inside.
+- Take ownership of a meaningful project: a content series, a community initiative, a partnership pipeline, or a campaign.
+- Collaborate with the team and contribute ideas — your perspective matters from day one.
+
+## What We Look For
+
+- A portfolio or track record of creating something: writing, videos, social media content, event organizing, community building — anything that shows initiative.
+- Comfort with or curiosity about AI creative and productivity tools.
+- Strong written communication skills: clear, engaging, and adaptable to different audiences.
+- Self-direction: you can identify what needs to be done and make progress without constant guidance.
+- Professional fluency in English. A second language is a plus; one that no existing teammate speaks is a big plus.
+
+## Nice to Have
+
+- Experience with social media management, content creation, or community moderation.
+- Interest in domains, Web3, or internet infrastructure.
+- Background in marketing, communications, journalism, or a related field.


### PR DESCRIPTION
## Summary

Adds all 10 remaining job posts to the careers content collection.

### Builder Series
- `build-dns-2026-05` — Engineer with Specialty in DNS and EPP
- `build-web3-2026-05` — Engineer with Specialty in Smart Contract and Web3
- `build-security-2026-05` — Engineer with Specialty in Cyber Security
- `build-design-2026-05` — Non-Engineer (PM / Product Designer / UXUI Designer)
- `build-nontraditional-2026-05` — Without Traditional Product Experience

### Connector Series
- `conn-creative-2026-05` — Creative Creator
- `conn-bd-2026-05` — Business Development
- `conn-community-2026-05` — Community Manager

### Intern Roles
- `intern-builder-2026-05` — Intern: AI Empowered Builder (generally unpaid)
- `intern-connector-2026-05` — Intern: AI Empowered Connector (generally unpaid)

Companion PR: d3servelabs/namefi-astra#4283

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only markdown additions and copy edits with no runtime, auth, or data-path changes.
> 
> **Overview**
> This PR **publishes the remaining careers content** for the AI Empowered Builder / Connector hiring wave: **10 new English job posts** under `content/careers/en/` (DNS/EPP, Web3, security, product/design, non-traditional builder, creative, BD, community, plus two intern roles), each with front matter (`type: job`, remote location, `validThrough`, team, compensation).
> 
> It also **expands shared careers copy**: `about-namefi.md` gains a **“Learn about our industry”** section with links to seven blog explainers, and **`how-we-hire.md`** strengthens equal-opportunity language (including an EEOC poster link), emphasizes **portfolio/work over resume pedigree**, and adds a **Legal and Compliance** note (Delaware entity, US/Delaware hiring law, global compliance).
> 
> No application code or infrastructure changes—markdown content only, intended to surface on the careers site (companion PR in namefi-astra).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a21f474a22bc6a30d6f996bf6996363f6955876. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->