### PR TITLE
[codex] Add Facebook domain upgrade case study

### DIFF
--- a/content/blog/en/from-thefacebook-com-to-facebook-com.md
+++ b/content/blog/en/from-thefacebook-com-to-facebook-com.md
@@ -1,0 +1,162 @@
+---
+title: 'From TheFacebook.com to Facebook.com: The $200K Domain Upgrade That Made a Campus App Feel Inevitable'
+date: '2026-06-10'
+language: en
+tags: ['domains', 'branding', 'startups', 'domain-upgrades']
+authors: ['namefiteam']
+draft: false
+description: 'How Facebook dropped TheFacebook.com, bought Facebook.com for $200K, and turned a descriptive campus URL into a category-defining brand.'
+keywords: ['thefacebook.com', 'facebook.com', 'facebook domain name', 'domain upgrade', 'startup naming', 'brand naming', 'premium domain', 'domain strategy', 'facebook history', 'domain acquisition', 'company rebrand', 'category-defining domain']
+---
+
+Before Facebook became one of the default verbs of the internet, it was a narrower, more literal thing: **TheFacebook.com**.
+
+The original name made sense. When Mark Zuckerberg [launched the site at Harvard on February 4, 2004](https://www.thecrimson.com/article/2014/2/4/facebook-ten-years-feature-1/#:~:text=got%20its%20start%20in%20a%20Kirkland%20House%20dorm%20room%20on%20Feb.%204%2C%202004%20as%20an%20internal%20directory%20for%20Harvard%20undergraduates), a "facebook" was already a familiar campus object: [a student directory with a photograph and identifying facts](https://www.newyorker.com/magazine/2006/05/15/me-media#:~:text=known%20as%20the%20%E2%80%9Cfacebook%2C%E2%80%9D%20which%20features%20a%20photograph%20of%20each%20member%2C%20accompanied%20by%20a%20few%20identifying%20facts). The product was not trying to be a universal social graph yet. It was trying to make the offline college directory searchable, clickable, and alive.
+
+For that first audience, TheFacebook.com was clear. It explained the product.
+
+But the product's ambition changed faster than the name. By 2005, Facebook was no longer just a Harvard utility. It had [nearly three million registered users at over 800 colleges](https://www.thecrimson.com/article/2005/5/27/firm-invests-13m-in-facebook-a/#:~:text=nearly%20three%20million%20registered%20users%20at%20over%20800%20colleges), raised major venture funding, and was pushing toward a larger identity in the middle of the social networking boom. At that point, the extra word "The" started to feel like launch scaffolding: useful when the product needed explanation, awkward when the company wanted to own the category.
+
+So Facebook bought **Facebook.com** for a reported **[$200,000](https://www.informationweek.com/it-sectors/facebook-paid-8-5-million-for-fb-com#:~:text=Back%20in%20August%202005%2C%20TheFacebook%20purchased%20Facebook.com%20for%20%24200%2C000)** and dropped "The."
+
+That was not just a cosmetic URL cleanup. It was an early example of a startup using a premium domain to turn momentum into inevitability.
+
+## 2004: the campus network that needed a literal name
+
+TheFacebook.com launched into a very specific historical moment. [Friendster was the social media leader in early 2004](https://www.wired.com/2011/02/0204facebook-debuts/#:~:text=Friendster%20was%20the%20social%20media%20leader%20in%20early%202004), and MySpace was beginning its run toward mass-market dominance. But most social networks of that era were open, messy, and identity-light.
+
+Facebook's early distinction was the opposite: it was restricted, structured, and tied to real campus identity.
+
+The New Yorker described the early product as a Harvard social network built around profiles, search, "poking," and friend links, with membership initially tied to [a Harvard e-mail address](https://www.newyorker.com/magazine/2006/05/15/me-media#:~:text=Anybody%20with%20a%20Harvard%20e-mail%20address%20could%20join%20and%20create%20a%20profile). The same account notes that [by the end of February, about three-quarters of Harvard undergraduates had signed up](https://www.newyorker.com/magazine/2006/05/15/me-media#:~:text=By%20the%20end%20of%20February%2C%20about%20three-quarters%20of%20the%20undergraduates), and The Harvard Crimson later remembered the early service as an [internal directory for Harvard undergraduates](https://www.thecrimson.com/article/2014/2/4/facebook-ten-years-feature-1/#:~:text=internal%20directory%20for%20Harvard%20undergraduates) that quickly became part of campus life.
+
+That context matters because the name "The Facebook" was not random branding. It was a reference users already understood. In the early days, a descriptive domain was an advantage:
+
+- It mapped the online product to a familiar offline object.
+- It signaled that this was for students, not a generic public profile site.
+- It reduced the explanation cost for the first wave of users.
+
+TheFacebook.com was not a bad domain. It was the right kind of domain for the first stage: descriptive, campus-native, and good enough to start a network effect.
+
+## 2005: the name had to grow up
+
+By 2005, the company was moving into a different phase. The Facebook was no longer a dorm-room experiment. The Harvard Crimson reported in May 2005 that [Accel Partners would invest $13 million into the 15-month-old company](https://www.thecrimson.com/article/2005/5/27/firm-invests-13m-in-facebook-a/#:~:text=invest%20%2413%20million%20into%20thefacebook.com), which already had [nearly three million registered users across more than 800 colleges](https://www.thecrimson.com/article/2005/5/27/firm-invests-13m-in-facebook-a/#:~:text=nearly%20three%20million%20registered%20users%20at%20over%20800%20colleges).
+
+That financing headline is important because it puts the domain purchase in context. Today, $200,000 for Facebook.com sounds like a bargain. In 2005, it was still a meaningful capital-allocation decision for a very young company.
+
+Several histories report that Facebook acquired Facebook.com in August 2005 for $200,000. InformationWeek later compared that purchase with Facebook's much larger acquisition of FB.com, noting that [Facebook.com cost 42.5 times less than the later FB.com deal](https://www.informationweek.com/it-sectors/facebook-paid-8-5-million-for-fb-com#:~:text=for%20%24200%2C000%20%2D%2D%2042.5%20times%20less%20than%20the%20estimated%20price%20tag%20for%20FB.com). Wired's history of Facebook also describes the move from [TheFacebook.com to Facebook.com in 2005](https://www.wired.com/story/15-years-later-what-is-facebook/#:~:text=August%202005%3A%20TheFacebook%20is%20officially%20Facebook).
+
+Even with the Accel round announced, $200,000 was not "just" $200,000. It was:
+
+- A large single spend for a company that was only about a year and a half old.
+- Equal to 20% of Jim Breyer's reported [$1 million personal investment](https://www.forbes.com/2011/04/06/midas-list-11-jim-breyer-venture-capital-comeback-kid.html#:~:text=Thanks%20to%20the%20%241%20million%20of%20his%20own%20he%20put%20into%20Facebook%20back%20in%202005) alongside Accel.
+- A bet that the cleanest version of the name would matter more than another short-term hire, server allocation, or campus marketing push.
+
+That last point is the lesson. Facebook was spending startup capital on brand infrastructure.
+
+## The money looked different then
+
+The temptation is to judge the deal from the end of the story. Facebook became Meta. Facebook.com became one of the most visited domains in the world. $200,000 now looks almost comically cheap.
+
+But a domain purchase should be evaluated at the moment of uncertainty, not after the outcome is obvious.
+
+In 2005, Facebook was still one player in a crowded social networking market. MySpace was the mainstream giant. Friendster had already shown how quickly a social network could rise and stumble. News Corp bought MySpace in 2005 for [$580 million](https://www.newyorker.com/magazine/2006/05/15/me-media#:~:text=Rupert%20Murdoch%E2%80%99s%20News%20Corporation%20purchased%20the%20company%20that%20owns%20MySpace%20for%20five%20hundred%20and%20eighty%20million%20dollars), which made the category look enormous but also intensely competitive. The New Yorker captured the mood in 2006: Facebook was growing quickly, but it was still mostly [a college network with about seven and a half million registered members](https://www.newyorker.com/magazine/2006/05/15/me-media#:~:text=Today%2C%20Facebook%20has%20about%20seven%20and%20a%20half%20million%20registered%20members), still negotiating how open it should become, and still facing questions about whether college-only identity could scale.
+
+Against that backdrop, spending $200,000 on a domain was not obvious. It was a thesis:
+
+> If this network becomes much bigger than campuses, the shorter, exact-match brand will compound every day.
+
+That thesis turned out to be right.
+
+## Why dropping "The" mattered
+
+The difference between TheFacebook.com and Facebook.com is only three letters and a space in speech, but strategically it is much larger.
+
+**TheFacebook.com** sounds like a product description. It points to a thing: the facebook, the directory, the campus tool.
+
+**Facebook.com** sounds like a proper noun. It can become the name of a company, a platform, a verb, and eventually a social layer of the web.
+
+The upgrade improved the brand in several ways:
+
+| Before | After |
+| --- | --- |
+| TheFacebook.com | Facebook.com |
+| Describes a campus directory | Names a broader network |
+| Feels like an early product | Feels like the canonical destination |
+| Carries the launch context | Travels beyond the launch context |
+| Makes users remember an article | Reduces the brand to one word |
+
+This is a common pattern in startup naming. Early names explain. Great names own.
+
+At launch, explanation helps. Later, explanation can become drag. The best domain upgrades happen when the company has enough traction to know the brand matters, but early enough that the cleaner name can still become canonical.
+
+Facebook hit that timing well.
+
+## Public discussion: hindsight, regret, and the "right domain"
+
+The Facebook.com purchase has become a recurring example in domain and startup discussions because it is so easy to understand in hindsight. Domain investors point to it as proof that exact-match brand domains can look expensive before they look obvious. Startup communities often use it as a counterexample to the idea that a young company should never spend serious money on a domain.
+
+The most interesting public comment came from Zuckerberg himself. In a 2009 TechCrunch interview, when asked what he would do differently, he answered that he would [get the right domain name](https://techcrunch.com/2009/10/24/startup-school-an-interview-with-mark-zuckerberg/#:~:text=I%E2%80%99d%20get%20the%20right%20domain%20name). TechCrunch's transcript frames the lesson plainly: Facebook eventually could get the domain, but it had to pay for the mistake later.
+
+Domain-industry retrospectives have kept returning to the same point. Smart Branding's write-up treats [TheFacebook.com to Facebook.com to FB.com](https://smartbranding.com/thefacebook-com-facebook-com-fb-com/#:~:text=The%20evolution%20of%20its%20domain%20names%20from%20TheFacebook.com%20to%20the%20sleeker%20Facebook.com%2C%20and%20ultimately%20to%20the%20succinct%20FB.com) as part of a broader pattern of Facebook tightening its domain portfolio as the company matured. Strategic Revenue made a similar argument, noting that the company later acquired domains such as [FB.com, Messenger.com, and Internet.org](https://www.strategicrevenue.com/if-you-didnt-already-know-facebook-com-sold-for-just-200000-in-2005/#:~:text=also%20acquiring%20the%20domains%20Messenger.com%2C%20Internet.org%2C%20and%20most%20notably).
+
+There is also a useful tension in public forum discussions. In a Hacker News discussion about [spending serious money on a startup domain](https://news.ycombinator.com/item?id=10031246), some commenters argue that early-stage companies should not overpay before product-market fit. Others point to Facebook, Airbnb, and similar upgrades as evidence that once the product is working, the exact brand domain can be a high-leverage asset. Both sides are right at different stages. TheFacebook.com was good enough to start. Facebook.com was better once the network was clearly working.
+
+The smart move was not buying the perfect domain on day one. The smart move was upgrading as soon as the company knew the name could carry a much larger business.
+
+## The domain became part of the operating system
+
+The reason premium domains matter is not vanity. It is repetition.
+
+A core domain appears everywhere:
+
+- In email addresses.
+- In press coverage.
+- In campus flyers, pitch decks, and investor memos.
+- In search results.
+- In browser bars and links.
+- In every spoken recommendation from one user to another.
+
+Every repetition either adds friction or removes it.
+
+TheFacebook.com asked users to remember the article. Facebook.com did not. That small change multiplied across millions, then hundreds of millions, then billions of interactions. The domain did not create Facebook's network effects, but it made those network effects easier to communicate.
+
+That is why the $200,000 decision aged so well. It was not a one-time branding expense. It was a permanent reduction in friction.
+
+## What founders should learn from Case 1
+
+The Facebook story is sometimes simplified into "buy the best domain early." That is too blunt.
+
+The better lesson is staged:
+
+1. **Use a descriptive domain to start if it helps users understand the product.** TheFacebook.com worked because it matched the Harvard use case.
+2. **Watch for the moment when the name stops matching the ambition.** Once the service was no longer just a campus directory, "The" became limiting.
+3. **Treat the upgrade as infrastructure, not decoration.** A canonical domain improves memory, trust, recruiting, fundraising, press, and user sharing.
+4. **Move before the weaker name hardens.** Facebook upgraded early enough that most of the world only ever knew the clean version.
+
+The domain upgrade did not make Facebook win by itself. Product, timing, exclusivity, execution, capital, and network effects mattered more.
+
+But Facebook.com made the win easier to name.
+
+## The Namefi angle
+
+Most domain upgrades are not just naming decisions. They are asset-transfer decisions.
+
+The hard part is often not deciding that the better domain matters. It is making the transaction happen safely: finding the owner, agreeing on price, coordinating payment, transferring control, preserving DNS continuity, documenting ownership, and making sure the domain does not sit inside one person's registrar account after the deal.
+
+[Namefi](https://namefi.io) is built around the idea that domains should behave more like internet-native assets. Tokenized ownership can make domain control easier to verify, transfer, and integrate into modern workflows while preserving compatibility with DNS.
+
+Facebook's upgrade is obvious now because the company became enormous. But the strategic lesson applies much earlier: when a name is going to carry the business, the domain is not decoration. It is part of the brand's foundation.
+
+## Sources and further reading
+
+- The Harvard Crimson — [Ten Years Later, Facebook's First Users Look Back at Site's Earliest Days](https://www.thecrimson.com/article/2014/2/4/facebook-ten-years-feature-1/#:~:text=got%20its%20start%20in%20a%20Kirkland%20House%20dorm%20room%20on%20Feb.%204%2C%202004%20as%20an%20internal%20directory%20for%20Harvard%20undergraduates)
+- The Harvard Crimson — [Firm Invests $13M in Facebook](https://www.thecrimson.com/article/2005/5/27/firm-invests-13m-in-facebook-a/#:~:text=invest%20%2413%20million%20into%20thefacebook.com)
+- The New Yorker — [Me Media](https://www.newyorker.com/magazine/2006/05/15/me-media#:~:text=Anybody%20with%20a%20Harvard%20e-mail%20address%20could%20join%20and%20create%20a%20profile)
+- Wired — [Feb. 4, 2004: You've Got a 'Friend' in TheFacebook](https://www.wired.com/2011/02/0204facebook-debuts/#:~:text=Friendster%20was%20the%20social%20media%20leader%20in%20early%202004)
+- Wired — [All the Times Facebook Moved Fast and Sometimes Broke Things](https://www.wired.com/story/15-years-later-what-is-facebook/#:~:text=August%202005%3A%20TheFacebook%20is%20officially%20Facebook)
+- InformationWeek — [Facebook Paid $8.5 Million For FB.com](https://www.informationweek.com/it-sectors/facebook-paid-8-5-million-for-fb-com#:~:text=Back%20in%20August%202005%2C%20TheFacebook%20purchased%20Facebook.com%20for%20%24200%2C000)
+- Forbes — [The Comeback Kid](https://www.forbes.com/2011/04/06/midas-list-11-jim-breyer-venture-capital-comeback-kid.html#:~:text=Thanks%20to%20the%20%241%20million%20of%20his%20own%20he%20put%20into%20Facebook%20back%20in%202005)
+- TechCrunch — [Startup School: An Interview With Mark Zuckerberg](https://techcrunch.com/2009/10/24/startup-school-an-interview-with-mark-zuckerberg/#:~:text=I%E2%80%99d%20get%20the%20right%20domain%20name)
+- Smart Branding — [From TheFacebook.com to Facebook.com to FB.com](https://smartbranding.com/thefacebook-com-facebook-com-fb-com/#:~:text=The%20evolution%20of%20its%20domain%20names%20from%20TheFacebook.com%20to%20the%20sleeker%20Facebook.com%2C%20and%20ultimately%20to%20the%20succinct%20FB.com)
+- Strategic Revenue — [If You Didn't Already Know, Facebook.com Was Sold for Just $200,000 in 2005](https://www.strategicrevenue.com/if-you-didnt-already-know-facebook-com-sold-for-just-200000-in-2005/#:~:text=recognized%20the%20need%20for%20a%20shorter%20and%20better%20domain%20name)
+- Hacker News — [Discussion of a startup domain purchase](https://news.ycombinator.com/item?id=10031246)


### PR DESCRIPTION
## What changed

Adds a new English blog post for Case 1 of the domain upgrade story series: TheFacebook.com to Facebook.com.

The draft covers the 2004 campus-network context, the 2005 domain acquisition, the funding-context nuance around the reported $200K price, public discussion of the upgrade, and the Namefi angle for safer domain ownership and transfer workflows.

The article now follows the preferred citation style: important claims are cited inline on the relevant phrase, and major citations use URL text fragments where practical to highlight the supporting sentence on the source page. The same sources are also listed in the final reference section.

## Validation

- `bun run data:validate` passes with existing repository warnings about missing keywords in unrelated content.
- `bun run lint:mdx` passes.
- Checked external links in the new post; source pages returned HTTP 200. Hacker News returned 200 with a browser user agent and may rate-limit basic curl requests.

## Notes

This PR intentionally adds only the English source article. It does not generate translations or add an OG image.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only addition with no application, auth, or infrastructure changes; main review surface is editorial accuracy and external links.
> 
> **Overview**
> Adds a new English blog article at `content/blog/en/from-thefacebook-com-to-facebook-com.md` as **Case 1** in a domain-upgrade series, published with front matter (`draft: false`, tags including `domain-upgrades`, SEO keywords/description).
> 
> The piece walks from **TheFacebook.com** (2004 campus directory) through the reported **$200K Facebook.com** purchase in 2005, framing it as brand infrastructure after Accel-scale growth—not a cosmetic URL change. It covers competitive context (MySpace, Friendster), why dropping “The” mattered, public hindsight (e.g. Zuckerberg on “the right domain”), founder takeaways, and a short **Namefi** tie-in on safe domain transfers.
> 
> **Out of scope for this PR:** translations, OG image, and any code changes—content-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e79b3311ca1505839b31ee84780bdd631971ecbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new blog post exploring Facebook's domain transition from TheFacebook.com to Facebook.com, including historical context, branding insights, and foundational lessons from the company's early evolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->