### PR TITLE
fix(career): drop /r/ prefix from about-namefi blog links

### DIFF
--- a/content/careers/_shared/about-namefi.md
+++ b/content/careers/_shared/about-namefi.md
@@ -4,10 +4,10 @@ Namefi is an ICANN-accredited registrar tokenizing internet domain names for tra
 
 ### Learn about our industry
 
-- [What is a Domain?](/r/en/blog/what-is-domain)
-- [What are Tokenized Domains?](/r/en/blog/what-are-tokenized-domains)
-- [Why Tokenize Domains?](/r/en/blog/why-tokenize-domains)
-- [DNS on Tokenized Domains](/r/en/blog/dns-on-tokenized-domains)
-- [DNS is the Control Plane](/r/en/blog/dns-is-the-control-plane)
-- [How to Tokenize Your .com](/r/en/blog/how-to-tokenize-your-com)
-- [Tokenized Domain vs Web3 Domain](/r/en/blog/tokenized-domain-vs-web3-domain)
+- [What is a Domain?](/en/blog/what-is-domain)
+- [What are Tokenized Domains?](/en/blog/what-are-tokenized-domains)
+- [Why Tokenize Domains?](/en/blog/why-tokenize-domains)
+- [DNS on Tokenized Domains](/en/blog/dns-on-tokenized-domains)
+- [DNS is the Control Plane](/en/blog/dns-is-the-control-plane)
+- [How to Tokenize Your .com](/en/blog/how-to-tokenize-your-com)
+- [Tokenized Domain vs Web3 Domain](/en/blog/tokenized-domain-vs-web3-domain)


### PR DESCRIPTION
## Summary

The careers job-posting pages render a shared "About Namefi" block sourced from `content/careers/_shared/about-namefi.md`. Its blog cross-links were hardcoded as `/r/en/blog/...`, but the consuming Next.js app (`apps/resources` in `namefi-astra`) sets `basePath: '/r'` in `next.config.ts`. Next's `<Link>` auto-prepends the basePath, so every link rendered as `https://namefi.io/r/r/en/blog/...` — a 404 on every job page.

All other cross-links in this content tree (e.g. `content/blog/en/*.md`, `content/glossary/en/*.md`) correctly use plain `/en/blog/...` paths. This PR aligns the careers `_shared/about-namefi.md` with that convention.

## Test plan

- [ ] Verify no other content files under `content/` use the `/r/...` prefix pattern
- [ ] After bumping the submodule pointer in `namefi-astra`, open any `/r/en/careers/<slug>` page locally and confirm each "Learn about our industry" link resolves to the correct blog post
- [ ] Spot-check `https://namefi.io/r/en/careers/<slug>` after deploy to confirm the bug is gone

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only URL corrections in shared careers copy; no application or security logic changes.
> 
> **Overview**
> Fixes broken **“Learn about our industry”** links on careers job pages by updating seven blog URLs in `content/careers/_shared/about-namefi.md` from `/r/en/blog/...` to `/en/blog/...`, matching the rest of the content tree.
> 
> With the resources app’s `basePath: '/r'`, Next.js was prepending `/r` again, producing double-prefixed `/r/r/en/blog/...` URLs and 404s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d167e404bdc52d180735e0516ea5cc810db4350c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect link routing in the careers section that prevented proper navigation to related blog content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d3servelabs/namefi-resources/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->