### PR TITLE
fix: update gemini model defaults

### DIFF
--- a/.github/workflows/translate-blog.yml
+++ b/.github/workflows/translate-blog.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run Translation Script
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GEMINI_MODEL: "gemini-3-pro-preview"
+          GEMINI_MODEL: "gemini-3.1-pro-preview"
         run: bun scripts/translate-blog.ts
 
       - name: Create Pull Request

--- a/scripts/generate-blog.ts
+++ b/scripts/generate-blog.ts
@@ -12,7 +12,7 @@ if (!apiKey) {
 }
 
 const genAI = new GoogleGenerativeAI(apiKey);
-const MODEL_NAME = process.env.GEMINI_MODEL || "gemini-3-pro-preview";
+const MODEL_NAME = process.env.GEMINI_MODEL || "gemini-3.1-pro-preview";
 const model = genAI.getGenerativeModel({ model: MODEL_NAME });
 
 // Arguments

--- a/scripts/generate-tld.ts
+++ b/scripts/generate-tld.ts
@@ -13,8 +13,8 @@ if (!apiKey) {
 }
 
 const genAI = new GoogleGenerativeAI(apiKey);
-// Default to gemini-3-pro-preview as requested
-let modelName = "gemini-3-pro-preview";
+// Default to the current Gemini Pro replacement model.
+let modelName = "gemini-3.1-pro-preview";
 
 // CLI Argument Parsing
 const args = process.argv.slice(2);

--- a/scripts/translate-blog.ts
+++ b/scripts/translate-blog.ts
@@ -13,7 +13,7 @@ if (!apiKey) {
 }
 
 const genAI = new GoogleGenerativeAI(apiKey);
-const MODEL_NAME = process.env.GEMINI_MODEL || "gemini-3-pro-preview";
+const MODEL_NAME = process.env.GEMINI_MODEL || "gemini-3.1-pro-preview";
 
 const model = genAI.getGenerativeModel({ model: MODEL_NAME });
 


### PR DESCRIPTION
## Summary
- replace retired `gemini-3-pro-preview` with `gemini-3.1-pro-preview` in the translate workflow
- update local script defaults for blog/TLD generation to use the newer model

## Verification
- `bun install --frozen-lockfile`
- `bun data:validate` (passes with existing keyword warnings)
- `bun lint:mdx`
- pre-push hook passed `data_validate` and `lint_mdx`

Note: I did not run a live translation locally because `GEMINI_API_KEY` is not set in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AI model configuration used for automated blog generation and translation tasks to leverage a newer model version, potentially improving content quality and generation performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->