### PR TITLE
[DELAYED MERGE — do not merge before 2026-06-24] feat(seo): wave 4 — domain escrow (EN+ES), UDRP

### DIFF
--- a/content/blog/en/domain-escrow-explained.md
+++ b/content/blog/en/domain-escrow-explained.md
@@ -1,0 +1,141 @@
+---
+title: "Domain Escrow Explained: How Safe Domain Transactions Work"
+date: '2026-06-10'
+language: en
+tags: ['guide']
+authors: ['namefiteam']
+draft: false
+description: A plain-English guide to escrow and domain escrow — what an escrow account is, how escrow works step by step in a domain sale, why it matters for avoiding fraud, traditional escrow services vs. the modern tokenized approach, and how smart contracts can replace escrow with atomic on-chain settlement.
+keywords: ['domain escrow', 'what is escrow', 'escrow account', 'escrow meaning', 'how does escrow work', 'domain escrow service', 'escrow.com alternative', 'buy a domain safely', 'sell a domain safely', 'auth code', 'EPP code', 'registrar transfer', 'escrow fees', 'safe domain transaction', 'domain sale fraud', 'tokenized domain escrow', 'smart contract escrow', 'atomic settlement', 'on-chain domain sale', 'how to avoid domain fraud']
+---
+
+If you've ever bought or sold something expensive between strangers — a car, a house, a `.com` worth five figures — you've run into the same problem: the buyer doesn't want to pay before they get the thing, and the seller doesn't want to hand over the thing before they get paid. Somebody has to go first, and going first means trusting the other person.
+
+**Escrow** is the standard solution to that problem. This guide explains what an escrow account is in plain terms, how escrow works step by step in a domain sale, why it matters, and how a newer approach — [tokenized domains](/en/blog/what-are-tokenized-domains/) and smart contracts — is starting to replace traditional escrow entirely.
+
+---
+
+## What Is an Escrow Account? (Plain English)
+
+An **escrow account** is a neutral holding account, controlled by a trusted third party, that sits in the middle of a transaction. Instead of paying the seller directly, the buyer pays *the escrow*. The escrow holds the money — and sometimes the asset — until both sides have done their part. Only then does the escrow release the funds to the seller.
+
+The key word is **neutral**. The escrow provider has no stake in whether the deal goes through. Their only job is to follow a simple rule:
+
+> Hold the money. Release it to the seller only when the agreed conditions are met. Otherwise, return it to the buyer.
+
+That's the whole idea. Escrow doesn't make either party more honest — it removes the need for them to trust each other at all, by inserting a referee who's paid to be impartial. You'll see escrow in real estate, in mergers and acquisitions, in freelance marketplaces, and very commonly in the domain industry.
+
+---
+
+## How Escrow Works Step by Step in a Domain Sale
+
+Here's the classic flow for selling a domain name through an escrow service such as [Escrow.com](https://www.escrow.com/):
+
+1. **Agree on terms.** Buyer and seller settle on a price and who pays the escrow fee. They open a transaction at the escrow service.
+2. **Buyer funds the escrow.** The buyer sends the agreed amount to the escrow account — by wire, card, or crypto. Critically, the seller does *not* have this money yet; the escrow is just holding it.
+3. **Escrow confirms the funds.** The escrow service verifies the payment has cleared and notifies the seller: *"The money is here. You're safe to transfer the domain."*
+4. **Seller transfers the domain.** The seller unlocks the domain at their [registrar](/en/glossary/registrar/) and provides the [auth code](/en/glossary/auth-code/) (also called an EPP code) — a password that authorizes moving the domain to another registrar.
+5. **Buyer initiates the transfer.** Using that auth code, the buyer starts a transfer to their own registrar. An [ICANN](https://www.icann.org/) inter-registrar transfer typically takes around five to seven days to fully clear.
+6. **Buyer confirms receipt.** Once the domain lands in the buyer's account, they confirm it through the escrow service.
+7. **Escrow releases the funds.** Now — and only now — the escrow pays the seller. The deal is complete.
+8. **Fees come out.** Escrow services usually charge a percentage (often in the low single digits), plus there may be marketplace commissions on top.
+
+Notice what escrow accomplishes: it breaks the standoff. The seller transfers the domain *knowing the money already exists* in the escrow account, and the buyer pays *knowing they'll get their money back* if the domain never arrives. Neither party has to trust the other — they both trust the referee.
+
+---
+
+## Why Escrow Matters: It's About Avoiding Fraud
+
+Domains are a favorite target for fraud precisely because they're valuable, intangible, and move between anonymous parties around the world. Without escrow, a domain sale is full of ways to get burned:
+
+- **The buyer pays and the domain never arrives.** The seller takes the wire and disappears.
+- **The seller transfers and the payment never comes.** Or the buyer reverses the charge after receiving the domain (a chargeback).
+- **The "domain" was never the seller's to sell.** Stolen or hijacked domains get listed by people who don't actually own them.
+
+Escrow neutralizes the first two directly: money and asset can't both vanish, because the escrow holds one until the other is confirmed. Reputable escrow services also add identity checks and payment verification that catch some of the third category too. For any meaningful domain sale between people who don't know each other, **escrow is the baseline expectation** — refusing to use it is itself a red flag.
+
+For more on the threat landscape, see [how domain hijacking actually happens](/en/blog/how-domain-hijacking-actually-happens/).
+
+---
+
+## Traditional Domain Escrow Services: The Trade-offs
+
+The escrow model has been the standard in domains for two decades, and it works. But it carries real costs:
+
+- **Fees.** A percentage of the sale price goes to the escrow service — money that comes out of the deal.
+- **Time.** Between funding, the registrar transfer, and the ICANN clearing window, a sale can take a week or more.
+- **Manual steps.** Auth codes, unlocks, transfer confirmations — each is a place for a mistake or a delay.
+- **You still trust a third party.** Escrow moves trust from "the other person" to "the escrow company." That's a big improvement, but it's not zero trust. The escrow company holds your money for the duration of the deal.
+
+These trade-offs were simply the price of safety — until a different settlement model arrived.
+
+---
+
+## How Tokenized Domains + Smart Contracts Replace Escrow
+
+When a domain is [tokenized](/en/blog/what-are-tokenized-domains/), ownership is represented by an on-chain token (an NFT) rather than only a registrar database entry. That changes what's possible at settlement.
+
+A [smart contract](/en/glossary/smart-contract/) is code that runs on a blockchain and executes automatically when its conditions are met. Crucially, an on-chain transaction is **atomic**: payment and asset transfer happen in the *same* transaction, in the same block — or neither happens at all. There is no in-between state where one side has moved and the other hasn't.
+
+That property does exactly what escrow was invented to do, without a third party holding anything:
+
+- The buyer's payment and the seller's token swap **at the same instant**. The seller can't take the money and run, because the token only moves if the payment moves with it.
+- There's **no auth code to share** and no multi-day registrar transfer for the on-chain ownership change — the token moves immediately.
+- There's **no escrow fee**, because no neutral party is holding funds. The smart contract *is* the impartial referee, and it's free to run beyond normal network costs.
+
+In other words, the smart contract becomes the escrow — but it's transparent, automatic, instant, and doesn't take a cut for holding your money. For a deeper walkthrough of the full marketplace flow and where the risks shift, see [From Listing to Settlement: How Tokenized Marketplaces Replace Escrow](/en/blog/how-tokenized-marketplaces-replace-escrow/).
+
+This isn't risk-free — it just moves the risks. Instead of trusting an escrow company, you now rely on wallet security and the soundness of the smart contract. The point isn't that tokenized settlement is magic; it's that the *job escrow does* can be done by code rather than by a paid intermediary.
+
+---
+
+## So Should You Still Use Escrow?
+
+It depends on what you're transacting:
+
+- **Buying or selling a traditional, non-tokenized domain between strangers?** Yes — use a reputable escrow service. The fees are worth it, and skipping escrow is how people get defrauded.
+- **Transacting a tokenized domain on a marketplace?** Atomic on-chain settlement already gives you escrow's core guarantee. Your focus shifts to verifying the contract and the recipient address.
+
+Namefi works with tokenized domains so that buying and selling can settle on-chain — getting you the safety escrow provides without the wait or the percentage. If you want to see how it works in practice, head to [namefi.io](https://namefi.io).
+
+---
+
+## Frequently Asked Questions
+
+### What is an escrow account?
+
+An escrow account is a neutral account held by a trusted third party that holds a buyer's payment during a transaction. The funds are released to the seller only once the agreed conditions are met — and returned to the buyer if they're not. It lets two parties transact without having to trust each other directly.
+
+### What does escrow mean in a domain sale?
+
+In a domain sale, escrow means a third-party service holds the buyer's money while the domain is transferred from the seller's registrar to the buyer's. Once the buyer confirms they've received the domain, the escrow releases the funds to the seller. It protects both sides from fraud.
+
+### How does domain escrow work step by step?
+
+The buyer funds the escrow account; the escrow confirms the payment; the seller unlocks the domain and shares the auth code; the buyer transfers the domain to their registrar; the buyer confirms receipt; and the escrow then releases the money to the seller.
+
+### Why do I need escrow to buy a domain?
+
+Because without it, either the buyer can pay and never receive the domain, or the seller can transfer it and never get paid. Escrow holds the money in the middle so neither party can cheat the other. For any meaningful sale between strangers, it's the baseline safe practice.
+
+### Can smart contracts replace escrow?
+
+Yes, for tokenized assets. A smart contract can settle payment and asset transfer atomically — both happen together or neither does — which delivers escrow's core guarantee automatically, instantly, and without a third party holding funds or taking a fee.
+
+---
+
+## Friendly Disclaimer (Read Me!)
+
+> We're not lawyers, accountants, financial advisors, or doctors — and **nothing in this article is legal, financial, tax, accounting, medical, or any other flavor of professional advice.** We write these posts to educate ourselves and as a convenience for our customers. Info here may be out of date, geography-specific, or just plain wrong — we make mistakes too.
+>
+> For any important decision, **please consult a real professional (seriously!)**. Or if that's not your vibe, ask a friend, ask Twitter, ask Reddit, ask an AI, or ask a psychic. In short: **DOYR — Do Your Own Research**. Let's learn and have fun.
+
+---
+
+## Summary
+
+- An **escrow account** is a neutral, third-party holding account that releases funds to the seller only after the agreed conditions are met.
+- In a domain sale, escrow holds the buyer's money while the domain transfers via the registrar and auth code, then pays the seller once the buyer confirms receipt.
+- Escrow matters because it **removes the need to trust the other party**, neutralizing the most common domain-sale frauds.
+- Traditional escrow works but costs a fee, takes time, and still requires trusting an intermediary.
+- **Tokenized domains + smart contracts** can replace escrow with atomic on-chain settlement — payment and asset move together or not at all — giving the same safety without the wait or the cut.

--- a/content/blog/en/what-is-udrp.md
+++ b/content/blog/en/what-is-udrp.md
@@ -1,0 +1,135 @@
+---
+title: "What Is UDRP? Domain Name Dispute Resolution Explained"
+date: '2026-06-10'
+language: en
+tags: ['guide']
+authors: ['namefiteam']
+draft: false
+description: "UDRP explained for domain owners and investors: the three elements a complainant must prove, the process and timeline, outcomes, UDRP vs URS vs court, and how to respond."
+keywords: ['udrp', 'what is udrp', 'udrp process', 'udrp policy', 'udrp complaint', 'udrp verfahren', 'udrp-verfahren', 'uniform domain-name dispute-resolution policy', 'domain dispute', 'domain name dispute', 'cybersquatting', 'reverse domain name hijacking', 'bad faith registration', 'icann udrp', 'wipo', 'urs', 'uniform rapid suspension', 'trademark domain dispute', 'domain investor legal', 'respond to udrp complaint']
+---
+
+If you own domain names long enough, you will eventually hear about the UDRP — usually because someone is threatening to use it against you, or because you are wondering whether a name in your portfolio is safe to hold. For domain investors, understanding the UDRP is not optional. It is the single most common way a domain you registered can be taken away from you without a courtroom.
+
+This guide explains what the UDRP is, when it applies, what a complainant actually has to prove, how the process works, and how owners of valuable names can both avoid and respond to a complaint.
+
+> **Not legal advice.** This article is general information for domain owners, not legal advice. The UDRP is a legal-procedural mechanism, and outcomes turn on specific facts. If you receive a complaint or are considering filing one, consult a qualified attorney.
+
+## What Is the UDRP?
+
+The **UDRP** — the **Uniform Domain-Name Dispute-Resolution Policy** (in German, **UDRP-Verfahren**) — is a policy created by [ICANN](/en/glossary/icann/) in 1999 to resolve disputes over domain names that allegedly infringe someone's trademark. Every accredited registrar requires you to agree to the UDRP when you register a domain. That agreement is why a private arbitration panel, rather than a national court, can order your domain transferred away.
+
+The UDRP exists to deal with **cybersquatting**: registering a domain that matches someone else's brand in order to profit from it. It is deliberately narrow. It is not a tool for resolving every disagreement about who "deserves" a name. It targets bad-faith registration of trademark-infringing domains, and nothing more.
+
+The UDRP applies to all generic top-level domains (`.com`, `.net`, `.org`, and the newer gTLDs) and to country-code TLDs whose operators have voluntarily adopted it. Many ccTLDs run their own separate dispute policies instead.
+
+## The Three Elements a Complainant Must Prove
+
+A UDRP complaint does not succeed just because a brand owner is unhappy. The complainant must prove **all three** of the following elements. If even one fails, the complaint is denied and the domain stays with its registrant.
+
+1. **Identical or confusingly similar.** The domain is identical or confusingly similar to a trademark or service mark in which the complainant has rights. In practice this first element functions mostly as a standing requirement — it confirms the complainant actually owns a relevant mark.
+
+2. **No rights or legitimate interests.** The registrant has no rights or legitimate interests in the domain. Once the complainant makes a credible case here, the burden effectively shifts to the registrant to show a legitimate interest — for example, that they are using the name for a genuine business, a descriptive term, or non-commercial speech.
+
+3. **Registered *and* used in bad faith.** The domain was both **registered in bad faith and is being used in bad faith.** This conjunctive "and" is the most important word in the entire policy for domain investors. A name registered years before a complainant's trademark even existed generally cannot have been registered in bad faith — you cannot target a brand that did not yet exist.
+
+That third element is where most defensible portfolios survive. The UDRP recognizes specific bad-faith patterns: registering a name primarily to sell it to the trademark owner at an inflated price, registering to block the brand from owning its own name (as part of a pattern), registering to disrupt a competitor, or using the name to attract traffic by creating confusion with the mark.
+
+Crucially, **owning and offering generic or descriptive domains for sale is not, by itself, bad faith.** Domain investing is a legitimate business. The line is intent: were you trading in dictionary words and brandable terms, or were you targeting a specific brand?
+
+## The UDRP Process and Timeline
+
+The process is administrative arbitration, not litigation. It is conducted almost entirely in writing, with no live hearings in the typical case.
+
+1. **Filing.** The complainant files with an ICANN-approved dispute-resolution provider. The two main ones are the [World Intellectual Property Organization (WIPO)](https://www.wipo.int/amc/en/domains/guide/) — the largest provider — and **FORUM** (formerly the National Arbitration Forum).
+
+2. **Notification and lock.** The registrar locks the domain so it cannot be transferred or changed during the dispute, and the registrant (respondent) is formally notified.
+
+3. **Response.** The respondent typically has **20 days** to file a response defending their rights to the name. Missing this deadline is one of the most common ways registrants lose names they could have kept.
+
+4. **Panel appointment.** A one- or three-member panel is appointed. The complainant pays the provider's fees; a respondent who wants a three-member panel shares in that cost.
+
+5. **Decision.** The panel issues a written decision, generally within **14 days** of appointment. End to end, a single-member case typically runs around **60 days**, and a three-member case around **75 days**.
+
+The standard of proof is the civil "preponderance of the evidence" — more likely than not — applied across all three elements.
+
+## Possible Outcomes
+
+UDRP remedies are narrow by design. A panel can order only:
+
+- **Transfer** of the domain to the complainant, or
+- **Cancellation** of the domain, or
+- **Denial** of the complaint, leaving the domain with the registrant.
+
+That is the entire menu. There are **no monetary damages, no attorney's fees, and no injunctions** under the UDRP. A losing registrant does not pay the complainant money; they lose the name (or keep it). If either side wants damages or a binding judgment, they have to go to court — the UDRP is not a substitute for litigation, and a losing party can usually file a lawsuit to challenge the result.
+
+## UDRP vs URS vs Court
+
+Three different mechanisms address domain disputes, and they are easy to confuse.
+
+| | UDRP | URS | Court litigation |
+|---|---|---|---|
+| **Purpose** | Cybersquatting disputes | Clear-cut cybersquatting only | Any domain or trademark claim |
+| **Applies to** | gTLDs + adopting ccTLDs | New gTLDs only (not `.com`/`.net`) | Any domain |
+| **Burden of proof** | Preponderance of evidence | Clear and convincing evidence | Varies by jurisdiction |
+| **Speed** | ~60–75 days | ~3 weeks | Months to years |
+| **Outcome** | Transfer or cancellation | Temporary suspension only | Damages, transfer, injunctions |
+| **Cost** | Moderate | Low | High |
+
+The **URS (Uniform Rapid Suspension)** is the fast, cheap cousin of the UDRP, built only for new gTLDs and only for obvious abuse. Its highest burden of proof ("clear and convincing") and its limited remedy matter: a winning URS complainant only gets the domain **suspended** for the rest of its registration term — they do **not** get it transferred to them. For `.com` and `.net`, the URS is not even available, so the UDRP remains the primary tool.
+
+Court litigation (in the U.S., often under the Anticybersquatting Consumer Protection Act) is slower and far more expensive, but it is the only path to monetary damages — and the only forum that can be binding.
+
+## Reverse Domain Name Hijacking
+
+The UDRP cuts both ways. If a complainant abuses the process — filing in bad faith to try to wrest a legitimately held name from its owner — a panel can make a formal finding of **Reverse Domain Name Hijacking (RDNH)**, defined as "using the Policy in bad faith to attempt to deprive a registered domain-name holder of a domain name."
+
+An RDNH finding does not award the registrant any money, but it is a public rebuke that can damage the complainant's credibility in future disputes and litigation. For a domain investor with a clearly legitimate registration, raising RDNH in a response is a meaningful defensive tool against a brand owner trying to use the UDRP as a cheap shortcut to a name they did not buy in time.
+
+## How Domain Owners and Investors Can Avoid and Respond to Complaints
+
+**Avoiding complaints starts at registration.** Before you register or buy a name, ask whether it targets an existing brand. Practical habits that keep a portfolio defensible:
+
+- **Stick to generic, descriptive, and brandable terms** rather than registering near-matches of existing trademarks.
+- **Document your registration date and your reasoning.** Because bad faith generally must exist *at registration*, proof that a name predates a trademark — or that you bought it for its dictionary meaning — is often dispositive.
+- **Avoid PPC parking pages that show ads competing with the trademark owner.** That kind of use is frequently cited as evidence of bad faith, even for an otherwise generic name.
+- **Be careful about how you respond to inbound offers.** Demanding a large sum from a brand owner who approaches you can be twisted into "registered primarily to sell to the trademark owner."
+
+**If you receive a complaint, do not ignore it.** The single biggest avoidable loss is a default — missing the ~20-day response window. A well-documented response showing a legitimate interest and a good-faith registration date wins many cases. This is the point to bring in counsel.
+
+It is also worth understanding that a UDRP transfer is a different problem from a [security hijack](/en/blog/how-domain-hijacking-actually-happens/). One is a legal process you can respond to; the other is an attack you have to prevent. Both can cost you a name, and a serious owner plans for each.
+
+## What UDRP Means for Valuable and Tokenized Domains
+
+For high-value names, a UDRP complaint is an existential risk — and it is one reason provenance and clear records matter so much when you [sell a domain you own](/en/blog/how-to-sell-a-domain-name-you-own/). A clean registration history and a legitimate-use story are assets that protect the name's value.
+
+This is also where [tokenized domains](/en/blog/what-are-tokenized-domains/) fit into the picture. Tokenization changes *who provably controls* a name and creates a durable, on-chain record of ownership and transfers — useful provenance if a registration date or chain of custody is ever questioned. It does **not**, however, place a domain outside the UDRP: the underlying name still lives in the DNS under an accredited registrar, and the UDRP still applies. Tokenization strengthens your evidence and your control; it does not exempt you from trademark law.
+
+[Namefi](https://namefi.io) tokenizes the registrant relationship while keeping the domain fully ICANN-compliant, so owners get on-chain provenance and self-custody without stepping outside the system that the UDRP governs. The goal is simple: own valuable names with stronger records and cleaner control, while staying squarely within the rules.
+
+## Frequently Asked Questions
+
+### What is the UDRP?
+The Uniform Domain-Name Dispute-Resolution Policy is an ICANN policy, created in 1999, that lets trademark owners challenge domain registrations that infringe their marks through private arbitration instead of court. Every registrant agrees to it when registering a domain.
+
+### What are the three elements of a UDRP complaint?
+The complainant must prove all three: (1) the domain is identical or confusingly similar to their trademark; (2) the registrant has no rights or legitimate interests in the domain; and (3) the domain was both registered and used in bad faith. Failing any one element defeats the complaint.
+
+### How long does a UDRP case take?
+A single-member panel case typically runs about 60 days from filing to decision, and a three-member case about 75 days. The respondent generally has 20 days to file a response, and the panel issues its decision within roughly 14 days of being appointed.
+
+### What outcomes are possible under the UDRP?
+A panel can order the domain transferred to the complainant, cancelled, or it can deny the complaint and leave the name with the registrant. There are no monetary damages or attorney's fees under the UDRP.
+
+### What is the difference between UDRP and URS?
+The URS (Uniform Rapid Suspension) is faster and cheaper but applies only to new gTLDs, requires a higher "clear and convincing" standard of proof, and only suspends the domain rather than transferring it. The UDRP applies more broadly (including `.com`) and can result in transfer or cancellation.
+
+### Can a UDRP complaint be filed in bad faith?
+Yes. If a complainant abuses the process to try to take a legitimately held name, a panel can find Reverse Domain Name Hijacking (RDNH) — a formal, public finding that the complaint was brought in bad faith.
+
+### Does tokenizing a domain protect it from the UDRP?
+No. Tokenization improves provenance, control, and self-custody, but the underlying domain still operates under an ICANN-accredited registrar, so the UDRP still applies. Tokenization can strengthen your evidence; it does not exempt a name from trademark law.
+
+---
+
+*Sources: ICANN — [Uniform Domain-Name Dispute-Resolution Policy](https://www.icann.org/resources/pages/policy-2012-02-25-en); WIPO — [Guide to the UDRP](https://www.wipo.int/amc/en/domains/guide/). This article is general information, not legal advice.*

--- a/content/blog/es/domain-escrow-explained.md
+++ b/content/blog/es/domain-escrow-explained.md
@@ -1,0 +1,143 @@
+---
+title: "Qué es una cuenta escrow y cómo funciona en la compraventa de dominios"
+date: '2026-06-10'
+language: es
+tags: ['guide']
+authors: ['namefiteam']
+draft: false
+description: "Una guía en lenguaje sencillo sobre el escrow y el escrow de dominios: qué es una cuenta escrow, qué significa escrow, cómo funciona paso a paso en la venta de un dominio, por qué importa para evitar fraudes, los servicios de escrow tradicionales frente al enfoque moderno, y cómo los contratos inteligentes pueden reemplazar el escrow con liquidación atómica en cadena."
+keywords: ['cuenta escrow', 'que es una cuenta escrow', 'qué es una cuenta escrow', 'cuenta de depósito escrow', 'escrow significado', 'cuenta de escrow', 'qué es escrow', 'que es escrow', 'cuentas escrow', 'depósito en garantía', 'cómo funciona el escrow', 'escrow de dominios', 'servicio de escrow', 'comprar un dominio de forma segura', 'vender un dominio de forma segura', 'código de autorización', 'transferencia de dominio', 'comisiones de escrow', 'evitar fraude en dominios', 'escrow significa', 'cuenta de depósito en garantía', 'contrato inteligente escrow', 'liquidación atómica', 'dominio tokenizado']
+---
+
+Si alguna vez has comprado o vendido algo caro entre desconocidos — un coche, una casa, un `.com` de cinco cifras — te has topado con el mismo problema: el comprador no quiere pagar antes de recibir la cosa, y el vendedor no quiere entregar la cosa antes de recibir el pago. Alguien tiene que ir primero, e ir primero significa confiar en la otra persona.
+
+El **escrow** (también llamado **depósito en garantía**) es la solución estándar a ese problema. Esta guía explica, en lenguaje sencillo, qué es una cuenta escrow, qué significa escrow, cómo funciona paso a paso en la venta de un dominio, por qué importa, y cómo un enfoque más reciente — los [dominios tokenizados](/en/blog/what-are-tokenized-domains/) y los contratos inteligentes — está empezando a reemplazar por completo al escrow tradicional.
+
+---
+
+## ¿Qué es una cuenta escrow? (en lenguaje sencillo)
+
+Una **cuenta escrow** (o **cuenta de depósito en garantía**) es una cuenta neutral, controlada por un tercero de confianza, que se ubica en el medio de una transacción. En lugar de pagarle directamente al vendedor, el comprador le paga *al escrow*. El escrow retiene el dinero — y a veces también el activo — hasta que ambas partes han cumplido con su parte. Solo entonces el escrow libera los fondos al vendedor.
+
+La palabra clave es **neutral**. El proveedor de escrow no tiene ningún interés en si el trato se cierra o no. Su único trabajo es seguir una regla muy simple:
+
+> Retén el dinero. Libéralo al vendedor únicamente cuando se cumplan las condiciones acordadas. De lo contrario, devuélveselo al comprador.
+
+Esa es toda la idea. El escrow no hace que ninguna de las partes sea más honesta — elimina la necesidad de que confíen entre sí, al insertar un árbitro al que se le paga por ser imparcial. Verás cuentas escrow en bienes raíces, en fusiones y adquisiciones, en plataformas de trabajo freelance y, muy comúnmente, en el sector de los dominios.
+
+En resumen, el **escrow significa** literalmente "depósito en garantía": un tercero guarda el valor en custodia hasta que se cumplan las reglas del trato.
+
+---
+
+## Cómo funciona el escrow paso a paso en la venta de un dominio
+
+Este es el flujo clásico para vender un nombre de dominio a través de un servicio de escrow como [Escrow.com](https://www.escrow.com/):
+
+1. **Acordar los términos.** Comprador y vendedor fijan un precio y deciden quién paga la comisión del escrow. Abren una transacción en el servicio de escrow.
+2. **El comprador deposita en la cuenta escrow.** El comprador envía el monto acordado a la cuenta escrow — por transferencia bancaria, tarjeta o cripto. Es clave entender que el vendedor *todavía no* tiene ese dinero; el escrow solo lo está reteniendo.
+3. **El escrow confirma los fondos.** El servicio de escrow verifica que el pago se haya acreditado y le avisa al vendedor: *"El dinero ya está aquí. Puedes transferir el dominio con seguridad."*
+4. **El vendedor transfiere el dominio.** El vendedor desbloquea el dominio en su [registrador](/en/glossary/registrar/) y proporciona el [código de autorización](/en/glossary/auth-code/) (también llamado código EPP) — una contraseña que autoriza mover el dominio a otro registrador.
+5. **El comprador inicia la transferencia.** Con ese código de autorización, el comprador inicia la transferencia hacia su propio registrador. Una transferencia entre registradores de la [ICANN](https://www.icann.org/) suele tardar entre cinco y siete días en completarse por completo.
+6. **El comprador confirma la recepción.** Una vez que el dominio aparece en la cuenta del comprador, este lo confirma a través del servicio de escrow.
+7. **El escrow libera los fondos.** Ahora — y solo ahora — el escrow le paga al vendedor. El trato queda cerrado.
+8. **Se descuentan las comisiones.** Los servicios de escrow normalmente cobran un porcentaje (a menudo de un dígito bajo), y además puede haber comisiones del mercado.
+
+Fíjate en lo que logra el escrow: rompe el punto muerto. El vendedor transfiere el dominio *sabiendo que el dinero ya existe* en la cuenta escrow, y el comprador paga *sabiendo que recuperará su dinero* si el dominio nunca llega. Ninguna de las partes tiene que confiar en la otra — ambas confían en el árbitro.
+
+---
+
+## Por qué importa el escrow: se trata de evitar el fraude
+
+Los dominios son un objetivo favorito del fraude precisamente porque son valiosos, intangibles y se mueven entre partes anónimas en todo el mundo. Sin escrow, la venta de un dominio está llena de formas de salir estafado:
+
+- **El comprador paga y el dominio nunca llega.** El vendedor recibe la transferencia y desaparece.
+- **El vendedor transfiere y el pago nunca llega.** O el comprador revierte el cargo después de recibir el dominio (un contracargo).
+- **El "dominio" nunca fue del vendedor para venderlo.** Personas que en realidad no son dueñas listan dominios robados o secuestrados.
+
+El escrow neutraliza los dos primeros casos de forma directa: el dinero y el activo no pueden desaparecer a la vez, porque el escrow retiene uno hasta que el otro se confirma. Los servicios de escrow serios también añaden verificaciones de identidad y de pago que atrapan parte del tercer caso. Para cualquier venta de dominio relevante entre personas que no se conocen, **el escrow es la expectativa mínima** — negarse a usarlo es, en sí mismo, una señal de alerta.
+
+Para profundizar en el panorama de amenazas, consulta [cómo ocurre realmente el secuestro de dominios](/en/blog/how-domain-hijacking-actually-happens/).
+
+---
+
+## Servicios de escrow de dominios tradicionales: las contrapartidas
+
+El modelo de escrow ha sido el estándar en los dominios durante dos décadas, y funciona. Pero tiene costos reales:
+
+- **Comisiones.** Un porcentaje del precio de venta se lo lleva el servicio de escrow — dinero que sale del trato.
+- **Tiempo.** Entre el depósito, la transferencia del registrador y la ventana de la ICANN, una venta puede tardar una semana o más.
+- **Pasos manuales.** Códigos de autorización, desbloqueos, confirmaciones de transferencia — cada uno es una oportunidad para un error o un retraso.
+- **Sigues confiando en un tercero.** El escrow traslada la confianza de "la otra persona" a "la empresa de escrow". Eso es una gran mejora, pero no es confianza cero. La empresa de escrow retiene tu dinero durante todo el trato.
+
+Estas contrapartidas eran simplemente el precio de la seguridad — hasta que llegó un modelo de liquidación distinto.
+
+---
+
+## Cómo los dominios tokenizados + los contratos inteligentes reemplazan el escrow
+
+Cuando un dominio está [tokenizado](/en/blog/what-are-tokenized-domains/), la propiedad se representa mediante un token en cadena (un NFT) y no solo mediante una entrada en la base de datos de un registrador. Eso cambia lo que es posible en el momento de la liquidación.
+
+Un [contrato inteligente](/en/glossary/smart-contract/) es código que se ejecuta en una blockchain y se cumple automáticamente cuando se dan sus condiciones. Y lo crucial: una transacción en cadena es **atómica**: el pago y la transferencia del activo ocurren en la *misma* transacción, en el mismo bloque — o no ocurre ninguno de los dos. No existe un estado intermedio en el que una parte ya se movió y la otra no.
+
+Esa propiedad hace exactamente lo que el escrow fue inventado para hacer, sin que un tercero retenga nada:
+
+- El pago del comprador y el token del vendedor se intercambian **en el mismo instante**. El vendedor no puede tomar el dinero y huir, porque el token solo se mueve si el pago se mueve con él.
+- **No hay código de autorización que compartir** ni una transferencia de registrador de varios días para el cambio de propiedad en cadena — el token se mueve de inmediato.
+- **No hay comisión de escrow**, porque ningún tercero neutral está reteniendo fondos. El contrato inteligente *es* el árbitro imparcial, y su ejecución no tiene costo más allá de las comisiones normales de la red.
+
+En otras palabras, el contrato inteligente se convierte en el escrow — pero es transparente, automático, instantáneo y no se queda con una comisión por guardar tu dinero. Para un recorrido más detallado del flujo completo del mercado y de hacia dónde se trasladan los riesgos, consulta [Desde el listado hasta la liquidación: cómo los mercados tokenizados reemplazan el escrow](/en/blog/how-tokenized-marketplaces-replace-escrow/).
+
+Esto no está libre de riesgos — solo los traslada. En lugar de confiar en una empresa de escrow, ahora dependes de la seguridad de tu billetera y de la solidez del contrato inteligente. La idea no es que la liquidación tokenizada sea magia; es que *el trabajo que hace el escrow* puede hacerlo el código en lugar de un intermediario al que se le paga.
+
+---
+
+## Entonces, ¿deberías seguir usando escrow?
+
+Depende de qué estés transaccionando:
+
+- **¿Compras o vendes un dominio tradicional, no tokenizado, entre desconocidos?** Sí — usa un servicio de escrow de confianza. Las comisiones valen la pena, y saltarse el escrow es la forma en que la gente termina estafada.
+- **¿Transaccionas un dominio tokenizado en un mercado?** La liquidación atómica en cadena ya te da la garantía esencial del escrow. Tu atención se desplaza a verificar el contrato y la dirección del destinatario.
+
+Namefi trabaja con dominios tokenizados para que la compra y la venta puedan liquidarse en cadena — dándote la seguridad que ofrece el escrow sin la espera ni el porcentaje. Si quieres ver cómo funciona en la práctica, visita [namefi.io](https://namefi.io).
+
+---
+
+## Preguntas frecuentes
+
+### ¿Qué es una cuenta escrow?
+
+Una cuenta escrow es una cuenta neutral, en manos de un tercero de confianza, que retiene el pago del comprador durante una transacción. Los fondos se liberan al vendedor solo cuando se cumplen las condiciones acordadas — y se devuelven al comprador si no se cumplen. Permite que dos partes transaccionen sin tener que confiar directamente la una en la otra.
+
+### ¿Qué significa escrow en la venta de un dominio?
+
+En la venta de un dominio, escrow significa que un servicio externo retiene el dinero del comprador mientras el dominio se transfiere desde el registrador del vendedor al del comprador. Una vez que el comprador confirma que recibió el dominio, el escrow libera los fondos al vendedor. Protege a ambas partes contra el fraude.
+
+### ¿Cómo funciona el escrow de dominios paso a paso?
+
+El comprador deposita en la cuenta escrow; el escrow confirma el pago; el vendedor desbloquea el dominio y comparte el código de autorización; el comprador transfiere el dominio a su registrador; el comprador confirma la recepción; y el escrow entonces libera el dinero al vendedor.
+
+### ¿Por qué necesito escrow para comprar un dominio?
+
+Porque sin él, o bien el comprador puede pagar y nunca recibir el dominio, o bien el vendedor puede transferirlo y nunca cobrar. El escrow retiene el dinero en el medio para que ninguna de las partes pueda engañar a la otra. Para cualquier venta relevante entre desconocidos, es la práctica segura mínima.
+
+### ¿Pueden los contratos inteligentes reemplazar el escrow?
+
+Sí, para activos tokenizados. Un contrato inteligente puede liquidar el pago y la transferencia del activo de forma atómica — ambos ocurren juntos o no ocurre ninguno — lo que ofrece la garantía esencial del escrow de manera automática, instantánea y sin que un tercero retenga fondos ni cobre una comisión.
+
+---
+
+## Aviso legal amistoso (¡Léeme!)
+
+> No somos abogados, contadores, asesores financieros ni médicos; y **nada en este artículo constituye asesoramiento legal, financiero, fiscal, contable, médico ni de ningún otro tipo profesional.** Escribimos estas publicaciones para educarnos a nosotros mismos y como una conveniencia para nuestros clientes. La información aquí contenida puede estar desactualizada, ser específica de una región o simplemente estar equivocada; nosotros también cometemos errores.
+>
+> Para cualquier decisión importante, **por favor consulta a un profesional real (¡en serio!)**. O si esa no es tu onda, pregúntale a un amigo, a Twitter, a Reddit, a una IA o a un vidente. En resumen: **DOYR — Do Your Own Research (Haz tu propia investigación)**. Aprendamos y divirtámonos.
+
+---
+
+## Resumen
+
+- Una **cuenta escrow** es una cuenta neutral de un tercero que libera los fondos al vendedor solo después de que se cumplen las condiciones acordadas.
+- En la venta de un dominio, el escrow retiene el dinero del comprador mientras el dominio se transfiere mediante el registrador y el código de autorización, y luego paga al vendedor cuando el comprador confirma la recepción.
+- El escrow importa porque **elimina la necesidad de confiar en la otra parte**, neutralizando los fraudes más comunes en la venta de dominios.
+- El escrow tradicional funciona, pero cuesta una comisión, lleva tiempo y aún exige confiar en un intermediario.
+- Los **dominios tokenizados + los contratos inteligentes** pueden reemplazar el escrow con liquidación atómica en cadena — el pago y el activo se mueven juntos o no se mueven — ofreciendo la misma seguridad sin la espera ni la comisión.


### PR DESCRIPTION
## ⏳ DELAYED MERGE — do NOT merge before **2026-06-24**

**For any human or LLM executing the merge:** verify today's date is on or after **2026-06-24** before merging. This is the final wave (**4 of 4**) in a staggered SEO drip-publishing schedule. Merge waves 1–3 (#41, #42, #43) first.

| Wave | Do-not-merge-before |
|------|---------------------|
| 1 — .sbs, .ai, tokenized-domains pillar (#41) | 2026-06-10 |
| 2 — .io, .app, .vip, .ae, xStocks, TLD pillar (#42) | 2026-06-15 |
| 3 — .ai-vs-.io, premium web3 TLDs, why .io expensive (#43) | 2026-06-20 |
| **4 (this)** — domain escrow (EN+ES), UDRP | **2026-06-24** |

## 📣 After merge — DON'T FORGET TO PUBLISH
- [ ] `draft: false` confirmed on every file (already set)
- [ ] Bump the `namefi-resources` submodule pointer in **namefi-astra** and deploy the `resources` app
- [ ] Verify each page renders at the URLs below (incl. the **/es/** escrow page)
- [ ] Update sitemap `lastmod` / trigger redeploy so Google re-crawls
- [ ] Submit the new URLs in **Google Search Console** for indexing
- [ ] Confirm hreflang links the EN ↔ ES escrow pages correctly

## What's in this wave (all **new** posts)

| File | Target queries | URL |
|------|----------------|-----|
| `content/blog/en/domain-escrow-explained.md` | `domain escrow`, `what is escrow`, `escrow account` | `/r/en/blog/domain-escrow-explained` |
| `content/blog/es/domain-escrow-explained.md` | **Spanish-first**: `cuenta escrow` (pos 77!), `que es una cuenta escrow`, `cuenta de depósito escrow` | `/r/es/blog/domain-escrow-explained` |
| `content/blog/en/what-is-udrp.md` | `udrp`, `what is udrp`, `udrp verfahren` (DE) | `/r/en/blog/what-is-udrp` |

### Notes for reviewer
- **The Spanish page is the priority here.** GSC shows a large `cuenta escrow` cluster ranking at position 75–91 (effectively invisible). The ES post is written in real Spanish (not machine-translated tone) and is the canonical sibling of the EN page. Please make sure the ES locale actually deploys and that hreflang pairs EN↔ES.
- Both escrow posts tie into the existing `how-tokenized-marketplaces-replace-escrow` post and the tokenized-domains pillar.
- UDRP is an evergreen authority piece for domain investors; carries a clear "not legal advice" note and a soft Namefi tie-in. Facts (three elements, providers, timelines) are web-verified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only additions to the blog; no runtime, auth, or data-layer changes. Legal/educational copy should be reviewed for accuracy before publish, but merge risk to the product is minimal.
> 
> **Overview**
> **Wave 4 SEO content** adds three published blog guides (all `draft: false`, dated 2026-06-10): English **domain escrow** (`domain-escrow-explained.md`), Spanish sibling **cuenta escrow / depósito en garantía** (`es/domain-escrow-explained.md`), and English **UDRP** for domain investors (`what-is-udrp.md`).
> 
> The escrow posts explain traditional third-party escrow for registrar transfers (auth code, ICANN timing, fraud) and contrast **tokenized domains + smart contracts** with atomic on-chain settlement, linking to existing pillar posts (`what-are-tokenized-domains`, `how-tokenized-marketplaces-replace-escrow`, hijacking). The UDRP piece covers the three proof elements, process/timeline, outcomes, UDRP vs URS vs court, RDNH, investor avoidance/response, and a clear **not legal advice** disclaimer plus a note that tokenization does not exempt names from UDRP.
> 
> No application code changes—markdown content only. Merge is gated until **2026-06-24** per the staggered drip schedule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01ddccec6c59171f571f6d28266c17376e192042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->