### PR TITLE
[DELAYED MERGE — do not merge before 2026-06-15] feat(seo): wave 2 — .io, .app, .vip, .ae, xStocks, TLD pillar

### DIFF
--- a/content/blog/en/what-are-xstocks.md
+++ b/content/blog/en/what-are-xstocks.md
@@ -1,54 +1,128 @@
 ---
 title: What are xStocks? Why should domainers care?
 date: '2025-07-02'
+updated: '2026-06-10'
 language: en
 tags: ['faq', 'domains', 'tokenization']
 authors: ['namefiteam']
 draft: false
-description: Explore how xStocks are revolutionizing finance and why domainers using tokenization via Namefi are uniquely positioned to lead this digital shift.
-keywords: ['xStocks', 'tokenized stocks', 'tokenized equities', 'domain investing', 'domain tokenization', 'Namefi', 'blockchain stocks', 'fractional ownership', 'web3 finance', 'digital asset trading', 'Solana tokenized assets', 'crypto stocks', 'on-chain equities', 'tokenization of real-world assets', 'tokenized domain names']
+description: A clear explainer on xStocks—tokenized stocks (tokenized equities) on Solana, issued by Backed Finance. Learn what xStocks are, how they work, how they differ from traditional stocks, the risks, and how they fit the broader real-world-asset (RWA) tokenization trend that tokenized domains are part of.
+keywords: ['xStocks', 'what are xStocks', 'what is xStocks', 'xStocks crypto', 'tokenized stocks', 'tokenized equities', 'was sind xStocks', 'xStocks是什么', '什么是xstocks', 'que son los xStocks', 'unterschied xStocks traditionelle Aktien', 'Backed Finance', 'Kraken xStocks', 'Bybit xStocks', 'Solana tokenized stocks', 'on-chain equities', 'tokenization of real-world assets', 'RWA tokenization', 'tokenized domains', 'domain tokenization', 'Namefi']
 ---
 
-## What is xStocks?
+You may have seen the word **xStocks** on a crypto exchange, in a trading app, or in a headline about "stocks on the blockchain," and wondered what it actually means. Is an xStock a real share? A crypto coin? A bet on a stock price? And what does any of it have to do with domains?
 
-_Bridging domain assets and tokenized equities onchain_
+This article answers the **"what"** directly: what xStocks *are*, how they *work*, who *issues* them, how they *differ* from traditional stocks, the *risks* to understand—and why this matters to anyone watching the broader **real-world-asset (RWA) tokenization** trend that [tokenized domains](/en/blog/what-are-tokenized-domains/) are also part of.
 
-Tokenized equities or _xStocks_ have recently gone mainstream, with platforms like Robinhood, Coinbase, Kraken, and Bybit launching or planning offerings that bring U.S. stock access to crypto-native and overseas investors. What used to be confined to brokers and banks is now accessible 24/5, globally, via platforms like Kraken, Bybit, Coinbase, and Robinhood. **But what exactly are xStocks? These so-called xStocks are onchain tokens, backed 1:1 by actual shares, and storable in self‑custodial wallets, making them ready to slip into DeFi as collateral or liquidity.**
+> A note up front: **xStocks are not a Namefi product.** We cover them here as an educational example of where asset tokenization is heading. Nothing in this post is financial, legal, or tax advice.
 
-Now imagine not just trading in minutes, but milliseconds. Thanks to f.E. Solana-level speed, tokenized assets settle almost instantly often in under a second. In fact, Solana boasts settlement speeds around 0.4 seconds while blockchain transactions more broadly typically complete in just 3–5 seconds . As one expert put it, “Tokenized financial securities could be traded and settled in milliseconds, like handing someone cash”. This kind of speed transforms domains, too: _imagine a premium_ **_.com_** _transferring ownership or being used as collateral in the blink of an eye, unlocking rapid liquidity and seamless utility._
+---
 
-For domainers who trade, tokenize, and sometimes fractionalize domain assets, this isn’t just stock news. It’s a playbook! Tokenized equities have created a model for transforming illiquid “real-world” assets into high-access, composable digital instruments. You could do the same with prime domains.
+## The Short Definition
 
-**Picture this:** a portfolio of premium .coms tokenized, fractionally owned, and tradable round-the-clock. Domain-backed tokens might be used as collateral, combined with other tokens in baskets, traded on global markets, or leveraged in creative DeFi strategies. The mechanics and infrastructure are already here. The transparency-proof systems mean token holders can trust that each token really is backed by a real asset, much like xStocks.
+An **xStock** is a token on a public blockchain that tracks the price of a single real-world stock or ETF—and that is intended to be **backed 1:1** by the underlying share held in custody by the issuer. xStocks are **tokenized stocks** (also called *tokenized equities*): a blockchain-based way to get price exposure to companies like Apple or Tesla without going through a traditional brokerage.
 
-## Why this matters now
+In plain terms:
 
-xStocks represent more than headline-grabbing innovation, they mark a shift in how we think about asset ownership. With DeFi-ready tokenization, legacy asset owners are discovering new pathways to monetize and mobilize value. And it’s accelerating. Coinbase is applying to the SEC for tokenized equities in the U.S., and Robinhood is rolling out 200 tokenized U.S. equities in Europe, even private company mirror tokens for SpaceX and Anthropic.
+> An xStock is a crypto token that mirrors the economic value of one share (e.g. `AAPLx` tracks Apple, `TSLAx` tracks Tesla), lives in a self-custodial wallet, and trades on crypto exchanges and decentralized protocols—largely outside traditional market hours.
 
-Domainers in the Web2 space have a powerful opportunity to align with this trend. Why stop at domains when you could create onchain domain+ equity baskets? Or let fractional domain investors stake to earn yield? It's all compatible with today’s xStock infrastructure.
+xStocks are issued by **Backed Assets (a Backed Finance entity)** and run primarily on the **Solana** blockchain as standard SPL tokens. They are distributed through the **xStocks Alliance**—a group that includes exchanges and protocols such as **Kraken**, **Bybit**, and Solana DeFi venues like **Raydium**, **Jupiter**, and **Kamino**. In late 2025, Kraken announced it would **acquire Backed**, the company behind xStocks.
 
-Tokenized stocks show us what’s next: ownership without borders, transactions without frictions, and assets that move as fast as ideas. For domainers, it’s not just a stock story, it’s a preview of how tokenized domains can power the next wave of internet-native assets. With Namefi, that future is not theoretical - it’s deployable.
+---
 
-## The future? Global, composable, transparent and yours to claim.
+## How xStocks Work
 
-Want a quick dive into how hot this really is? Check out [Kraken’s video](https://www.youtube.com/watch?v=OpiyVve5URM) on xStocks.
+The mechanics are simpler than the marketing sometimes makes them sound:
 
-👉 Don’t forget to check out [Namefi.io](https://namefi.io/?utm_source=blog&utm_medium=blog&utm_campaign=xtocks) for more about Domain Tokenization, AI-Tools and smooth domain management, also follow us on X at [@namefi\_io](https://x.com/namefi_io?utm_source=blog&utm_medium=blog&utm_campaign=xtocks) to stay ahead of the curve.
+1. **A real share is custodied.** For each xStock token in circulation, the issuer is meant to hold one corresponding real share (or ETF unit) with a regulated custodian—so the supply is collateralized 1:1.
+2. **A token is minted on-chain.** That holding is represented as a token (e.g. `AAPLx`) on Solana, which you can hold in a self-custodial wallet like Phantom or Solflare.
+3. **It trades nearly around the clock.** Because it's an on-chain token, an xStock can be bought, sold, and moved **24/5** on exchanges—and effectively 24/7 on DeFi protocols—rather than only during the underlying stock market's open hours.
+4. **It plugs into DeFi.** xStocks are *composable*: they can be supplied as collateral, paired in liquidity pools, or used in other on-chain strategies, the same way other crypto tokens are.
 
-## Tags / Hashtags (for social & blog)
+On **dividends**: xStocks do not pay cash dividends to your wallet. Instead, the issuer reinvests the dividend value into the underlying position and adjusts the token so its value reflects the distribution—an economic pass-through rather than a cash payout.
 
-*   #xStocks
-*   #TokenizedAssets
-*   #TokenizedStocks
-*   #Web3Finance
-*   #DigitalAssets
-*   #Namefi
-*   #Domainers
-*   #Solana
-*   #FractionalOwnership
-*   #DeFi
-*   #CryptoFinance
-*   #OnChain
-*   #DomainInvesting
-*   #FutureOfFinance
-*   #TokenEconomy
+By early 2026, xStocks had grown into the largest tokenized-equity offering by transaction volume, expanding from an initial ~60 assets at launch (June 2025) toward a catalog of 100+ tokenized stocks and ETFs, with the issuer signaling ambitions to widen coverage further.
+
+---
+
+## How xStocks Differ From Traditional Stocks
+
+This is the question many non-English searchers are really asking—*was sind xStocks*, *xStocks是什么*, *qué son los xStocks*, and especially *"how do xStocks differ from traditional stocks?"* Here's the honest comparison:
+
+| Feature | Traditional Stock | xStock (Tokenized Stock) |
+|---|---|---|
+| What you legally hold | A share in the company | A token tracking the share's value |
+| Voting rights | Yes (typically) | No |
+| Dividends | Paid in cash | Reflected in token value, not paid as cash |
+| Where it lives | Brokerage account | Self-custodial crypto wallet |
+| Trading hours | Exchange hours (e.g. ~6.5 hrs/day) | 24/5 on exchanges, ~24/7 on DeFi |
+| Settlement | T+1 (about one business day) | Near-instant on-chain |
+| Composable with DeFi | No | Yes |
+| Who you rely on | Broker, clearinghouse | Token issuer + custodian + blockchain |
+
+The crucial point: **an xStock is not the share itself.** It gives you *economic exposure* to the share's price (and dividend value) but generally **does not convey shareholder rights** such as voting, and it carries **issuer and custody risk** that you don't have when you hold a share directly through a regulated broker.
+
+---
+
+## Risks and Considerations
+
+xStocks are an interesting innovation, but they are not risk-free, and a balanced explainer has to say so:
+
+- **Issuer & counterparty risk.** Your token's value depends on the issuer actually holding and maintaining the backing shares with its custodians. You take on the issuer's creditworthiness, operational, and solvency risk.
+- **No shareholder rights.** No voting; no cash dividends; no direct legal claim on the company or its assets in a liquidation.
+- **Liquidity risk.** On-chain markets for a given xStock may be thin, making it hard to exit at a fair price when you want to.
+- **Regulatory uncertainty.** The legal status of tokenized securities is still evolving and varies by country. xStocks are offered to eligible clients in many jurisdictions but are **not available to U.S. persons** (and not in Canada, the UK, or Australia, among others). In the EU they have been treated within established securities frameworks.
+- **Smart-contract & platform risk.** As with any on-chain asset, bugs, exploits, or platform downtime are possible.
+
+Always check current eligibility and the issuer's risk disclosures for your jurisdiction before acting.
+
+---
+
+## Why Should Domainers and Namefi Users Care?
+
+Here's the connection. xStocks aren't a domain story—but they *are* a vivid example of the same megatrend that **tokenized domains** belong to: the **tokenization of real-world assets (RWAs)**.
+
+The pattern is identical across asset classes. Take something traditionally illiquid and locked inside a specialized system—**equities** behind brokerages, **domains** behind registrars—and give it a synchronized on-chain representation. Suddenly that asset becomes:
+
+- **Wallet-native** — you hold it yourself instead of inside a hosted account.
+- **Transferable in seconds** — no multi-day settlement or escrow ceremony.
+- **Composable** — usable as collateral, in marketplaces, in [DeFi](/en/glossary/defi/).
+- **Globally accessible** — tradable across borders, around the clock.
+
+That's exactly what a [tokenized domain](/en/blog/what-are-tokenized-domains/) is: a real, ICANN-recognized domain (like `example.com`) whose ownership *also* lives as an NFT in your wallet, kept in sync with the DNS registry. The same mechanics that let an xStock settle in under a second can let a premium `.com` change hands—or be pledged as collateral—just as fast.
+
+If you want to see what that unlocks for domains specifically, we've mapped it out in [Tokenized Domain Use Cases in 2026](/en/blog/tokenized-domain-use-cases-2026/): collateralized lending, fractional ownership, on-chain marketplaces, leasing, and more. xStocks show the broader market validating the *model*; tokenized domains apply that model to one of the internet's oldest and most valuable asset classes.
+
+One important difference worth keeping straight: an xStock is a token that *tracks* an off-chain share you don't directly own, whereas a Namefi-tokenized domain *is* the real domain—the on-chain token and the registry record are two synchronized layers of the **same** asset, not a tracker of something held elsewhere.
+
+---
+
+## Frequently Asked Questions
+
+**What are xStocks?** xStocks are tokenized stocks—blockchain tokens, issued by Backed and running primarily on Solana, that track the price of real stocks and ETFs and are intended to be backed 1:1 by the underlying shares held in custody.
+
+**Was sind xStocks? (What are xStocks, in German intent.)** xStocks are tokenized equities: crypto tokens that mirror the value of real shares (e.g. Apple, Tesla), held in a self-custodial wallet and tradable nearly around the clock.
+
+**xStocks 是什么？/ 什么是 xStocks？ (What are xStocks, in Chinese intent.)** xStocks 是代币化股票（tokenized stocks），即在区块链（主要是 Solana）上发行、按 1:1 锚定真实股票或 ETF 的代币，由 Backed 发行，可在加密钱包中自托管并近乎全天候交易。
+
+**¿Qué son los xStocks? (What are xStocks, in Spanish intent.)** Los xStocks son acciones tokenizadas: tokens en blockchain (principalmente Solana) que replican el valor de acciones reales, respaldados 1:1 por las acciones subyacentes y negociables casi a toda hora.
+
+**Worin liegt der Unterschied zwischen xStocks und traditionellen Aktien? (How do xStocks differ from traditional stocks?)** A traditional stock is legal ownership of a share, with voting rights, cash dividends, and broker/clearinghouse settlement during market hours. An xStock is a token that tracks a share's value: no voting rights, dividends reflected in token value rather than paid as cash, self-custodied in a wallet, settled on-chain near-instantly, and exposed to issuer and custody risk.
+
+**Are xStocks the same as crypto?** xStocks are crypto *tokens*, but unlike Bitcoin or a stablecoin they track an individual equity's price. (For how dollar-pegged tokens differ, see [What Are Stablecoins?](/en/blog/what-are-stablecoins/).)
+
+**Who issues xStocks?** Backed (Backed Finance), distributed via the xStocks Alliance including Kraken and Bybit; Kraken announced plans to acquire Backed in 2025.
+
+**Can U.S. persons buy xStocks?** No—at the time of writing xStocks are not available to U.S. persons, nor in Canada, the UK, or Australia, among other restrictions. Check current eligibility for your jurisdiction.
+
+**Do xStocks give voting rights or cash dividends?** No to voting; dividends are passed through as token-value adjustments rather than cash payouts.
+
+---
+
+## The Bigger Picture
+
+xStocks are a clear signal that **real-world-asset tokenization has gone mainstream**—not as a slogan, but as billions in actual on-chain trading volume. Equities were one of the first big asset classes to make the jump. Domains—globally recognized, decades-proven, and already digital—are a natural next chapter.
+
+If you want to go deeper on the domain side of this trend, start with [What Are Tokenized Domains?](/en/blog/what-are-tokenized-domains/) and then explore [Tokenized Domain Use Cases in 2026](/en/blog/tokenized-domain-use-cases-2026/). To put it into practice, visit [namefi.io](https://namefi.io) and follow us on X at [@namefi_io](https://x.com/namefi_io).
+
+*This explainer is published in English; translated versions can help German, Spanish, and Chinese readers reach the same understanding of what xStocks are and how they relate to the wider tokenization movement.*

--- a/content/blog/en/what-is-a-tld.md
+++ b/content/blog/en/what-is-a-tld.md
@@ -1,0 +1,212 @@
+---
+title: What Is a TLD (Top-Level Domain)? A Complete Guide
+date: '2026-06-10'
+language: en
+tags: ['guide']
+authors: ['namefiteam']
+draft: false
+description: A TLD is the part of a domain after the last dot, like .com or .io. Learn what a TLD is, the types (gTLD, ccTLD, sponsored, new gTLD, IDN), and how to choose one.
+keywords: ['tld', 'tld meaning', 'what is a tld', 'what is a top level domain', 'top-level domain', 'tld def', 'tld definition', 'que es un tld', "qu'est-ce qu'un tld", 'types of tld', 'gtld vs cctld', 'tld examples', 'what is a domain extension', 'domain extension', 'gTLD', 'ccTLD', 'sponsored TLD', 'new gTLD', 'IDN TLD', 'ICANN', 'IANA', 'domain registry', 'domain registrar', 'choosing a TLD', 'popular TLDs', 'namefi']
+---
+
+## What Is a TLD?
+
+A **TLD (top-level domain)** is the part of a domain name that comes **after the last dot**. In `namefi.io`, the TLD is `.io`. In `google.com`, the TLD is `.com`. In `wikipedia.org`, the TLD is `.org`.
+
+That's the whole **TLD definition** in one sentence: the rightmost label of a [domain name](/en/blog/what-is-domain/). People also call it a **domain extension** or **domain suffix**, but the technically correct term is *top-level domain*. It sits at the very top of the internet's naming hierarchy — hence the name.
+
+> **TLD meaning, quickly:** *Top-Level Domain* — the suffix at the end of a web address (`.com`, `.org`, `.io`, `.ai`, `.xyz`) that identifies the highest level of the [Domain Name System (DNS)](/en/glossary/dns/).
+
+If you've searched for **"que es un TLD"** (Spanish) or **"qu'est-ce qu'un TLD"** (French), the answer is the same in any language: a TLD is the ending of a domain name, and it's managed by a global system of registries under the oversight of [ICANN](/en/glossary/icann/).
+
+---
+
+## TLD vs Domain vs Subdomain
+
+A full domain name is built from several parts, read **right to left**. Understanding where the TLD fits clears up most of the confusion:
+
+```
+blog . namefi . io
+ │       │       │
+ │       │       └── TLD (top-level domain)
+ │       └────────── SLD (second-level domain)
+ └────────────────── Subdomain
+```
+
+| Part | Example (in `blog.namefi.io`) | What it is |
+|------|-------------------------------|------------|
+| **TLD** | `.io` | The top-level domain — the suffix you register *under*. |
+| **Second-level domain (SLD)** | `namefi` | The unique name you choose and own. |
+| **Subdomain** | `blog` | An optional prefix you create yourself to organize content. |
+
+A few distinctions worth nailing down:
+
+- The **domain** (or *registrable domain*) is usually the SLD + TLD together — `namefi.io`. That's the thing you actually register and pay for.
+- The **TLD** is the shared ending. You don't own `.io`; you own a name *under* it.
+- A **subdomain** is something you control for free once you own the domain — `mail.namefi.io`, `shop.namefi.io`, and so on.
+
+For a deeper walkthrough of how domains are structured, see [What Is a Domain Name?](/en/blog/what-is-domain/) and our [domain terminology guide](/en/blog/domain-terminology-guide/).
+
+---
+
+## The Types of TLD
+
+Not all TLDs are the same. ICANN and IANA classify them into a handful of categories. Here are the main **types of TLD** you'll encounter.
+
+### 1. Generic TLDs (gTLDs)
+
+**gTLDs** are the classic, general-purpose extensions. The original set is small and globally recognized:
+
+- [`.com`](/en/tld/com/) — *commercial*, the default for the entire web
+- [`.net`](/en/tld/net/) — originally for network infrastructure
+- [`.org`](/en/tld/org/) — originally for organizations and nonprofits
+- [`.info`](/en/tld/info/) — informational sites
+
+These are open to anyone and remain the most trusted, liquid endings on the internet.
+
+### 2. Country-Code TLDs (ccTLDs)
+
+**ccTLDs** are two-letter TLDs tied to a country or territory, based on the ISO 3166 country-code list. Examples include `.us` (United States), `.uk` (United Kingdom), `.de` (Germany), `.cn` (China), [`.ae`](/en/tld/ae/) (United Arab Emirates), and [`.ac`](/en/tld/ac/) (Ascension Island).
+
+Here's the interesting part — many ccTLDs have been repurposed far beyond their home country because the letters spell something useful:
+
+- [`.ai`](/en/tld/ai/) is technically Anguilla's ccTLD, but it's become *the* extension for artificial-intelligence companies.
+- [`.io`](/en/tld/io/) belongs to the British Indian Ocean Territory, yet dominates tech and startup branding ("I/O").
+- `.co` (Colombia) is widely used as a short stand-in for `.com`.
+
+This is the **gTLD vs ccTLD** distinction in a nutshell: gTLDs are governed directly under ICANN contracts and open globally, while ccTLDs are delegated to national authorities, each with its own rules (some require local presence, some don't).
+
+### 3. Sponsored TLDs (sTLDs)
+
+**Sponsored TLDs** are restricted gTLDs backed by a specific community or organization that sets eligibility rules. You generally have to qualify to register one. Classic examples: `.gov` (US government), `.edu` (accredited US educational institutions), `.mil` (US military), `.aero` (the aviation industry), and `.museum`.
+
+### 4. New gTLDs
+
+Starting in 2013, ICANN opened the floodgates with the **new gTLD program**, expanding the namespace from a couple dozen endings to well over a thousand. These cover keywords, industries, hobbies, and brands:
+
+| Category | Examples |
+|----------|----------|
+| Tech & web | [`.app`](/en/tld/app/), [`.dev`](/en/tld/dev/), [`.tech`](/en/tld/tech/), [`.cloud`](/en/tld/cloud/), [`.click`](/en/tld/click/) |
+| Modern & generic | [`.xyz`](/en/tld/xyz/), [`.site`](/en/tld/site/), [`.online`](/en/tld/online/), [`.world`](/en/tld/world/), [`.space`](/en/tld/space/) |
+| Commerce | [`.shop`](/en/tld/shop/), [`.store`](/en/tld/store/), [`.vip`](/en/tld/vip/) |
+| Community & content | [`.blog`](/en/tld/blog/), [`.club`](/en/tld/club/), [`.live`](/en/tld/live/), [`.fun`](/en/tld/fun/) |
+| Short & memorable | [`.io`](/en/tld/io/), [`.top`](/en/tld/top/), [`.sbs`](/en/tld/sbs/), [`.now`](/en/tld/now/) |
+
+New gTLDs gave the internet breathing room: when every good `.com` was taken, endings like [`.xyz`](/en/tld/xyz/), [`.site`](/en/tld/site/), and [`.app`](/en/tld/app/) opened up fresh, memorable naming space.
+
+### 5. Internationalized TLDs (IDN TLDs)
+
+**IDN TLDs** are top-level domains written in non-Latin scripts — Arabic, Chinese, Cyrillic, Devanagari, and more. Examples include `.рф` (Russia), `.中国` (China), and `.السعودية` (Saudi Arabia). They let people use the internet in their own language and writing system, end to end.
+
+### A note on Web3 endings
+
+You may also have seen blockchain-native endings like `.eth` or `.crypto`. These are *not* ICANN TLDs — they live outside the traditional DNS root and resolve only through special wallets or resolvers. Namefi catalogs them too (see [`.eth`](/en/tld/eth/)), but it's worth knowing they're a different category. We unpack that distinction in [Tokenized Domain vs Web3 Domain](/en/blog/tokenized-domain-vs-web3-domain/).
+
+---
+
+## How TLDs Are Governed
+
+Behind every TLD is a layered system of governance. Here's who does what:
+
+- **ICANN** — the [Internet Corporation for Assigned Names and Numbers](/en/glossary/icann/) is the nonprofit that coordinates the global namespace, sets policy for gTLDs, and accredits registrars. Founded in 1998, it's the closest thing the domain world has to a referee.
+- **IANA** — the Internet Assigned Numbers Authority (operated under ICANN) maintains the authoritative **root zone**: the master list of every valid TLD and which registry runs it.
+- **Registries** — each TLD is operated by a *registry*, the organization that runs the central database for that ending. For example, **Verisign** operates `.com` and `.net`, and the **Public Interest Registry (PIR)** runs `.org`. ccTLD registries are typically national bodies — for instance, [`.ae`](/en/tld/ae/) is administered by the UAE's TDRA.
+- **Registrars** — a [registrar](/en/glossary/registrar/) is the retailer you buy from. ICANN-accredited registrars (like Namefi, GoDaddy, and Namecheap) sell names to the public and pass registrations up to the registry.
+
+So the chain looks like this: **ICANN/IANA** sets the rules and the root → **registries** operate each TLD → **registrars** sell names to **you**. When you register `yourname.com`, you're buying from a registrar, who records it with the registry (Verisign), all under ICANN policy.
+
+---
+
+## TLD Examples: Popular Endings at a Glance
+
+A quick, scannable reference of common **TLD examples** and what each is best known for:
+
+| TLD | Type | Best known for |
+|-----|------|----------------|
+| [`.com`](/en/tld/com/) | gTLD | The default for any business — most trusted, most valuable |
+| [`.org`](/en/tld/org/) | gTLD | Nonprofits, communities, open-source projects |
+| [`.net`](/en/tld/net/) | gTLD | Tech, networks, infrastructure |
+| [`.io`](/en/tld/io/) | ccTLD (repurposed) | Startups, developers, SaaS |
+| [`.ai`](/en/tld/ai/) | ccTLD (repurposed) | Artificial intelligence and tech |
+| [`.app`](/en/tld/app/) | new gTLD | Mobile and web apps (HTTPS-only) |
+| [`.dev`](/en/tld/dev/) | new gTLD | Developers and engineering teams |
+| [`.tech`](/en/tld/tech/) | new gTLD | Technology brands and products |
+| [`.xyz`](/en/tld/xyz/) | new gTLD | Modern, flexible, generation-neutral |
+| [`.shop`](/en/tld/shop/) | new gTLD | E-commerce and retail |
+| [`.vip`](/en/tld/vip/) | new gTLD | Premium, exclusive, membership brands |
+| [`.sbs`](/en/tld/sbs/) | new gTLD | "Side-by-side" — affordable, expressive names |
+
+Want to go deeper on a specific one? Browse the full library of [TLD guides](/en/tld/), including [`.cloud`](/en/tld/cloud/), [`.online`](/en/tld/online/), [`.store`](/en/tld/store/), [`.site`](/en/tld/site/), [`.club`](/en/tld/club/), [`.world`](/en/tld/world/), and dozens more.
+
+---
+
+## How to Choose a TLD
+
+With well over a thousand options, picking the right ending comes down to a few practical questions:
+
+1. **Is `.com` available?** It's still the gold standard for trust and resale value. If your exact `.com` is free and affordable, it's usually the safe default. See [why `.com` remains the gold standard](/en/tld/com/).
+2. **Does the TLD match your purpose?** A startup fits [`.io`](/en/tld/io/) or [`.ai`](/en/tld/ai/); a store fits [`.shop`](/en/tld/shop/) or [`.store`](/en/tld/store/); a developer tool fits [`.dev`](/en/tld/dev/). The right ending can *describe* what you do.
+3. **Are you targeting a specific country?** A ccTLD like [`.ae`](/en/tld/ae/) signals local presence and can help with local search visibility — but check eligibility rules first.
+4. **Is the name memorable and brandable?** A short SLD on a modern TLD ([`.xyz`](/en/tld/xyz/), [`.app`](/en/tld/app/)) often beats a long, awkward `.com`.
+5. **What does renewal cost?** Some TLDs have low first-year promos but higher renewals. Always check the long-term price, not just the intro price.
+6. **Any restrictions?** Sponsored TLDs (`.gov`, `.edu`) and some ccTLDs require eligibility. New gTLDs like [`.app`](/en/tld/app/) and [`.dev`](/en/tld/dev/) enforce HTTPS by default.
+
+A good rule of thumb: **choose the TLD your audience will trust and remember**, then make sure the price and rules fit your plans.
+
+---
+
+## TLDs and Tokenization
+
+Here's where it gets interesting for the next era of domains. Your TLD doesn't just shape your branding — it also affects whether your domain can be brought **on-chain**.
+
+A [tokenized domain](/en/blog/what-are-tokenized-domains/) is a real, ICANN-recognized domain whose ownership is *also* represented as a token (typically an [NFT](/en/glossary/nft/)) in your wallet. The DNS layer keeps working exactly as before; you simply gain a second, programmable layer of ownership on top.
+
+But not every TLD is equally ready for this. Some registries have moved early to support on-chain ownership layers; others haven't moved at all. That's why the TLD you pick matters if you ever want to:
+
+- Hold your domain directly in your own wallet
+- Transfer it on-chain in seconds (the DNS record follows)
+- List it on NFT marketplaces or use it as collateral in [DeFi](/en/glossary/defi/)
+
+**Namefi** was the first platform to tokenize real ICANN domains on Ethereum mainnet — and the first to do so on Base — across many of the TLDs above, including [`.com`](/en/tld/com/), [`.xyz`](/en/tld/xyz/), [`.io`](/en/tld/io/), and more. You keep a real, browser-resolvable domain *and* wallet-native ownership in one product.
+
+> Curious how the two layers fit together? Read [What Are Tokenized Domains?](/en/blog/what-are-tokenized-domains/) or visit [namefi.io](https://namefi.io) to register or tokenize a domain.
+
+---
+
+## Frequently Asked Questions
+
+### What is a TLD?
+A TLD (top-level domain) is the part of a domain name after the last dot — like `.com`, `.org`, or `.io`. It's the highest level in the Domain Name System hierarchy and is often called a domain extension or suffix.
+
+### What does TLD stand for?
+TLD stands for **Top-Level Domain**. It refers to the suffix at the end of a web address that sits at the top of the internet's naming hierarchy.
+
+### What is the difference between a TLD and a domain?
+A *domain* is the full registrable name, usually the second-level name plus the TLD (e.g., `namefi.io`). The *TLD* is just the shared ending (`.io`). You register and own a domain; you register names *under* a TLD but don't own the TLD itself.
+
+### What are the main types of TLD?
+The main types are generic TLDs (gTLDs) like `.com`, country-code TLDs (ccTLDs) like `.uk` and `.ai`, sponsored TLDs (sTLDs) like `.edu` and `.gov`, new gTLDs like `.xyz` and `.app`, and internationalized TLDs (IDNs) written in non-Latin scripts.
+
+### What is the difference between gTLD and ccTLD?
+A gTLD is a generic, globally available ending governed directly under ICANN contracts (e.g., `.com`, `.org`). A ccTLD is a two-letter ending tied to a country or territory and delegated to a national authority (e.g., `.uk`, `.de`, `.ai`), each with its own registration rules.
+
+### What are some examples of TLDs?
+Common examples include `.com`, `.org`, `.net`, `.io`, `.ai`, `.app`, `.dev`, `.tech`, `.xyz`, `.shop`, and `.vip`. There are well over 1,000 TLDs available today.
+
+### Who controls TLDs?
+ICANN coordinates the global namespace and accredits registrars, IANA maintains the authoritative root zone of all valid TLDs, registries operate individual TLDs (e.g., Verisign runs `.com`), and registrars sell domains to the public.
+
+### Which TLD should I choose?
+If your exact `.com` is available and affordable, it's usually the safest choice for trust and resale value. Otherwise, pick a TLD that matches your purpose — `.io` or `.ai` for startups, `.shop` for stores, `.dev` for developers — and check the renewal price and any eligibility rules before registering.
+
+---
+
+## Summary
+
+- A **TLD (top-level domain)** is the part of a domain after the last dot — `.com`, `.org`, `.io`, and so on. It's also called a domain extension.
+- Read right to left, a domain breaks into **TLD → second-level domain → subdomain**.
+- The main **types of TLD** are gTLDs, ccTLDs, sponsored TLDs, new gTLDs, and internationalized (IDN) TLDs.
+- TLDs are governed by **ICANN** and **IANA** at the top, **registries** that operate each ending, and **[registrars](/en/glossary/registrar/)** that sell names to you.
+- Choosing a TLD is about trust, fit, cost, and — increasingly — whether it can be brought **on-chain** as a [tokenized domain](/en/blog/what-are-tokenized-domains/).
+
+Ready to register or tokenize a domain across your favorite TLD? Visit [namefi.io](https://namefi.io) to get started.

--- a/content/tld/en/ae.md
+++ b/content/tld/en/ae.md
@@ -1,59 +1,122 @@
 ---
-title: 'What is the .ae Domain and Why Choose It for Your Business?'
+title: 'What is the .ae Domain? UAE ccTLD Guide, Eligibility & Registration'
 date: '2025-12-10'
+updated: '2026-06-10'
 language: 'en'
-tags: ['tld', 'domain-investing', 'business', 'uae']
+tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: 'Unlock the potential of the UAE market with the .ae TLD. Learn why businesses choose .ae for trust, local SEO, and brand growth, and how to register yours today.'
-keywords: ['.ae domains', '.ae TLD', 'top-level domain', 'what is .ae', 'why choose .ae', 'what is the .ae domain', 'why choose the .ae domain', 'UAE domain name', 'Dubai business domains', 'Gulf region SEO', 'domain investing .ae', 'blockchain domains', 'tokenized domains', 'Namefi registrar', 'buy .ae domain']
+description: 'The .ae domain is the country code TLD for the United Arab Emirates. Learn what country .ae is, who can register a .ae domain, eligibility rules, and why it wins UAE and Dubai business trust.'
+keywords: ['ae domain', '.ae domain', 'ae tld', 'ae top level domain', 'uae domain', 'uae tld', 'uae domain extension', 'what is .ae domain', 'what is the .ae domain', 'ae domain country', 'who can register a .ae domain', '.ae domain eligibility', 'dubai domain', 'abu dhabi domain', 'internet tld vereinigte arabische emirate', 'ae land', 'aeDA', 'TDRA domain', 'uae country code', 'buy .ae domain', 'register .ae domain', 'why choose .ae', 'tokenized domains', 'Namefi registrar', 'middle east domain']
 ---
 
-## **What is .ae?**
+## What is .ae?
 
-The **.ae** domain is the **country code Top-Level Domain (ccTLD)** for the **United Arab Emirates (UAE)**. Administered by the [.aeDA (part of the Telecommunications and Digital Government Regulatory Authority - TDRA)](https://tdra.gov.ae/en/), this extension serves as the definitive digital address for businesses and individuals operating in or targeting the Emirates.
+The **.ae** domain is the **country code Top-Level Domain (ccTLD)** for the **United Arab Emirates (UAE)**. It is the official internet TLD for the country known in German as the **Vereinigte Arabische Emirate**, and in the world of domains "ae" is the two-letter code that pins your website to one of the fastest-growing economies on earth.
 
-While originally created to represent the UAE's digital sovereignty, the .ae extension has evolved into a symbol of modern commerce, luxury, and technological innovation. With cities like Dubai and Abu Dhabi becoming global hubs for fintech, tourism, and real estate, the .ae TLD has transcended its geographical boundaries to represent a connection to one of the world's fastest-growing economies.
+Administered by the **.aeDA** (the .ae Domain Administration), a department of the UAE's **Telecommunications and Digital Government Regulatory Authority (TDRA)**, the .ae extension serves as the definitive digital address for businesses and individuals operating in — or targeting — the Emirates. You can read the official policies on the [TDRA / .aeDA website](https://tdra.gov.ae/en/aeda).
 
-Unlike many strict ccTLDs, the .ae registry has adopted a relatively open policy, making it accessible to international companies who wish to secure their brand presence in the Gulf region.
+While originally created to represent the UAE's digital sovereignty, the .ae TLD has evolved into a symbol of modern commerce, luxury, and technological innovation. With cities like **Dubai** and **Abu Dhabi** becoming global hubs for fintech, tourism, and real estate, the .ae extension has transcended its borders to represent a connection to a high-trust, high-growth market.
 
-## **How People Are Using .ae**
+If you are comparing extensions, it helps to understand what a [Top-Level Domain (TLD)](/en/glossary/tld/) is and how a ccTLD differs from a generic gTLD like [.com](/en/tld/com/) or [.io](/en/tld/io/).
 
-The usage of .ae has surged in recent years, mirroring the economic boom of the region. Here is how different sectors are utilizing this powerful extension:
+## What country is .ae? (United Arab Emirates)
 
-*   **E-Commerce Giants:** With online shopping skyrocketing in the Middle East, international retailers use .ae to create localized storefronts that offer currency-specific pricing and local shipping options.
-*   **Tech and Blockchain Startups:** Dubai is positioning itself as a global capital for Web3 and crypto. Many blockchain startups use .ae to signal compliance and physical presence in this regulatory-friendly environment.
-*   **Real Estate Agencies:** Given the high-profile nature of UAE property markets, real estate firms use .ae to establish immediate trust with investors looking for properties in the region.
-*   **Local SEO Strategy:** Businesses that want to rank on Google.ae (the local version of the search engine) utilize this TLD to signal relevance to local search algorithms.
-*   **Brand Protection:** Multinational corporations register their .ae counterparts to protect their trademark and prevent cybersquatting in the Middle East market.
+**.ae is the country code domain for the United Arab Emirates.** That is the short, direct answer to "what country is .ae?" and "what is the .ae domain country."
 
-## **Notable Entities Using .ae**
+The "ae" code is the same two-letter identifier (ISO 3166-1 alpha-2) used to represent the UAE across many international systems. So when you see a website ending in `.ae`, you are looking at a domain officially tied to the Emirates — the federation of Abu Dhabi, Dubai, Sharjah, Ajman, Umm Al Quwain, Ras Al Khaimah, and Fujairah.
 
-The credibility of a TLD is often defined by who uses it. The .ae domain is home to some of the largest companies in the region and the world:
+Quick facts about the **.ae TLD**:
 
-1.  **[Amazon.ae](https://www.amazon.ae):** Formerly Souq.com, Amazon rebranded its Middle Eastern operations to Amazon.ae, cementing the TLD's status as the standard for regional e-commerce.
-2.  **[Google.ae](https://www.google.ae):** The tech giant maintains a specific localized version of its search engine for the UAE, emphasizing the importance of local relevance.
-3.  **[Noon.ae](https://www.noon.com/uae-en/):** One of the Middle East's largest homegrown digital marketplaces, competing directly with global giants.
-4.  **Dubizzle:** A household name in the UAE for classifieds and community trading, relying heavily on its local identity.
+*   **Country:** United Arab Emirates (UAE) — *Vereinigte Arabische Emirate* in German.
+*   **TLD type:** Country code Top-Level Domain (ccTLD).
+*   **Registry / administrator:** .aeDA, part of the TDRA.
+*   **Arabic equivalent:** The UAE also operates **.امارات** (dotEmarat), the Arabic-script country code TLD.
+*   **Primary cities behind it:** Dubai, Abu Dhabi.
 
-## **Why Choose .ae?**
+## Who can register a .ae domain?
 
-If you are debating between a generic .com or a local .ae, here are the compelling advantages of choosing the UAE extension:
+One of the reasons the **.ae domain** has grown so quickly is that its eligibility policy is comparatively open — but the exact rules depend on which level you register.
 
-*   **Instant Local Trust:** Using .ae tells customers you are committed to the region. It implies you understand the local market, currency, and culture.
-*   **Superior Local SEO:** Search engines like Google prioritize ccTLDs for users searching within that country. If your target audience is in Dubai or Abu Dhabi, a .ae domain gives you a significant ranking advantage over a .com.
-*   **Domain Availability:** Finding a short, one-word, or premium brand name on .com is nearly impossible or prohibitively expensive. The .ae namespace, while popular, still offers excellent availability for high-value keywords.
-*   **Economic Association:** The UAE is associated with innovation, wealth, and rapid growth. Having a .ae extension can subtly align your brand with these prestige factors.
-*   **Safe and Regulated:** The registry operates under strict guidelines by the TDRA, ensuring a secure and stable namespace that adheres to [international best practices](https://www.icann.org).
+According to the [.aeDA / TDRA](https://tdra.gov.ae/en/aeda/faq):
 
-## **Register Your .ae Domain at Namefi**
+*   **First-level .ae (e.g. `yourbrand.ae`):** Generally **open to everyone**. Anyone — individuals or companies, local or international — is eligible to register a first-level .ae (and .امارات) domain.
+*   **Second-level zones (e.g. `.co.ae`, `.net.ae`, `.gov.ae`, `.ac.ae`):** These carry **additional eligibility requirements** tied to the entity type (for example, government, academic, or licensed-business zones).
+*   **International registrants without a UAE trade license** can typically still secure a first-level .ae name, and where stricter zones apply they may qualify by holding a **UAE-registered trademark** or by registering through a **local agent, distributor, or accredited registrar** that meets the requirements.
 
-Whether you are a local startup in the heart of Dubai or an international investor looking to expand your portfolio into the Gulf region, securing a **.ae** domain is a strategic move for the future.
+A few practical details from the official **.ae Domain Name Policy**:
 
-At **Namefi**, we make domain ownership smarter. Not only are we an ICANN-accredited registrar providing seamless registration for traditional domains, but we also bridge the gap to Web3. With Namefi, you can easily manage your .ae domain and, if you choose, tokenize it for easier transfer and management on the blockchain.
+*   Names may use letters **a–z**, digits **0–9**, and hyphens (`-`).
+*   Registration terms run from **1 to 5 years**.
+*   Domains are registered through an **.aeDA Accredited Registrar** or its resellers — you do not register directly with the registry. (See our glossary entry on what a [registrar](/en/glossary/registrar/) does and how it relates to [ICANN](/en/glossary/icann/).)
+
+> **Always confirm current eligibility** for restricted second-level zones against the official [.aeDA policy documents](https://tdra.gov.ae/en/aeda/ae-policies) before you build a registration strategy, as registry rules can change.
+
+## Why a .ae domain for UAE and Dubai businesses
+
+If you are weighing a generic [.com](/en/tld/com/) against a local **.ae**, the UAE extension delivers signals that a global gTLD simply cannot:
+
+*   **Instant local trust:** A .ae domain tells customers in Dubai, Abu Dhabi, and across the Gulf that you are committed to *their* market — that you understand local currency (AED), culture, and regulation. It is the difference between looking like a visitor and looking like a neighbor.
+*   **A clear market signal:** For a regional storefront, support page, or campaign landing site, `.ae` is an unambiguous flag that says "we operate here." This matters for procurement, partnerships, and consumers who prefer to buy local.
+*   **Superior local SEO:** Search engines associate a ccTLD with its country. If your target audience searches from inside the UAE — including on Google.ae — a .ae domain can give you a geo-relevance advantage over a generic extension.
+*   **Strong namespace availability:** Finding a short, one-word, premium brand on .com is nearly impossible or prohibitively expensive. The .ae namespace, though popular, still offers excellent availability for high-value keywords and exact-match brand names.
+*   **Prestige by association:** The UAE is synonymous with innovation, wealth, and rapid growth. A .ae extension subtly aligns your brand with those qualities.
+*   **Brand protection:** Multinationals register their .ae counterparts to defend trademarks and prevent cybersquatting in the Middle East.
+
+## How people are using .ae
+
+Usage of .ae has surged alongside the region's economic boom. Here is how different sectors put the **UAE domain extension** to work:
+
+*   **E-commerce:** International and homegrown retailers use .ae for localized storefronts with AED pricing and local fulfillment.
+*   **Tech and blockchain startups:** Dubai is positioning itself as a global capital for Web3 and crypto, so many startups use .ae to signal real, compliant presence in a regulation-friendly hub.
+*   **Real estate agencies:** Given the high-profile UAE property market, agencies use .ae to earn immediate trust with investors.
+*   **Local SEO strategy:** Businesses that want to rank for UAE searches use the ccTLD as a relevance signal.
+*   **Brand protection:** Global corporations register .ae versions of their names defensively.
+
+## Notable entities using .ae
+
+The credibility of a TLD is defined by who uses it, and .ae is home to leading regional and global brands:
+
+1.  **[Amazon.ae](https://www.amazon.ae):** Formerly Souq.com, Amazon rebranded its Middle Eastern operations to Amazon.ae, cementing the TLD as the standard for regional e-commerce.
+2.  **[Google.ae](https://www.google.ae):** A localized version of the search engine for the UAE, underscoring the value of local relevance.
+3.  **Noon:** One of the Middle East's largest homegrown digital marketplaces, competing directly with global giants.
+4.  **Dubizzle:** A household name in the UAE for classifieds and community trading, built on a strong local identity.
+
+## Frequently asked questions about .ae domains
+
+**What is a .ae domain?**
+A .ae domain is the official country code Top-Level Domain (ccTLD) for the United Arab Emirates, administered by the .aeDA under the TDRA. It is the standard web address for businesses and individuals connected to the UAE.
+
+**What country is .ae?**
+.ae is the country code for the **United Arab Emirates** (in German, the *Vereinigte Arabische Emirate*). The "ae" code is the country's two-letter ISO identifier.
+
+**Who can register a .ae domain?**
+First-level .ae names (like `yourbrand.ae`) are generally open to everyone, including international registrants. Restricted second-level zones (such as `.gov.ae` or `.ac.ae`) have extra eligibility requirements. Foreign companies without a UAE trade license can often still register by holding a UAE-registered trademark or by going through a local agent or accredited registrar. Always confirm current rules with the [.aeDA policies](https://tdra.gov.ae/en/aeda/ae-policies).
+
+**Is .ae the right domain for a Dubai business?**
+Yes. Dubai and Abu Dhabi businesses use .ae to signal local presence, build trust with UAE customers, and strengthen local SEO. It is one of the clearest market signals you can put in a URL for the Gulf region.
+
+**How long can I register a .ae domain for?**
+.ae domains can be registered for periods of 1 to 5 years through an accredited registrar.
+
+**Does .ae have an Arabic version?**
+Yes. The UAE also operates **.امارات** (dotEmarat), the Arabic-script country code TLD, alongside .ae.
+
+**Can I tokenize a .ae domain?**
+With Namefi, you can manage your domain and, where supported, tokenize it as an NFT for easier transfer and ownership. Learn more in our guide to [tokenized domains](/en/blog/what-are-tokenized-domains/).
+
+## Register your .ae domain at Namefi
+
+Whether you are a local startup in the heart of Dubai or an international company expanding into the Gulf, securing a **.ae** domain is a strategic move for the future.
+
+At **Namefi**, we make domain ownership smarter. We are an ICANN-accredited [registrar](/en/glossary/registrar/) for traditional domains, and we also bridge the gap to Web3: you can manage your .ae domain and, if you choose, [tokenize it](/en/blog/what-are-tokenized-domains/) for easier, more secure transfer and management on the blockchain.
+
+*   **Transparent pricing:** Competitive rates, no hidden fees.
+*   **Tokenized ownership:** Manage your domain as an NFT for instant, frictionless transfers.
+*   **Seamless management:** One dashboard for DNS and asset tracking.
 
 **Ready to establish your presence in the UAE?**
 
 [**Search for your perfect .ae domain at Namefi today.**](https://namefi.io)
 
-Don't wait until your brand name is taken—secure your digital real estate in the Middle East now.
+Don't wait until your brand name is taken — secure your digital real estate in the Middle East now.

--- a/content/tld/en/app.md
+++ b/content/tld/en/app.md
@@ -1,64 +1,105 @@
 ---
-title: "What is the .app TLD and Why Choose It for Your Project?"
+title: "What is a .app Domain? The Secure TLD for Apps (HTTPS by Default)"
 date: '2025-12-10'
+updated: '2026-06-10'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: "Discover the security and branding power of the .app TLD. Learn why developers choose .app and how to register your tokenized domain with Namefi today."
-keywords: ['.app domains', '.app TLD', 'top-level domain .app', 'what is .app', 'why choose .app', 'what is the .app domain', 'why choose the .app domain', 'Google Registry .app', 'secure domains HSTS', 'mobile app landing page', 'SaaS domain names', 'tokenized domains', 'blockchain domain assets', 'domain investing', 'web3 domain registration']
+description: "What is a .app domain and what is it used for? Learn why Google's .app TLD requires HTTPS (HSTS preload), who should use it, and how to register a tokenized .app at Namefi."
+keywords: ['.app domain', '.app TLD', 'app domain', 'app tld', 'app tlds', '.app top level domain', 'what is .app domain used for', 'what is a .app domain', 'why choose .app', 'Google Registry .app', '.app HTTPS required', '.app HSTS preload', 'secure domains HSTS', 'mobile app landing page', 'SaaS domain names', 'developer domains', 'tokenized domains', 'blockchain domains', 'buy .app domain', 'dominio .app', 'dominios app', 'dominio app', 'qué es un dominio .app', 'registrar dominio .app', 'Namefi .app']
 ---
 
-## **What is .app?**
+## **What is a .app Domain?**
 
-The **.app** domain is a generic Top-Level Domain (gTLD) specifically designed for applications, software developers, and technology products. Launched to the general public in May 2018, it is managed by the **Google Registry**.
+The **.app** domain is a generic Top-Level Domain (gTLD) designed for applications, software developers, and technology products. It launched to the general public in **May 2018** and is operated by **Google Registry**, the same operator behind sibling extensions like [.dev](/en/tld/dev/) and .page.
 
-Unlike traditional domains like .com or .net, the .app TLD was created with a specific purpose in mind: to provide a secure and relevant home for the booming app economy. Whether it is a mobile application, a web-based tool, or a backend service, .app tells users exactly what to expect before they even click the link.
+Unlike legacy extensions such as .com or .net, the .app TLD was created with a clear purpose: to give the booming app economy a secure, instantly recognizable home on the internet. Whether your product is a mobile application, a web-based tool, or a backend service, a `.app` address tells users exactly what to expect before they even click the link.
 
-A defining characteristic of the .app domain is its focus on security. It is the first TLD to require **HTTPS** for all websites. This is achieved through the **HSTS (HTTP Strict Transport Security)** preload list. While you can buy the domain like any other, it will not resolve in a browser unless you have an SSL certificate configured. This built-in security makes .app a highly trustworthy namespace on the internet.
+The single most important thing to know about .app is its **security model**: it was the first TLD to require **HTTPS for every site**, enforced through the **HSTS preload list**. We explain exactly how that works—and what it means for you as an owner—further down this page.
 
-For more technical details on the launch and specifications, you can visit the [ICANN Wiki for .app](https://icannwiki.org/.app) or the official [Google Registry .app page](https://www.registry.google/domains/app/).
+For background on how new extensions like this are introduced and governed, see our glossary entries on [ICANN](/en/glossary/icann/) and what a [registrar](/en/glossary/registrar/) actually does.
 
-## **How People Are Using .app**
+## **What is a .app Domain Used For?**
 
-The .app extension has seen rapid adoption within the tech community. Because "app" is a universally recognized term, it bridges the gap between developers and end-users. Here is how it is currently being utilized:
+Because "app" is a universally understood term, .app bridges the gap between developers and everyday users. Here is how it is most commonly used:
 
-*   **Mobile App Landing Pages:** Companies with apps on the Apple App Store or Google Play use .app domains (e.g., `getproduct.app`) as a central hub to provide download links, release notes, and support.
-*   **Web Applications (SaaS):** Since modern software often lives in the browser, SaaS (Software as a Service) providers use .app for the actual login and interface of their product, separating it from their marketing site (often on a .com).
-*   **Developer Portfolios:** Individual coders and software engineers use `lastname.app` or `projectname.app` to showcase their coding projects and resume.
-*   **Documentation and Support:** Tech companies create dedicated sub-sites using .app to host API documentation or user guides.
+*   **Mobile App Landing Pages:** Companies with apps on the Apple App Store or Google Play use a `.app` domain (e.g., `getproduct.app`) as a central hub for download links, release notes, and support.
+*   **Web Applications (SaaS):** Modern software lives in the browser, so SaaS providers use .app for the actual product interface and login, separating it from a marketing site that often sits on a .com.
+*   **Developer Portfolios:** Engineers use `lastname.app` or `projectname.app` to showcase coding projects, side projects, and résumés.
+*   **Documentation and Support Portals:** Tech companies spin up dedicated .app sites to host API docs, user guides, and status pages.
+*   **Product Launches:** On platforms like [Product Hunt](https://www.producthunt.com/), a growing share of new tech launches now use .app addresses, in part because the short, brandable .com market is so saturated.
+
+## **Why Does .app Require HTTPS? (HSTS Preload Explained)**
+
+This is the defining feature of the .app TLD, and it is worth understanding properly because it directly affects how you set up your site.
+
+**Every .app domain is on the HSTS preload list at the registry level.** Google Registry submitted the entire `.app` zone to the **HSTS (HTTP Strict Transport Security) preload list** *before* the TLD launched. That list is honored by Chrome, Firefox, Safari, Edge, and most other modern browsers. The practical consequences:
+
+*   **HTTP is disabled, automatically.** When a browser sees any address ending in `.app`, it upgrades the connection to **HTTPS before the request is even sent**—the user never touches an insecure HTTP connection.
+*   **No certificate means no website.** If you register a .app domain but do not configure a valid **TLS/SSL certificate**, browsers will simply refuse to load it (you'll see an error like "HTTP is disabled for this domain"). The domain can be *bought* like any other, but it will not *resolve* in a browser until HTTPS is in place.
+*   **You cannot opt out.** Because the requirement is baked into the TLD via the preload list, it applies to every `.app` site, and individual domains cannot be removed from it.
+
+### **What This Means for You as an Owner**
+
+*   **You need a TLS certificate before going live.** The good news: certificates are typically free and automatic. Most hosts (Vercel, Netlify, Cloudflare, GitHub Pages) and tools like [Let's Encrypt](https://letsencrypt.org/) provision and renew them for you with no manual work.
+*   **You are secure by default.** Mandatory HTTPS protects your visitors from man-in-the-middle attacks, content injection by ISPs, and credential interception on public Wi-Fi. There is no "I forgot to turn on SSL" failure mode on .app.
+*   **It builds trust.** Users see the secure-connection indicator on every visit, with no insecure-page warnings—valuable for any product handling logins, payments, or personal data.
+*   **It's good for SEO.** Google has confirmed that HTTPS is a positive ranking signal. Because .app enforces HTTPS by design, you meet that best practice automatically from day one.
 
 ## **Notable Entities Using .app**
 
-Since its launch, many high-profile companies and innovative startups have adopted the TLD to signal security and relevance. Here are a few notable examples:
+Since launch, many high-profile companies have adopted the extension to signal security and relevance:
 
-1.  **Cash App (cash.app):** One of the most famous examples, Cash App uses this domain for its massive peer-to-peer payment service, perfectly aligning the brand name with the URL.
-2.  **Google (google.app):** As the registry operator, Google utilizes the extension for various internal projects and redirects to showcase the domain's utility.
-3.  **Sitata (sitata.app):** A travel safety application that uses the domain to host its web-based services.
-4.  **Puppeteer (pptr.dev / hosted apps):** While many developer tools use various extensions, the .app space is frequently populated by open-source projects hosted by the community.
+1.  **Cash App (cash.app):** Perhaps the most famous example—Block's peer-to-peer payment service, with the brand name and URL perfectly aligned.
+2.  **Google (google.app):** As the registry operator, Google uses the extension for projects and redirects that showcase the namespace.
+3.  **Oh Dear (ohdear.app):** A well-known website monitoring service, featured by Google Registry as a flagship .app site.
+4.  **Sitata (sitata.app):** A travel safety application that hosts its web-based services on the extension.
 
-If you are browsing [Product Hunt](https://www.producthunt.com/), you will notice a significant percentage of new tech launches now utilize .app addresses due to the saturation of the .com market.
+These examples show .app is trusted by products handling real users, payments, and sensitive data.
 
-## **Why Choose .app?**
+## **Why Choose a .app Domain?**
 
-Choosing the right extension is critical for your brand's digital identity. Here is why .app is a superior choice for developers and tech businesses:
+Choosing the right extension shapes your brand's digital identity. Here's why .app is a strong choice for developers and tech businesses:
 
-*   **Built-in Security (HSTS):** As mentioned, the enforced HTTPS requirement protects your users from malware and tracking by ISPs on unsecured connections. It signals to your visitors—and search engines—that you take security seriously.
-*   **Instant Recognition:** The extension describes your product immediately. If your domain ends in .app, users know they are visiting a functional tool or application.
-*   **SEO Benefits:** Google has stated that HTTPS is a ranking signal. Because .app enforces HTTPS, you are adhering to best practices for Search Engine Optimization (SEO) by default.
-*   **Availability:** While finding a short, one-word .com is nearly impossible or prohibitively expensive, the .app namespace still offers excellent availability for short, memorable, and brandable names.
-*   **Trust Factor:** In an era of phishing and insecure sites, the green padlock associated with .app sites (due to mandatory SSL) increases user confidence.
+*   **Built-in Security:** Enforced HTTPS via HSTS preload means your users are protected by default—and so is your reputation.
+*   **Instant Recognition:** The extension describes your product immediately. A `.app` address tells visitors they're heading to a functional tool or application.
+*   **SEO Advantage by Default:** Mandatory HTTPS aligns you with Google's ranking best practices from the start.
+*   **Availability:** Short, one-word .com names are nearly impossible to find or wildly expensive. The .app namespace still offers excellent availability for concise, memorable, brandable names.
+*   **Trust Factor:** In an era of phishing and spoofed sites, a guaranteed secure connection raises user confidence.
+
+If you're weighing .app against other developer-friendly extensions, compare it with our guides to [.dev](/en/tld/dev/) and [.tech](/en/tld/tech/) to find the best fit for your project.
+
+## **Frequently Asked Questions About .app Domains**
+
+**What is a .app domain used for?**
+It's used for anything app-related: mobile app landing pages, web apps and SaaS products, developer portfolios, documentation portals, and product launch sites. The extension signals "this is a functional application" at a glance.
+
+**Why does .app require HTTPS?**
+Because Google Registry placed the entire .app TLD on the browser HSTS preload list before launch. Browsers automatically upgrade every .app connection to HTTPS, so a valid TLS/SSL certificate is mandatory for the site to load.
+
+**Can I buy a .app domain without an SSL certificate?**
+Yes—you can register and own a .app domain without one. But it will not display in a browser until you add a valid TLS certificate. Most modern hosting providers supply these for free and automatically.
+
+**Is .app good for SEO?**
+Yes. Google treats HTTPS as a ranking signal, and .app enforces HTTPS by default, so you satisfy that requirement automatically. The extension itself is treated neutrally for ranking, just like other gTLDs.
+
+**Who operates the .app TLD?**
+Google Registry operates .app. It is a generic Top-Level Domain (gTLD) available to anyone, not restricted to a specific country or industry.
+
+**Can I tokenize a .app domain?**
+Yes. With Namefi you can register a .app domain and mint it as an on-chain asset (an NFT), making it easy to transfer, trade, or use in Web3 applications while keeping full ICANN-compliant ownership. Learn more in [What Are Tokenized Domains?](/en/blog/what-are-tokenized-domains/)
 
 ## **Register Your .app Domain at Namefi**
 
-Ready to secure the perfect home for your application? At Namefi, we make registering your .app domain simple, secure, and future-proof.
+Ready to secure the perfect home for your application? At Namefi, registering your **.app** domain is simple, secure, and future-proof.
 
-Namefi is not just a standard registrar; we are bridging the gap between Web2 and Web3. When you register a domain with us, you aren't just renting a name; you are securing a digital asset that can be tokenized and easily managed or traded on the blockchain.
+Namefi isn't just a standard registrar—we bridge Web2 and Web3. When you register with us, you don't just rent a name; you secure a digital asset that can be tokenized and easily managed or traded on the blockchain.
 
 **Why register with Namefi?**
-*   **ICANN Accredited:** Fully compliant and secure registration.
-*   **Seamless Web3 Integration:** Option to mint your domain as an NFT for easier transfer and liquidity.
-*   **Competitive Pricing:** Get your project started without breaking the budget.
+*   **ICANN Accredited:** Fully compliant, secure registration.
+*   **Seamless Web3 Integration:** Mint your domain as an NFT for easier transfer and liquidity.
+*   **Competitive Pricing:** Launch your project without breaking the budget.
 
 Don't let your perfect app name get taken by a competitor. Secure your digital real estate today.
 

--- a/content/tld/en/io.md
+++ b/content/tld/en/io.md
@@ -1,58 +1,110 @@
 ---
-title: "What is the .io TLD? The Tech Startup Standard Explained"
+title: "What Is the .io Domain? Meaning, Uses, Pricing & Future (2026)"
 date: '2025-12-10'
+updated: '2026-06-10'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: "Discover why .io is the go-to domain for tech startups and developers. Learn about its history, benefits, and how to register your .io domain with Namefi today."
-keywords: [".io domains", ".io TLD", ".io top-level domain", "what is .io", "why choose .io", "what is the .io domain", "why choose the .io domain", "tech startup domains", "developer domains", "blockchain domains", "tokenized domains", "Web3 domains", "investing in .io domains", "buy .io domain", "Namefi .io"]
+description: "What is the .io domain? Learn its British Indian Ocean Territory origin, why .io is the tech-startup standard, why .io domains are expensive, .io vs .ai, and what the Chagos news means for its future."
+keywords: [".io domains", ".io TLD", "io tld", ".io tld", ".io top-level domain", "io top level domain", "what is .io", "what is .io domain", "what is .io domain used for", "io domain meaning", ".io domain extension", "why choose .io", "why are .io domains expensive", "io vs ai domain", ".io vs .ai", "British Indian Ocean Territory domain", "Chagos Islands io domain", "tech startup domains", "developer domains", "blockchain domains", "tokenized domains", "Web3 domains", "buy .io domain", "register io domain", "Namefi .io"]
 ---
 
-## **What is .io?**
+## What Is the .io Domain? (British Indian Ocean Territory)
 
-The **.io** extension is technically a country code Top-Level Domain (ccTLD) assigned to the **British Indian Ocean Territory**. However, in the digital landscape, it has transcended its geographical roots to become one of the most recognized and coveted domain extensions in the technology sector.
+The **.io** domain is technically a **country code Top-Level Domain (ccTLD)** assigned to the **British Indian Ocean Territory (BIOT)**, a remote group of islands in the Indian Ocean known as the Chagos Archipelago. It was delegated in 1997 under the **ISO 3166-1** country-code standard, the same standard the [Internet Assigned Numbers Authority (IANA)](https://www.iana.org/domains/root/db/io.html) and [ICANN](/en/glossary/icann/) use to decide which two-letter codes are eligible to become a TLD.
 
-For developers, engineers, and tech entrepreneurs, **.io** is widely interpreted as an abbreviation for **Input/Output** (I/O), a core concept in computing. This happy coincidence has transformed a niche island domain into a powerful symbol of technical innovation.
+But the **.io domain meaning** that matters today has almost nothing to do with geography. For developers, engineers, and tech entrepreneurs, **.io** reads as an abbreviation for **Input/Output (I/O)**, a foundational concept in computing. That happy coincidence transformed a tiny island ccTLD into one of the most recognized **top level domain** extensions in the technology world.
 
-Importantly, major search engines like Google treat .io as a **Generic Top-Level Domain (gTLD)** rather than a country code. This means that unlike other ccTLDs (like .fr or .jp), .io is not geotargeted to a specific region, making it perfectly suitable for global businesses and international SEO strategies. You can read more about how Google handles these domains on [Google Search Central](https://developers.google.com/search/docs/crawling-indexing/manage-international-sites).
+Importantly, major search engines treat the **.io domain extension** as a **generic** TLD rather than a geographic one. Google classifies it among the [generic ccTLDs it does not geotarget](https://developers.google.com/search/docs/crawling-indexing/manage-international-sites), so unlike .fr or .jp, a .io site is not tied to one region and is perfectly suitable for global businesses and international SEO. (Curious how a "country code" becomes "generic"? See our [glossary entry on registrars](/en/glossary/registrar/) and how the [ICANN](/en/glossary/icann/) accreditation system works.)
 
-## **How People Are Using .io**
+## What Is the .io Domain Used For?
 
-Because of its strong association with computer science, the .io domain has become the de facto standard for the modern tech ecosystem. Here is how it is currently being utilized:
+Because of its strong association with computer science, the **.io top level domain** has become the de facto standard for the modern tech ecosystem. Here is what .io is used for in practice:
 
-*   **SaaS and Tech Startups:** It is the primary choice for new software-as-a-service companies, AI platforms, and cloud infrastructure businesses looking to establish instant credibility.
-*   **Web3 and Blockchain:** Given the technical nature of the crypto space, many blockchain projects, decentralized applications (dApps), and tokenized assets utilize .io to signal their tech-savvy nature.
-*   **Open Source & Developers:** Programmers frequently use .io for personal portfolios, documentation sites, and code repositories.
-*   **Gaming:** The extension saw a massive surge in popularity due to "IO games"—browser-based multiplayer games that require no downloads.
+*   **SaaS and Tech Startups:** The primary choice for new software-as-a-service companies, AI platforms, and cloud-infrastructure businesses looking to establish instant credibility.
+*   **Web3 and Blockchain:** Given the technical nature of the crypto space, many blockchain projects, decentralized applications (dApps), and [tokenized assets](/en/blog/what-are-tokenized-domains/) use .io to signal their tech-savvy nature.
+*   **Open Source and Developers:** Programmers frequently use .io for personal portfolios, documentation sites, and project pages.
+*   **Gaming:** The extension surged in popularity thanks to "IO games" — browser-based multiplayer titles that require no downloads.
 
-## **Notable Entities Using .io**
+### Notable Entities Using .io
 
-The legitimacy of the .io extension is bolstered by industry giants and essential tools in the web ecosystem. Some notable examples include:
+The legitimacy of the **.io TLD** is reinforced by industry giants and essential tools across the web ecosystem:
 
-1.  **Github.io:** Perhaps the most famous usage, GitHub uses this domain for [GitHub Pages](https://pages.github.com/), allowing millions of developers to host websites directly from their repositories.
-2.  **Etherscan.io:** The leading block explorer for the Ethereum blockchain, essential for the Web3 and crypto community.
-3.  **Itch.io:** A popular open marketplace for independent digital creators with a focus on indie video games.
-4.  **Greenhouse.io:** A major applicant tracking system used by companies globally to manage hiring.
+1.  **GitHub.io:** Perhaps the most famous usage. GitHub uses this domain for [GitHub Pages](https://pages.github.com/), letting millions of developers host websites directly from their repositories.
+2.  **Etherscan.io:** The leading block explorer for the Ethereum blockchain, essential to the Web3 and crypto community.
+3.  **Itch.io:** A popular open marketplace for independent digital creators with a focus on indie games.
+4.  **Greenhouse.io:** A major applicant-tracking system used by companies worldwide to manage hiring.
 
-These examples demonstrate that .io is trusted by massive platforms handling millions of daily users.
+These examples show that .io is trusted by major platforms serving millions of daily users.
 
-## **Why Choose .io?**
+## Why Are .io Domains Expensive?
 
-If you are launching a new digital venture, here is why you should consider securing a .io domain:
+A common question from founders is **why are .io domains expensive** compared to a standard .com or .net. There are three main drivers:
 
-*   **Industry Recognition:** It serves as a "secret handshake" in the tech world. Using a .io domain immediately signals to investors and users that you are a technology-focused entity.
-*   **Availability:** While .com is arguably the king of domains, finding a short, memorable .com name is increasingly difficult and expensive. The .io namespace offers better availability for concise, brandable names.
-*   **Creativity:** The two-letter extension allows for clever "domain hacks" (using the domain extension as part of the word), such as *rad.io* or *stud.io*.
-*   **Global SEO:** As mentioned earlier, search engines treat it as generic, ensuring your site can rank globally without being restricted to the British Indian Ocean Territory.
+*   **Registry pricing.** The .io registry (operated under the Identity Digital portfolio after its acquisition of the original operator) sets a relatively high wholesale price. Registrars pass that floor on to you, so even a plain, unregistered .io name typically costs several times the price of a basic .com.
+*   **Startup demand and branding.** The tech and crypto communities treat .io as a status signal — a "secret handshake" that tells investors and users you are a serious technology company. That concentrated demand from well-funded startups keeps both registration prices and secondary-market resale values elevated.
+*   **Short, memorable names.** Because the namespace is younger and smaller than .com, short, brandable, and "domain hack" names (like `rad.io` or `stud.io`) are still attainable — and scarcity of premium short names pushes prices up further.
 
-For a deeper dive into domain statistics and the growth of .io, you can view reports from the [Internet Assigned Numbers Authority (IANA)](https://www.iana.org/domains/root/db/io.html).
+We break the numbers down in our dedicated guide: **[Why are .io domains expensive?](/en/blog/why-are-io-domains-expensive/)**
 
-## **Register Your .io Domain at Namefi**
+## Why Choose .io?
+
+If you are launching a new digital venture, here is why securing a **.io domain** still makes sense:
+
+*   **Industry recognition:** A .io domain instantly signals that you are a technology-focused entity.
+*   **Availability:** Finding a short, memorable .com is increasingly difficult and expensive; the .io namespace offers far better availability for concise, brandable names.
+*   **Creativity:** The two-letter extension enables clever domain hacks that fold the TLD into the word itself.
+*   **Global SEO:** Search engines treat it as generic, so your site can rank globally without being boxed into one region.
+
+## The Future of .io: What Domain Owners Should Know
+
+There has been real news around the **.io domain** that owners should understand — calmly and accurately, because the headlines have run ahead of the facts.
+
+In 2024 the UK announced it would transfer sovereignty of the **Chagos Archipelago** (the territory behind BIOT) to **Mauritius**, and the two governments signed a treaty on **May 22, 2025**. Because the .io ccTLD exists on the basis of the **"IO" ISO 3166-1 country code** for that territory, the deal sparked widespread speculation that .io could eventually be retired.
+
+Here is what is actually true as of **June 2026**:
+
+*   **.io is fully operational.** Registrations and renewals continue normally, and the ISO 3166-1 code "IO" remains active. The treaty has not yet completed ratification, and the Chagos arrangement has even been **paused at points amid US political review**, adding further uncertainty rather than triggering any shutdown.
+*   **Retirement is a slow, multi-year process — not an automatic switch.** A ccTLD is only put on a path to removal if the underlying ISO code actually changes. Even then, IANA/ICANN policy provides for a multi-year transition (often cited as a roughly **five-year** window) so registrants can migrate. ICANN's own [statement on the Chagos Archipelago and the .io domain](https://www.icann.org/en/blogs/details/the-chagos-archipelago-and-the-io-domain-14-11-2024-en) stresses that its overriding goal is the **security and stability of the DNS**, and that any change would be handled deliberately, not abruptly.
+*   **There is more than one possible outcome.** Codes can persist, be reassigned, or be grandfathered. With a large ecosystem of major platforms depending on it, there is strong practical pressure toward continuity.
+
+**Bottom line:** It is **not** a settled fact that .io is being deleted. This is an evolving situation. A prudent owner should treat .io as safe for the foreseeable future, keep an eye on official IANA/ICANN updates rather than headlines, and — as with any single TLD — avoid betting an entire brand on one extension without a backup. One advantage of registering through a modern registrar is portability: [tokenized domains](/en/blog/what-are-tokenized-domains/) make it far easier to move, manage, and prove ownership of your asset if you ever need to diversify.
+
+## .io vs .ai: Which Should You Choose?
+
+Both extensions started as ccTLDs (.io for BIOT, **.ai** for Anguilla) and both became tech-brand magnets. The short version:
+
+*   Choose **.io** for general tech, SaaS, developer tools, infrastructure, gaming, and Web3 projects where the "Input/Output" association fits.
+*   Choose **.ai** when your product is explicitly about artificial intelligence — the keyword is literally in your URL, and demand has pushed it to premium "digital gold" pricing.
+
+For a full side-by-side on pricing, branding, SEO, and longevity, read **[.ai vs .io domain: which is right for your startup?](/en/blog/ai-vs-io-domain/)** — and see our complete **[.ai TLD guide](/en/tld/ai/)**.
+
+## .io Domain FAQ
+
+**What is the .io domain?**
+It is the country code Top-Level Domain for the British Indian Ocean Territory, now used globally by tech companies because "io" also reads as "Input/Output."
+
+**What is the .io domain used for?**
+SaaS and tech startups, developer portfolios, open-source projects, Web3 and blockchain platforms, and browser-based "IO games."
+
+**Why are .io domains expensive?**
+A high registry wholesale price, strong demand from well-funded startups using it as a branding signal, and scarcity of short, memorable names. See our [pricing deep dive](/en/blog/why-are-io-domains-expensive/).
+
+**Is the .io domain going away because of the Chagos Islands deal?**
+No — not as a settled fact. As of June 2026 .io is fully operational. Any retirement would only follow an ISO code change and a multi-year IANA/ICANN transition process. It is an evolving situation worth monitoring, not a reason to panic.
+
+**Is .io good for SEO?**
+Yes. Google treats .io as a generic (non-geotargeted) TLD, so .io sites can rank globally.
+
+**Should I choose .io or .ai?**
+Pick .io for general tech and Web3 projects; pick .ai for explicitly AI-focused products. See our [.ai vs .io comparison](/en/blog/ai-vs-io-domain/).
+
+## Register Your .io Domain at Namefi
 
 Ready to launch your next big idea? There is no better place to start than by securing the perfect **.io** domain.
 
-At **Namefi**, we go beyond traditional registration. As an ICANN-accredited registrar, we offer a bridge between Web2 and Web3. When you register with us, you enjoy seamless management features and the ability to leverage tokenized domains, giving you true ownership and flexibility over your digital assets.
+At **Namefi**, we go beyond traditional registration. As an [ICANN-accredited](/en/glossary/icann/) [registrar](/en/glossary/registrar/), we bridge Web2 and Web3. When you register with us, you enjoy seamless management features and the ability to hold your name as a [tokenized domain](/en/blog/what-are-tokenized-domains/) — giving you true ownership, easy transferability, and a built-in path to diversify if any single TLD's future ever shifts.
 
 Don't let your perfect name get snatched up by someone else.
 

--- a/content/tld/en/vip.md
+++ b/content/tld/en/vip.md
@@ -1,62 +1,114 @@
 ---
-title: 'Unlocking Exclusivity: What is the .vip TLD and Why Choose It?'
+title: 'What Is a .vip Domain? Meaning, Uses & Is It Safe? (2026 Guide)'
 date: '2025-12-10'
+updated: '2026-06-10'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: 'Discover the power of the .vip TLD. Learn why this premium domain extension boosts branding, ensures exclusivity, and how to register yours with Namefi today.'
-keywords: ['.vip domains', '.vip TLD', 'top-level domain', 'what is .vip', 'why choose .vip', 'what is the .vip domain', 'why choose the .vip domain', 'buy .vip domain name', 'luxury branding', 'premium domain names', 'domain investing', 'tokenized domains', 'blockchain domains', 'Web3 identity', 'register .vip']
+description: 'What is a .vip domain? It is a gTLD meaning "Very Important Person," used for membership, exclusive, and premium brands. Learn its meaning, uses, safety, and how to register .vip at Namefi.'
+keywords: ['.vip domain', 'vip domain', '.vip domain meaning', 'what is .vip domain', 'what is a .vip website', 'vip tld', '.vip tld', 'is .vip domain safe', 'vip domain names', '.vip domain names', 'what is .vip domain used for', '.vip domains', '.vip TLD', 'top-level domain', 'what is .vip', 'why choose .vip', 'buy .vip domain name', 'premium domain names', 'membership domains', 'domain investing', 'tokenized domains', 'blockchain domains', 'Web3 identity', 'register .vip', 'Namefi .vip']
 ---
 
-## **What is .vip?**
+## **What is a .vip website / .vip domain?**
 
-The **.vip** domain is a generic Top-Level Domain (gTLD) that stands for **"Very Important Person."** Unlike traditional extensions like .com or .net, which are broad and undefined, .vip immediately conveys a sense of prestige, exclusivity, and high status.
+A **.vip domain** is a generic Top-Level Domain (gTLD) whose three-letter ending stands for **"Very Important Person."** A **.vip website** is simply any website that uses an address ending in `.vip` — for example, `members.brand.vip` or `john.vip`. There is no technical difference between a .vip site and a .com site in how it loads in your browser; the difference is purely in what the ending *signals*: prestige, membership, exclusivity, and premium access.
 
-Launched to the general public in May 2016, .vip was originally managed by Minds + Machines Group Limited before becoming part of the GoDaddy Registry portfolio. Upon its release, it became one of the most successful new gTLD launches in history, particularly gaining immense traction in the Asian markets before spreading globally.
+In plain terms, **.vip domain meaning** comes down to status and inclusion. The acronym "VIP" is recognized worldwide, so the extension instantly communicates that whatever sits behind it is intended for important people, valued customers, fans, or members.
 
-The primary purpose of the .vip extension is to help brands and individuals distinguish themselves as leaders in their field. It is designed for luxury goods, exclusive clubs, loyalty programs, and any entity that wishes to signal superior quality or special access to its audience.
+So **what is a .vip domain used for?** The most common use cases are:
 
-*For more information on the technical classification of gTLDs, you can visit the [ICANN website](https://www.icann.org/).*
+*   **Membership and loyalty:** exclusive member portals, rewards clubs, and subscriber-only areas.
+*   **Premium and luxury brands:** high-end services, boutique labels, and concierge businesses that want a name that reads as upscale.
+*   **Fan clubs and personal brands:** creators, athletes, musicians, and influencers hosting fan communities or premium content.
+*   **Events and access:** ticketing pages for galas, backstage passes, and private launches.
+*   **Web3 communities:** whitelist gateways, exclusive DAOs, and token-gated groups.
+
+Launched to the public in **May 2016**, .vip was originally operated by Minds + Machines and is now part of the **GoDaddy Registry** portfolio. It became one of the most successful new gTLD launches in history, gaining especially strong adoption across Asian markets before spreading globally. Like other modern gTLDs (see our guides to [.club](/en/tld/club/), [.online](/en/tld/online/), and [.store](/en/tld/store/)), it gives you access to short, memorable names that are long gone in the crowded [.com namespace](/en/tld/com/).
+
+*For the technical classification of gTLDs, see the [ICANN website](https://www.icann.org/) or the [IANA root database entry for .vip](https://www.iana.org/domains/root/db/vip.html).*
+
+## **What is .vip? (Quick Definition)**
+
+The **.vip** TLD is an unrestricted generic Top-Level Domain meaning **"Very Important Person."** Unlike traditional extensions like .com or .net — which are broad and undefined — .vip immediately conveys prestige, exclusivity, and high status. Anyone can register a .vip domain; there is no eligibility requirement, which is part of why it is so flexible (and, as we cover below, part of why you should evaluate individual .vip sites on their merits).
 
 ## **How People Are Using .vip**
 
-The versatility of the .vip extension allows it to be used across various industries, though it always maintains an air of sophistication. Here is how different sectors are utilizing this TLD:
+The versatility of the .vip extension lets it work across many industries while keeping an air of sophistication. Here is how different sectors use this TLD:
 
-*   **Luxury Brands and Services:** High-end real estate agents, limousine services, and boutique fashion labels use .vip to instantly tell customers that they offer a premium experience.
-*   **Customer Loyalty Portals:** Major corporations often use a subdomain or a specific .vip domain (e.g., `rewards.brand.vip`) to host their exclusive member areas or loyalty programs.
-*   **Influencers and Personal Branding:** Celebrities, bloggers, and industry thought leaders use .vip to brand their personal portfolios, signaling that their content is top-tier.
-*   **Web3 and Blockchain Projects:** In the world of decentralized finance and NFTs, a .vip domain is increasingly used to denote "whitelist" access, exclusive DAOs, or premium tokenized communities.
-*   **Event Hosting:** Organizers of galas, backstage passes, and private webinars use the extension to manage ticketing for special guests.
+*   **Luxury brands and services:** High-end real estate agents, limousine services, and boutique fashion labels use .vip to instantly tell customers they offer a premium experience.
+*   **Customer loyalty portals:** Major corporations use a dedicated .vip address (e.g., `rewards.brand.vip`) to host exclusive member areas or loyalty programs.
+*   **Influencers and personal branding:** Celebrities, bloggers, and thought leaders use .vip to brand their personal portfolios and signal top-tier content.
+*   **Web3 and blockchain projects:** In DeFi and NFTs, a .vip domain is increasingly used to denote "whitelist" access, exclusive DAOs, or premium tokenized communities.
+*   **Event hosting:** Organizers of galas, backstage passes, and private webinars use the extension to manage ticketing for special guests.
 
 ## **Notable Entities Using .vip**
 
-While many .vip domains are used for specific marketing campaigns or sub-sections of a business, several major entities have secured these domains to protect their brand and offer exclusive services.
+While many .vip domains power specific campaigns or sub-sections of a business, several major entities have secured these names to protect their brand and offer exclusive services.
 
-1.  **Tencent (QQ):** One of the largest technology companies in Asia utilizes `qq.vip` for its premium membership services, demonstrating the massive scale at which this TLD operates.
-2.  **Google:** The tech giant has secured `google.vip`, often used for internal purposes or specific partner gateways, showcasing the corporate utility of the extension.
-3.  **Real Estate Leaders:** Numerous luxury property groups (e.g., `MiamiCondos.vip` or similar variations) utilize the extension to separate high-value listings from standard market fare.
-4.  **Blockchain Identities:** With the rise of on-chain identity, many crypto-natives are securing their "OG" handles on .vip to signal early adoption or "whale" status within the Web3 ecosystem.
+1.  **Tencent (QQ):** One of the largest technology companies in Asia uses `qq.vip` for premium membership services, demonstrating the scale at which this TLD operates.
+2.  **Google:** The tech giant has secured `google.vip`, typically used for internal purposes or partner gateways, showcasing the corporate utility of the extension.
+3.  **Real estate leaders:** Numerous luxury property groups use .vip variations to separate high-value listings from standard market fare.
+4.  **Blockchain identities:** With the rise of on-chain identity, many crypto-natives secure their "OG" handles on .vip to signal early adoption or "whale" status within the Web3 ecosystem.
+
+## **Is a .vip domain safe?**
+
+**Short answer:** The **.vip TLD itself is completely legitimate** — it is an ICANN-delegated gTLD operated by a major, established registry (GoDaddy Registry). Visiting a .vip website is no more inherently dangerous than visiting a .com, .net, or [.io](/en/tld/io/) site. The extension does not carry malware or compromise your security on its own.
+
+**The nuance:** Because .vip is inexpensive and open to anyone, it — like many cheap, unrestricted new gTLDs (.top, .xyz, .online, and similar) — is sometimes abused by spammers and scammers who register large numbers of throwaway domains. As a result, some spam filters and security tools may apply extra scrutiny to unfamiliar .vip addresses. This is a reflection of *who registers some of these domains*, **not** a flaw in the TLD itself, and the overwhelming majority of .vip domains are used by legitimate brands, creators, and businesses.
+
+**How to judge whether a specific .vip site is trustworthy** (the same checklist applies to any TLD):
+
+*   **Check for HTTPS:** Look for a valid SSL certificate (the padlock). A secure connection is a baseline requirement, though by itself it does not prove legitimacy.
+*   **Verify the brand and contact details:** Confirm the site belongs to the real organization. Cross-check the company name, support email, and links against the brand's known official .com or social channels.
+*   **Be wary of urgency and "too good to be true" offers:** Unsolicited "you've been selected as a VIP" messages, prize claims, or pressure to pay quickly are classic scam signals — regardless of the domain ending.
+*   **Look up the domain's history:** A [WHOIS](/en/glossary/whois/) lookup can reveal how recently the domain was registered. Brand-new domains used for high-stakes transactions deserve extra caution.
+*   **Use the brand's official link:** When in doubt, navigate to the company through a search engine or a link you already trust rather than clicking one sent to you.
+
+**Bottom line:** `.vip` is a safe, legitimate namespace. Evaluate *individual websites* on their content, security signals, and reputation — exactly as you would for any other extension.
 
 ## **Why Choose .vip?**
 
 Choosing the right domain extension is critical for your digital identity. Here is why .vip might be the perfect choice for your next project or investment:
 
-*   **Instant Prestige and Branding:** The acronym "VIP" is universally recognized. It automatically associates your brand with quality, importance, and exclusivity without needing extra explanation.
-*   **High Availability:** While .com is overcrowded, making it difficult to find short, memorable names, the .vip namespace still offers excellent availability for short, keyword-rich domain names.
-*   **SEO Relevance:** Search engines like Google treat .vip as a standard gTLD. However, the distinctiveness of the name can lead to higher Click-Through Rates (CTR) when users are looking for premium or exclusive services.
-*   **Domain Investing Potential:** Short, memorable .vip domains are considered valuable assets in the domain investing community. As digital real estate becomes scarcer, owning a premium TLD becomes a store of value.
-*   **Perfect for Tokenization:** For those in the Web3 space, a .vip domain pairs perfectly with tokenized assets. It serves as a unique, high-value identifier for your wallet or decentralized website.
+*   **Instant prestige and branding:** "VIP" is universally recognized. It associates your brand with quality, importance, and exclusivity without extra explanation.
+*   **High availability:** While .com is overcrowded, the .vip namespace still offers excellent availability for short, keyword-rich, brandable names.
+*   **SEO relevance:** Search engines like Google treat .vip as a standard gTLD with no ranking penalty. Its distinctiveness can even lift Click-Through Rates (CTR) for users seeking premium or exclusive services.
+*   **Domain investing potential:** Short, memorable .vip domains are valued assets in the domain investing community. As digital real estate grows scarcer, premium names become a store of value.
+*   **Perfect for tokenization:** For the Web3 space, a .vip domain pairs naturally with [tokenized assets](/en/blog/what-are-tokenized-domains/), serving as a unique, high-value identifier for your wallet or decentralized website.
+
+## **Frequently Asked Questions about .vip**
+
+**What does .vip mean?**
+.vip stands for **"Very Important Person."** It is a generic Top-Level Domain used to signal status, exclusivity, membership, and premium access.
+
+**What is a .vip website?**
+A .vip website is any site whose address ends in `.vip`. Technically it works just like any other website; the ending simply communicates that the content is premium, exclusive, or membership-oriented.
+
+**Is a .vip domain safe?**
+Yes. The .vip TLD is a legitimate, ICANN-delegated extension operated by GoDaddy Registry. As with any TLD, judge an individual site by its HTTPS security, verifiable brand identity, and reputation rather than by the ending alone.
+
+**Who can register a .vip domain?**
+Anyone. .vip is an unrestricted gTLD with no eligibility requirements, so individuals, brands, creators, and communities can all register one.
+
+**What is a .vip domain used for?**
+Common uses include membership and loyalty portals, luxury and premium brands, fan clubs and personal branding, event ticketing, and exclusive Web3 communities.
+
+**Is .vip good for SEO?**
+Yes. Google treats .vip as a normal gTLD with no inherent ranking disadvantage. Your content, links, and site quality determine rankings — not the extension.
+
+**Who operates the .vip registry?**
+The .vip TLD launched in May 2016 and is operated by the GoDaddy Registry. You can verify its delegation in the [IANA root database](https://www.iana.org/domains/root/db/vip.html).
 
 ## **Register Your .vip Domain at Namefi**
 
-Whether you are launching a luxury brand, creating an exclusive membership community, or simply want a domain name that stands out from the crowd, .vip is an exceptional choice.
+Whether you are launching a luxury brand, creating an exclusive membership community, or simply want a domain name that stands out, .vip is an exceptional choice.
 
-At **Namefi**, we make registering and managing your .vip domain seamless. As an ICANN-accredited registrar, we bridge the gap between Web2 and Web3. When you register with us, you don't just get a domain; you get the option to tokenize your domain, allowing for easy transfer, enhanced security, and integration with the blockchain ecosystem.
+At **Namefi**, we make registering and managing your .vip domain seamless. As an [ICANN-accredited registrar](/en/glossary/registrar/), we bridge the gap between Web2 and Web3. When you register with us, you don't just get a domain — you get the option to tokenize it, enabling easy transfer, enhanced security, and integration with the blockchain ecosystem.
 
-*   **Simple Registration:** Search and secure your name in seconds.
-*   **Web3 Ready:** Manage your DNS settings or mint your domain as an NFT.
-*   **Transparent Pricing:** No hidden fees, just premium service.
+*   **Simple registration:** Search and secure your name in seconds.
+*   **Web3 ready:** Manage your DNS settings or mint your domain as an NFT.
+*   **Transparent pricing:** No hidden fees, just premium service.
 
 **Don't let your perfect name get taken.** Establish your status today.
 


### PR DESCRIPTION
## ⏳ DELAYED MERGE — do NOT merge before **2026-06-15**

**For any human or LLM executing the merge:** verify today's date is on or after **2026-06-15** before merging. This is **wave 2 of 4** in a staggered SEO drip-publishing schedule. Merge wave 1 (PR #41) first.

| Wave | Do-not-merge-before |
|------|---------------------|
| 1 — .sbs, .ai, tokenized-domains pillar (#41) | 2026-06-10 |
| **2 (this)** — .io, .app, .vip, .ae, xStocks, "What is a TLD" pillar | **2026-06-15** |
| 3 — .ai-vs-.io, premium web3 TLDs, why .io expensive | 2026-06-20 |
| 4 — domain escrow (EN+ES), UDRP | 2026-06-24 |

## 📣 After merge — DON'T FORGET TO PUBLISH
- [ ] `draft: false` confirmed on every file (already set)
- [ ] Bump the `namefi-resources` submodule pointer in **namefi-astra** and deploy the `resources` app
- [ ] Verify each page renders at the URLs below
- [ ] Update sitemap `lastmod` / trigger redeploy so Google re-crawls
- [ ] Submit the new + updated URLs in **Google Search Console** for (re)indexing
- [ ] (later) queue auto-translation for non-EN locales (esp. ES/DE/ZH for xStocks, .app)

## What's in this wave

| File | Type | Target queries (impressions) | URL |
|------|------|------------------------------|-----|
| `content/tld/en/io.md` | improve | `io tld` (387), `.io tld` (367), `what is .io domain used for`, `why are .io domains expensive` + Chagos future | `/r/en/tld/io` |
| `content/tld/en/app.md` | improve | `dominio .app` (640, ES), `app domain`, `.app https required` (HSTS angle) | `/r/en/tld/app` |
| `content/tld/en/vip.md` | improve | `.vip domain` (611), `.vip domain meaning` (149), `is .vip domain safe` | `/r/en/tld/vip` |
| `content/tld/en/ae.md` | improve | `ae domain` (224), `.ae domain` (205), `uae domain`, `internet tld vereinigte arabische emirate` (DE) | `/r/en/tld/ae` |
| `content/blog/en/what-are-xstocks.md` | improve | `xstocks` (405), `was sind xstocks` (DE), `que son los xstocks` (ES), `xstocks是什么` (ZH) | `/r/en/blog/what-are-xstocks` |
| `content/blog/en/what-is-a-tld.md` | **new pillar** | `tld`, `tld meaning`, `what is a tld`, `que es un tld` — also an internal-link hub for all TLD pages | `/r/en/blog/what-is-a-tld` |

### Notes for reviewer
- The new **"What is a TLD" pillar** links out to ~25 existing `/en/tld/*` pages and the tokenized-domains pillar — it's the internal-link hub designed to lift the whole TLD section. Worth publishing early in the wave.
- The `.io` page and the new TLD pillar contain **forward links** to `/en/blog/ai-vs-io-domain/` and `/en/blog/why-are-io-domains-expensive/`, which land in **wave 3 (PR for ≥2026-06-20)**. Those links 404 until wave 3 merges — expected given the schedule.
- `.io` "future of .io" section is deliberately measured about the Chagos/BIOT sovereignty question (web-verified, no "it's being deleted" claims).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only marketing/SEO content with no application or auth changes; the only caveat is temporary 404s on forward links to wave-3 blog URLs from the updated `.io` page.
> 
> **Overview**
> **Wave 2 SEO content** expands five existing English pages and adds one new pillar article, all marked `draft: false` with refreshed `updated` dates and keyword-focused front matter.
> 
> The **new** `what-is-a-tld` blog post is a long-form hub: TLD types, ICANN/IANA governance, how to choose an extension, tokenization tie-in, FAQs, and **many internal links** to `/en/tld/*` and related blog/glossary pages.
> 
> **`what-are-xstocks`** is rewritten from promotional copy into a structured explainer (definition, mechanics, comparison table vs traditional stocks, risks, multilingual FAQ intents, RWA → tokenized domains bridge).
> 
> **TLD guides** (`.io`, `.app`, `.vip`, `.ae`) get deeper sections, FAQs, and SEO titles/descriptions—e.g. `.io` adds pricing drivers, Chagos/BIOT future context, and `.ai` comparison; `.app` centers **HSTS/HTTPS-by-default**; `.vip` adds meaning, use cases, and **“is .vip safe?”**; `.ae` adds country/eligibility (TDRA/.aeDA) and DE-intent keywords.
> 
> **Note:** `.io` links to `/en/blog/ai-vs-io-domain/` and `/en/blog/why-are-io-domains-expensive/` until a later wave ships those posts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c758d00f255557cb1233117943d3b7d5b50baeab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Updated xStocks guide** with expanded coverage of how they work, dividend treatment, risk considerations, regulatory implications, and comparison to traditional stocks
* **New TLD (top-level domain) educational article** covering domain categories, governance structures, and selection best practices
* **Enhanced TLD pages** for .ae, .app, .io, and .vip featuring comprehensive FAQs, real-world usage examples, and detailed guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->