### PR TITLE
fix(blog): correct internal TLD links (double /r basePath bug)

### DIFF
--- a/content/blog/en/top-tlds-to-secure-for-your-accounting-firm.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-accounting-firm.md
@@ -22,7 +22,7 @@ When evaluating extensions, weigh three criteria. **Trust signals** matter most 
 
 ### 1. .com — your flagship and primary brand
 
-The [.com](/r/en/tld/com) extension remains the default expectation for any business website, and it is almost always where clients, partners, and search engines will look first. It is operated by Verisign under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/com), and registration is open to anyone. Make this your canonical address and redirect your other domains to it.
+The [.com](/en/tld/com) extension remains the default expectation for any business website, and it is almost always where clients, partners, and search engines will look first. It is operated by Verisign under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/com), and registration is open to anyone. Make this your canonical address and redirect your other domains to it.
 
 ### 2. .cpa — the gold-standard trust signal (restricted)
 
@@ -38,7 +38,7 @@ The .accountant extension is operated by dog beach, LLC (an Identity Digital reg
 
 ### 5. .accountants — industry-focused, plural variant
 
-The plural [.accountants](/r/en/tld/accountants) extension is operated by Binky Moon, LLC under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/accountants) and is well suited to multi-partner practices and firms. While registries can apply targeted policies, .accountants is generally available to accounting professionals and related businesses without the strict licensure vetting that governs .cpa. Securing it alongside .accountant prevents confusion between the singular and plural forms.
+The plural [.accountants](/en/tld/accountants) extension is operated by Binky Moon, LLC under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/accountants) and is well suited to multi-partner practices and firms. While registries can apply targeted policies, .accountants is generally available to accounting professionals and related businesses without the strict licensure vetting that governs .cpa. Securing it alongside .accountant prevents confusion between the singular and plural forms.
 
 ### 6. .finance — for advisory and wealth services
 
@@ -46,19 +46,19 @@ The .finance extension positions your firm in the broader financial-services lan
 
 ### 7. .net — the classic technical alternate
 
-The [.net](/r/en/tld/net) extension is one of the original generic TLDs, operated by Verisign under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/net). It is widely recognized and frequently registered defensively alongside .com so that no one can stand up a confusingly similar site. Redirect it to your flagship domain.
+The [.net](/en/tld/net) extension is one of the original generic TLDs, operated by Verisign under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/net). It is widely recognized and frequently registered defensively alongside .com so that no one can stand up a confusingly similar site. Redirect it to your flagship domain.
 
 ### 8. .org — credibility for associations and nonprofits
 
-The [.org](/r/en/tld/org) extension, operated by Public Interest Registry under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/org), conveys institutional trust. It is a smart defensive registration for any firm, and a natural primary choice if your practice runs an associated foundation, professional association, or community program.
+The [.org](/en/tld/org) extension, operated by Public Interest Registry under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/org), conveys institutional trust. It is a smart defensive registration for any firm, and a natural primary choice if your practice runs an associated foundation, professional association, or community program.
 
 ### 9. .agency — modern and service-oriented
 
-The [.agency](/r/en/tld/agency) extension suits firms that present themselves as full-service partners rather than transactional preparers. It is operated by Binky Moon, LLC under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/agency) and is open to general registration, giving you a contemporary, brandable option for campaigns or sub-brands.
+The [.agency](/en/tld/agency) extension suits firms that present themselves as full-service partners rather than transactional preparers. It is operated by Binky Moon, LLC under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/agency) and is open to general registration, giving you a contemporary, brandable option for campaigns or sub-brands.
 
 ### 10. .info — informational and defensive
 
-The [.info](/r/en/tld/info) extension, operated by Identity Digital under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/info), is an open TLD well suited to resource hubs, client portals, and knowledge bases — or simply as an inexpensive defensive registration to round out your portfolio.
+The [.info](/en/tld/info) extension, operated by Identity Digital under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/info), is an open TLD well suited to resource hubs, client portals, and knowledge bases — or simply as an inexpensive defensive registration to round out your portfolio.
 
 ## Defensive registration strategy
 

--- a/content/blog/en/top-tlds-to-secure-for-your-business.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-business.md
@@ -22,7 +22,7 @@ Weigh four criteria. **Relevance**: does the suffix fit your industry, audience,
 
 ### 1. .com — the default of the web
 
-[.com](/r/en/tld/com) is the original commercial gTLD and remains the most recognized and trusted suffix in the world. It is operated by [Verisign](https://www.icann.org/en/registry-agreements/details/com) under contract with ICANN. For most businesses, the exact-match `.com` is the single most important name to own, because customers type it by reflex and competitors covet it most.
+[.com](/en/tld/com) is the original commercial gTLD and remains the most recognized and trusted suffix in the world. It is operated by [Verisign](https://www.icann.org/en/registry-agreements/details/com) under contract with ICANN. For most businesses, the exact-match `.com` is the single most important name to own, because customers type it by reflex and competitors covet it most.
 
 ### 2. .co — the modern, brandable alternative
 
@@ -34,11 +34,11 @@ Weigh four criteria. **Relevance**: does the suffix fit your industry, audience,
 
 ### 4. .org — credibility and trust
 
-[.org](/r/en/tld/org) signals an organization or mission-driven entity and is operated by the [Public Interest Registry](https://www.iana.org/domains/root/db/org.html), a non-profit. Even purely commercial businesses often register `.org` defensively so that no one can spin up a critical or impostor "organization" using their brand. It is unrestricted and open to anyone.
+[.org](/en/tld/org) signals an organization or mission-driven entity and is operated by the [Public Interest Registry](https://www.iana.org/domains/root/db/org.html), a non-profit. Even purely commercial businesses often register `.org` defensively so that no one can spin up a critical or impostor "organization" using their brand. It is unrestricted and open to anyone.
 
 ### 5. .io — the tech and startup favorite
 
-[.io](/r/en/tld/io) is technically the country-code TLD for the British Indian Ocean Territory, but the letters echo "input/output," which made it the darling of developers, SaaS, and startups. It is administered through [Identity Digital's subsidiary, the Internet Computer Bureau](https://www.iana.org/domains/root/db/io.html), and registration is open globally without local presence requirements. If your business is tech-facing, owning the `.io` is worth the consideration.
+[.io](/en/tld/io) is technically the country-code TLD for the British Indian Ocean Territory, but the letters echo "input/output," which made it the darling of developers, SaaS, and startups. It is administered through [Identity Digital's subsidiary, the Internet Computer Bureau](https://www.iana.org/domains/root/db/io.html), and registration is open globally without local presence requirements. If your business is tech-facing, owning the `.io` is worth the consideration.
 
 ### 6. .biz — the business-only suffix
 
@@ -46,7 +46,7 @@ Weigh four criteria. **Relevance**: does the suffix fit your industry, audience,
 
 ### 7. .info — informational and approachable
 
-[.info](/r/en/tld/info) is one of the original new gTLDs and is widely used for knowledge bases, documentation, and informational microsites. It is operated by [Identity Digital](https://www.iana.org/domains/root/db/info.html) with no registration restrictions. Owning it lets you host a help center or campaign page — and keeps a copycat from publishing "facts" under your name.
+[.info](/en/tld/info) is one of the original new gTLDs and is widely used for knowledge bases, documentation, and informational microsites. It is operated by [Identity Digital](https://www.iana.org/domains/root/db/info.html) with no registration restrictions. Owning it lets you host a help center or campaign page — and keeps a copycat from publishing "facts" under your name.
 
 ### 8. .online — broad, descriptive, global
 
@@ -58,9 +58,9 @@ Weigh four criteria. **Relevance**: does the suffix fit your industry, audience,
 
 ### 10. .vip — premium positioning
 
-[.vip](/r/en/tld/vip) stands for "very important person" and is used to signal exclusivity, membership, or premium tiers. It is operated by [GoDaddy Registry](https://www.iana.org/domains/root/db/vip.html), which acquired it as part of the former Minds + Machines portfolio, and registration is open to everyone. For loyalty programs, members-only content, or a high-end product line, `.vip` is a memorable choice.
+[.vip](/en/tld/vip) stands for "very important person" and is used to signal exclusivity, membership, or premium tiers. It is operated by [GoDaddy Registry](https://www.iana.org/domains/root/db/vip.html), which acquired it as part of the former Minds + Machines portfolio, and registration is open to everyone. For loyalty programs, members-only content, or a high-end product line, `.vip` is a memorable choice.
 
-Two more worth a quick mention as you build out a portfolio: [.agency](https://www.icann.org/en/registry-agreements/details/agency) suits service firms, and [.com](/r/en/tld/com) variations in your category should always be your anchor.
+Two more worth a quick mention as you build out a portfolio: [.agency](https://www.icann.org/en/registry-agreements/details/agency) suits service firms, and [.com](/en/tld/com) variations in your category should always be your anchor.
 
 ## Defensive registration strategy
 

--- a/content/blog/en/top-tlds-to-secure-for-your-ecommerce-store.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-ecommerce-store.md
@@ -20,23 +20,23 @@ Three criteria should drive the decision. First, **trust and conversion**: shopp
 
 ## The top 10 TLDs to secure for your e-commerce store
 
-### 1. [.com](/r/en/tld/com) — the default you cannot skip
+### 1. [.com](/en/tld/com) — the default you cannot skip
 
 `.com` remains the most recognized and trusted extension in the world, and for most stores it is the canonical home of the brand. It is operated by Verisign under an [ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/com) and is open to anyone. If your exact-match `.com` is available, secure it first; everything else in your portfolio should point customers back toward it.
 
-### 2. [.shop](/r/en/tld/shop) — built for retail
+### 2. [.shop](/en/tld/shop) — built for retail
 
 `.shop` is a generic TLD purpose-built for commerce, [delegated in 2016](https://www.iana.org/domains/root/db/shop.html) and operated by GMO Registry, which won the rights at an ICANN auction. It is open to all registrants with no special eligibility rules ([ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/shop)). The keyword-in-the-extension reads instantly as "this is a place to buy," which makes it a natural fit for a storefront or a campaign microsite.
 
-### 3. [.store](/r/en/tld/store) — a clear commercial signal
+### 3. [.store](/en/tld/store) — a clear commercial signal
 
 `.store` is operated by Radix and was [introduced in 2016](https://en.wikipedia.org/wiki/.store) with no registration restrictions for end users beyond ICANN's standard reserved-names rules ([ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/store)). It is interchangeable in spirit with `.shop` and is worth holding both to broaden your retail footprint and to keep a near-identical lookalike out of someone else's hands.
 
-### 4. [.online](/r/en/tld/online) — broad and versatile
+### 4. [.online](/en/tld/online) — broad and versatile
 
 `.online` is another open Radix extension, [introduced in 2015](https://en.wikipedia.org/wiki/.online) with no eligibility restrictions ([ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/online)). Its generic meaning makes it flexible: useful as a landing page, a regional store, or simply a defensive hold so impersonators cannot claim "yourbrand.online."
 
-### 5. [.site](/r/en/tld/site) — a simple, recognizable alternative
+### 5. [.site](/en/tld/site) — a simple, recognizable alternative
 
 `.site` is an open Radix TLD ([delegated in 2015](https://en.wikipedia.org/wiki/.site)) with no registration restrictions ([ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/site)). It is short, easy to say, and widely understood, which makes it a sensible defensive register and a usable home for a microsite or a one-page promotion.
 
@@ -52,11 +52,11 @@ Three criteria should drive the decision. First, **trust and conversion**: shopp
 
 `.deals` is also operated by Identity Digital and is open to all registrants ([ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/deals)). For an e-commerce brand that runs frequent sales, "yourbrand.deals" is a memorable home for clearance pages and coupon landing pages — and a useful one to hold so it cannot be weaponized in a fake-discount scam. It is unlinked here as `.deals` is not in the allow-list.
 
-### 9. [.club](/r/en/tld/club) — community and membership
+### 9. [.club](/en/tld/club) — community and membership
 
 `.club` is a generic TLD that [launched to the public in 2014](https://en.wikipedia.org/wiki/.club) and is now operated by GoDaddy Registry, with no general registration restrictions ([ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/club)). If your store runs a loyalty program, subscription tier, or members-only drop, `.club` frames it perfectly.
 
-### 10. [.vip](/r/en/tld/vip) — premium tiers and exclusivity
+### 10. [.vip](/en/tld/vip) — premium tiers and exclusivity
 
 `.vip` is a generic TLD that [launched in 2016](https://en.wikipedia.org/wiki/.vip) — originally under Minds + Machines and now part of GoDaddy Registry — and is open to all ([ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/vip)). It is a strong choice for premium product lines, early-access programs, or high-value customer portals where exclusivity is part of the pitch.
 

--- a/content/blog/en/top-tlds-to-secure-for-your-fashion-brand.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-fashion-brand.md
@@ -24,23 +24,23 @@ You do not need hundreds of domains. You need the canonical `.com`, a small clus
 
 ### 1. .com — your non-negotiable anchor
 
-[.com](/r/en/tld/com) remains the default extension shoppers type and trust, operated by [VeriSign Global Registry Services](https://www.iana.org/domains/root/db/com.html). For a fashion brand it is the primary storefront and email domain, full stop. Secure it first; everything else is built around it. There are no eligibility restrictions—any registrant can hold a `.com`.
+[.com](/en/tld/com) remains the default extension shoppers type and trust, operated by [VeriSign Global Registry Services](https://www.iana.org/domains/root/db/com.html). For a fashion brand it is the primary storefront and email domain, full stop. Secure it first; everything else is built around it. There are no eligibility restrictions—any registrant can hold a `.com`.
 
 ### 2. .shop — retail intent in the name
 
-[.shop](/r/en/tld/shop) is operated by [GMO Registry, Inc.](https://www.iana.org/domains/root/db/shop.html) of Tokyo and is purpose-built for commerce. For a label, `yourbrand.shop` reads as an unambiguous "buy here" signal, which is ideal for a dedicated e-commerce property or a seasonal drop. It is open to all registrants with no special restrictions.
+[.shop](/en/tld/shop) is operated by [GMO Registry, Inc.](https://www.iana.org/domains/root/db/shop.html) of Tokyo and is purpose-built for commerce. For a label, `yourbrand.shop` reads as an unambiguous "buy here" signal, which is ideal for a dedicated e-commerce property or a seasonal drop. It is open to all registrants with no special restrictions.
 
 ### 3. .store — built for the storefront
 
-[.store](/r/en/tld/store) is run by [Radix](https://www.iana.org/domains/root/db/store.html) (Radix Technologies Inc.) and, like `.shop`, signals retail directly. It pairs well with a flagship online boutique or a pop-up/limited-edition site, and it is a strong defensive companion to `.shop` so neither sits in someone else's hands. Open registration, no restrictions.
+[.store](/en/tld/store) is run by [Radix](https://www.iana.org/domains/root/db/store.html) (Radix Technologies Inc.) and, like `.shop`, signals retail directly. It pairs well with a flagship online boutique or a pop-up/limited-edition site, and it is a strong defensive companion to `.shop` so neither sits in someone else's hands. Open registration, no restrictions.
 
 ### 4. .online — broad, flexible presence
 
-[.online](/r/en/tld/online) is also a [Radix](https://www.iana.org/domains/root/db/online.html) extension and works as a catch-all when `.com` is taken or as a campaign and lookbook domain. It is generic enough to point anywhere—a brand hub, a press kit, a seasonal teaser—and carries no eligibility restrictions.
+[.online](/en/tld/online) is also a [Radix](https://www.iana.org/domains/root/db/online.html) extension and works as a catch-all when `.com` is taken or as a campaign and lookbook domain. It is generic enough to point anywhere—a brand hub, a press kit, a seasonal teaser—and carries no eligibility restrictions.
 
 ### 5. .site — a versatile defensive pick
 
-[.site](/r/en/tld/site) (another [Radix](https://www.iana.org/domains/root/db/site.html) namespace) is inexpensive, widely recognized, and an easy defensive hold. Use it for a microsite or campaign landing page, or simply park it so it cannot be weaponized against your name. Open to all.
+[.site](/en/tld/site) (another [Radix](https://www.iana.org/domains/root/db/site.html) namespace) is inexpensive, widely recognized, and an easy defensive hold. Use it for a microsite or campaign landing page, or simply park it so it cannot be weaponized against your name. Open to all.
 
 ### 6. .co — the short, premium alternative
 
@@ -60,7 +60,7 @@ You do not need hundreds of domains. You need the canonical `.com`, a small clus
 
 ### 10. .vip — exclusivity and loyalty
 
-[.vip](/r/en/tld/vip) is operated by [Registry Services, LLC](https://www.iana.org/domains/root/db/vip.html) (GoDaddy Registry). For fashion, it maps neatly to members-only drops, loyalty programs, and early-access events—`yourbrand.vip` frames a gated experience. It is open to any registrant with no membership requirement.
+[.vip](/en/tld/vip) is operated by [Registry Services, LLC](https://www.iana.org/domains/root/db/vip.html) (GoDaddy Registry). For fashion, it maps neatly to members-only drops, loyalty programs, and early-access events—`yourbrand.vip` frames a gated experience. It is open to any registrant with no membership requirement.
 
 ## Defensive registration strategy
 

--- a/content/blog/en/top-tlds-to-secure-for-your-law-firm.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-law-firm.md
@@ -20,7 +20,7 @@ Three criteria matter most. First, **trust signals**: extensions like `.com` and
 
 ## The top 10 TLDs to secure for your law firm
 
-### 1. [.com](/r/en/tld/com) — the non-negotiable anchor
+### 1. [.com](/en/tld/com) — the non-negotiable anchor
 
 `.com` remains the most recognized and trusted extension in the world, and most clients will type it by default. Secure your firm's primary `.com` first and point everything else to it. It is the one domain you should never let lapse. The registry is operated by [Verisign](https://www.iana.org/domains/root/db/com.html) under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/com).
 
@@ -44,19 +44,19 @@ Three criteria matter most. First, **trust signals**: extensions like `.com` and
 
 `.lawyer` pairs naturally with an individual practitioner's name and, like `.attorney`, is **not** restricted to verified credentials. You can confirm its delegation in the [IANA root database](https://www.iana.org/domains/root/db/lawyer.html) and its [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/lawyer). Grab it to protect your name and to support partner microsites.
 
-### 7. [.abogado](/r/en/tld/abogado) — reach Spanish-speaking clients
+### 7. [.abogado](/en/tld/abogado) — reach Spanish-speaking clients
 
 `.abogado` ("lawyer" in Spanish) is a smart pick for firms serving Hispanic and Latino communities or operating in Spanish-speaking markets. It is openly available; see its [IANA root entry](https://www.iana.org/domains/root/db/abogado.html) and [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/abogado). A focused way to signal language and cultural fit.
 
-### 8. [.net](/r/en/tld/net) — the classic defensive backup
+### 8. [.net](/en/tld/net) — the classic defensive backup
 
 `.net` is one of the oldest and most trusted generic extensions, making it the natural defensive companion to your `.com`. Registering it prevents confusion and blocks an easy impersonation vector. It is operated by [Verisign](https://www.iana.org/domains/root/db/net.html) under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/net).
 
-### 9. [.org](/r/en/tld/org) — for nonprofits, clinics, and associations
+### 9. [.org](/en/tld/org) — for nonprofits, clinics, and associations
 
 `.org` carries connotations of mission and public service — fitting for legal aid organizations, bar-adjacent groups, and pro bono initiatives, and worth securing defensively even for commercial firms. It is administered by [Public Interest Registry](https://www.iana.org/domains/root/db/org.html). It rounds out the legacy trio alongside `.com` and `.net`.
 
-### 10. [.info](/r/en/tld/info) — for client-facing resources
+### 10. [.info](/en/tld/info) — for client-facing resources
 
 `.info` suits FAQ hubs, practice-area explainers, and intake resources where the name should say "information." It is an inexpensive defensive registration and a flexible home for content. See its [IANA root entry](https://www.iana.org/domains/root/db/info.html) for delegation details.
 

--- a/content/blog/en/top-tlds-to-secure-for-your-real-estate-business.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-real-estate-business.md
@@ -20,7 +20,7 @@ A few criteria should drive every registration. **Trust** comes first: the exten
 
 ## The top 10 TLDs to secure as a realtor
 
-### 1. [.com](/r/en/tld/com) — your non-negotiable anchor
+### 1. [.com](/en/tld/com) — your non-negotiable anchor
 
 `.com` is still the default extension buyers type and trust, and it remains the largest TLD in the world. Register the `.com` of your personal brand and your brokerage name first; everything else is secondary. If your exact `.com` is taken, a tight variation is worth more than a perfect match on an unfamiliar ending. Operated by Verisign under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/com).
 
@@ -48,15 +48,15 @@ A few criteria should drive every registration. **Trust** comes first: the exten
 
 `.house` is a compact, friendly ending that works for open-house campaigns, single-property sites, and casual personal brands alike. It is open to anyone and easy to say out loud, which helps on yard signs and radio. Its registry details are available from [ICANN](https://www.icann.org/en/registry-agreements/details/house).
 
-### 8. [.net](/r/en/tld/net) — the classic defensive backup
+### 8. [.net](/en/tld/net) — the classic defensive backup
 
 `.net` is one of the oldest and most recognized extensions, making it the natural defensive companion to your `.com`. Owning it prevents a competitor from picking up the obvious second choice on your name. It is operated by Verisign under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/net).
 
-### 9. [.org](/r/en/tld/org) — credibility for associations and community work
+### 9. [.org](/en/tld/org) — credibility for associations and community work
 
 `.org` carries a trustworthy, community-oriented tone that fits realtor associations, neighborhood resources, and non-commercial projects you run alongside your practice. Registering it also keeps it out of impersonators' hands. The `.org` TLD is documented in the [IANA root database](https://www.iana.org/domains/root/db/org.html).
 
-### 10. [.vip](/r/en/tld/vip) — premium positioning for top clients
+### 10. [.vip](/en/tld/vip) — premium positioning for top clients
 
 `.vip` signals exclusivity, which can fit a luxury practice or a private client portal like `clients.yourname.vip`. It is unrestricted and short, so it stands out on a business card. Its registry agreement is published by [ICANN](https://www.icann.org/en/registry-agreements/details/vip).
 

--- a/content/blog/en/top-tlds-to-secure-for-your-saas.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-saas.md
@@ -10,7 +10,7 @@ description: 'The top 10 TLDs to secure for your SaaS — from .com and .io to .
 keywords: ['top TLDs for SaaS', 'best domain extensions for SaaS', 'TLDs to secure for startup', 'defensive domain registration', '.io for SaaS', '.ai domain', '.app domain HTTPS', '.dev domain', 'SaaS domain strategy', 'brand protection domains', 'which TLD to choose', 'register SaaS domains']
 ---
 
-When you launch a SaaS product, your domain is more than an address — it is the surface your users, your API clients, and your search rankings all attach to. Choosing the right [top-level domain](/r/en/tld/com) (TLD) is the first decision, but for any product you intend to grow, it is rarely the only registration you should make. Securing several TLDs around your brand protects you from typo-squatters, lookalike phishing pages, and competitors quietly parking the extension you forgot.
+When you launch a SaaS product, your domain is more than an address — it is the surface your users, your API clients, and your search rankings all attach to. Choosing the right [top-level domain](/en/tld/com) (TLD) is the first decision, but for any product you intend to grow, it is rarely the only registration you should make. Securing several TLDs around your brand protects you from typo-squatters, lookalike phishing pages, and competitors quietly parking the extension you forgot.
 
 There is also a product reason to hold multiple TLDs. SaaS companies routinely split traffic across subbrands — a marketing site, a documentation portal, a developer-facing API, a status page, a customer dashboard. Owning the right mix of extensions lets you map those subbrands cleanly (think `app.yourbrand.io` or a dedicated `yourbrand.dev`) instead of stretching one name to do everything. This guide covers the top TLDs to secure for your SaaS, what each one signals, and how to build a defensive registration strategy around your core name.
 
@@ -22,35 +22,35 @@ Pick TLDs against three filters: **brand fit** (does the extension reinforce wha
 
 ### 1. .com — the default everyone still trusts
 
-[.com](/r/en/tld/com) is the original commercial gTLD and remains the most recognized extension on the internet, operated by Verisign as the [authoritative registry](https://www.iana.org/domains/root/db/com.html). For most SaaS brands the `.com` is the canonical name users will guess first and type without thinking. Even if you launch on another extension, securing the matching `.com` is the single highest-priority defensive registration you can make.
+[.com](/en/tld/com) is the original commercial gTLD and remains the most recognized extension on the internet, operated by Verisign as the [authoritative registry](https://www.iana.org/domains/root/db/com.html). For most SaaS brands the `.com` is the canonical name users will guess first and type without thinking. Even if you launch on another extension, securing the matching `.com` is the single highest-priority defensive registration you can make.
 
 ### 2. .io — the developer-tooling favorite
 
-[.io](/r/en/tld/io) is technically the country-code TLD for the British Indian Ocean Territory, [delegated by IANA](https://www.iana.org/domains/root/db/io.html) and today administered by Identity Digital. Despite that origin, the tech industry reads it as "input/output," and it has become a default for developer tools, infrastructure, and API-first SaaS. Note that .io's long-term status has been discussed publicly following a 2025 sovereignty agreement, so treat it as a strong brand layer rather than your sole canonical name.
+[.io](/en/tld/io) is technically the country-code TLD for the British Indian Ocean Territory, [delegated by IANA](https://www.iana.org/domains/root/db/io.html) and today administered by Identity Digital. Despite that origin, the tech industry reads it as "input/output," and it has become a default for developer tools, infrastructure, and API-first SaaS. Note that .io's long-term status has been discussed publicly following a 2025 sovereignty agreement, so treat it as a strong brand layer rather than your sole canonical name.
 
 ### 3. .ai — the signal for AI products
 
-[.ai](/r/en/tld/ai) is the ccTLD for Anguilla, [delegated to the territory by IANA](https://www.iana.org/domains/root/db/ai.html) and now managed with Identity Digital as the technical operator. Because "AI" matches the abbreviation for artificial intelligence, the extension has become a powerful signal for AI and ML SaaS products. Registration is open globally with no Anguilla residency requirement, which is why adoption has grown so quickly.
+[.ai](/en/tld/ai) is the ccTLD for Anguilla, [delegated to the territory by IANA](https://www.iana.org/domains/root/db/ai.html) and now managed with Identity Digital as the technical operator. Because "AI" matches the abbreviation for artificial intelligence, the extension has become a powerful signal for AI and ML SaaS products. Registration is open globally with no Anguilla residency requirement, which is why adoption has grown so quickly.
 
 ### 4. .app — secure by default
 
-[.app](/r/en/tld/app) is a Google Registry gTLD aimed at applications, governed by its [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/app). Its defining feature: the entire TLD is on the [HSTS preload list](https://www.iana.org/domains/root/db/app.html), so every `.app` site must be served over HTTPS — browsers will refuse plain HTTP. For a SaaS shipping a web or mobile app, that enforced security is a feature, but plan to have a valid TLS certificate before launch.
+[.app](/en/tld/app) is a Google Registry gTLD aimed at applications, governed by its [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/app). Its defining feature: the entire TLD is on the [HSTS preload list](https://www.iana.org/domains/root/db/app.html), so every `.app` site must be served over HTTPS — browsers will refuse plain HTTP. For a SaaS shipping a web or mobile app, that enforced security is a feature, but plan to have a valid TLS certificate before launch.
 
 ### 5. .dev — for developer-facing surfaces
 
-[.dev](/r/en/tld/dev) is another Google Registry gTLD ([registry agreement](https://www.icann.org/en/registry-agreements/details/dev)) and, like `.app`, is on the HSTS preload list, requiring HTTPS across the whole extension. It fits developer portals, SDK docs, and internal tooling beautifully. If your SaaS sells to engineers, a `yourbrand.dev` for documentation or API references is a natural, credible home.
+[.dev](/en/tld/dev) is another Google Registry gTLD ([registry agreement](https://www.icann.org/en/registry-agreements/details/dev)) and, like `.app`, is on the HSTS preload list, requiring HTTPS across the whole extension. It fits developer portals, SDK docs, and internal tooling beautifully. If your SaaS sells to engineers, a `yourbrand.dev` for documentation or API references is a natural, credible home.
 
 ### 6. .cloud — infrastructure and platform branding
 
-[.cloud](/r/en/tld/cloud) is a gTLD operated by Aruba S.p.A., [delegated in 2015](https://www.iana.org/domains/root/db/cloud.html) under its [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/cloud). It reads naturally for cloud platforms, hosting, and infrastructure SaaS. If your product is positioned around managed services or platform-as-a-service, `.cloud` communicates that category instantly.
+[.cloud](/en/tld/cloud) is a gTLD operated by Aruba S.p.A., [delegated in 2015](https://www.iana.org/domains/root/db/cloud.html) under its [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/cloud). It reads naturally for cloud platforms, hosting, and infrastructure SaaS. If your product is positioned around managed services or platform-as-a-service, `.cloud` communicates that category instantly.
 
 ### 7. .tech — for hardware-adjacent and deep-tech SaaS
 
-[.tech](/r/en/tld/tech) is a gTLD operated by Radix, one of the largest new-gTLD registries, and is [listed in the IANA root database](https://www.iana.org/domains/root/db/tech.html). It is a flexible umbrella extension for any technology company, and it is broad enough to suit SaaS that doesn't fit a narrower category like AI or cloud. It works especially well for product launches and event subdomains.
+[.tech](/en/tld/tech) is a gTLD operated by Radix, one of the largest new-gTLD registries, and is [listed in the IANA root database](https://www.iana.org/domains/root/db/tech.html). It is a flexible umbrella extension for any technology company, and it is broad enough to suit SaaS that doesn't fit a narrower category like AI or cloud. It works especially well for product launches and event subdomains.
 
 ### 8. .net — the established alternate
 
-[.net](/r/en/tld/net) is a legacy gTLD also operated by Verisign, with its [delegation recorded at IANA](https://www.iana.org/domains/root/db/net.html). Originally intended for network infrastructure, it is now a widely trusted general-purpose extension. As a defensive registration it is high value: it is the most common alternate users try after `.com`, so holding it prevents lookalike confusion.
+[.net](/en/tld/net) is a legacy gTLD also operated by Verisign, with its [delegation recorded at IANA](https://www.iana.org/domains/root/db/net.html). Originally intended for network infrastructure, it is now a widely trusted general-purpose extension. As a defensive registration it is high value: it is the most common alternate users try after `.com`, so holding it prevents lookalike confusion.
 
 ### 9. .co — the short, brandable alternate to .com
 
@@ -58,7 +58,7 @@ Pick TLDs against three filters: **brand fit** (does the extension reinforce wha
 
 ### 10. .xyz — flexible and widely adopted
 
-[.xyz](/r/en/tld/xyz) is a general-purpose gTLD operated by XYZ.com LLC, [recorded in the IANA root database](https://www.iana.org/domains/root/db/xyz.html). It carries no category baggage, which makes it a blank-canvas option for brands that want a short, distinctive name. It is also popular in Web3 communities, making it a natural fit if your SaaS has a tokenized or on-chain dimension.
+[.xyz](/en/tld/xyz) is a general-purpose gTLD operated by XYZ.com LLC, [recorded in the IANA root database](https://www.iana.org/domains/root/db/xyz.html). It carries no category baggage, which makes it a blank-canvas option for brands that want a short, distinctive name. It is also popular in Web3 communities, making it a natural fit if your SaaS has a tokenized or on-chain dimension.
 
 ## Defensive registration strategy
 

--- a/content/blog/en/top-tlds-to-secure-for-your-startup.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-startup.md
@@ -22,23 +22,23 @@ Focus on four criteria. **Relevance**: does the suffix signal what you do (a dev
 
 ### 1. .com — the default the world still types
 
-[.com](/r/en/tld/com) remains the most recognized and trusted extension on the internet, the one users type by reflex and the one most email clients and apps assume. It is operated by Verisign under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/com), and you can review its delegation record in the [IANA root database](https://www.iana.org/domains/root/db/com.html). If you secure only one domain, make it your .com. There are no eligibility restrictions, so the main challenge is availability.
+[.com](/en/tld/com) remains the most recognized and trusted extension on the internet, the one users type by reflex and the one most email clients and apps assume. It is operated by Verisign under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/com), and you can review its delegation record in the [IANA root database](https://www.iana.org/domains/root/db/com.html). If you secure only one domain, make it your .com. There are no eligibility restrictions, so the main challenge is availability.
 
 ### 2. .io — the tech and SaaS favorite
 
-[.io](/r/en/tld/io) became a darling of startups because "I/O" means input/output in software, giving it built-in technical resonance. It is the country-code TLD assigned to the British Indian Ocean Territory, with the registry now operated by Internet Computer Bureau under [Identity Digital](https://www.identity.digital/), per its [IANA delegation record](https://www.iana.org/domains/root/db/io.html). Registration is open to anyone worldwide. Note that the territory's long-term geopolitical status has been [discussed publicly](https://www.theregister.com/2024/10/10/io_domain_uk_mauritius/), so treat .io as a strong complement to, not a replacement for, your .com.
+[.io](/en/tld/io) became a darling of startups because "I/O" means input/output in software, giving it built-in technical resonance. It is the country-code TLD assigned to the British Indian Ocean Territory, with the registry now operated by Internet Computer Bureau under [Identity Digital](https://www.identity.digital/), per its [IANA delegation record](https://www.iana.org/domains/root/db/io.html). Registration is open to anyone worldwide. Note that the territory's long-term geopolitical status has been [discussed publicly](https://www.theregister.com/2024/10/10/io_domain_uk_mauritius/), so treat .io as a strong complement to, not a replacement for, your .com.
 
 ### 3. .ai — the obvious choice for AI startups
 
-[.ai](/r/en/tld/ai) has exploded alongside the artificial-intelligence boom, making it close to mandatory for any AI-focused company. It is the country-code TLD for Anguilla, administered by the government of Anguilla, which [announced a partnership with Identity Digital in 2024](https://www.businesswire.com/news/home/20241015024971/en/The-Government-of-Anguilla-and-Identity-Digital-Announce-New-Partnership-to-Manage-Explosive-Growth-of-.AI-Web-Addresses) to manage its growth; see the [IANA record](https://www.iana.org/domains/root/db/ai.html). Registration is open with no AI-industry requirement, but pricing and renewal terms differ from typical gTLDs, so plan ahead.
+[.ai](/en/tld/ai) has exploded alongside the artificial-intelligence boom, making it close to mandatory for any AI-focused company. It is the country-code TLD for Anguilla, administered by the government of Anguilla, which [announced a partnership with Identity Digital in 2024](https://www.businesswire.com/news/home/20241015024971/en/The-Government-of-Anguilla-and-Identity-Digital-Announce-New-Partnership-to-Manage-Explosive-Growth-of-.AI-Web-Addresses) to manage its growth; see the [IANA record](https://www.iana.org/domains/root/db/ai.html). Registration is open with no AI-industry requirement, but pricing and renewal terms differ from typical gTLDs, so plan ahead.
 
 ### 4. .app — secure by default
 
-[.app](/r/en/tld/app) is operated by Google Registry and is purpose-built for software, apps, and mobile products. Its standout feature: the entire .app namespace is on the [HSTS preload list](https://hstspreload.org/), meaning every .app site is required to load over HTTPS, as Google [documents in its policies](https://www.registry.google/policies/). That security-by-default makes it a credible home for a product or download page. You will need a valid TLS certificate for the site to load at all.
+[.app](/en/tld/app) is operated by Google Registry and is purpose-built for software, apps, and mobile products. Its standout feature: the entire .app namespace is on the [HSTS preload list](https://hstspreload.org/), meaning every .app site is required to load over HTTPS, as Google [documents in its policies](https://www.registry.google/policies/). That security-by-default makes it a credible home for a product or download page. You will need a valid TLS certificate for the site to load at all.
 
 ### 5. .dev — built for builders
 
-[.dev](/r/en/tld/dev), also run by Google Registry, is aimed squarely at developers, engineering teams, and technical documentation. Like .app, the whole .dev zone is on the [HSTS preload list](https://hstspreload.org/), so HTTPS is mandatory across the extension. It is a natural fit for developer-tooling startups, API docs, or an internal engineering portal. Confirm the requirements in [Google Registry's documentation](https://www.registry.google/policies/) before you build.
+[.dev](/en/tld/dev), also run by Google Registry, is aimed squarely at developers, engineering teams, and technical documentation. Like .app, the whole .dev zone is on the [HSTS preload list](https://hstspreload.org/), so HTTPS is mandatory across the extension. It is a natural fit for developer-tooling startups, API docs, or an internal engineering portal. Confirm the requirements in [Google Registry's documentation](https://www.registry.google/policies/) before you build.
 
 ### 6. .tech — descriptive and broadly available
 
@@ -46,7 +46,7 @@ Focus on four criteria. **Relevance**: does the suffix signal what you do (a dev
 
 ### 7. .xyz — flexible and startup-friendly
 
-[.xyz](/r/en/tld/xyz) is a deliberately generic, unrestricted extension operated by XYZ.COM LLC under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/xyz). Its open, neutral branding has made it popular with startups and Web3 projects alike (Alphabet's abc.xyz is a well-known example). With no relevance constraints, it is a versatile pick for a landing page, campaign, or experimental product.
+[.xyz](/en/tld/xyz) is a deliberately generic, unrestricted extension operated by XYZ.COM LLC under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/xyz). Its open, neutral branding has made it popular with startups and Web3 projects alike (Alphabet's abc.xyz is a well-known example). With no relevance constraints, it is a versatile pick for a landing page, campaign, or experimental product.
 
 ### 8. .co — the short stand-in for .com
 
@@ -54,11 +54,11 @@ Focus on four criteria. **Relevance**: does the suffix signal what you do (a dev
 
 ### 9. .net — the classic backup
 
-[.net](/r/en/tld/net) is one of the original generic TLDs, operated by Verisign under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/net) (see its [IANA record](https://www.iana.org/domains/root/db/net.html)). It carries an established, trustworthy reputation, especially for infrastructure, networking, and platform companies. Even if you do not build your primary brand on it, securing the .net of your exact name is a sensible defensive move.
+[.net](/en/tld/net) is one of the original generic TLDs, operated by Verisign under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/net) (see its [IANA record](https://www.iana.org/domains/root/db/net.html)). It carries an established, trustworthy reputation, especially for infrastructure, networking, and platform companies. Even if you do not build your primary brand on it, securing the .net of your exact name is a sensible defensive move.
 
 ### 10. .club — for community-driven startups
 
-[.club](/r/en/tld/club) is an unrestricted generic TLD operated by GoDaddy Registry's Registry Services, LLC, per its [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/club) and [IANA record](https://www.iana.org/domains/root/db/club.html). If your startup is built around membership, community, or a recurring audience, .club communicates belonging in a single word. It is a strong category extension for creator platforms, subscription products, and social ventures.
+[.club](/en/tld/club) is an unrestricted generic TLD operated by GoDaddy Registry's Registry Services, LLC, per its [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/club) and [IANA record](https://www.iana.org/domains/root/db/club.html). If your startup is built around membership, community, or a recurring audience, .club communicates belonging in a single word. It is a strong category extension for creator platforms, subscription products, and social ventures.
 
 ## Defensive registration strategy
 

--- a/prompts/tld-page.md
+++ b/prompts/tld-page.md
@@ -83,11 +83,11 @@ exist.** Dead links hurt SEO and trust, and slugs change over time.
 `content/tld/en/`, `content/blog/en/`, and `content/glossary/en/`. If you cannot verify it, do
 not link it.
 
-URL patterns (all live under `/r/en/...`):
+URL patterns (all live under `/en/...`):
 
-- TLD index: `/r/en/tld` — TLD page: `/r/en/tld/<tld>` (e.g. `/r/en/tld/com`, `/r/en/tld/io`)
-- Blog post: `/r/en/blog/<slug>`
-- Glossary term: `/r/en/glossary/<slug>`
+- TLD index: `/en/tld` — TLD page: `/en/tld/<tld>` (e.g. `/en/tld/com`, `/en/tld/io`)
+- Blog post: `/en/blog/<slug>`
+- Glossary term: `/en/glossary/<slug>`
 
 Examples of real pages you can link when relevant (verify they still exist; this list is not
 exhaustive and will grow):


### PR DESCRIPTION
## Problem
Internal TLD links in the 8 "Top 10 TLDs" listicles were written as `/r/en/tld/<x>`. The resources app sets `basePath: '/r'` and renders markdown links through `next/link`, which **auto-prepends `/r`** — so they resolved to **`/r/r/en/tld/<x>`** → 404.

## Fix
Drop the `/r` prefix: `/r/en/tld/x` → `/en/tld/x` (basePath re-adds `/r` at render). 56 links across the 8 articles, plus the `prompts/tld-page.md` internal-linking guidance.

`data:validate` ✅

> Companion to namefi-astra #4544 (breadcrumb + related-guides + related-TLD chips), which uses the same basePath-relative link convention.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only path rewrites with no application logic changes; risk is limited to any other surfaces still hardcoding `/r/en/` in markdown outside this PR.
> 
> **Overview**
> Fixes **broken internal TLD links** in the eight “Top 10 TLDs” listicles and aligns future content with how the resources app routes markdown through `next/link` with **`basePath: '/r'`**.
> 
> Links were written as `/r/en/tld/<suffix>`; the router **prepends `/r` again**, so users hit **`/r/r/en/tld/...`** and 404. The change rewrites them to **`/en/tld/<suffix>`** (and the same pattern for blog/glossary in the prompt), so the rendered href is **`/r/en/tld/...`**.
> 
> **`prompts/tld-page.md`** now documents **`/en/...`** URL patterns instead of `/r/en/...`, matching the companion convention in namefi-astra #4544.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 266eea026181f3287072113854b97d1d3ddd06b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected internal navigation links across industry-specific blog articles for proper site navigation.
  * Updated URL patterns in documentation to reflect the correct site structure and ensure consistent link resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->