### PR TITLE
content(tld): add 23 TLD docs + internal-first link the listicles

### DIFF
--- a/content/blog/en/top-tlds-to-secure-for-your-accounting-firm.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-accounting-firm.md
@@ -26,15 +26,15 @@ The [.com](/en/tld/com) extension remains the default expectation for any busine
 
 ### 2. .cpa — the gold-standard trust signal (restricted)
 
-The [.cpa](https://www.iana.org/domains/root/db/cpa.html) extension is the most credible domain an accounting firm can hold — and it is also the most restricted. It is administered in association with the American Institute of CPAs (AICPA), whose technology affiliate CPA.com runs the registry. Eligibility is limited to licensed CPA firms and individual CPAs: per [CPA.com's official .cpa program](https://register.domains.cpa/faqs/), you must hold a CPA firm license issued by a state board of accountancy or an individual CPA license, with availability currently limited to firms based in the United States, Canada, and Ireland. Because licensure is validated at purchase and at every renewal, a .cpa address proves to clients that your firm has been verified — a guarantee no open TLD can offer.
+The [.cpa](https://www.iana.org/domains/root/db/cpa.html) extension is the most credible domain an accounting firm can hold — and it is also the most restricted. It is administered in association with the American Institute of CPAs (AICPA), whose technology affiliate CPA.com runs the registry. Eligibility is limited to licensed CPA firms and individual CPAs: per [CPA.com's official .cpa program](https://register.domains.cpa/faqs/), you must hold a CPA firm license issued by a state board of accountancy or an individual CPA license, with availability currently limited to firms based in the United States, Canada, and Ireland. Because licensure is validated at purchase and at every renewal, a [.cpa](/en/tld/cpa) address proves to clients that your firm has been verified — a guarantee no open TLD can offer.
 
 ### 3. .tax — clear, descriptive, and topical
 
-The .tax extension immediately communicates a specialty in tax preparation, planning, or advisory work. It is operated by Identity Digital (through Binky Moon, LLC) under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/tax), and unlike .cpa it is open to general registration. It pairs well with a service-focused landing page or a seasonal tax campaign.
+The [.tax](/en/tld/tax) extension immediately communicates a specialty in tax preparation, planning, or advisory work. It is operated by Identity Digital (through Binky Moon, LLC) under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/tax), and unlike .cpa it is open to general registration. It pairs well with a service-focused landing page or a seasonal tax campaign.
 
 ### 4. .accountant — open and broadly available
 
-The .accountant extension is operated by dog beach, LLC (an Identity Digital registry) under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/accountant). Importantly, .accountant is **open to the public** with no professional verification requirement — anyone can register it first-come, first-served. That makes it useful for marketing and defensive purposes, but it carries no built-in licensure signal the way .cpa does.
+The [.accountant](/en/tld/accountant) extension is operated by dog beach, LLC (an Identity Digital registry) under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/accountant). Importantly, .accountant is **open to the public** with no professional verification requirement — anyone can register it first-come, first-served. That makes it useful for marketing and defensive purposes, but it carries no built-in licensure signal the way .cpa does.
 
 ### 5. .accountants — industry-focused, plural variant
 
@@ -42,7 +42,7 @@ The plural [.accountants](/en/tld/accountants) extension is operated by Binky Mo
 
 ### 6. .finance — for advisory and wealth services
 
-The .finance extension positions your firm in the broader financial-services landscape, which is ideal if you offer advisory, wealth, or CFO services beyond compliance work. It is operated by Binky Moon, LLC under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/finance) and is open for general registration. It reads as serious and professional, complementing a tax- or audit-focused brand.
+The [.finance](/en/tld/finance) extension positions your firm in the broader financial-services landscape, which is ideal if you offer advisory, wealth, or CFO services beyond compliance work. It is operated by Binky Moon, LLC under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/finance) and is open for general registration. It reads as serious and professional, complementing a tax- or audit-focused brand.
 
 ### 7. .net — the classic technical alternate
 

--- a/content/blog/en/top-tlds-to-secure-for-your-business.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-business.md
@@ -26,11 +26,11 @@ Weigh four criteria. **Relevance**: does the suffix fit your industry, audience,
 
 ### 2. .co — the modern, brandable alternative
 
-.co reads as a clean shorthand for "company" and is a favorite for startups when the `.com` is taken. It is the country-code TLD for Colombia, now operated by [GoDaddy Registry](https://www.iana.org/domains/root/db/co.html) following its acquisition of Neustar's registry business, and it is open for global, unrestricted registration. It is short, memorable, and a strong defensive pairing with `.com`.
+[.co](/en/tld/co) reads as a clean shorthand for "company" and is a favorite for startups when the `.com` is taken. It is the country-code TLD for Colombia, now operated by [GoDaddy Registry](https://www.iana.org/domains/root/db/co.html) following its acquisition of Neustar's registry business, and it is open for global, unrestricted registration. It is short, memorable, and a strong defensive pairing with `.com`.
 
 ### 3. .net — the trusted classic
 
-.net was originally intended for network infrastructure providers and, like `.com`, is operated by [Verisign](https://www.iana.org/domains/root/db/net.html). It carries decades of credibility and remains a common fallback that customers recognize instantly. Securing it prevents a third party from fielding a near-identical address to your primary `.com`.
+[.net](/en/tld/net) was originally intended for network infrastructure providers and, like `.com`, is operated by [Verisign](https://www.iana.org/domains/root/db/net.html). It carries decades of credibility and remains a common fallback that customers recognize instantly. Securing it prevents a third party from fielding a near-identical address to your primary `.com`.
 
 ### 4. .org — credibility and trust
 
@@ -42,7 +42,7 @@ Weigh four criteria. **Relevance**: does the suffix fit your industry, audience,
 
 ### 6. .biz — the business-only suffix
 
-[.biz](https://www.iana.org/domains/root/db/biz.html) was created explicitly as a commercial alternative to `.com` and is restricted to bona fide business or commercial use under its registry policy. Now operated by GoDaddy Registry, it is a natural defensive pick precisely because its name screams "business," making it attractive to anyone trying to impersonate a commercial brand.
+[.biz](/en/tld/biz) was created explicitly as a commercial alternative to `.com` and is restricted to bona fide business or commercial use under its [registry policy](https://www.iana.org/domains/root/db/biz.html). Now operated by GoDaddy Registry, it is a natural defensive pick precisely because its name screams "business," making it attractive to anyone trying to impersonate a commercial brand.
 
 ### 7. .info — informational and approachable
 
@@ -50,11 +50,11 @@ Weigh four criteria. **Relevance**: does the suffix fit your industry, audience,
 
 ### 8. .online — broad, descriptive, global
 
-.online is a descriptive new gTLD that works for almost any business with a web presence. It is owned and operated by [Radix](https://www.iana.org/domains/root/db/online.html) and is open for unrestricted registration worldwide. Its plain-language meaning makes it an easy, intuitive address for landing pages and regional storefronts.
+[.online](/en/tld/online) is a descriptive new gTLD that works for almost any business with a web presence. It is owned and operated by [Radix](https://www.iana.org/domains/root/db/online.html) and is open for unrestricted registration worldwide. Its plain-language meaning makes it an easy, intuitive address for landing pages and regional storefronts.
 
 ### 9. .company — a literal fit for any firm
 
-[.company](https://www.iana.org/domains/root/db/company.html) is exactly what it says, operated by [Identity Digital](https://www.icann.org/en/registry-agreements/details/company). It is unrestricted and reads naturally for established firms that want a self-explanatory address. It is also a sensible defensive registration, since the word maps so directly onto a business identity.
+[.company](/en/tld/company) is exactly what it says, operated by [Identity Digital](https://www.icann.org/en/registry-agreements/details/company). It is [unrestricted](https://www.iana.org/domains/root/db/company.html) and reads naturally for established firms that want a self-explanatory address. It is also a sensible defensive registration, since the word maps so directly onto a business identity.
 
 ### 10. .vip — premium positioning
 

--- a/content/blog/en/top-tlds-to-secure-for-your-ecommerce-store.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-ecommerce-store.md
@@ -12,11 +12,11 @@ keywords: ['top TLDs for e-commerce', 'best domain extensions for online store',
 
 For an online retailer, a domain name is not just an address — it is a storefront, a trust signal, and a brand asset all at once. Securing the right **top-level domains (TLDs) for your e-commerce store** is one of the cheapest forms of brand protection you can buy. When you own the extensions that customers and bad actors are most likely to type, you control where your traffic goes and you deny that real estate to anyone who might misuse it.
 
-That last point matters more than most merchants realize. Lookalike storefronts on alternate extensions are a common vector for phishing and counterfeit-goods scams: a fraudster registers your brand on a retail-flavored TLD you skipped, spins up a convincing checkout page, and harvests payment details from your shoppers. Securing a handful of high-intent extensions up front — alongside your primary `.com` — closes those gaps before someone else opens them.
+That last point matters more than most merchants realize. Lookalike storefronts on alternate extensions are a common vector for phishing and counterfeit-goods scams: a fraudster registers your brand on a retail-flavored TLD you skipped, spins up a convincing checkout page, and harvests payment details from your shoppers. Securing a handful of high-intent extensions up front — alongside your primary [`.com`](/en/tld/com) — closes those gaps before someone else opens them.
 
 ## How to choose TLDs for your online store
 
-Three criteria should drive the decision. First, **trust and conversion**: shoppers recognize and trust some extensions more than others, and a familiar TLD reduces hesitation at the moment of purchase. Second, **retail intent**: extensions like `.shop` and `.store` carry obvious commercial meaning, which can reinforce your positioning and make marketing copy read naturally. Third, **defensive coverage**: even extensions you never plan to launch on are worth holding if a competitor or impersonator could plausibly use them against your brand. The goal is a small, deliberate portfolio — not every TLD in existence, but the ones that protect your name and serve your customers.
+Three criteria should drive the decision. First, **trust and conversion**: shoppers recognize and trust some extensions more than others, and a familiar TLD reduces hesitation at the moment of purchase. Second, **retail intent**: extensions like [`.shop`](/en/tld/shop) and [`.store`](/en/tld/store) carry obvious commercial meaning, which can reinforce your positioning and make marketing copy read naturally. Third, **defensive coverage**: even extensions you never plan to launch on are worth holding if a competitor or impersonator could plausibly use them against your brand. The goal is a small, deliberate portfolio — not every TLD in existence, but the ones that protect your name and serve your customers.
 
 ## The top 10 TLDs to secure for your e-commerce store
 
@@ -34,31 +34,31 @@ Three criteria should drive the decision. First, **trust and conversion**: shopp
 
 ### 4. [.online](/en/tld/online) — broad and versatile
 
-`.online` is another open Radix extension, [introduced in 2015](https://en.wikipedia.org/wiki/.online) with no eligibility restrictions ([ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/online)). Its generic meaning makes it flexible: useful as a landing page, a regional store, or simply a defensive hold so impersonators cannot claim "yourbrand.online."
+[`.online`](/en/tld/online) is another open Radix extension, [introduced in 2015](https://en.wikipedia.org/wiki/.online) with no eligibility restrictions ([ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/online)). Its generic meaning makes it flexible: useful as a landing page, a regional store, or simply a defensive hold so impersonators cannot claim "yourbrand.online."
 
 ### 5. [.site](/en/tld/site) — a simple, recognizable alternative
 
-`.site` is an open Radix TLD ([delegated in 2015](https://en.wikipedia.org/wiki/.site)) with no registration restrictions ([ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/site)). It is short, easy to say, and widely understood, which makes it a sensible defensive register and a usable home for a microsite or a one-page promotion.
+[`.site`](/en/tld/site) is an open Radix TLD ([delegated in 2015](https://en.wikipedia.org/wiki/.site)) with no registration restrictions ([ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/site)). It is short, easy to say, and widely understood, which makes it a sensible defensive register and a usable home for a microsite or a one-page promotion.
 
 ### 6. .co — the short, startup-friendly option
 
-`.co` is technically Colombia's country-code TLD, but proof-of-presence restrictions were lifted in 2010, so anyone worldwide can register one ([Wikipedia: .co](https://en.wikipedia.org/wiki/.co)). It is widely adopted by startups and brands that cannot get their `.com`, and notably it is one of the few ccTLDs that Google treats as a generic, non-geographic extension. Because `.co` is a single typo away from `.com`, holding your brand here is as much defensive as it is strategic. (Note: `.co` is not in Namefi's internal link allow-list, so it is unlinked here.)
+[`.co`](/en/tld/co) is technically Colombia's country-code TLD, but proof-of-presence restrictions were lifted in 2010, so anyone worldwide can register one ([Wikipedia: .co](https://en.wikipedia.org/wiki/.co)). It is widely adopted by startups and brands that cannot get their `.com`, and notably it is one of the few ccTLDs that Google treats as a generic, non-geographic extension. Because `.co` is a single typo away from `.com`, holding your brand here is as much defensive as it is strategic.
 
 ### 7. .shopping — high commercial intent
 
-`.shopping` is a generic TLD operated by Identity Digital (formerly Donuts) and is open for registration ([ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/shopping)). It carries explicit purchase intent and pairs well with comparison pages, deal hubs, or seasonal campaigns. It is unlinked here because `.shopping` is not in the allow-list.
+[`.shopping`](/en/tld/shopping) is a generic TLD operated by Identity Digital (formerly Donuts) and is open for registration ([ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/shopping)). It carries explicit purchase intent and pairs well with comparison pages, deal hubs, or seasonal campaigns.
 
 ### 8. .deals — promotions and discounts
 
-`.deals` is also operated by Identity Digital and is open to all registrants ([ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/deals)). For an e-commerce brand that runs frequent sales, "yourbrand.deals" is a memorable home for clearance pages and coupon landing pages — and a useful one to hold so it cannot be weaponized in a fake-discount scam. It is unlinked here as `.deals` is not in the allow-list.
+[`.deals`](/en/tld/deals) is also operated by Identity Digital and is open to all registrants ([ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/deals)). For an e-commerce brand that runs frequent sales, "yourbrand.deals" is a memorable home for clearance pages and coupon landing pages — and a useful one to hold so it cannot be weaponized in a fake-discount scam.
 
 ### 9. [.club](/en/tld/club) — community and membership
 
-`.club` is a generic TLD that [launched to the public in 2014](https://en.wikipedia.org/wiki/.club) and is now operated by GoDaddy Registry, with no general registration restrictions ([ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/club)). If your store runs a loyalty program, subscription tier, or members-only drop, `.club` frames it perfectly.
+[`.club`](/en/tld/club) is a generic TLD that [launched to the public in 2014](https://en.wikipedia.org/wiki/.club) and is now operated by GoDaddy Registry, with no general registration restrictions ([ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/club)). If your store runs a loyalty program, subscription tier, or members-only drop, `.club` frames it perfectly.
 
 ### 10. [.vip](/en/tld/vip) — premium tiers and exclusivity
 
-`.vip` is a generic TLD that [launched in 2016](https://en.wikipedia.org/wiki/.vip) — originally under Minds + Machines and now part of GoDaddy Registry — and is open to all ([ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/vip)). It is a strong choice for premium product lines, early-access programs, or high-value customer portals where exclusivity is part of the pitch.
+[`.vip`](/en/tld/vip) is a generic TLD that [launched in 2016](https://en.wikipedia.org/wiki/.vip) — originally under Minds + Machines and now part of GoDaddy Registry — and is open to all ([ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/vip)). It is a strong choice for premium product lines, early-access programs, or high-value customer portals where exclusivity is part of the pitch.
 
 ## Defensive registration strategy
 

--- a/content/blog/en/top-tlds-to-secure-for-your-fashion-brand.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-fashion-brand.md
@@ -44,19 +44,19 @@ You do not need hundreds of domains. You need the canonical `.com`, a small clus
 
 ### 6. .co — the short, premium alternative
 
-`.co` is the country-code domain for Colombia, managed by Colombia's [Ministry of Information and Communications Technologies (MinTIC)](https://www.iana.org/domains/root/db/co.html) with technical operations by CentralNic, but it is marketed and used globally as a short stand-in for "company" or "commerce." Many fashion startups adopt `.co` when the `.com` is unavailable. Registration is open worldwide; because it is a ccTLD operated under a national authority, review the registry's terms before relying on it as your sole storefront.
+[.co](/en/tld/co) is the country-code domain for Colombia, managed by Colombia's [Ministry of Information and Communications Technologies (MinTIC)](https://www.iana.org/domains/root/db/co.html) with technical operations by CentralNic, but it is marketed and used globally as a short stand-in for "company" or "commerce." Many fashion startups adopt `.co` when the `.com` is unavailable. Registration is open worldwide; because it is a ccTLD operated under a national authority, review the registry's terms before relying on it as your sole storefront.
 
 ### 7. .fashion — category-defining relevance
 
-`.fashion` is operated by [Registry Services, LLC](https://www.iana.org/domains/root/db/fashion.html) (GoDaddy Registry) and is the most on-the-nose extension for the industry. It instantly communicates your sector and is excellent for a brand statement, an editorial hub, or a designer portfolio. It is open to all registrants with no industry-membership restriction. (It is not on Namefi's internal directory, so it is referenced here without a link.)
+[.fashion](/en/tld/fashion) is operated by [Registry Services, LLC](https://www.iana.org/domains/root/db/fashion.html) (GoDaddy Registry) and is the most on-the-nose extension for the industry. It instantly communicates your sector and is excellent for a brand statement, an editorial hub, or a designer portfolio. It is open to all registrants with no industry-membership restriction.
 
 ### 8. .boutique — for curated, upscale labels
 
-`.boutique` is run by [Binky Moon, LLC](https://www.iana.org/domains/root/db/boutique.html) under Identity Digital. The word itself connotes curated, small-batch, premium retail—exactly the positioning many independent fashion houses want. It suits a capsule collection or a high-touch concept store and has no special eligibility rules.
+[.boutique](/en/tld/boutique) is run by [Binky Moon, LLC](https://www.iana.org/domains/root/db/boutique.html) under Identity Digital. The word itself connotes curated, small-batch, premium retail—exactly the positioning many independent fashion houses want. It suits a capsule collection or a high-touch concept store and has no special eligibility rules.
 
 ### 9. .style — lifestyle and editorial angle
 
-`.style` is also a [Binky Moon, LLC](https://www.iana.org/domains/root/db/style.html) / Identity Digital extension. It leans editorial and aspirational, making it a natural fit for a styling service, a trend journal, or an influencer-led sub-brand. Open registration, no restrictions—useful both as an active property and a defensive hold.
+[.style](/en/tld/style) is also a [Binky Moon, LLC](https://www.iana.org/domains/root/db/style.html) / Identity Digital extension. It leans editorial and aspirational, making it a natural fit for a styling service, a trend journal, or an influencer-led sub-brand. Open registration, no restrictions—useful both as an active property and a defensive hold.
 
 ### 10. .vip — exclusivity and loyalty
 

--- a/content/blog/en/top-tlds-to-secure-for-your-law-firm.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-law-firm.md
@@ -6,17 +6,17 @@ tags: ['tld', 'domains']
 authors: ['namefiteam']
 draft: false
 ogImage: ../../assets/top-tlds-to-secure-for-your-law-firm-og.jpg
-description: 'The top 10 TLDs to secure for your law firm, including which legal TLDs like .law and .esq are restricted to verified attorneys, plus a defensive strategy.'
-keywords: ['tlds for law firms', 'best domains for lawyers', '.law domain', '.esq domain restrictions', 'legal domain extensions', 'defensive domain registration', 'attorney domain names', 'law firm branding', 'restricted legal TLDs', 'register law firm domains']
+description: 'The top 10 TLDs to secure for your law firm, including why .law is the only legal TLD restricted to verified attorneys (while .esq, .legal, .attorney, and .lawyer are open), plus a defensive strategy.'
+keywords: ['tlds for law firms', 'best domains for lawyers', '.law domain', 'is .esq restricted', 'legal domain extensions', 'defensive domain registration', 'attorney domain names', 'law firm branding', 'restricted legal TLDs', 'register law firm domains']
 ---
 
 For a law firm, a domain name is more than an address — it is a trust signal. Clients judge credibility in seconds, and a clean, professional domain on a recognized extension does quiet work that a brochure cannot. Securing the right set of **TLDs for your law firm** protects the names that matter most: your firm, your partners, and the practice areas you want to rank for.
 
-There is also a defensive dimension. If you only register `.com`, nothing stops a competitor, a disgruntled party, or a typosquatter from grabbing the same name on `.net`, `.law`, or a misspelling. Buying a handful of relevant extensions up front is far cheaper than litigating a cybersquatting dispute later, and it keeps your brand consistent across the web.
+There is also a defensive dimension. If you only register [`.com`](/en/tld/com), nothing stops a competitor, a disgruntled party, or a typosquatter from grabbing the same name on [`.net`](/en/tld/net), [`.law`](/en/tld/law), or a misspelling. Buying a handful of relevant extensions up front is far cheaper than litigating a cybersquatting dispute later, and it keeps your brand consistent across the web.
 
 ## How to choose TLDs for your law firm
 
-Three criteria matter most. First, **trust signals**: extensions like `.com` and the verified legal TLDs carry instant professional weight. Second, **restricted "verified" TLDs**: some legal extensions (notably `.law` and `.esq`) require proof of legal credentials, which is a feature — it signals to clients that the registrant was vetted. Third, **defensive coverage**: register the obvious variants and partner names so no one else can. You do not need every extension on the internet; you need the few your clients and competitors would actually look for.
+Three criteria matter most. First, **trust signals**: extensions like `.com` and the legal-themed TLDs carry instant professional weight. Second, **restricted "verified" TLDs**: among the legal extensions, only `.law` actually gates registration behind proof of legal credentials, which is a feature — it signals to clients that the registrant was vetted. Despite being marketed to lawyers, [`.esq`](/en/tld/esq) is openly available with no registry-level credential check, as are [`.legal`](/en/tld/legal), [`.attorney`](/en/tld/attorney), and [`.lawyer`](/en/tld/lawyer). Third, **defensive coverage**: register the obvious variants and partner names so no one else can. You do not need every extension on the internet; you need the few your clients and competitors would actually look for.
 
 ## The top 10 TLDs to secure for your law firm
 
@@ -28,13 +28,13 @@ Three criteria matter most. First, **trust signals**: extensions like `.com` and
 
 `.law` signals an authenticated legal identity, but it is a **restricted TLD**. Registration is limited to qualified lawyers, law firms, and legal regulators who can be verified as licensed to practice, and the registry uses independent validation and may request proof of eligibility at any time, per the registry's [eligibility requirements](https://www.namecheap.com/support/knowledgebase/article.aspx/10378/35/law-domain-registration-requirements/). The TLD is operated by [Registry Services, LLC (GoDaddy Registry)](https://www.iana.org/domains/root/db/law.html). Do not assume just anyone can register one.
 
-### 3. .esq — a credentialed extension for attorneys (RESTRICTED)
+### 3. .esq — an attorney-branded extension (OPEN)
 
-`.esq` (for "Esquire") is aimed at individual attorneys and legal professionals, and it is **restricted** to registrants who can verify their legal status; registrars are required to confirm eligibility before registration. It is operated by [Charleston Road Registry (Google Registry)](https://www.iana.org/domains/root/db/esq.html); see [Google Registry's .esq page](https://www.registry.google/tlds/esq/) for the registry operator's positioning. As with `.law`, eligibility verification is a gating requirement.
+`.esq` (for "Esquire") is marketed to individual attorneys and legal professionals, but contrary to common belief it is **not** credential-gated — there is no registry-level verification of legal status, so anyone can register one. It is operated by [Charleston Road Registry (Google Registry)](https://www.iana.org/domains/root/db/esq.html) and, like Google's other TLDs, is served HTTPS-only via [HSTS preloading](https://hstspreload.org/); see [Google Registry's .esq page](https://www.registry.google/tlds/esq/) for the registry operator's positioning. Because it is open, register it defensively rather than assuming the credential bar protects your name.
 
 ### 4. .legal — a descriptive, openly available option
 
-`.legal` reads clearly and works for firms, legal-tech products, and resource sites. Unlike `.law` and `.esq`, `.legal` is **not** subject to verified-credential restrictions and is openly available to register, per its [IANA root entry](https://www.iana.org/domains/root/db/legal.html) and [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/legal). It is a strong, unrestricted alternative if you want a legal-themed name without the verification step.
+`.legal` reads clearly and works for firms, legal-tech products, and resource sites. Unlike `.law`, `.legal` is **not** subject to verified-credential restrictions and is openly available to register, per its [IANA root entry](https://www.iana.org/domains/root/db/legal.html) and [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/legal). It is a strong, unrestricted alternative if you want a legal-themed name without the verification step.
 
 ### 5. .attorney — practice-specific and unrestricted
 
@@ -46,7 +46,7 @@ Three criteria matter most. First, **trust signals**: extensions like `.com` and
 
 ### 7. [.abogado](/en/tld/abogado) — reach Spanish-speaking clients
 
-`.abogado` ("lawyer" in Spanish) is a smart pick for firms serving Hispanic and Latino communities or operating in Spanish-speaking markets. It is openly available; see its [IANA root entry](https://www.iana.org/domains/root/db/abogado.html) and [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/abogado). A focused way to signal language and cultural fit.
+[`.abogado`](/en/tld/abogado) ("lawyer" in Spanish) is a smart pick for firms serving Hispanic and Latino communities or operating in Spanish-speaking markets. It is openly available; see its [IANA root entry](https://www.iana.org/domains/root/db/abogado.html) and [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/abogado). A focused way to signal language and cultural fit.
 
 ### 8. [.net](/en/tld/net) — the classic defensive backup
 
@@ -54,11 +54,11 @@ Three criteria matter most. First, **trust signals**: extensions like `.com` and
 
 ### 9. [.org](/en/tld/org) — for nonprofits, clinics, and associations
 
-`.org` carries connotations of mission and public service — fitting for legal aid organizations, bar-adjacent groups, and pro bono initiatives, and worth securing defensively even for commercial firms. It is administered by [Public Interest Registry](https://www.iana.org/domains/root/db/org.html). It rounds out the legacy trio alongside `.com` and `.net`.
+[`.org`](/en/tld/org) carries connotations of mission and public service — fitting for legal aid organizations, bar-adjacent groups, and pro bono initiatives, and worth securing defensively even for commercial firms. It is administered by [Public Interest Registry](https://www.iana.org/domains/root/db/org.html). It rounds out the legacy trio alongside `.com` and `.net`.
 
 ### 10. [.info](/en/tld/info) — for client-facing resources
 
-`.info` suits FAQ hubs, practice-area explainers, and intake resources where the name should say "information." It is an inexpensive defensive registration and a flexible home for content. See its [IANA root entry](https://www.iana.org/domains/root/db/info.html) for delegation details.
+[`.info`](/en/tld/info) suits FAQ hubs, practice-area explainers, and intake resources where the name should say "information." It is an inexpensive defensive registration and a flexible home for content. See its [IANA root entry](https://www.iana.org/domains/root/db/info.html) for delegation details.
 
 ## Defensive registration strategy
 
@@ -76,7 +76,7 @@ Namefi also supports Web3 domain tokenization, letting you hold eligible domains
 
 ### Can any law firm register a .law domain?
 
-No. `.law` is a restricted TLD. Registration is limited to qualified lawyers, law firms, and legal regulators who can be verified as licensed to practice law, and the registry uses an independent validator and may request proof of eligibility at any time, per the registry's [eligibility requirements](https://www.namecheap.com/support/knowledgebase/article.aspx/10378/35/law-domain-registration-requirements/). `.esq` is similarly restricted to verified legal professionals. By contrast, `.legal`, `.attorney`, and `.lawyer` are open to anyone.
+No. `.law` is a restricted TLD. Registration is limited to qualified lawyers, law firms, and legal regulators who can be verified as licensed to practice law, and the registry uses an independent validator and may request proof of eligibility at any time, per the registry's [eligibility requirements](https://www.namecheap.com/support/knowledgebase/article.aspx/10378/35/law-domain-registration-requirements/). Among the legal-themed extensions, `.law` is the only one that gates registration this way. Despite being marketed to attorneys, `.esq` is **not** credential-gated, and `.legal`, `.attorney`, and `.lawyer` are likewise open to anyone.
 
 ### Does the TLD I choose affect my SEO?
 
@@ -88,4 +88,4 @@ There is no fixed number, but most firms are well served by their primary `.com`
 
 ### Should I register a legal TLD I am not yet eligible for?
 
-If you cannot pass eligibility verification for a restricted TLD like `.law` or `.esq`, you cannot register it — the [registry verifies credentials](https://www.iana.org/domains/root/db/law.html) before and after registration. Focus your defensive budget on the unrestricted extensions you can control today, such as `.legal`, `.attorney`, `.lawyer`, and `.com`.
+If you cannot pass eligibility verification for `.law` — the one restricted legal TLD — you cannot register it, because the [registry verifies credentials](https://www.iana.org/domains/root/db/law.html) before and after registration. The other legal-themed extensions have no such gate: focus your defensive budget on the unrestricted ones you can control today, such as `.esq`, `.legal`, `.attorney`, `.lawyer`, and `.com`.

--- a/content/blog/en/top-tlds-to-secure-for-your-real-estate-business.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-real-estate-business.md
@@ -12,11 +12,11 @@ keywords: ['tlds for realtors', 'real estate domain names', '.realtor domain', '
 
 Your name and your local brand are the two most valuable assets in real estate. When a buyer searches for "Jane Smith Realtor" or for the name of the neighborhood you farm, the domains tied to those terms should point to you — not to a competitor, a lookalike, or a parked page running ads. That is why securing more than one **TLD (top-level domain)** for your real estate business is one of the cheapest forms of brand insurance you can buy.
 
-A realtor who only owns the `.com` of their name leaves the door open for someone else to register the `.realty`, `.homes`, or `.house` version and trade on the reputation you built. Registering a small portfolio of the right top-level domains lets you protect your local brand, spin up clean subbrands for listings or farm areas, and shut down obvious impersonation before it starts. This guide walks through the best TLDs for realtors, the eligibility rules that matter, and a simple defensive strategy.
+A realtor who only owns the [`.com`](/en/tld/com) of their name leaves the door open for someone else to register the [`.realty`](/en/tld/realty), [`.homes`](/en/tld/homes), or [`.house`](/en/tld/house) version and trade on the reputation you built. Registering a small portfolio of the right top-level domains lets you protect your local brand, spin up clean subbrands for listings or farm areas, and shut down obvious impersonation before it starts. This guide walks through the best TLDs for realtors, the eligibility rules that matter, and a simple defensive strategy.
 
 ## How to choose TLDs for your real estate business
 
-A few criteria should drive every registration. **Trust** comes first: the extensions buyers recognize (`.com` above all) carry the least friction. **Geographic and industry relevance** comes next — real-estate-specific endings like `.realtor`, `.realty`, and `.homes` signal what you do at a glance. Some of the most credible options are **restricted "verified" TLDs**: `.realtor` requires a qualifying relationship with the National Association of REALTORS®, which is exactly what makes owning one a trust signal. Finally, **defensive coverage** means grabbing the obvious lookalikes of your primary name so no one else can. You do not need all of these — pick your anchor `.com`, add one or two industry endings, and round out with defensive picks.
+A few criteria should drive every registration. **Trust** comes first: the extensions buyers recognize (`.com` above all) carry the least friction. **Geographic and industry relevance** comes next — real-estate-specific endings like [`.realtor`](/en/tld/realtor), `.realty`, and `.homes` signal what you do at a glance. Some of the most credible options are **restricted "verified" TLDs**: `.realtor` requires a qualifying relationship with the National Association of REALTORS®, which is exactly what makes owning one a trust signal. Finally, **defensive coverage** means grabbing the obvious lookalikes of your primary name so no one else can. You do not need all of these — pick your anchor `.com`, add one or two industry endings, and round out with defensive picks.
 
 ## The top 10 TLDs to secure as a realtor
 
@@ -34,7 +34,7 @@ A few criteria should drive every registration. **Trust** comes first: the exten
 
 ### 4. .estate — broad and brandable
 
-`.estate` works well for luxury, commercial, and estate-focused practices, and reads naturally in a brand like `harborview.estate`. It is an unrestricted generic TLD, so registration is open to anyone. See its delegation record in the [IANA root database](https://www.iana.org/domains/root/db/estate.html).
+[`.estate`](/en/tld/estate) works well for luxury, commercial, and estate-focused practices, and reads naturally in a brand like `harborview.estate`. It is an unrestricted generic TLD, so registration is open to anyone. See its delegation record in the [IANA root database](https://www.iana.org/domains/root/db/estate.html).
 
 ### 5. .homes — listing- and consumer-friendly
 
@@ -42,7 +42,7 @@ A few criteria should drive every registration. **Trust** comes first: the exten
 
 ### 6. .properties — for portfolios and teams
 
-`.properties` suits agents and teams managing multiple listings or a property portfolio, and it reinforces a professional, inventory-driven brand. Like most new gTLDs it is unrestricted. The TLD is recorded in the [IANA root database](https://www.iana.org/domains/root/db/properties.html).
+[`.properties`](/en/tld/properties) suits agents and teams managing multiple listings or a property portfolio, and it reinforces a professional, inventory-driven brand. Like most new gTLDs it is unrestricted. The TLD is recorded in the [IANA root database](https://www.iana.org/domains/root/db/properties.html).
 
 ### 7. .house — short, memorable, flexible
 
@@ -50,15 +50,15 @@ A few criteria should drive every registration. **Trust** comes first: the exten
 
 ### 8. [.net](/en/tld/net) — the classic defensive backup
 
-`.net` is one of the oldest and most recognized extensions, making it the natural defensive companion to your `.com`. Owning it prevents a competitor from picking up the obvious second choice on your name. It is operated by Verisign under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/net).
+[`.net`](/en/tld/net) is one of the oldest and most recognized extensions, making it the natural defensive companion to your `.com`. Owning it prevents a competitor from picking up the obvious second choice on your name. It is operated by Verisign under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/net).
 
 ### 9. [.org](/en/tld/org) — credibility for associations and community work
 
-`.org` carries a trustworthy, community-oriented tone that fits realtor associations, neighborhood resources, and non-commercial projects you run alongside your practice. Registering it also keeps it out of impersonators' hands. The `.org` TLD is documented in the [IANA root database](https://www.iana.org/domains/root/db/org.html).
+[`.org`](/en/tld/org) carries a trustworthy, community-oriented tone that fits realtor associations, neighborhood resources, and non-commercial projects you run alongside your practice. Registering it also keeps it out of impersonators' hands. The `.org` TLD is documented in the [IANA root database](https://www.iana.org/domains/root/db/org.html).
 
 ### 10. [.vip](/en/tld/vip) — premium positioning for top clients
 
-`.vip` signals exclusivity, which can fit a luxury practice or a private client portal like `clients.yourname.vip`. It is unrestricted and short, so it stands out on a business card. Its registry agreement is published by [ICANN](https://www.icann.org/en/registry-agreements/details/vip).
+[`.vip`](/en/tld/vip) signals exclusivity, which can fit a luxury practice or a private client portal like `clients.yourname.vip`. It is unrestricted and short, so it stands out on a business card. Its registry agreement is published by [ICANN](https://www.icann.org/en/registry-agreements/details/vip).
 
 ## Defensive registration strategy
 

--- a/content/blog/en/top-tlds-to-secure-for-your-saas.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-saas.md
@@ -54,7 +54,7 @@ Pick TLDs against three filters: **brand fit** (does the extension reinforce wha
 
 ### 9. .co — the short, brandable alternate to .com
 
-.co is the ccTLD for Colombia, [delegated by IANA](https://www.iana.org/domains/root/db/co.html), but marketed and used globally as a short stand-in for "company" or ".com." Many startups adopt it when the `.com` is taken. It is brandable and memorable, though because of its visual similarity to `.com` you should secure both to avoid misdirected traffic.
+[.co](/en/tld/co) is the ccTLD for Colombia, [delegated by IANA](https://www.iana.org/domains/root/db/co.html), but marketed and used globally as a short stand-in for "company" or ".com." Many startups adopt it when the `.com` is taken. It is brandable and memorable, though because of its visual similarity to `.com` you should secure both to avoid misdirected traffic.
 
 ### 10. .xyz — flexible and widely adopted
 

--- a/content/blog/en/top-tlds-to-secure-for-your-startup.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-startup.md
@@ -42,7 +42,7 @@ Focus on four criteria. **Relevance**: does the suffix signal what you do (a dev
 
 ### 6. .tech — descriptive and broadly available
 
-.tech is a generic TLD operated by [Radix](https://radix.com/), one of the largest new-gTLD registries, with technical backend services provided by Tucows. It plainly labels your company as technology-focused and tends to have wider availability than the crowded .com space, which can help when your ideal exact-match .com is taken. There are no special eligibility restrictions for .tech.
+[.tech](/en/tld/tech) is a generic TLD operated by [Radix](https://radix.com/), one of the largest new-gTLD registries, with technical backend services provided by Tucows. It plainly labels your company as technology-focused and tends to have wider availability than the crowded .com space, which can help when your ideal exact-match .com is taken. There are no special eligibility restrictions for .tech.
 
 ### 7. .xyz — flexible and startup-friendly
 
@@ -50,7 +50,7 @@ Focus on four criteria. **Relevance**: does the suffix signal what you do (a dev
 
 ### 8. .co — the short stand-in for .com
 
-.co is widely read as shorthand for "company," "corporation," or "commerce," and it is short enough to be highly memorable. It is the country-code TLD for Colombia; in 2025 the operating contract [transferred to a new consortium](https://domainnamewire.com/2025/06/12/big-new-godaddy-loses-co-contract-to-tig-partnership/) involving Team Internet, as shown in its [IANA record](https://www.iana.org/domains/root/db/co.html). Registration is open globally, making .co a popular fallback when the matching .com is unavailable.
+[.co](/en/tld/co) is widely read as shorthand for "company," "corporation," or "commerce," and it is short enough to be highly memorable. It is the country-code TLD for Colombia; in 2025 the operating contract [transferred to a new consortium](https://domainnamewire.com/2025/06/12/big-new-godaddy-loses-co-contract-to-tig-partnership/) involving Team Internet, as shown in its [IANA record](https://www.iana.org/domains/root/db/co.html). Registration is open globally, making .co a popular fallback when the matching .com is unavailable.
 
 ### 9. .net — the classic backup
 

--- a/content/tld/en/accountant.md
+++ b/content/tld/en/accountant.md
@@ -1,0 +1,153 @@
+---
+title: 'What Is the .accountant Domain? The Finance Niche TLD Explained'
+date: '2026-06-15'
+language: 'en'
+tags: ['tld']
+authors: ['namefiteam']
+draft: false
+description: 'The .accountant domain is an open new gTLD for accountants, bookkeepers, and finance professionals. Learn who runs it, who can register, and whether it suits your brand.'
+keywords: ['.accountant domain', 'what is .accountant', '.accountant TLD', 'accountant domain name', 'finance domain extension', 'new gTLD for accountants', 'register .accountant', 'bookkeeping website domain']
+faqs:
+  - question: 'Can anyone register a .accountant domain?'
+    answer: 'Yes. .accountant is an open, unrestricted new gTLD. You do not need to be a chartered accountant, CPA, or hold any professional credential to register one, and there is no local-presence requirement.'
+  - question: 'Does a .accountant domain affect SEO?'
+    answer: 'No. Google treats new gTLDs like .accountant the same as legacy extensions such as .com, with no inherent ranking boost or penalty. Rankings depend on content, links, and user experience, not the suffix.'
+  - question: 'Who should register a .accountant domain?'
+    answer: 'Accountants, bookkeepers, tax preparers, audit firms, and finance-focused software or content businesses that want a descriptive, keyword-relevant web address and find their preferred .com name is taken or expensive.'
+  - question: 'Is .accountant the same as .accountants?'
+    answer: 'No. They are two separate top-level domains. .accountant is singular and .accountants is plural; they have different registry operators and separate name inventories, so a name available on one may be taken or unavailable on the other.'
+  - question: 'Who operates the .accountant registry?'
+    answer: 'The ICANN Registry Agreement for .accountant is held by dot Accountant Limited, a Gibraltar entity from the Famous Four Media portfolio. Technical registry operations have since been run by Global Registry Services (GRS Domains).'
+---
+
+The **.accountant domain** is a niche new generic top-level domain (gTLD) built for one of the world's most established professions: accounting. It lets accountants, bookkeepers, tax advisers, and audit firms put their specialty directly in the web address — `yourname.accountant` — instead of competing for an ever-scarcer `.com`.
+
+If you are weighing whether a descriptive extension is worth it, this page covers what `.accountant` is, who runs it, who can register one, how it is perceived, and how it compares to the alternatives — including its near-identical plural cousin, `.accountants`.
+
+## .accountant at a glance
+
+| Fact | Detail |
+| --- | --- |
+| TLD type | New gTLD (generic, not geo-targeted) |
+| Registry operator | dot Accountant Limited (Famous Four Media lineage); operated by Global Registry Services / GRS Domains |
+| Year launched | Delegated 2015; general availability November 2015 |
+| IDN support | Yes (internationalized domain names supported) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no credential, license, or local presence required |
+| Best for | Accountants, bookkeepers, tax and audit firms, finance content and tools |
+
+## What is .accountant?
+
+`.accountant` is a **generic top-level domain**, one of hundreds of new gTLDs delegated through ICANN's New gTLD Program in the mid-2010s. Unlike a country-code TLD such as `.uk` or `.de`, it carries no geographic meaning, so Google treats it as a generic extension with no built-in geo-targeting. The suffix is simply the English word "accountant" — a self-describing label that tells a visitor what the site is about before they read a single line.
+
+You can confirm its delegation and technical details in the official [IANA root-zone record for .accountant](https://www.iana.org/domains/root/db/accountant.html). On the SEO question, Google's [Search Central](https://developers.google.com/search/docs/crawling-indexing/special-tags) guidance is the authority: new gTLDs are ranked on the same footing as legacy ones.
+
+A point worth stressing up front: `.accountant` (singular) and `.accountants` (plural) are **two distinct top-level domains** with different operators and separate name pools. Registering one does not reserve the other — see [.accountants](/en/tld/accountants) for the plural counterpart.
+
+## History of .accountant
+
+`.accountant` was part of the large portfolio assembled by **Famous Four Media (FFM)**, a registry group that applied for dozens of generic strings in ICANN's 2012 round. Its ICANN Registry Agreement is held by **dot Accountant Limited**, a Gibraltar-registered entity, with the base agreement dated late 2014. The string was delegated to the DNS root in 2015 and reached general availability in November 2015.
+
+The operator picture has shifted since launch. After disputes within the Famous Four Media group, technical and commercial operation of FFM's strings — `.accountant` among them, alongside siblings like `.loan`, `.download`, `.science`, and `.review` — moved to **Global Registry Services (GRS Domains)**. So while the registry agreement still names dot Accountant Limited, day-to-day backend operation has run through GRS. This lineage matters because the FFM/GRS family historically priced aggressively to drive volume, shaping both the affordability and the reputation of these extensions (more below). There are no headline multi-million-dollar sales tied to `.accountant`; it has been a steady, utilitarian extension rather than a speculative one.
+
+## How people use .accountant
+
+The suffix reads as a finished noun, so the most natural use is a brand or surname followed by the extension. Common real-world patterns include:
+
+- **Solo practitioners and small firms** — swapping clunky names like `smith-and-co-accounting.com` for a cleaner `smith.accountant`.
+- **Bookkeepers and tax preparers** wanting an instantly descriptive address for local clients.
+- **Audit, advisory, and forensic-accounting specialists** differentiating from generic financial-planning sites.
+- **Finance content and tools** — blogs, calculators, and small SaaS products aimed at the accounting audience.
+- **Descriptive domain hacks** — phrases that complete naturally, such as `the.accountant`, read aloud as a sentence.
+
+**Who it's not ideal for:** large brands whose audience already knows them by their `.com`; businesses outside finance (the word is too specific to repurpose); and anyone whose customers default-type `.com` regardless.
+
+## Notable sites using .accountant
+
+`.accountant` is used mostly by independent practitioners and small firms rather than household-name companies, so it has no globally famous flagship site the way [.io](/en/tld/io) or [.ai](/en/tld/ai) do. Its honest, typical use is exactly what the name implies: individual accountants and boutique firms running their primary or campaign site on a `yourname.accountant` address, plus the registry's own reference pages at `nic.accountant`. Rather than cite a private firm that may lapse, the accurate description is that this is a working professional's extension, not a showcase of marquee brands.
+
+## .accountant vs other domains
+
+| Extension | Meaning | Restrictions | Best fit |
+| --- | --- | --- | --- |
+| .accountant | Singular profession label | Open to all | Individual accountants, small firms |
+| [.accountants](/en/tld/accountants) | Plural profession label | Open to all | Multi-partner firms, the broader trade |
+| [.com](/en/tld/com) | Generic, universal | Open to all | Default mainstream choice, maximum recall |
+
+Pick `.com` when broad recognition matters most. Choose `.accountant` for a descriptive, on-topic address when your ideal `.com` is taken or costly. Choose `.accountants` if the plural reads better for a multi-partner firm — and consider holding both to prevent confusion.
+
+## Why choose .accountant?
+
+- **Descriptive by design.** The address states the profession, improving click-through from listings and cards where context is short.
+- **Availability.** Short, exact-match names long gone under `.com` are frequently still open under `.accountant`.
+- **Affordable positioning.** This family has historically been priced to encourage registration, lowering the barrier to a memorable name.
+- **No gatekeeping.** Being unrestricted, you can register and launch immediately without credentials or verification.
+
+## Things to consider
+
+- **Default-typing bias.** Many users still assume `.com`, so you may lose direct type-in traffic to a `.com` you don't own.
+- **Niche meaning.** The word locks you into accounting — great for focus, limiting if you pivot.
+- **Singular/plural confusion.** `.accountant` and `.accountants` are easy to mix up; clients may land on the wrong one.
+- **Family reputation.** The FFM/GRS low-cost extensions have at times attracted spam, affecting how filters perceive the cohort (see Reputation below).
+
+## Who can register a .accountant domain?
+
+**Registration restrictions: open to all.** `.accountant` is an unrestricted, open new gTLD. You do **not** need to be a chartered or certified accountant, hold a CPA or ACCA credential, belong to a professional body, or have any local presence to register one. This is a key difference from credential-gated professional TLDs such as `.cpa`, where eligibility is verified.
+
+Standard new-gTLD mechanics apply: a sunrise period for trademark holders ran at launch, names follow the usual length and IDN rules, DNSSEC is supported, and WHOIS, transfer, renewal, and redemption-grace behavior follow standard ICANN registry/registrar practice. The authoritative source is the [ICANN Registry Agreement for .accountant](https://www.icann.org/en/registry-agreements/details/accountant), with registry policies published at `nic.accountant`.
+
+## .accountant pricing and value
+
+This page intentionally quotes no prices, but the **dynamics** matter. Registries reserve a tier of **premium names** — short, high-demand, exact-match words — that carry higher recurring fees than standard registrations. **First-year and renewal pricing usually differ**: an introductory first-year rate rarely reflects what you'll pay annually thereafter, so always check the renewal figure before committing. Cost is driven by the registry's wholesale fee, the registrar's margin, and whether a name is flagged premium. For an extension from a historically volume-driven family, standard names sit at the accessible end of the market, while premium keywords can be considerably higher.
+
+## Reputation and email deliverability
+
+This is the most important caveat for `.accountant`. The broader Famous Four Media / GRS family of low-cost new gTLDs (`.loan`, `.download`, `.science`, `.review`, and others) has historically appeared on abuse and spam reports, partly because rock-bottom pricing attracted bulk and throwaway registrations. As a result, some spam filters have at times applied extra scrutiny to mail and links from these extensions.
+
+That does not doom a legitimate `.accountant` site, but be deliberate: authenticate email with SPF, DKIM, and DMARC; warm up any new sending domain; maintain clean sending practices; and monitor blocklists. A well-run, authenticated `.accountant` domain can deliver reliably — but you start from a more skeptical baseline than on a long-trusted `.com`.
+
+## Branding and naming tips
+
+- **Lean into the sentence.** Names that read aloud naturally — `the.accountant`, `your.accountant` — are the strongest hooks.
+- **Keep the label short.** A brand or surname plus `.accountant` is already long; brevity before the dot aids recall and typing.
+- **Mind the singular/plural trap.** Decide early between `.accountant` and `.accountants`, and if budget allows secure both plus the matching `.com`.
+- **Watch pronunciation.** Said aloud, listeners may still assume `.com` — reinforce the full address in print and audio.
+
+## How to register a .accountant domain at Namefi
+
+1. **Search** for your desired name on [Namefi](https://namefi.io) to check availability across `.accountant` and related extensions.
+2. **Choose** the exact name and review whether it is a standard or premium registration, and note the renewal terms.
+3. **Register** and configure DNS — and, if you want it, mint your domain as an on-chain asset.
+
+Namefi is an ICANN-accredited registrar with transparent pricing, fast DNS, and optional Web3 tokenization, so you can hold a `.accountant` name as a portable, verifiable digital asset. Get started at [Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .accountant domain?
+
+Yes. `.accountant` is an open, unrestricted new gTLD. You do not need to be a chartered accountant, CPA, or hold any professional credential to register one, and there is no local-presence requirement.
+
+### Does a .accountant domain affect SEO?
+
+No. Google treats new gTLDs like `.accountant` the same as legacy extensions such as `.com`, with no inherent ranking boost or penalty. Rankings depend on content, links, and user experience, not the suffix.
+
+### Who should register a .accountant domain?
+
+Accountants, bookkeepers, tax preparers, audit firms, and finance-focused software or content businesses that want a descriptive, keyword-relevant web address and find their preferred `.com` name is taken or expensive.
+
+### Is .accountant the same as .accountants?
+
+No. They are two separate top-level domains. `.accountant` is singular and `.accountants` is plural; they have different registry operators and separate name inventories, so a name available on one may be taken or unavailable on the other.
+
+### Who operates the .accountant registry?
+
+The ICANN Registry Agreement for `.accountant` is held by dot Accountant Limited, a Gibraltar entity from the Famous Four Media portfolio. Technical registry operations have since been run by Global Registry Services (GRS Domains).
+
+## Related resources
+
+- [.accountants](/en/tld/accountants) — the plural professional extension and its differences
+- [.com](/en/tld/com) — the mainstream default to compare against
+- [What is a domain?](/en/blog/what-is-domain) — the fundamentals of domain names
+- [Domain terminology guide](/en/blog/domain-terminology-guide) — TLDs, gTLDs, and registry terms explained
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains) — holding a domain as an on-chain asset
+- [ICANN](/en/glossary/icann) and [registrar](/en/glossary/registrar) — key registration terms

--- a/content/tld/en/attorney.md
+++ b/content/tld/en/attorney.md
@@ -1,0 +1,160 @@
+---
+title: 'What Is the .attorney Domain? A Legal-Sector TLD Explained'
+date: '2026-06-15'
+language: 'en'
+tags: ['tld']
+authors: ['namefiteam']
+draft: false
+description: 'The .attorney domain is an open new gTLD built for the legal profession. Learn who runs it, who can register, how it ranks, and whether it suits your firm.'
+keywords: ['.attorney domains', 'what is .attorney', '.attorney TLD', 'attorney domain extension', 'legal domain names', 'law firm domains', 'lawyer website domain', 'Identity Digital TLD']
+faqs:
+  - question: 'Can anyone register a .attorney domain?'
+    answer: 'Yes. The .attorney domain is an open generic TLD with no credential or bar-membership requirement. Anyone can register one, though it is naturally aimed at attorneys, law firms, and legal-service providers. This makes it different from gated legal TLDs that verify licensure.'
+  - question: 'Does a .attorney domain affect SEO?'
+    answer: 'Google treats .attorney like any other generic TLD, so the extension itself gives no inherent ranking boost or penalty. Rankings come from content, links, and user experience. A descriptive .attorney name can improve click-through by signaling the site is legal-related.'
+  - question: 'Who should register a .attorney domain?'
+    answer: 'It suits solo practitioners, boutique and mid-size law firms, legal-tech startups, and legal marketers who want a descriptive, available name. It is especially useful when the matching .com is taken, expensive, or less self-explanatory than a name ending in .attorney.'
+  - question: 'Is .attorney a verified or restricted legal TLD?'
+    answer: 'No. Unlike .law or .cpa, .attorney does not verify professional credentials. It is open to all registrants, so the suffix signals a legal focus but does not guarantee the owner is a licensed attorney.'
+  - question: 'Who operates the .attorney registry?'
+    answer: 'The .attorney registry is operated by Dog Beach, LLC, a subsidiary of Identity Digital (formerly Donuts), under an ICANN registry agreement. The TLD was delegated to the DNS root zone in 2014.'
+---
+
+The **.attorney** domain is a new generic top-level domain (new gTLD) created specifically for the legal profession. For lawyers, law firms, and legal-service businesses, it offers a self-explanatory web address that says exactly what the site is about before a visitor reads a single word. If you practice law and the matching `.com` is taken or generic, a `.attorney` name is one of the clearest ways to claim a descriptive, on-brand presence.
+
+Crucially, `.attorney` is an **open** TLD. Despite its professional focus, it does not check bar membership or any credential — so it is positioned very differently from gated legal extensions like `.law` or `.cpa`. That openness is its biggest strength and its biggest caveat, and this page covers both.
+
+## .attorney at a glance
+
+| Fact | Detail |
+| --- | --- |
+| TLD type | New gTLD (generic) |
+| Registry operator | Dog Beach, LLC (an [Identity Digital](https://www.identity.digital/) company, formerly Donuts) |
+| Year launched | Delegated to the root zone in 2014 |
+| IDN support | Supported (varies by registrar) |
+| DNSSEC | Supported |
+| Registration restrictions | **Open to all** — no credential or bar-membership requirement |
+| Best for | Lawyers, law firms, legal-tech, and legal marketers wanting a descriptive name |
+
+## What is .attorney?
+
+The word "attorney" needs no translation in the United States and most English-speaking legal markets: it is the everyday term for a licensed legal practitioner. As a domain suffix, it instantly frames a website as legal in nature, which is why it has become a popular alternative to crowded generic extensions for law-focused sites.
+
+`.attorney` is a **generic** new gTLD, not a country-code extension. According to its [IANA root-zone entry](https://www.iana.org/domains/root/db/attorney.html), it was delegated to the DNS root in 2014 as part of ICANN's New gTLD Program. Because it is generic rather than geographic, Google does not tie it to any single country. As [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites) explains, many newer gTLDs are treated as generic and can be geo-targeted in Search Console like a `.com` — the suffix carries no built-in country signal. In practice that means a `.attorney` site can rank globally and target any market you choose.
+
+## History of .attorney
+
+`.attorney` emerged from the 2012 round of ICANN's New gTLD Program, when hundreds of new suffixes were proposed to expand the namespace beyond legacy options like `.com` and `.net`. It came out of the Donuts portfolio — the prolific operator behind dozens of profession- and interest-themed extensions — and was delegated to the root zone in 2014.
+
+Its back-end registry technology was historically provided through Rightside Registry, which later [signed a multi-year extension with Donuts](https://www.globenewswire.com/news-release/2017/02/07/914675/0/en/Rightside-and-Donuts-Sign-Multi-Year-Extension-of-its-New-gTLD-Registry-Services-Agreement.html) before Donuts acquired Rightside's registry business. Donuts then rebranded as **Identity Digital**, and the registry agreement today is held by its subsidiary **Dog Beach, LLC**. The lineage is continuous: Donuts → Rightside consolidation → Identity Digital / Dog Beach. The same portfolio also includes the closely related `.lawyer` extension, giving the legal vertical two parallel open options under one operator.
+
+## How people use .attorney
+
+`.attorney` is used wherever a descriptive, legal-signaling name adds value:
+
+- **Solo and boutique firms** that want a name like `firstnamelastname.attorney` as a professional digital business card.
+- **Practice-area landing pages** — descriptive names such as `accident.attorney` or `divorce.attorney` that double as marketing keywords.
+- **Legal-tech startups** building tools, directories, or consultation platforms who want to stand out from generic `.com` tech branding.
+- **Brand-protection registrations** by larger firms that already own the `.com` and grab the `.attorney` match defensively.
+- **Microsites and campaigns** for a specific case type, location, or service offering.
+
+**Who it's not ideal for:** anyone outside the legal field — the suffix is so semantically loaded that a non-legal business would confuse visitors. It is also a weaker fit if your brand is already strongly associated with its existing `.com` and you have no descriptive angle to exploit.
+
+## Notable sites using .attorney
+
+`.attorney` adoption is concentrated among independent practices, regional firms, and practice-area marketing sites rather than household-name brands, so there is no single dominant public flagship to point to. Its typical real-world use is a small-to-mid-size law firm or solo practitioner using either a personal-name domain (`janedoe.attorney`) or a keyword-rich practice-area domain to capture local search intent. Rather than name a site that may change hands, it is more accurate to describe the pattern: descriptive, legal-focused names where the suffix itself does part of the marketing work.
+
+## .attorney vs other domains
+
+| Feature | .attorney | [.com](/en/tld/com) | .law | .abogado |
+| --- | --- | --- | --- | --- |
+| Type | New gTLD (generic) | Legacy gTLD | New gTLD (generic) | New gTLD (generic) |
+| Restrictions | Open to all | Open to all | Credential-verified (legal) | Targets Spanish-speaking legal market |
+| Legal signal | Strong | None | Strong + verified | Strong (Spanish) |
+| Audience | Lawyers / firms | Everyone | Verified legal pros | Hispanic legal market |
+
+Choose `.com` when broad familiarity and resale value matter most and your brand is not strictly legal. Choose `.law` when you want the suffix to *prove* you are a licensed practitioner, since it verifies credentials. Choose [`.abogado`](/en/tld/abogado) if your audience is Spanish-speaking. Choose `.attorney` when you want a clear, English-language legal signal, broad availability, and no verification hurdle to clear.
+
+## Why choose .attorney?
+
+- **Instant clarity.** The suffix tells visitors and search engines that the site is legal-related before they read the content.
+- **Strong availability.** Short, memorable, keyword-rich names that are long gone in `.com` are often still open in `.attorney`.
+- **Descriptive marketing.** Names like `injury.attorney` work as both a brand and a keyword phrase.
+- **No gatekeeping.** Because it is open, you can register without submitting credentials — useful for legal marketers, paralegal services, and firms alike.
+- **Brand protection.** Firms can secure the `.attorney` match to keep competitors and impersonators away from an obvious variant.
+
+## Things to consider
+
+`.attorney` is not the right tool for every situation, and an honest buyer should weigh the trade-offs:
+
+- **It is a longer suffix.** "attorney" is eight characters, so full addresses can run long; pair it with a short second-level name.
+- **Openness cuts both ways.** Because it does not verify credentials, the suffix signals a legal focus but does not *prove* licensure the way `.law` does — visitors who care about that distinction may not notice it.
+- **Lower recognition than .com.** Some users still default to typing `.com`, so you may want to own the `.com` defensively or use redirects.
+- **Niche by design.** Outside the legal field the name makes no sense, which is the point but also a hard constraint.
+
+## Who can register a .attorney domain?
+
+**Registration restrictions: open to all.** `.attorney` is an unrestricted, open generic TLD. There is **no requirement** to be a licensed attorney, bar member, or legal professional — anyone may register one. This is the key difference from credential-gated legal TLDs such as `.law` (which verifies legal-sector eligibility) or `.cpa` (which requires accounting credentials). The suffix communicates a legal focus, but it is an open marketplace, not a verified registry.
+
+Standard new gTLD rules apply: registrations went through the usual sunrise and trademark-claims phases at launch (handled via ICANN's Trademark Clearinghouse), names follow normal length and IDN conventions, and the registry supports **DNSSEC** for signed-zone integrity. WHOIS privacy, transfer, renewal, and the redemption grace period are administered per the operator's and your registrar's policies. The authoritative rules live in the [ICANN .attorney Registry Agreement](https://www.icann.org/en/registry-agreements/details/attorney), held by Dog Beach, LLC.
+
+## .attorney pricing and value
+
+`.attorney` sits in the mid-tier of new gTLD pricing — generally above commodity extensions like `.com` but in line with other profession-themed suffixes. A few pricing dynamics are worth understanding before you buy:
+
+- **Premium names exist.** The registry reserves high-demand generic terms (think single-word practice areas) as premium domains that carry higher registration and sometimes higher renewal fees.
+- **First-year and renewal pricing differ.** As with most TLDs, an introductory first-year rate is not the same as the recurring renewal rate; always check the renewal figure before committing for the long term.
+- **Cost drivers** include premium tiering, the registrar you choose, and any multi-year or bundle terms.
+
+This page intentionally avoids quoting figures, because prices and promotions change constantly across registrars. Check live pricing at registration time.
+
+## Reputation and email deliverability
+
+`.attorney` is perceived as a credible, professional suffix — its meaning is unambiguous and tied to a respected profession, which helps it avoid the "cheap" or "spammy" reputation that has dogged some bargain-priced new gTLDs. Because it is not a giveaway extension, it has not become a magnet for bulk spam registration.
+
+That said, deliverability depends far more on how you configure email than on the suffix itself. Newer gTLDs occasionally face stricter spam-filter scrutiny simply because they are less familiar than `.com`. Mitigate this the standard way: set up correct **SPF, DKIM, and DMARC** records, warm up new sending domains gradually, and keep list hygiene tight. Done properly, a `.attorney` domain delivers mail as reliably as any legacy extension.
+
+## Branding and naming tips
+
+- **Lead with the keyword.** Practice-area names like `bankruptcy.attorney` or `tax.attorney` turn the suffix into part of the message.
+- **Keep the left side short.** Since "attorney" is already long, a concise second-level label keeps the full address readable and typable.
+- **Mind the spelling.** "Attorney" is occasionally misspelled (double-t, single-r); a very long or tricky left-hand label compounds the risk. Say the full domain aloud before committing.
+- **Pair defensively.** If budget allows, hold both the `.attorney` and the matching `.com` to cover users who type by habit.
+
+## How to register a .attorney domain at Namefi
+
+1. **Search** for your desired name on [Namefi](https://namefi.io) to check availability.
+2. **Choose** the exact `.attorney` name that fits your firm, practice area, or campaign.
+3. **Register** and configure DNS — Namefi provides fast, reliable DNS management out of the box.
+
+Namefi is an ICANN-accredited registrar with transparent pricing, and it also supports Web3 tokenization, so you can optionally tokenize your domain for easier transfer and on-chain liquidity. [Search and register your .attorney domain at Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .attorney domain?
+
+Yes. The `.attorney` domain is an open generic TLD with no credential or bar-membership requirement. Anyone can register one, though it is naturally aimed at attorneys, law firms, and legal-service providers. This makes it different from gated legal TLDs that verify licensure.
+
+### Does a .attorney domain affect SEO?
+
+Google treats `.attorney` like any other generic TLD, so the extension itself gives no inherent ranking boost or penalty. Rankings come from content, links, and user experience. A descriptive `.attorney` name can improve click-through by signaling the site is legal-related.
+
+### Who should register a .attorney domain?
+
+It suits solo practitioners, boutique and mid-size law firms, legal-tech startups, and legal marketers who want a descriptive, available name. It is especially useful when the matching `.com` is taken, expensive, or less self-explanatory than a name ending in `.attorney`.
+
+### Is .attorney a verified or restricted legal TLD?
+
+No. Unlike `.law` or `.cpa`, `.attorney` does not verify professional credentials. It is open to all registrants, so the suffix signals a legal focus but does not guarantee the owner is a licensed attorney.
+
+### Who operates the .attorney registry?
+
+The `.attorney` registry is operated by Dog Beach, LLC, a subsidiary of Identity Digital (formerly Donuts), under an ICANN registry agreement. The TLD was delegated to the DNS root zone in 2014.
+
+## Related resources
+
+- [.com domain](/en/tld/com) — the legacy benchmark to compare against.
+- [.abogado domain](/en/tld/abogado) — the Spanish-language legal counterpart.
+- [What is a domain?](/en/blog/what-is-domain) — the fundamentals, if you are new to domains.
+- [Domain terminology guide](/en/blog/domain-terminology-guide) — a glossary of the terms used above.
+- [ICANN](/en/glossary/icann), [registrar](/en/glossary/registrar), [DNS](/en/glossary/dns), and [DNSSEC](/en/glossary/dnssec) glossary entries.

--- a/content/tld/en/biz.md
+++ b/content/tld/en/biz.md
@@ -1,0 +1,149 @@
+---
+title: 'What Is the .biz Domain? The Business gTLD Explained'
+date: '2026-06-15'
+language: 'en'
+tags: ['tld']
+authors: ['namefiteam']
+draft: false
+description: 'The .biz domain is an open, business-oriented gTLD run by GoDaddy Registry. Learn who it suits, how it compares to .com, and what to know before buying.'
+keywords: ['.biz', '.biz domains', '.biz TLD', 'what is .biz', 'business domain extension', 'biz vs com', 'GoDaddy Registry', 'bona fide business use']
+faqs:
+  - question: 'Can anyone register a .biz domain?'
+    answer: 'Almost. The .biz namespace is open worldwide with no credential, trademark, or local-presence gate, but registrations are meant for bona fide business or commercial use. Non-commercial or purely speculative registrations can in principle be challenged, though enforcement in practice is light.'
+  - question: 'Does a .biz domain affect SEO?'
+    answer: 'No. Google treats .biz as a standard generic top-level domain with no inherent ranking penalty or boost. Your rankings come from content quality, links, and user experience, not from the .biz suffix itself.'
+  - question: 'Who should register a .biz domain?'
+    answer: 'Small businesses, startups, local services, and B2B brands whose ideal .com name is taken or unaffordable. It is a clear, business-signaling fallback that pairs well with a matching .com if you can secure both.'
+  - question: 'Is .biz seen as spammy?'
+    answer: 'It carries a mixed reputation. Cheap promotions historically attracted some low-quality and spam registrations, so a few aggressive filters scrutinize it more. A real site, proper email authentication, and good sending habits resolve this for legitimate businesses.'
+  - question: 'Does .biz support WHOIS privacy and DNSSEC?'
+    answer: 'Yes. Registrars offer WHOIS privacy on .biz like other gTLDs, and the registry supports DNSSEC for cryptographically signed DNS, so you can harden your zone against tampering.'
+---
+
+The **.biz** domain is one of the internet's original business-focused web addresses. A phonetic spelling of the first syllable of "business," it was created specifically to give commercial entities a home when their preferred **.com** name was already gone. More than two decades on, **.biz** remains an open, globally available gTLD with a clear, self-explanatory meaning: this is a place of business.
+
+For founders, small businesses, and B2B brands hunting for a short, available name, **.biz** is one of the most direct alternatives to a crowded **.com** namespace. This guide covers what the suffix is, who runs it, who can register one, how it compares to the mainstream options, and the reputation trade-offs worth knowing before you buy.
+
+## .biz at a glance
+
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (gTLD), classified by IANA as a "restricted generic" |
+| Registry operator | Registry Services, LLC — a GoDaddy company (formerly Neustar) |
+| Year launched | 2001 (delegated June 26, 2001) |
+| IDN support | Yes (internationalized domain names supported) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all worldwide; intended for bona fide business or commercial use |
+| Best for | Small businesses, startups, local services, and B2B brands needing a clear business name |
+
+## What is .biz?
+
+**.biz** is a [generic top-level domain](/en/blog/what-is-a-tld) introduced in 2001. Because it is a gTLD rather than a country-code TLD, it carries no geographic association — [Google](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites) treats it as a generic suffix that targets a global audience, so registering a **.biz** does not lock your site to any single country the way a ccTLD can.
+
+The name is deliberately phonetic. "Biz" reads instantly as "business" in English and is widely understood beyond it, which is the entire point of the extension: the suffix itself tells visitors what kind of site they are looking at. You can verify its root-zone status on the [IANA .biz database entry](https://www.iana.org/domains/root/db/biz.html), the authoritative record for any delegated TLD.
+
+## History of .biz
+
+**.biz** has a notable place in domain history: along with **.info**, it was part of the very first batch of new gTLDs that [ICANN](/en/glossary/icann) approved in 2001 — the first expansion of the top-level namespace since the original gTLDs of the 1980s. ICANN's stated goal was to "increase consumer choice" and relieve pressure on the saturated **.com** zone.
+
+It was delegated on June 26, 2001 and originally operated by NeuStar, which built dedicated business-use policies around it. Two of those were the Start-Up Trademark Opposition Policy (STOP) and the Restrictions Dispute Resolution Policy (RDRP), both designed to keep the namespace genuinely commercial and to protect trademark holders during the launch. The **.biz** launch also pioneered an unusual round-robin allocation system instead of pure first-come, first-served, an early experiment in fairer name distribution.
+
+In 2020, GoDaddy acquired NeuStar's registry business, and **.biz** has been operated by GoDaddy Registry (under the entity Registry Services, LLC) ever since. The TLD passed the two-million-registrations milestone years ago and remains a steady, established alternative within the gTLD landscape.
+
+## How people use .biz
+
+**.biz** earns its keep wherever a name needs to read unambiguously as a business:
+
+- **Small and local businesses** — shops, contractors, agencies, and service providers that want a professional address when the **.com** is taken.
+- **Startups and side projects** — founders who can grab a short, brandable **.biz** while a matching **.com** is unavailable or expensive.
+- **B2B and trade brands** — companies whose audience is other businesses, where "biz" reinforces the commercial positioning.
+- **Defensive registrations** — brands that already own the **.com** registering the **.biz** to protect their name and prevent lookalikes.
+- **Domain investors** — buyers acquiring short, dictionary, or keyword **.biz** names for resale or to [tokenize on-chain](/en/blog/what-are-tokenized-domains).
+
+**Who it's not ideal for:** non-commercial projects (personal blogs, hobby sites, nonprofits where **.org** fits better), and brands whose **.com** is readily available and affordable — in that case the **.com** almost always wins on default recognition.
+
+## Notable sites using .biz
+
+Well-known public-facing **.biz** sites are less common than on **.com**, partly because many large brands hold their **.biz** defensively and redirect it. Rather than name a site that may have changed hands, the honest picture is this: **.biz** is used most visibly by small-to-mid-sized businesses, local service providers, and B2B vendors, and frequently as a registered-but-redirecting defensive asset for larger brands. If you cannot independently verify that a given **.biz** site is live and operated by the brand it appears to represent, treat it with the usual caution you would any unfamiliar domain.
+
+## .biz vs other domains
+
+| Feature | .biz | [.com](/en/tld/com) | [.net](/en/tld/net) | [.info](/en/tld/info) |
+| --- | --- | --- | --- | --- |
+| Primary meaning | Business | Commercial (default) | Network / general | Information |
+| Launched | 2001 | 1985 | 1985 | 2001 |
+| Default recognition | Moderate | Highest | High | Moderate |
+| Availability of good names | Good | Very low | Limited | Good |
+| Registration restrictions | Open (business intent) | Open | Open | Open |
+
+Pick **.com** whenever you can get it — it is the universal default and what users type by reflex. Choose **.biz** when the **.com** is gone and you want a suffix that still reads clearly as a business. Prefer **.net** for infrastructure or network-flavored brands, and **.info** for knowledge or resource sites rather than commercial ones.
+
+## Why choose .biz?
+
+- **Instant meaning** — the suffix communicates "business" with zero explanation, useful for commercial trust.
+- **Strong availability** — short, one- and two-word names that are long gone in **.com** are often still open in **.biz**.
+- **No geographic baggage** — as a global gTLD, it works for an international audience without country targeting.
+- **Standard, neutral SEO** — search engines rank it on merit; the suffix is no handicap.
+- **Established and stable** — backed by GoDaddy Registry, one of the largest registry operators, with a 20-plus-year track record.
+
+## Things to consider
+
+Be honest with yourself about the trade-offs. The biggest is **default recall**: many users still assume **.com** and may mistype your address. **.biz** also carries a **mixed reputation** in some circles (see below), and because it is inexpensive it has historically attracted some low-quality registrations. Finally, owning **.biz** without the matching **.com** leaves the door open for a competitor or squatter to take the **.com** — if budget allows, securing both is the safer play.
+
+## Who can register a .biz domain?
+
+**Registration restrictions: open to all, with a business-use expectation.** There is no credential, license, trademark, or local-presence requirement to register a **.biz** domain — anyone, anywhere in the world can buy one through an accredited [registrar](/en/glossary/registrar). The one condition baked into the namespace from day one is that names are intended for **bona fide business or commercial use** rather than purely personal or speculative purposes. Historically this was backed by the RDRP dispute process, so in principle a registration can be challenged if it is plainly non-commercial; in everyday practice, enforcement is light and the suffix functions as an open TLD.
+
+Standard gTLD rules apply: names run 1–63 characters, internationalized domain names (IDNs) are supported, and trademark protections (including ICANN's Trademark Clearinghouse during sunrise periods for new launches) apply as with any gTLD. On the administrative side, **.biz** supports [DNSSEC](/en/glossary/dnssec) for signed DNS, registrars offer WHOIS privacy, and the usual transfer, renewal, and redemption-grace-period lifecycle applies. The authoritative rules live in the [ICANN .biz Registry Agreement](https://www.icann.org/en/registry-agreements/details/biz), which governs the operator's obligations.
+
+## .biz pricing and value
+
+**.biz** sits in the affordable, mainstream gTLD tier rather than the premium bracket. A few dynamics are worth understanding without quoting any number. First, **first-year and renewal pricing usually differ** — introductory promotions can make the initial registration cheaper than the recurring renewal, so always check the renewal rate, not just the headline. Second, the registry reserves a pool of **premium names** — short, dictionary, or high-demand keyword terms — that carry higher registration and renewal fees set above the standard rate. Third, cost is driven by the wholesale registry fee plus each registrar's markup and any privacy or add-on services. As an established, non-premium suffix, standard **.biz** names remain budget-friendly, which is part of why the namespace still has good availability.
+
+## Reputation and email deliverability
+
+This is the area buyers most often overlook. **.biz** carries a **mixed reputation**: because it launched cheaply and was marketed aggressively, the namespace attracted a meaningful share of low-quality, parked, and spam registrations over the years. As a result, a minority of aggressive spam filters and blocklists have historically scrutinized **.biz** sending domains more closely than a long-established **.com**.
+
+The practical impact for a legitimate business is small and fully manageable. To keep email deliverability strong, run a real website on the domain, and configure proper email authentication — **SPF, DKIM, and DMARC** — before sending at volume. Warm up new sending domains gradually and keep your lists clean. With those basics in place, a **.biz** delivers reliably; the reputation concern is about the suffix's history, not a technical limitation of the TLD.
+
+## Branding and naming tips
+
+**.biz** works best when the second-level name is a real, pronounceable word or brand — `acme.biz` reads cleanly, while a hyphen-and-number soup undermines the trust the suffix is meant to convey. The domain-hack potential is modest (it does not spell into many words the way some suffixes do), so lean on clarity rather than cleverness. Watch one pitfall: spoken aloud, listeners may default to assuming "**.com**," so reinforce the "**.biz**" suffix in voiceovers, ads, and verbal introductions. If you own or can get the matching **.com**, point it at the same site to capture mistyped traffic.
+
+## How to register a .biz domain at Namefi
+
+1. **Search** your desired name on [Namefi](https://namefi.io) to check **.biz** availability.
+2. **Choose** the **.biz** result (and grab the matching **.com** or other extensions if you want them).
+3. **Register** and complete checkout to secure the name.
+
+Namefi combines an ICANN-accredited [registrar](/en/glossary/registrar) with Web3 capabilities: transparent pricing, fast DNS management, and the option to [tokenize your domain](/en/blog/why-tokenize-domains) for easier transfer and liquidity. [Register your .biz domain at Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .biz domain?
+
+Almost. The **.biz** namespace is open worldwide with no credential, trademark, or local-presence gate, but registrations are meant for bona fide business or commercial use. Non-commercial or purely speculative registrations can in principle be challenged under the registry's historical dispute policy, though enforcement in practice is light and the suffix functions as an open TLD.
+
+### Does a .biz domain affect SEO?
+
+No. Google treats **.biz** as a standard generic top-level domain with no inherent ranking penalty or boost. Your rankings come from content quality, backlinks, and user experience, not from the suffix. A well-built **.biz** site competes on equal footing with a **.com**.
+
+### Who should register a .biz domain?
+
+Small businesses, startups, local services, and B2B brands whose ideal **.com** name is already taken or too expensive. It is a clear, business-signaling fallback. If you can secure the matching **.com** as well, owning both gives you the strongest protection and recall.
+
+### Is .biz seen as spammy?
+
+It carries a mixed reputation. Cheap promotions historically drew some low-quality and spam registrations, so a few aggressive filters scrutinize it more. Running a real site and configuring SPF, DKIM, and DMARC resolves any deliverability concern for legitimate businesses.
+
+### Does .biz support WHOIS privacy and DNSSEC?
+
+Yes. Registrars offer WHOIS privacy on **.biz** as they do on other gTLDs, and the registry supports DNSSEC, letting you cryptographically sign your DNS zone to guard against tampering and cache poisoning.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [Top TLDs to secure for your business](/en/blog/top-tlds-to-secure-for-your-business)
+- [.com TLD](/en/tld/com) · [.net TLD](/en/tld/net) · [.info TLD](/en/tld/info)
+- Glossary: [ICANN](/en/glossary/icann) · [Registrar](/en/glossary/registrar) · [DNSSEC](/en/glossary/dnssec) · [WHOIS](/en/glossary/whois)

--- a/content/tld/en/boutique.md
+++ b/content/tld/en/boutique.md
@@ -1,0 +1,154 @@
+---
+title: 'What Is the .boutique Domain? A Guide for Small Brands'
+date: '2026-06-15'
+language: 'en'
+tags: ['tld']
+authors: ['namefiteam']
+draft: false
+description: 'The .boutique domain is an open generic extension built for curated shops and small specialty brands. Learn who uses it, how it is priced, and whether it suits you.'
+keywords: ['.boutique domain', 'what is .boutique', 'boutique TLD', 'boutique domain registration', 'domains for small shops', 'curated brand domain', 'new gTLD', 'Binky Moon']
+faqs:
+  - question: 'Can anyone register a .boutique domain?'
+    answer: 'Yes. .boutique is an open generic top-level domain with no eligibility restrictions. There is no requirement to own a retail store, sell physical goods, or prove any credential, so individuals, brands, and agencies worldwide can register an available name.'
+  - question: 'Does a .boutique domain affect SEO?'
+    answer: 'No. Google treats .boutique as a generic top-level domain with no inherent ranking advantage or penalty. Search rankings depend on content quality, links, and user experience, not the suffix. A well-built .boutique site can rank as well as any .com.'
+  - question: 'Who should register a .boutique domain?'
+    answer: 'Small specialty retailers, fashion and lifestyle labels, designers, and curated online shops that want a descriptive, exact-match name. It also suits agencies, studios, and consultancies that present themselves as small, hand-picked operations.'
+  - question: 'Is .boutique good for an online store?'
+    answer: 'It can be, for a small curated catalog where the word "boutique" reinforces the brand. For a large general marketplace, broader suffixes like .shop or .store usually read better, since "boutique" implies a narrow, selective range of products.'
+---
+
+The **.boutique domain** is a descriptive new generic top-level domain (gTLD) aimed at small, curated brands: independent fashion labels, lifestyle shops, design studios, and any business that wants its web address to signal taste, selectivity, and a hand-picked range. Where a generic suffix says nothing, `.boutique` carries built-in meaning, turning the address itself into part of the brand story.
+
+For founders, indie retailers, and marketing managers weighing a niche extension, the core questions are: who actually runs this suffix, who uses it, and is it worth registering over a mainstream alternative? This page answers all three, with verifiable registry facts and an honest look at the trade-offs.
+
+## .boutique at a glance
+
+| Fact | Detail |
+| --- | --- |
+| TLD type | New generic top-level domain (gTLD) |
+| Registry operator | Binky Moon, LLC (an Identity Digital subsidiary) |
+| Year launched | 2014 |
+| IDN support | Yes (varies by registrar) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility requirements |
+| Best for | Small curated shops, fashion and lifestyle brands, design studios |
+
+## What is .boutique?
+
+`.boutique` is a dictionary-word gTLD delegated to the internet root in 2014 as part of ICANN's New gTLD Program, the expansion that introduced hundreds of word-based suffixes alongside the legacy set like `.com` and `.net`. The string is the French and English word *boutique* — originally a small shop selling fashionable, specialized goods, and now a widely understood label for any small, selective, high-touch business ("a boutique agency", "a boutique hotel").
+
+That semantic clarity is the suffix's whole value proposition. The word travels well across English, French, and many other languages, and it instantly frames the site as small-scale and curated rather than mass-market.
+
+As a generic gTLD, `.boutique` is **not tied to any country** and carries no geographic targeting signal. Per [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites), new gTLDs like this are treated as generic and are not used to infer a target country, so a `.boutique` site competes globally rather than being boxed into one region. You can confirm its registry details on the official [IANA root-zone entry for .boutique](https://www.iana.org/domains/root/db/boutique.html).
+
+## History of .boutique
+
+`.boutique` was one of the earliest waves of the 2012 New gTLD Program applications to reach the root, with delegation occurring in early 2014. It originally ran under the Donuts portfolio, the operator that applied for and launched one of the largest collections of word-based gTLDs.
+
+Over the following years the operating entity consolidated under **Binky Moon, LLC**, the registry-operator subsidiary that today holds the contracts for a large share of Identity Digital's portfolio (Identity Digital is the rebranded successor to Donuts after its merger with Afilias). So while marketing and registrar-facing branding say "Identity Digital", the contracted registry operator of record for `.boutique` is Binky Moon, LLC — the name you will see on the IANA entry and the ICANN registry agreement.
+
+Adoption has been steady rather than explosive. `.boutique` sits in the mid-tier of Identity Digital's "vertical" gTLDs — well-known among small-brand and agency buyers, without the headline-grabbing volumes of suffixes like `.shop` or `.store`. Registration counts fluctuate with promotions and renewals, so treat any single figure with caution.
+
+## How people use .boutique
+
+Real, specific niches where `.boutique` fits naturally:
+
+- **Independent fashion and apparel labels** that want "boutique" to convey a small, curated collection.
+- **Lifestyle and home-goods shops** — candles, ceramics, stationery, plants — selling a tight, hand-picked range.
+- **Boutique service firms** that already describe themselves that way: consultancies, creative studios, recruiting shops, law and advisory practices.
+- **Boutique hospitality** — small hotels, B&Bs, and event venues leaning into the intimate-experience angle.
+- **Pop-up and concept stores** wanting a memorable, on-theme address.
+
+**Who it is not ideal for:** large general-merchandise stores, marketplaces, or any brand aiming for mass-market scale — "boutique" actively signals *small and selective*, which works against a big-box positioning. It is also a poor fit where the audience may not know the word, or where you need a short, voice-friendly address.
+
+## Notable sites using .boutique
+
+`.boutique` is a niche suffix used mostly by small businesses rather than household-name brands, so its footprint is built from many independent shops and studios rather than a few famous flagship sites. Typical active use is an exact-match brand name — a label, studio, or small shop putting its name directly on the suffix (for example a name of the form `yourbrand.boutique`). Rather than invent a marquee example, the honest picture is this: it is a working extension for small curated businesses, not a suffix you will routinely see on a Fortune 500 homepage.
+
+## .boutique vs other domains
+
+| Feature | .boutique | [.shop](/en/tld/shop) | [.store](/en/tld/store) | [.com](/en/tld/com) |
+| --- | --- | --- | --- | --- |
+| Meaning | Small, curated shop | General retail | General retail/storefront | Neutral, universal |
+| Best fit | Niche specialty brands | Any commerce site | Any commerce site | Anything |
+| Restrictions | Open to all | Open to all | Open to all | Open to all |
+| Recognition | Moderate | High | High | Universal |
+
+Pick `.boutique` when "small and curated" is the message you want the address itself to send. Choose [.shop](/en/tld/shop) or [.store](/en/tld/store) for broader e-commerce where you do not want to imply a limited range, and default to [.com](/en/tld/com) when maximum familiarity and resale liquidity matter more than a descriptive suffix.
+
+## Why choose .boutique?
+
+- **Built-in meaning:** the address communicates "curated and small-scale" before a visitor reads a single word of copy.
+- **Exact-match availability:** because demand is moderate, the brand name you want is far more likely to be free than on `.com`.
+- **Cross-language reach:** "boutique" is understood in English, French, and well beyond, giving it natural appeal for brands going global.
+- **Open registration:** no credentials, no paperwork, no local-presence rule — anyone can register an available name.
+
+## Things to consider
+
+Be honest with yourself about the trade-offs:
+
+- **Narrowing effect:** "boutique" deliberately implies small and selective. If you intend to scale into a broad catalog, the name can work against you later.
+- **Recognition gap:** mainstream users still default to `.com`, and some may not immediately register a `.boutique` address as a "real" website.
+- **Premium pricing on some names:** short or high-demand terms may be classed as premium, with elevated registration and renewal fees (see pricing below).
+- **Spelling length:** "boutique" is nine letters and occasionally misspelled, which matters for word-of-mouth and voice contexts.
+
+## Who can register a .boutique domain?
+
+**Registration restrictions: none.** `.boutique` is an open generic gTLD with no eligibility gate — you do not need to own a retail business, sell physical products, or hold any credential. Any individual or organization worldwide can register an available `.boutique` name on a first-come, first-served basis.
+
+Standard new-gTLD policies apply. Trademark holders could claim matching names during the original Sunrise period, and ICANN's Trademark Clearinghouse Claims notices apply to flagged strings. Names generally follow common length and IDN rules, and DNSSEC is supported for registrants who want signed zones. WHOIS privacy availability, transfer, renewal, and redemption-grace handling are set by your registrar within the registry's framework. The authoritative rules live in the [ICANN Registry Agreement for .boutique](https://www.icann.org/en/registry-agreements/details/boutique) and the operator's policies at [Identity Digital](https://identity.digital/).
+
+## .boutique pricing and value
+
+This page never quotes live prices, but the **pricing dynamics** are worth understanding. `.boutique` is a descriptive gTLD, so standard names typically sit in the mid-range for word-based extensions — usually above bargain-bin suffixes but in line with comparable vertical gTLDs.
+
+Two cost factors matter most. First, **first-year and renewal pricing differ**: introductory or promotional first-year rates do not carry over, and `.boutique` renews at its standard rate every year, so budget for the recurring figure, not the entry price. Second, the registry classes some desirable strings — short words, common terms — as **premium names** with elevated registration and renewal fees that persist for the life of the registration. Always check whether a specific name is standard or premium before committing, since premium status follows the name, not the registrar.
+
+## Reputation and email deliverability
+
+New gTLDs as a class once carried a mild "unfamiliar suffix" perception, and a handful of cheap, abuse-prone extensions earned a poor reputation that occasionally spilled over to spam-filter heuristics. `.boutique` is **not** one of the abuse-magnet suffixes: it is mid-priced, runs under a major, well-governed operator (Identity Digital / Binky Moon), and is dominated by legitimate small-business use, which keeps its standing solid.
+
+For email deliverability, the suffix itself is rarely the deciding factor. What matters is correct authentication — SPF, DKIM, and DMARC properly configured, plus a warmed sending reputation. A `.boutique` domain with clean authentication and good sending practices reaches inboxes reliably; skip the setup on any suffix and you will land in spam regardless.
+
+## Branding and naming tips
+
+- **Lead with the brand, let the suffix do the framing:** `lumen.boutique` reads as a curated brand far more than `lumenshop.com` would.
+- **Avoid redundancy:** you rarely need "shop" or "store" in front of `.boutique` — the suffix already implies it.
+- **Mind the length and spelling:** nine letters is not short; favor a crisp, easy-to-say second-level name to offset it.
+- **Test it out loud:** because it is a real word, "[name] dot boutique" should sound natural when spoken — say it before you buy it.
+
+## How to register a .boutique domain at Namefi
+
+1. Search your desired name on [Namefi](https://namefi.io) to check availability and whether it is a standard or premium `.boutique` string.
+2. Choose the exact name that matches your brand, keeping it short and clear.
+3. Complete registration and configure DNS — Namefi offers transparent pricing, fast DNS, and optional Web3 tokenization for owners who want on-chain control of their domain.
+
+Ready to claim your name? Start at [Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .boutique domain?
+
+Yes. `.boutique` is an open generic top-level domain with no eligibility restrictions. There is no requirement to own a retail store, sell physical goods, or prove any credential, so individuals, brands, and agencies worldwide can register an available name on a first-come, first-served basis.
+
+### Does a .boutique domain affect SEO?
+
+No. Google treats `.boutique` as a generic top-level domain with no inherent ranking advantage or penalty. Search rankings depend on content quality, backlinks, and user experience, not on the suffix. A well-built `.boutique` site can rank just as well as a `.com` one.
+
+### Who should register a .boutique domain?
+
+Small specialty retailers, fashion and lifestyle labels, designers, and curated online shops that want a descriptive, exact-match name. It also suits agencies, studios, and consultancies that present themselves as small, hand-picked, boutique operations.
+
+### Is .boutique good for an online store?
+
+It can be, for a small curated catalog where the word "boutique" reinforces the brand. For a large general marketplace, broader suffixes like `.shop` or `.store` usually read better, since "boutique" implies a narrow, selective range of products.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [Top TLDs to secure for your fashion brand](/en/blog/top-tlds-to-secure-for-your-fashion-brand)
+- [Top TLDs to secure for your e-commerce store](/en/blog/top-tlds-to-secure-for-your-ecommerce-store)
+- [.shop domain](/en/tld/shop) and [.store domain](/en/tld/store) — broader retail alternatives
+- [Registrar](/en/glossary/registrar) and [ICANN](/en/glossary/icann) in the glossary

--- a/content/tld/en/co.md
+++ b/content/tld/en/co.md
@@ -1,0 +1,160 @@
+---
+title: 'What Is the .co Domain? The Global "Company" Alternative to .com'
+date: '2026-06-15'
+language: 'en'
+tags: ['tld']
+authors: ['namefiteam']
+draft: false
+description: 'What is the .co domain? Colombia''s country-code TLD, marketed worldwide as a short ".com" or "company" alternative. Learn who runs it, who can register, pricing, and SEO.'
+keywords: ['.co domains', '.co TLD', 'co domain', 'what is .co', 'what is the .co domain', '.co vs .com', 'co domain for startups', 'Colombia domain', 'register .co domain', 'short company domain']
+faqs:
+  - question: 'Can anyone register a .co domain?'
+    answer: 'Yes. Although .co is technically Colombia''s country-code TLD, it has been open to anyone in the world since its 2010 relaunch, with no local-presence or Colombian-residency requirement. Registration is first-come, first-served at the second level.'
+  - question: 'Does a .co domain affect SEO?'
+    answer: 'No, .co does not inherently hurt rankings. Google treats .co as a generic, non-geotargeted TLD, so a .co site is not boxed into Colombia and can rank globally. Content quality, links, and user experience matter far more than the suffix.'
+  - question: 'Who should register a .co domain?'
+    answer: 'Startups, companies, and founders whose ideal .com is taken or too expensive. The "co" string reads naturally as "company," "corporation," or "Colorado," making it a clean, brandable second choice for global ventures.'
+  - question: 'Is .co the same as .com?'
+    answer: 'No. They are separate TLDs run by different operators. The risk is that visitors who type your address from memory may add the trailing "m" and land on the .com instead, so the suffixes can be confused in conversation and typed traffic.'
+---
+
+The **.co** domain is one of the most successful examples of a country-code extension that broke free of its borders. Officially the ccTLD for **Colombia**, it has been marketed and adopted worldwide as a short, brandable stand-in for ".com" — where "co" reads instantly as **company**, **corporation**, or simply a clipped ".com." For founders who find their dream **.com** taken, **.co** is often the first place they look.
+
+This guide covers what .co really is, who runs it (the operator changed hands in 2025), who can register one, how it is priced, and how it is perceived for SEO and email — so you can decide whether it fits your brand.
+
+## .co at a glance
+
+| Fact | Detail |
+| --- | --- |
+| TLD type | Country-code TLD (ccTLD) for Colombia |
+| Registry operator | Registry.co / "PuntoCo" consortium (CCI REG + Team Internet Group), under Colombia's Ministry of ICT (MinTIC) |
+| Year delegated | 1991 (relaunched for global registration in 2010) |
+| IDN support | Yes (internationalized domain names supported) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no local presence or Colombian residency required |
+| Best for | Startups, companies, and global brands wanting a short ".com" alternative |
+
+## What is .co?
+
+**.co** is the country-code Top-Level Domain (ccTLD) assigned to **Colombia** under the ISO 3166-1 standard, the same two-letter system the [Internet Assigned Numbers Authority (IANA)](https://www.iana.org/domains/root/db/co.html) uses to delegate country codes. On paper it is Colombia's national namespace, governed by the country's **Ministry of Information and Communications Technologies (MinTIC)**, which IANA lists as the ccTLD manager.
+
+In practice, the **.co domain** is used almost entirely as a **generic, global** extension. The string "co" carries meaning in nearly every market — it is the universal abbreviation for **company** and **corporation**, the legal suffix in "Co." business names, and even shorthand for the US state of Colorado. That linguistic versatility is exactly what its operators leaned into when they reopened the namespace to the world.
+
+Crucially for international businesses, search engines do **not** treat .co as a geo-targeted ccTLD. Google lists .co among the ccTLDs it [treats as generic rather than country-specific](https://developers.google.com/search/docs/crawling-indexing/manage-international-sites), so a .co site is not tied to Colombian search results and is well suited to global audiences and international SEO.
+
+## History of .co
+
+The .co TLD was delegated to Colombia in **1991** and originally administered by the Universidad de los Andes, used mostly for Colombian organizations and as a second-level space (such as `com.co`).
+
+The turning point came in **2010**. Administration moved to a dedicated operator under MinTIC oversight, and on **July 20, 2010** second-level .co names were opened to registrants anywhere in the world on a first-come, first-served basis. Backed by a high-profile global marketing push positioning .co as the "company" domain, the relaunch drove rapid adoption among startups and brands worldwide.
+
+The most consequential recent milestone is the **2025 operator change**. Colombia's MinTIC ran a public tender to award a new 10-year contract for running the namespace. The incumbent (operating under the GoDaddy Registry portfolio, which had earlier absorbed the original .CO Internet operator) lost the bid. The contract went to the **"PuntoCo" consortium** — Colombian company **CCI REG** together with the **Team Internet Group** — now operating as **Registry.co**. The technical migration of more than three million records completed in **early October 2025**, and the new arrangement returns a substantially larger share of revenue to the Colombian state.
+
+## How people use .co
+
+Because "co" maps so cleanly onto business language, .co attracts a broad, business-leaning crowd:
+
+- **Startups and tech companies** whose preferred .com is unavailable or unaffordable.
+- **Corporate and brand sites** using "co" as a literal stand-in for "company."
+- **Short link and redirect domains**, where a concise suffix keeps URLs compact.
+- **Personal and portfolio sites** that want a tidy, professional alternative to .com.
+- **Domain hacks**, where the suffix completes a word — for example `t.co` or names ending in "-co."
+
+**Who it's not ideal for:** Brands that absolutely cannot tolerate confusion with their .com twin, or local businesses whose customers rely heavily on word-of-mouth and typed-from-memory addresses, where the missing "m" can misdirect traffic.
+
+## Notable sites using .co
+
+- **t.co** — Twitter/X's official URL-shortening domain, wrapping links across the platform. One of the most-resolved domains on the internet.
+- **angel.co** — the historical home of AngelList, the startup hiring and investing platform (later expanded to other domains, but long synonymous with the .co era of startups).
+- **vine.co** — the domain behind Vine, the short-video app that helped popularize .co among consumer apps.
+
+These cases show .co being trusted by major, high-traffic platforms — not just as a fallback, but as a deliberate brand choice.
+
+## .co vs other domains
+
+| Feature | .co | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.xyz](/en/tld/xyz/) |
+| --- | --- | --- | --- | --- |
+| Type | ccTLD (used globally) | Legacy gTLD | ccTLD (used globally) | New gTLD |
+| Core association | Company / corporation | The default web standard | Tech / "Input-Output" | Generic / Web3 |
+| Availability of short names | Good | Very poor | Moderate | Excellent |
+| Typical price tier | Mid | Low-to-mid | High | Low |
+
+Choose **.com** when you can get the exact name — it remains the trust default. Reach for **.co** when the .com is gone and you want the closest, most business-credible substitute. Pick **[.io](/en/tld/io/)** for developer- and infrastructure-focused tech brands, and **[.xyz](/en/tld/xyz/)** for generic or Web3-native projects where a fresh, neutral suffix is an advantage.
+
+## Why choose .co?
+
+- **Closest meaning to .com.** "co" reads as "company" and looks almost identical to ".com," so it carries comparable professional weight.
+- **Far better availability.** Short, one-word, and brandable names that are long gone in .com are frequently still open in .co.
+- **Global, not geo-locked.** Despite being Colombia's ccTLD, it is treated as generic by search engines and open to everyone.
+- **Proven by real brands.** Adoption by platforms like t.co and a generation of startups gives it genuine recognition.
+
+## Things to consider
+
+- **Confusion with .com.** This is the single biggest trade-off. People may instinctively append an "m," sending typed-from-memory traffic to the .com instead — which a competitor may own.
+- **A ccTLD by nature.** Because .co technically belongs to Colombia and is administered under national policy, its long-term rules are set by MinTIC and its appointed operator, not by ICANN registry agreements.
+- **Price above bargain gTLDs.** It is generally not the cheapest extension; premium names and renewals can cost more than entry-level new gTLDs.
+
+## Who can register a .co domain?
+
+**Registration restrictions: open to all.** There is **no local-presence, residency, or Colombian-nationality requirement** to register a second-level .co domain. Since the 2010 relaunch, registration has been **first-come, first-served** and available to individuals and organizations anywhere in the world.
+
+Standard practices apply: trademark holders could participate in sunrise phases during the original launch, names follow conventional length and character rules, **internationalized domain names (IDNs)** are supported, and **DNSSEC** is available for added DNS security. WHOIS privacy, transfer, renewal, and redemption-grace handling follow standard registrar and registry conventions. Because .co is a ccTLD, it is governed by Colombian policy rather than an ICANN registry agreement — the authoritative source for current rules is the operator's official site, [Registry.co](https://registry.co/), under MinTIC oversight.
+
+## .co pricing and value
+
+.co generally sits in a **mid-tier price band** — more than the cheapest promotional gTLDs, but well below scarce premium extensions. A few dynamics shape what you'll pay:
+
+- **Premium names exist.** The registry classifies many short, dictionary, or high-demand .co names as **premium**, carrying higher registration and sometimes higher renewal fees.
+- **First-year vs. renewal pricing differ.** As with most TLDs, an introductory first-year rate is not the renewal rate; always check the standard renewal before committing a brand.
+- **What drives cost.** Name length and desirability, premium classification, and registry wholesale pricing are the main factors. Aftermarket resale values for top one- and two-character or dictionary .co names can be substantial.
+
+For exact, current figures, check live pricing at registration time — this page intentionally quotes no numbers.
+
+## Reputation and email deliverability
+
+.co enjoys a **solid, business-leaning reputation**. Its long association with companies and credible adoption by major platforms mean it is generally perceived as professional rather than spammy. It does not carry the bargain-bin connotation that has dogged some ultra-cheap new gTLDs.
+
+For email deliverability, the suffix itself is rarely the deciding factor — modern spam filters weigh **sending reputation, SPF/DKIM/DMARC authentication, and list hygiene** far more than the TLD. A properly authenticated .co sender should reach inboxes normally. The main caveat is human, not technical: recipients may misread or mistype the address as .com.
+
+## Branding and naming tips
+
+- **Lean into "company."** .co shines for ventures where "Acme**co**" or "yourbrand.co" reads as a corporate identity.
+- **Watch the .com twin.** Before committing, consider who owns the matching .com — if a competitor holds it, weigh the typed-traffic leakage.
+- **Domain hacks work.** Names that naturally end in "co," or two-letter constructions before the dot, can produce memorable, compact URLs.
+- **Say it out loud.** ".co" is clear in writing but can be misheard as ".com" in speech, so pick a name that is unambiguous when spoken.
+
+## How to register a .co domain at Namefi
+
+1. **Search** for your desired name and the .co extension.
+2. **Choose** an available name (and check whether it is classified as premium).
+3. **Register** and configure DNS.
+
+[Namefi](https://namefi.io) is an ICANN-accredited registrar that bridges Web2 and Web3, with transparent pricing, fast DNS management, and the option to hold your name as a tokenized domain for easier transfer and provable ownership.
+
+## Frequently asked questions
+
+### Can anyone register a .co domain?
+
+Yes. Although .co is technically Colombia's country-code TLD, it has been open to anyone in the world since its 2010 relaunch, with no local-presence or Colombian-residency requirement. Registration is first-come, first-served at the second level.
+
+### Does a .co domain affect SEO?
+
+No, .co does not inherently hurt rankings. Google treats .co as a generic, non-geotargeted TLD, so a .co site is not boxed into Colombia and can rank globally. Content quality, links, and user experience matter far more than the suffix.
+
+### Who should register a .co domain?
+
+Startups, companies, and founders whose ideal .com is taken or too expensive. The "co" string reads naturally as "company," "corporation," or "Colorado," making it a clean, brandable second choice for global ventures.
+
+### Is .co the same as .com?
+
+No. They are separate TLDs run by different operators. The risk is that visitors who type your address from memory may add the trailing "m" and land on the .com instead, so the suffixes can be confused in conversation and typed traffic.
+
+## Related resources
+
+- [.com TLD guide](/en/tld/com/)
+- [.io TLD guide](/en/tld/io/)
+- [.xyz TLD guide](/en/tld/xyz/)
+- [What is a domain?](/en/blog/what-is-domain/)
+- [Domain terminology guide](/en/blog/domain-terminology-guide/)
+- [Glossary: registrar](/en/glossary/registrar/)
+- [Glossary: ICANN](/en/glossary/icann/)

--- a/content/tld/en/company.md
+++ b/content/tld/en/company.md
@@ -1,0 +1,150 @@
+---
+title: 'What Is the .company Domain? A Generic gTLD for Businesses'
+date: '2026-06-15'
+language: 'en'
+tags: ['tld']
+authors: ['namefiteam']
+draft: false
+description: 'The .company domain is an open generic gTLD anyone can register. Learn who runs it, how it compares to .com, its SEO impact, and whether it suits your business.'
+keywords: ['.company domain', 'what is .company', '.company TLD', '.company vs .com', 'register .company domain', 'business domain extension', 'new gTLD for business', 'Identity Digital TLD']
+faqs:
+  - question: 'Can anyone register a .company domain?'
+    answer: 'Yes. The .company TLD is an open generic gTLD with no eligibility restrictions. There is no requirement to be an incorporated business, hold a trademark, or have a local presence, so individuals, startups, and established firms can all register names on a first-come, first-served basis.'
+  - question: 'Does a .company domain affect SEO?'
+    answer: 'No. Google treats .company the same as .com or any other generic gTLD and applies no inherent ranking penalty or bonus. Rankings depend on content, links, and user experience. The keyword in the suffix does not directly boost rankings, though it can make a result look more relevant.'
+  - question: 'Who should register a .company domain?'
+    answer: 'It suits businesses, consultancies, holding entities, and corporate teams that want a descriptive web address when their preferred .com is taken or too expensive. It also works well for brand-protection registrations and short, keyword-style names that read naturally before the dot.'
+  - question: 'Is .company better than .com for a business website?'
+    answer: 'Not inherently. The .com extension still carries the strongest recognition and default recall. The .company TLD is a credible alternative when the .com is unavailable, especially for a clean, descriptive name, but most users still assume .com first when typing a brand from memory.'
+  - question: 'Does .company support WHOIS privacy and DNSSEC?'
+    answer: 'Yes. As a modern Identity Digital gTLD, .company supports DNSSEC for cryptographic DNS integrity, and registrars including Namefi offer WHOIS privacy so personal contact details are not exposed in public WHOIS records.'
+---
+
+The **.company** domain is one of the internet's broadest business-oriented suffixes: a generic top-level domain (gTLD) that any individual or organization can register, with no proof of incorporation required. If you run a business and the exact .com you want is taken, parked, or priced out of reach, **.company** offers a descriptive, self-explanatory alternative that says what you are right in the address bar.
+
+Because it is open and generic rather than tied to a country or a gated profession, .company appeals to startups, consultancies, holding entities, and brand-protection teams alike.
+
+## .company at a glance
+
+| Fact | Detail |
+| --- | --- |
+| TLD type | New gTLD (generic) |
+| Registry operator | Binky Moon, LLC (an [Identity Digital](https://www.identity.digital/) subsidiary) |
+| Year launched | 2013 (delegated December 2013) |
+| IDN support | Yes |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility requirement |
+| Best for | Businesses, consultancies, and brand-protection registrations |
+
+## What is .company?
+
+The **.company** domain is a generic top-level domain introduced under [ICANN's New gTLD Program](https://newgtlds.icann.org/en/about/program), the 2012 expansion that added hundreds of word-based suffixes to the root zone. According to the [IANA root-zone database](https://www.iana.org/domains/root/db/company.html), the string was delegated in December 2013 and is classified as a generic, not a sponsored or country-code, TLD.
+
+"Company" is one of the most universally understood business words in English, which is exactly the point of the suffix: a visitor reading `acme.company` instantly knows the site belongs to a business entity. Unlike a country-code TLD such as `.us` or `.de`, **.company** carries no geographic signal. Google [treats generic new gTLDs like .company](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level-domains) the same way it treats legacy gTLDs such as .com — there is no built-in geo-targeting and no ranking advantage or penalty for the suffix itself.
+
+## History of .company
+
+The .company string was applied for during the 2012 new gTLD round and delegated to the DNS root in December 2013, making it one of the earlier business-themed extensions to reach general availability. Its underlying ICANN [Registry Agreement](https://www.icann.org/en/registry-agreements/details/company) is dated 7 November 2013.
+
+The operator history mirrors a major industry consolidation. The TLD was originally launched by Donuts Inc., the company behind the largest portfolio of new gTLDs. Donuts later moved its hundreds of strings under a single contracting entity, **Binky Moon, LLC**, and the broader business rebranded as **Identity Digital** after merging with Afilias. Today .company is one of more than 200 generic gTLDs Identity Digital runs through Binky Moon, which gives it the stability of a large, established registry rather than a single-purpose startup operator.
+
+## How people use .company
+
+The breadth of the word "company" makes the suffix flexible across sectors:
+
+- **Holding and parent entities** — corporate groups use names like `acme.company` to host an umbrella or investor-facing site.
+- **Consultancies and service firms** — advisory, design, and engineering shops favor descriptive, professional-looking addresses.
+- **Brand protection** — established brands register their `.company` match defensively so others can't.
+- **Keyword-style names** — short words that read naturally before the dot (for example a craft business as `coffee.company`).
+- **Startups priced out of .com** — founders who can't get the .com use .company to launch quickly with a clear identity.
+
+**Who it's not ideal for:** consumer apps and casual personal projects where users will reflexively type `.com`, and creators who want a short, trendy hack (suffixes like [.io](/en/tld/io), [.app](/en/tld/app), or [.xyz](/en/tld/xyz) fit those better).
+
+## Notable sites using .company
+
+Because .company is most popular for corporate, holding, and brand-protection use, its registrations skew toward business sites rather than household-name consumer destinations. Many are defensive — large brands securing their `.company` match alongside their primary .com — so the suffix is more visible in B2B and corporate contexts than in mainstream traffic. Rather than name a specific site that may lapse or change hands, the honest description is this: .company is used as a descriptive business address by small-to-midsize firms and as a protective registration by larger ones, not as a flagship consumer brand suffix.
+
+## .company vs other domains
+
+| Feature | .company | [.com](/en/tld/com) | [.org](/en/tld/org) | [.info](/en/tld/info) |
+| --- | --- | --- | --- | --- |
+| Type | New gTLD | Legacy gTLD | Legacy gTLD | Legacy gTLD |
+| Meaning | "A business" | Generic / default | Organizations | Information |
+| Recognition | Moderate | Highest | High | Moderate |
+| Open to all | Yes | Yes | Yes | Yes |
+| Availability of short names | Good | Very limited | Limited | Good |
+
+Pick **.com** when you can get the exact name and want maximum default recall. Choose **.company** when the .com is taken and you want a descriptive business address with better short-name availability. Use [.org](/en/tld/org) if you're a nonprofit or association, and [.info](/en/tld/info) for reference-style or informational sites.
+
+## Why choose .company?
+
+- **Self-describing:** the suffix instantly frames the site as a business, reinforcing what your brand does.
+- **Open and unrestricted:** no incorporation papers, trademark, or local presence to prove — register and go.
+- **Short-name availability:** clean, one-word names that are long gone in .com are often still open here.
+- **Established registry:** run by Identity Digital through Binky Moon, a large operator with modern infrastructure and DNSSEC support.
+- **SEO-neutral:** Google handles it like any generic gTLD, so you're not starting at a disadvantage.
+
+## Things to consider
+
+Be honest with yourself about the trade-offs:
+
+- **Default-to-.com habit:** many users still type `.com` from memory, so you may lose some direct type-in traffic.
+- **Length:** "company" is seven letters, making the full address longer than a snappy three-letter suffix.
+- **Premium pricing on some names:** the most desirable keyword names are often classified as premium and cost more.
+- **Brand-protection overhead:** if you adopt .company, you may also want the matching .com to avoid confusion or impersonation.
+
+## Who can register a .company domain?
+
+**Registration restrictions: open to all.** The .company TLD has no eligibility gate. Unlike credential-locked suffixes such as .law or .cpa, or local-presence ccTLDs, there is no requirement to be an incorporated company, hold a trademark, or reside anywhere specific. Anyone — an individual, a startup, or a multinational — can register an available name on a first-come, first-served basis.
+
+Standard ICANN gTLD rules apply: a sunrise period gave trademark holders early access during launch, and registered marks can still be protected through the Trademark Clearinghouse. Names support internationalized domain name (IDN) characters and DNSSEC for DNS integrity, and registrars including Namefi offer WHOIS privacy to keep personal contact details out of public records. Transfers, renewals, and a redemption grace period for recently expired names follow the standard ICANN gTLD lifecycle. The authoritative rules are set out in the operator's [ICANN Registry Agreement for .company](https://www.icann.org/en/registry-agreements/details/company).
+
+## .company pricing and value
+
+The .company namespace is priced like a typical Identity Digital business gTLD rather than a budget promotional suffix. Two dynamics are worth understanding before you buy. First, the registry designates a subset of high-demand, short, or generic names as **premium**, and those carry standing prices well above the base tier. Second, **first-year and renewal pricing usually differ** — an introductory first-year rate does not lock in your renewal cost, so check the standard renewal figure before committing long term. Cost is driven by the registry wholesale fee, the registrar's margin, whether the string is premium, and any restoration fee for redeeming a lapsed name. Treat a domain as a recurring annual cost, not a one-time purchase.
+
+## Reputation and email deliverability
+
+Among new gTLDs, .company sits on the more credible end of the spectrum. It reads as a serious business suffix, not a throwaway, and Identity Digital's portfolio has a generally clean reputation. That said, any non-.com suffix can occasionally be treated more cautiously by aggressive spam filters simply because newer extensions have historically been cheaper to register in bulk. The practical mitigations are the same ones every domain needs: configure SPF, DKIM, and DMARC correctly, warm up new sending domains gradually, and avoid bulk unsolicited mail. With proper email authentication, a .company address delivers reliably and reads professionally in a "From" line.
+
+## Branding and naming tips
+
+The natural pattern is to move the word "company" out of your name and into the suffix — `thecoffeecompany.com` becomes the cleaner `coffee.company`. This works best when the part before the dot is a real word or a strong brand, so the whole address reads as a phrase. Watch the total length: because "company" is already seven letters, pairing it with a long left side produces an unwieldy URL. Pronunciation is rarely an issue since "company" is universally understood, but in spoken contexts (a podcast ad, a phone call) say the full suffix clearly so listeners don't assume .com. As always, secure social handles that match and, where budget allows, the matching .com to prevent confusion.
+
+## How to register a .company domain at Namefi
+
+1. **Search** your desired name on Namefi to confirm it's available and see whether it's a standard or premium registration.
+2. **Choose** the term length and review the standard renewal price, not just the first-year rate.
+3. **Register** and configure DNS — Namefi provides fast DNS, DNSSEC, and WHOIS privacy.
+
+As an ICANN-accredited registrar with transparent pricing, [Namefi](https://namefi.io) also lets you tokenize your domain as a Web3 asset for true on-chain ownership. Search your `.company` name and register it in minutes.
+
+## Frequently asked questions
+
+### Can anyone register a .company domain?
+
+Yes. The .company TLD is an open generic gTLD with no eligibility restrictions. There is no requirement to be an incorporated business, hold a trademark, or have a local presence, so individuals, startups, and established firms can all register names on a first-come, first-served basis.
+
+### Does a .company domain affect SEO?
+
+No. Google treats .company the same as .com or any other generic gTLD and applies no inherent ranking penalty or bonus. Rankings depend on content, links, and user experience. The keyword in the suffix does not directly boost rankings, though it can make a result look more relevant.
+
+### Who should register a .company domain?
+
+It suits businesses, consultancies, holding entities, and corporate teams that want a descriptive web address when their preferred .com is taken or too expensive. It also works well for brand-protection registrations and short, keyword-style names that read naturally before the dot.
+
+### Is .company better than .com for a business website?
+
+Not inherently. The .com extension still carries the strongest recognition and default recall. The .company TLD is a credible alternative when the .com is unavailable, especially for a clean, descriptive name, but most users still assume .com first when typing a brand from memory.
+
+### Does .company support WHOIS privacy and DNSSEC?
+
+Yes. As a modern Identity Digital gTLD, .company supports DNSSEC for cryptographic DNS integrity, and registrars including Namefi offer WHOIS privacy so personal contact details are not exposed in public WHOIS records.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld) — how top-level domains work.
+- [What is a domain?](/en/blog/what-is-domain) — domain-name basics.
+- [Top TLDs to secure for your business](/en/blog/top-tlds-to-secure-for-your-business) — a buyer's shortlist for companies.
+- [.com domain](/en/tld/com) and [.org domain](/en/tld/org) — compare the closest alternatives.
+- [ICANN](/en/glossary/icann) and [registrar](/en/glossary/registrar) glossary terms.

--- a/content/tld/en/cpa.md
+++ b/content/tld/en/cpa.md
@@ -1,0 +1,150 @@
+---
+title: 'What Is the .cpa Domain? The Verified Domain for Licensed CPAs'
+date: '2026-06-15'
+language: 'en'
+tags: ['tld']
+authors: ['namefiteam']
+draft: false
+description: 'The .cpa domain is a restricted, credential-gated extension for licensed CPAs and CPA firms in the US, Canada, and Ireland, verified at registration and renewal.'
+keywords: ['.cpa domain', 'what is .cpa', 'cpa domain registration', 'restricted TLD', 'AICPA domain', 'CPA.com', 'licensed CPA domain', 'accounting firm domain']
+faqs:
+  - question: 'Can anyone register a .cpa domain?'
+    answer: 'No. .cpa is a restricted, credential-gated TLD. Only licensed CPA firms and individually licensed CPAs based in the United States, Canada, or Ireland may register, and the registry verifies your CPA license and identity both at the time of purchase and at every renewal.'
+  - question: 'Does a .cpa domain affect SEO?'
+    answer: 'A TLD choice is not a direct Google ranking factor, so .cpa neither helps nor hurts rankings on its own. Its real value is trust and credibility: a .cpa address signals a verified accounting professional, which can improve click-through and reduce impersonation risk.'
+  - question: 'Who should register a .cpa domain?'
+    answer: 'Licensed CPA firms and individual CPAs who want a verified, profession-specific web and email identity. It suits practices that value anti-impersonation security and a credential signal more than a short, generic name.'
+  - question: 'What happens to my .cpa domain if my CPA license lapses?'
+    answer: 'Eligibility is re-checked at each renewal. If you can no longer demonstrate a valid CPA license or firm license, you may be unable to renew the domain, since the registry validates eligibility on an ongoing basis rather than only at first purchase.'
+---
+
+The **.cpa domain** is one of the internet's few truly restricted extensions: a credential-gated top-level domain reserved for licensed Certified Public Accountants and CPA firms. Unlike open suffixes that anyone can buy, .cpa is administered in association with the American Institute of CPAs (AICPA) and operated by CPA.com, and every registrant's license is verified before a name is issued. For accounting professionals, that verification is the entire point — a .cpa address tells clients, at a glance, that the firm behind it is a real, licensed CPA practice.
+
+This page explains what .cpa is, exactly who can register it, how the eligibility checks work, and where it fits relative to mainstream alternatives like [.com](/en/tld/com) and accounting-adjacent niche options.
+
+## .cpa at a glance
+
+| Fact | Detail |
+| --- | --- |
+| TLD type | New gTLD (restricted / specialty) |
+| Registry operator | CPA.com (in association with the AICPA) |
+| Year launched | 2020 (firms); individually licensed CPAs added in 2021 |
+| IDN support | Not a marketed feature; standard ASCII names |
+| DNSSEC | Supported at the registry level |
+| Registration restrictions | Credential-gated — licensed CPA firms and individually licensed CPAs in the US, Canada, or Ireland only; verified at registration **and** renewal |
+| Best for | Licensed accounting firms and CPAs wanting a verified, trusted web and email identity |
+
+## What is .cpa?
+
+.cpa is a **new generic top-level domain (gTLD)** delegated under ICANN's new gTLD program, but it belongs to the restricted, profession-specific category rather than the open commercial one. The AICPA was awarded the .cpa TLD by ICANN in 2019, and CPA.com — the AICPA's business and technology arm — administers and manages it. You can confirm the delegation and sponsoring organization on the [IANA root-zone entry for .cpa](https://www.iana.org/domains/root/db/cpa.html), and the operator's own program lives at [register.domains.cpa](https://register.domains.cpa/).
+
+Because it is a generic (not country-code) TLD, Google treats .cpa as a generic extension with no built-in geo-targeting. As [Google Search Central](https://developers.google.com/search/docs/crawling-indexing/managing-multi-regional-sites) explains, generic TLDs are not tied to a single country for ranking purposes, so a .cpa name does not signal "US-only" the way a ccTLD would. The defining characteristic is the restriction itself: most extensions sell to whoever pays, but .cpa sells only to whoever can prove a CPA credential, which makes the suffix function less like a marketing label and more like a verifiable badge.
+
+## History of .cpa
+
+The AICPA applied for and won the .cpa string through ICANN's new gTLD expansion, securing ownership in 2019. Rather than open the floodgates, the registry rolled the namespace out in deliberate phases:
+
+- **September 2020:** licensed CPA firms gained access first.
+- **Early 2021:** individually licensed CPAs became eligible.
+- **Later in 2021:** availability expanded beyond the United States to select additional countries.
+
+Adoption among established practices was notably strong early on. According to the *Journal of Accountancy*, by mid-2021 more than 6,000 .cpa domains had been registered, including registrations from roughly 90% of firms in the AICPA Major Firms Group. That concentration among large, well-known firms is unusual for a young TLD and reflects the suffix's positioning as a credibility asset rather than a speculative one.
+
+## How people use .cpa
+
+The use cases are narrow by design, which is exactly why they are strong:
+
+- **Firm homepages** that signal a verified, licensed practice (e.g. `yourfirm.cpa`).
+- **Trusted email** — a `name@firm.cpa` address is hard for impersonators to spoof because they cannot obtain a matching .cpa domain.
+- **Client portals and secure document exchange**, where a recognizable, restricted domain reduces phishing risk.
+- **Individual practitioner sites** for sole proprietors and partners who hold a personal CPA license.
+
+**Who it's *not* ideal for:** anyone who is not a licensed CPA or CPA firm — bookkeepers, tax preparers without a CPA credential, accounting software vendors, fintech startups, or international accountants outside the eligible jurisdictions. For those audiences, an open extension is the realistic choice.
+
+## Notable sites using .cpa
+
+Because eligibility is verified, public .cpa addresses are genuine CPA practices rather than parked or speculative names. CPA.com itself runs the program's registration hub at register.domains.cpa. Rather than name specific private firms that may change their setup, the honest description is this: the active .cpa namespace is composed almost entirely of licensed accounting firms and individual CPAs, with adoption skewed toward larger, well-known practices that value the anti-impersonation guarantee.
+
+## .cpa vs other domains
+
+| Feature | .cpa | [.com](/en/tld/com) | .accountants |
+| --- | --- | --- | --- |
+| Type | Restricted new gTLD | Legacy gTLD | Open new gTLD |
+| Who can register | Verified CPAs / CPA firms only | Anyone | Anyone |
+| Trust signal | Strong (credential-verified) | Neutral / universal | Topical, not verified |
+| Impersonation resistance | High | Low | Low |
+| Availability of short names | Good (small namespace) | Very scarce | Good |
+
+Choose **.cpa** when you are a licensed CPA and want the verification badge and anti-impersonation protection. Choose **.com** when you want the most universally recognized address and do not need a credential signal. Choose an open accounting-themed extension when you want topical relevance but are not (or do not want to gate on being) a licensed CPA.
+
+## Why choose .cpa?
+
+- **Verified credibility.** Every .cpa registrant has had their CPA license checked, so the suffix is a built-in trust signal no open TLD can replicate.
+- **Anti-impersonation by design.** Fraudsters cannot register a lookalike .cpa domain to mimic a real firm, which closes a common phishing and "imitator domain" vector.
+- **Professional clarity.** The name says exactly what the business is — a CPA practice — without extra words.
+- **A cleaner namespace.** Because the pool of eligible registrants is small, sensible firm names are more attainable than on saturated .com.
+
+## Things to consider
+
+- **You must qualify, and stay qualified.** This is the central trade-off: if you are not a licensed CPA or CPA firm, you simply cannot register, and you must remain eligible to renew.
+- **Limited geography.** Eligibility currently covers the US, Canada, and Ireland — practitioners elsewhere are excluded.
+- **Verification takes time.** Registration is not instant; the registry validates your license and identity, which can take from hours to longer depending on available data.
+- **Lower public recognition.** General consumers still expect .com, so some firms run .cpa alongside a .com they already own.
+
+## Who can register a .cpa domain?
+
+**Registration restrictions (read this first):** .cpa is **credential-gated and restricted**. To register, you must be either (i) a licensed CPA firm holding a CPA firm license issued by a state board of accountancy, or (ii) an individual holding a CPA license. Availability is limited to **United States, Canada, and Ireland** based applicants. Crucially, eligibility is verified **at the time of purchase and again at every renewal** — this is not a one-time check. The registry, operated by CPA.com in association with the AICPA, monitors ongoing compliance, and an inability to demonstrate a valid license at renewal can prevent you from keeping the name.
+
+The verification covers both your CPA credential and your identity, so applicants should expect a review window rather than instant activation. The authoritative rules live on the registry operator's own [.cpa eligibility FAQ](https://register.domains.cpa/faqs/). As a restricted new gTLD, .cpa is governed by an ICANN Registry Agreement and standard policies; DNSSEC is supported, and the restricted nature of the namespace means lookalike and abusive registrations are structurally prevented rather than merely policed after the fact.
+
+## .cpa pricing and value
+
+.cpa is a specialty, verified TLD, and that shapes its pricing **dynamics** (this page never quotes actual numbers). Expect it to sit well above commodity open extensions, reflecting the cost of identity and license verification rather than a generic registration. As with most TLDs, first-year and renewal pricing can differ, and the renewal price — not the introductory one — is what matters for a long-held firm identity. There is generally no large speculative premium-name market here, because the namespace is restricted to eligible professionals rather than open to investors. The real "value" calculus is qualitative: you are paying for a verified credential signal and impersonation resistance, not for a tradeable asset.
+
+## Reputation and email deliverability
+
+.cpa enjoys an unusually strong reputation for a young TLD precisely because it cannot be bought by spammers or impersonators. A restricted, license-verified namespace is the opposite of the cheap, high-volume TLDs that mailbox providers learn to distrust, so a `@firm.cpa` sending domain starts from a position of credibility rather than suspicion. As always, deliverability still depends on correct configuration: publish SPF, DKIM, and DMARC records, warm up new sending domains, and follow normal email hygiene. The suffix gives you a clean reputation to build on, but it does not exempt you from authentication best practices.
+
+## Branding and naming tips
+
+- **Lead with your firm name:** `smithcpa.cpa` is redundant; `smith.cpa` reads cleanly and lets the suffix do the work of saying "CPA."
+- **Mind the read-aloud test:** "smith dot c-p-a" is clear over the phone, which matters for a profession that still does a lot of business by voice and referral.
+- **Avoid confusing constructions** that bury the dot inside a word; the strength of .cpa is that the credential is obvious, so don't obscure it.
+- **Consider a defensive .com** if you have one, and point it at the .cpa site, so clients who type the familiar extension still reach you.
+
+## How to register a .cpa domain at Namefi
+
+1. **Search** your desired name on [Namefi](https://namefi.io) to check availability.
+2. **Confirm eligibility** — have your CPA or CPA firm license details ready, since the registry verifies them before issuing the name.
+3. **Choose and register**, then complete the verification step required for this restricted TLD.
+
+Namefi is an ICANN-accredited [registrar](/en/glossary/registrar) with transparent pricing, fast [DNS](/en/glossary/dns) management, and optional Web3 domain tokenization — so once your verified .cpa name is live, you can manage it the same way you would any other domain.
+
+## Frequently asked questions
+
+### Can anyone register a .cpa domain?
+
+No. .cpa is a restricted, credential-gated TLD. Only licensed CPA firms and individually licensed CPAs based in the United States, Canada, or Ireland may register, and the registry verifies your CPA license and identity both at the time of purchase and at every renewal.
+
+### Does a .cpa domain affect SEO?
+
+A TLD choice is not a direct Google ranking factor, so .cpa neither helps nor hurts rankings on its own. Its real value is trust and credibility: a .cpa address signals a verified accounting professional, which can improve click-through and reduce impersonation risk.
+
+### Who should register a .cpa domain?
+
+Licensed CPA firms and individual CPAs who want a verified, profession-specific web and email identity. It suits practices that value anti-impersonation security and a credential signal more than a short, generic name.
+
+### What happens to my .cpa domain if my CPA license lapses?
+
+Eligibility is re-checked at each renewal. If you can no longer demonstrate a valid CPA license or firm license, you may be unable to renew the domain, since the registry validates eligibility on an ongoing basis rather than only at first purchase.
+
+## Related resources
+
+- [What Is a TLD?](/en/blog/what-is-a-tld)
+- [What Is a Domain?](/en/blog/what-is-domain)
+- [Domain Terminology Guide](/en/blog/domain-terminology-guide)
+- [Top TLDs to Secure for Your Accounting Firm](/en/blog/top-tlds-to-secure-for-your-accounting-firm)
+- [.com domain](/en/tld/com)
+- [Glossary: Registrar](/en/glossary/registrar)
+- [Glossary: ICANN](/en/glossary/icann)
+- [Glossary: DNS](/en/glossary/dns)

--- a/content/tld/en/deals.md
+++ b/content/tld/en/deals.md
@@ -1,0 +1,159 @@
+---
+title: 'What Is the .deals Domain? The E-Commerce Deals Extension'
+date: '2026-06-15'
+language: 'en'
+tags: ['tld']
+authors: ['namefiteam']
+draft: false
+description: 'The .deals domain is an open new gTLD run by Binky Moon (Identity Digital), built for coupon sites, bargain hunters, and e-commerce promotions. Here is who it suits and why.'
+keywords: ['.deals domain', 'what is .deals', '.deals TLD', '.deals domain registration', 'coupon domain', 'deals website domain', 'Binky Moon', 'Identity Digital gTLD']
+faqs:
+  - question: 'Can anyone register a .deals domain?'
+    answer: 'Yes. The .deals domain is an open generic top-level domain with no eligibility restrictions. Any individual or business can register an available .deals name through an ICANN-accredited registrar, with no credential, membership, or local-presence requirement.'
+  - question: 'Does a .deals domain affect SEO?'
+    answer: 'No. Google treats .deals as a generic, non-geographic gTLD, so it ranks on the same footing as .com. There is no inherent ranking boost or penalty from the suffix itself; content quality, relevance, and links decide rankings.'
+  - question: 'Who should register a .deals domain?'
+    answer: 'It suits coupon and discount sites, deal aggregators, flash-sale and clearance pages, affiliate marketers, and brands that want a memorable address for a promotions or savings microsite separate from their main domain.'
+  - question: 'Is .deals good for an e-commerce or coupon site?'
+    answer: 'Yes. The word "deals" is exactly what bargain-hunting shoppers search for, so the suffix describes the offer in the name itself. It is a natural fit for coupon directories, daily-deal sites, and seasonal sale landing pages.'
+---
+
+The **.deals domain** is a descriptive new generic top-level domain (gTLD) built around one of the most commercially loaded words on the internet: *deals*. For coupon sites, discount aggregators, flash-sale pages, and any brand that wants an address shoppers instantly understand, .deals puts the value proposition right in the name. Instead of bolting "savings" onto a forgettable string, you can register something like `summer.deals` or `brand.deals` and tell visitors exactly what they will find.
+
+This page explains what .deals is, who runs it, how people use it, and the real trade-offs to weigh before you register one.
+
+## .deals at a glance
+
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (new gTLD) |
+| Registry operator | Binky Moon, LLC (an [Identity Digital](https://identity.digital/) company) |
+| Year launched | 2014 (general availability October 2014) |
+| IDN support | Yes (Identity Digital supports internationalized domain names) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility requirements |
+| Best for | Coupon sites, deal aggregators, e-commerce promotions, sale landing pages |
+
+## What is .deals?
+
+.deals is a **generic, non-sponsored gTLD** that entered the DNS root during ICANN's 2012 new-gTLD expansion. The word is a dictionary term in English, so the suffix carries an obvious meaning to a global audience: bargains, discounts, and offers. It is not tied to any country or community, which means it functions as a worldwide commercial extension rather than a regional one.
+
+For search engines, that generic status matters. Google does not geo-target .deals to any particular country — unlike a ccTLD such as `.de` or `.uk` — so a .deals site can rank globally without being boxed into one market. Google's own guidance is that new gTLDs are treated like any other generic domain for ranking purposes; the suffix neither helps nor hurts on its own. You can confirm the root-zone delegation in the official [IANA root database entry for .deals](https://www.iana.org/domains/root/db/deals.html).
+
+## History of .deals
+
+.deals was one of hundreds of descriptive "dot-word" extensions delegated during the new-gTLD program. It was originally delegated in 2014 and reached general availability in October 2014, opening registration to the public after the standard sunrise and landrush phases.
+
+The string was first operated under the Donuts portfolio (the company behind a large family of category gTLDs such as `.coupons`, `.discount`, `.sale`, and `.bargains`). Through the industry consolidation that produced **Identity Digital** — which brought together Donuts, Afilias, and their registry subsidiaries — .deals is today administered by **Binky Moon, LLC**, the entity that holds the registry agreements for a large block of Identity Digital's generic strings. You can read more about the operator on the [Identity Digital registry site](https://identity.digital/registry). Adoption has stayed steady within its niche: it is a focused commercial extension rather than a mass-market one, used most by deal-oriented and affiliate businesses rather than general-purpose websites.
+
+## How people use .deals
+
+Real-world use clusters tightly around savings and commerce:
+
+- **Coupon and discount directories** that list active promo codes.
+- **Daily-deal and flash-sale sites** where the whole brand is the offer.
+- **Seasonal sale microsites** — think a `blackfriday.deals` or `clearance.deals` landing page run alongside a main store.
+- **Affiliate and cashback marketers** who want a keyword-rich address.
+- **Brand promotion hubs** where a company points `yourbrand.deals` at its current offers.
+- **Travel, electronics, and category deal aggregators** that curate bargains in a vertical.
+
+**Who it's not ideal for:** if you are building a corporate homepage, a personal portfolio, a SaaS product, or anything where the word "deals" misrepresents what you do, the suffix will narrow perception. It signals discounts — great for a coupon site, off-message for a law firm or a fintech. Brands that want a neutral primary address usually still anchor on [.com](/en/tld/com) and use .deals for a campaign or savings section.
+
+## Notable sites using .deals
+
+.deals is a niche commercial suffix rather than a home for household-name flagship sites, so its typical use is best described by pattern rather than by famous example. In practice it appears most often as **promotional and campaign domains** — sale landing pages, coupon directories, and affiliate deal hubs — often registered defensively by retailers and deal publishers to match a "deals" search intent. Because naming specific live sites risks pointing at addresses that may change hands, the honest summary is this: when you see a .deals address, it almost always belongs to something offering discounts, coupons, or curated bargains.
+
+## .deals vs other domains
+
+| Suffix | Type | Signals | Notes |
+| --- | --- | --- | --- |
+| .deals | Generic new gTLD | "Discounts / bargains" | Exact-match for offer and coupon sites |
+| [.shop](/en/tld/shop) | Generic new gTLD | "Buy here / storefront" | Broader retail meaning, larger adoption |
+| [.store](/en/tld/store) | Generic new gTLD | "A shop / catalog" | Good for full e-commerce, less promo-specific |
+| [.com](/en/tld/com) | Legacy gTLD | "Default / trusted" | Most recognized; least descriptive |
+
+Pick **.deals** when the offer *is* the product — coupons, promo codes, flash sales. Choose [.shop](/en/tld/shop) or [.store](/en/tld/store) when you are selling goods directly and want a general retail signal, and keep [.com](/en/tld/com) as the trusted primary address if you can secure it. Many businesses register more than one and redirect them.
+
+## Why choose .deals?
+
+- **The name explains itself.** "Deals" is exactly what bargain-hunters type and search for, so a `something.deals` address communicates intent before a visitor reads a single word of copy.
+- **Strong exact-match potential.** Short, memorable left-of-dot words (`hot.deals`, `daily.deals`) read as natural phrases, which is hard to achieve on a crowded [.com](/en/tld/com).
+- **Globally generic.** No country targeting and no eligibility gate, so it works for any market and any registrant.
+- **Part of a coherent family.** Sitting alongside `.coupons`, `.sale`, and `.discount` under the same operator makes it easy to build a tidy set of campaign domains.
+
+## Things to consider
+
+- **It is a niche signal.** The suffix is excellent for promotions and badly fitting for anything else — it pigeonholes a brand toward discounting.
+- **Lower recognition than legacy TLDs.** Some non-technical users still default to typing `.com`; a .deals address may need reinforcement in marketing.
+- **Premium names cost more.** Many short or high-demand .deals strings are reserved as premium and carry higher, recurring pricing (see below).
+- **Spam-adjacent category.** Coupon and "deals" content is a space with a lot of low-quality and affiliate-spam activity, which can color first impressions and email reputation (see *Reputation* below).
+
+## Who can register a .deals domain?
+
+**Registration restrictions: open to all.** .deals is a non-sponsored, unrestricted gTLD. There is no credential, membership, trademark, or local-presence requirement — any individual or organization can register an available .deals name through an ICANN-accredited registrar.
+
+A few administrative facts worth knowing:
+
+- **Sunrise/trademark:** like all new gTLDs, .deals went through an ICANN-mandated sunrise period giving trademark holders (via the Trademark Clearinghouse) first claim on matching names. That period is long closed; registration is now first-come, first-served, and the Trademark Claims notice service protects matched marks.
+- **Length and IDN rules:** standard label rules apply (3–63 characters), and the registry supports internationalized domain names for non-Latin scripts.
+- **Admin behavior:** DNSSEC is supported, WHOIS privacy is offered by most registrars, and the suffix follows the standard ICANN gТLD lifecycle for transfers, renewals, and the redemption grace period after expiry.
+
+The governing rules live in the **ICANN Registry Agreement** for the string — see the official [.deals registry agreement details on ICANN](https://www.icann.org/en/registry-agreements/details/deals) for the authoritative operator and policy record.
+
+## .deals pricing and value
+
+Pricing for .deals is set by registrars within the framework the registry allows, so this page covers **dynamics, not numbers**. A few patterns hold across the suffix:
+
+- **Premium tiers exist.** The registry reserves a set of short, common, or commercially valuable names (often single dictionary words) as **premium** domains. These carry higher registration fees that typically recur every year, not just at signup.
+- **First-year and renewal pricing differ.** As with most new gTLDs, an introductory or promotional first-year rate at a registrar usually rises to a standard renewal rate afterward — always check the renewal price, not just the intro price, before committing.
+- **What drives cost:** the name's length and keyword value, whether it is flagged premium, and the registrar's own margin and promotions.
+
+Treat the left-of-dot word as the real asset: a clean, brandable `*.deals` phrase holds value precisely because it reads as a complete idea.
+
+## Reputation and email deliverability
+
+.deals is perceived as a **clearly commercial, promotion-focused** suffix. That is a strength when the content matches — a coupon site on .deals looks purpose-built. The trade-off is that the broader "deals/coupon" category attracts a lot of thin affiliate content and outright spam across the web, so some users and spam filters approach unfamiliar promotional domains with mild caution.
+
+In practice, deliverability is governed far more by your sending hygiene than by the suffix. To send trustworthy email from a .deals domain, configure **SPF, DKIM, and DMARC** correctly, warm up new sending domains gradually, keep lists clean, and avoid spammy subject lines. A well-authenticated .deals domain with genuine content reaches inboxes fine; the suffix is not blocklisted, but it does benefit from extra diligence given the company it keeps.
+
+## Branding and naming tips
+
+- **Lean into the domain hack.** The strongest .deals names treat the dot as a word break: `daily.deals`, `hot.deals`, `travel.deals`, `brand.deals`. Aim for a two-word phrase that reads naturally.
+- **Keep the left label short and concrete.** A category or brand word works best; long or abstract phrases dilute the punch.
+- **Mind the plural.** It is *deals*, not *deal* — make sure your marketing, logo, and verbal mentions consistently say "dot deals" so people type the right thing.
+- **Pair it with your main brand.** Using `yourbrand.deals` for a promotions hub keeps campaigns memorable while your primary site stays on its core domain.
+
+## How to register a .deals domain at Namefi
+
+1. **Search** for the name you want on [Namefi](https://namefi.io) to check availability across the suffix.
+2. **Choose** the exact `*.deals` string that best matches your campaign or brand.
+3. **Register** and configure DNS — Namefi offers transparent pricing, fast DNS setup, and the option to tokenize eligible domains for Web3 ownership.
+
+Namefi is an ICANN-accredited registrar, so your .deals domain is a standard, fully portable registration you can transfer or manage like any other. [Start your search on Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .deals domain?
+
+Yes. The .deals domain is an open generic top-level domain with no eligibility restrictions. Any individual or business can register an available .deals name through an ICANN-accredited registrar, with no credential, membership, or local-presence requirement.
+
+### Does a .deals domain affect SEO?
+
+No. Google treats .deals as a generic, non-geographic gTLD, so it ranks on the same footing as .com. There is no inherent ranking boost or penalty from the suffix itself; content quality, relevance, and links decide rankings.
+
+### Who should register a .deals domain?
+
+It suits coupon and discount sites, deal aggregators, flash-sale and clearance pages, affiliate marketers, and brands that want a memorable address for a promotions or savings microsite separate from their main domain.
+
+### Is .deals good for an e-commerce or coupon site?
+
+Yes. The word "deals" is exactly what bargain-hunting shoppers search for, so the suffix describes the offer in the name itself. It is a natural fit for coupon directories, daily-deal sites, and seasonal sale landing pages.
+
+## Related resources
+
+- [.shop domain](/en/tld/shop) — the broader retail extension and a close alternative.
+- [.store domain](/en/tld/store) — for full e-commerce storefronts.
+- [.com domain](/en/tld/com) — the default trusted primary address.
+- [What is a TLD?](/en/blog/what-is-a-tld) — how top-level domains work.
+- [Top TLDs to secure for your e-commerce store](/en/blog/top-tlds-to-secure-for-your-ecommerce-store) — a buyer's checklist for online retail.
+- [ICANN](/en/glossary/icann) and [registrar](/en/glossary/registrar) — key terms in the glossary.

--- a/content/tld/en/esq.md
+++ b/content/tld/en/esq.md
@@ -1,0 +1,161 @@
+---
+title: 'What Is the .esq Domain? The Extension for Lawyers Explained'
+date: '2026-06-15'
+language: 'en'
+tags: ['tld']
+authors: ['namefiteam']
+draft: false
+description: 'The .esq domain is a Google Registry extension built for lawyers and law firms. Learn who can register, how it is perceived, and whether it fits your practice.'
+keywords: ['.esq domain', 'what is .esq', '.esq domains', 'esq TLD for lawyers', 'esquire domain', 'Charleston Road Registry', 'Google Registry TLD', 'law firm domain']
+faqs:
+  - question: 'Can anyone register a .esq domain?'
+    answer: 'Yes. Despite being marketed for the legal profession, .esq is open to everyone on a first-come, first-served basis. The registry does not verify bar membership or legal credentials, so registration is not gated the way .law and .cpa are.'
+  - question: 'Does a .esq domain affect SEO?'
+    answer: 'No. Google treats .esq as a generic top-level domain with no inherent ranking advantage or penalty. As a new gTLD it carries no geographic targeting, so rankings depend on content, links, and user experience rather than the suffix itself.'
+  - question: 'Who should register a .esq domain?'
+    answer: 'Practicing attorneys, solo lawyers, and law firms who want a domain that signals their profession at a glance. It also suits legal professionals building a personal brand around their name, such as firstname.esq.'
+  - question: 'Why do .esq sites always need HTTPS?'
+    answer: 'Charleston Road Registry placed the entire .esq namespace on the HSTS preload list, so browsers force HTTPS on every .esq site. You must install a valid TLS certificate or the site will not load in modern browsers.'
+  - question: 'Is .esq better than .law or .attorney for a law firm?'
+    answer: '.esq is the shortest and most universally recognized of the legal extensions, but unlike .law it is open to anyone, which slightly dilutes its credentialing value. .law and .attorney are longer; the best choice depends on your name and budget.'
+---
+
+The **.esq domain** takes its name from "Esq.," the post-nominal abbreviation of "Esquire" that attorneys in the United States place after their names to signal they are admitted to practice law. Operated by Google's domain arm, it is a niche but instantly readable extension built for one audience above all others: lawyers and law firms who want a web address that announces their profession before a visitor reads a single word.
+
+If you are a solo attorney, a boutique firm, or a legal professional building a personal brand, .esq lets you turn your own name into a memorable address — `jane.esq` reads cleaner than `janesmithlaw.com`. This page covers what .esq is, who runs it, who can register it (the answer surprises most people), and how it compares to the other legal extensions.
+
+## .esq at a glance
+
+| Fact | Detail |
+| --- | --- |
+| TLD type | New gTLD (generic, not geographic) |
+| Registry operator | Charleston Road Registry Inc. (Google Registry) |
+| ICANN agreement signed | 2014 |
+| General availability | May 2023 |
+| IDN support | Yes |
+| DNSSEC | Supported |
+| HTTPS | Mandatory — entire namespace is HSTS-preloaded |
+| Registration restrictions | Open to all — first-come, first-served, no credential check |
+| Best for | Attorneys, law firms, legal professionals building a name-based brand |
+
+## What is .esq?
+
+.esq is a **new generic top-level domain (gTLD)** delegated to the internet's root zone during ICANN's 2012 new-gTLD expansion. The string is derived from "Esquire," a courtesy title that, in modern American usage, is appended to the names of practicing attorneys (for example, "Jane Smith, Esq."). The suffix therefore carries an immediate, profession-specific meaning that a generic extension like .com cannot.
+
+Because it is a generic gTLD and not a country-code domain, Google does not tie .esq to any country or region. As Google's own [Search Central documentation](https://developers.google.com/search/docs/specialty/international/locale-adaptive-pages) explains, generic new gTLDs are treated like any other generic domain for ranking purposes and are not geo-targeted by default. A .esq site can rank globally; the suffix neither helps nor hurts on its own.
+
+You can confirm the delegation and operator details in the authoritative [IANA root-zone entry for .esq](https://www.iana.org/domains/root/db/esq.html).
+
+## History of .esq
+
+The registry agreement for .esq was signed by ICANN and Charleston Road Registry in 2014, but the string sat largely dormant for years. The pivotal moment came in **May 2023**, when Google announced a batch of eight new top-level domains and opened .esq to the public. As reported by the legal-technology publication [LawSites](https://www.lawnext.com/2023/05/theres-a-new-top-level-domain-for-lawyers-esq.html), .esq reached general availability after a brief Early Access Period in which premium pricing started high and dropped daily until it hit the standard rate.
+
+To launch the extension, Google highlighted real attorneys already using it — **Erika Kullberg** at `erika.esq` and **Ugo Lord** ("the TikTok attorney") at `ugo.esq` — signaling that .esq was aimed at the personal-brand and legal-creator market rather than large institutional firms.
+
+## How people use .esq
+
+- **Solo and small-firm attorneys** turning their own name into a clean, professional address.
+- **Legal content creators and "law-fluencers"** who build an audience on social platforms and want a matching, memorable home base.
+- **Boutique practices** that want their suffix to communicate "law" without spelling it out.
+- **Personal-brand pages** for attorneys who blog, speak, or publish under their own name.
+
+**Who it's not ideal for:** Non-lawyers and businesses outside the legal field. Because "Esq." is a legal honorific, using .esq when you are not connected to law can read as misleading. It is also a poor fit for organizations that need a country-specific or broadly generic address, or for anyone on a tight budget who only needs a basic .com.
+
+## Notable sites using .esq
+
+- **erika.esq** — Erika Kullberg, attorney and personal-finance educator, featured by Google at launch.
+- **ugo.esq** — Ugo Lord, an attorney with a large social-media following.
+- **sam.esq** — Sam Higgs, a Houston-based lawyer who uses the domain for his personal site.
+
+These early adopters share a pattern: individual attorneys using `firstname.esq` as a personal brand, which is exactly the use case the extension was designed to encourage.
+
+## .esq vs other domains
+
+| Extension | Meaning | Open to all? | Length |
+| --- | --- | --- | --- |
+| .esq | "Esquire" (attorney honorific) | Yes | Short |
+| [.com](/en/tld/com) | Commercial / general | Yes | Short |
+| .law | Legal profession | No — bar verification required | Medium |
+| .attorney | Legal profession | Yes | Long |
+
+Pick **.com** for the most universally trusted, broadest-reach address when the legal angle is secondary. Pick **.law** when verified credentialing matters most and you want a registry that confirms every registrant is a licensed legal professional. Pick **.esq** for the shortest, most recognizable legal suffix when you value brevity and personal branding over gatekept exclusivity.
+
+## Why choose .esq?
+
+- **Instant professional signal.** Three letters that the legal world reads as "attorney" with no explanation needed.
+- **Short and brandable.** "Esq" is shorter than "law," "legal," or "attorney," leaving more room for a clean `firstname.esq` construction.
+- **Backed by a major operator.** Charleston Road Registry (Google Registry) runs the infrastructure, which means robust DNS and a serious long-term commitment to the namespace.
+- **Secure by default.** Every .esq site is forced onto HTTPS through HSTS preloading, so visitors always get an encrypted connection.
+
+## Things to consider
+
+- **It looks restricted but is not.** Many people assume only licensed attorneys can register .esq. Because the registry does not verify credentials, a .esq address proves nothing about bar admission — which weakens its value as a trust marker compared with .law.
+- **Mandatory HTTPS adds a setup step.** You cannot serve a .esq site over plain HTTP; a valid TLS certificate is required before it will load at all.
+- **Narrow meaning.** The suffix is tightly bound to the legal profession, with little use outside that niche.
+- **Recognition is still building.** Public since only 2023, .esq is far less familiar than .com, so some visitors may need reassurance the address is legitimate.
+
+## Who can register a .esq domain?
+
+**Registration restrictions: open to all.** This is the single most misunderstood fact about .esq. Although it is named after an attorney's honorific and marketed to "lawyers and law firms," the registry **does not gate registration behind any credential check**. Anyone can register an available .esq domain on a first-come, first-served basis, with no requirement to prove bar membership, a law degree, or any legal qualification. It differs sharply from [.law](https://www.icann.org/en/registry-agreements/details/law), where the registry verifies registrants are licensed legal professionals, and from .cpa, restricted to accountants.
+
+The governing rules live in the ICANN [Registry Agreement for .esq](https://www.icann.org/en/registry-agreements/details/esq) with Charleston Road Registry. Standard new-gTLD policies apply: a Sunrise period gave trademark holders first claim, and Google Registry honors all of ICANN's Rights Protection Mechanisms, including a Trademark Claims service that alerts brand owners to matching registrations. Domain strings follow the usual rules — 1 to 63 characters, letters, numbers, and hyphens (no hyphens in the third and fourth positions), with internationalized domain names (IDNs) supported. DNSSEC is available, and WHOIS privacy is typically offered by registrars subject to the registry's policies.
+
+One technical rule is non-negotiable: the **entire .esq zone is on the HSTS preload list**, so HTTPS is mandatory for every site, with no opt-out.
+
+## .esq pricing and value
+
+.esq sits in the **mid-premium tier** of new gTLDs — generally priced above a commodity .com but well below the most expensive niche extensions. A few dynamics drive what you will pay:
+
+- **First-year vs. renewal pricing differ.** An introductory or promotional first year does not predict the renewal rate; budget for the standing renewal price you pay every year thereafter.
+- **Premium names cost more.** Short, common, or high-demand strings (first names and generic legal terms) are often classified by the registry as premium and carry higher registration and renewal fees.
+- **Early-access pricing was steep, then normalized.** At launch, a premium-priced early-access window let buyers grab names at a steeply declining rate; that window has long closed, and standard names now register at the regular tier.
+
+Because pricing changes over time and varies by registrar, always check the current rate at registration rather than relying on figures you read elsewhere.
+
+## Reputation and email deliverability
+
+.esq is perceived as a **specialist, professional** extension rather than a cheap or spammy one. It has no notable history of abuse, and the mandatory-HTTPS posture signals a security-conscious namespace. That said, because it is a newer gTLD, some recipients and the occasional conservative spam filter may be less familiar with it than with .com. The mitigation is the same as for any newer extension: authenticate email with SPF, DKIM, and DMARC, and warm up sending domains gradually. Done right, a .esq address delivers just as reliably as a legacy domain.
+
+## Branding and naming tips
+
+The natural .esq domain hack is your **own name as the second-level label**: `jane.esq`, `smith.esq`, or `firmname.esq`. This reads almost like a signature line — "Jane, Esq." — and is the pattern early adopters like erika.esq and ugo.esq established. Keep it short; the whole appeal is brevity. Be aware that some listeners hear "esq" spelled out letter by letter, so test how your domain sounds aloud, and consider whether non-lawyers in your audience will recognize the abbreviation.
+
+## How to register a .esq domain at Namefi
+
+1. **Search** for your desired name (for example, your surname) using the [Namefi](https://namefi.io) domain search.
+2. **Choose** an available .esq string — shorter, name-based labels work best.
+3. **Register** and configure your DNS, remembering that a valid TLS certificate is required because .esq forces HTTPS.
+
+Namefi is an ICANN-accredited registrar with transparent pricing and fast DNS, and it also supports Web3 tokenization if you later want to hold your domain as an on-chain asset. Start your search at [Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .esq domain?
+
+Yes. Despite being marketed for the legal profession, .esq is open to everyone on a first-come, first-served basis. The registry does not verify bar membership or legal credentials, so registration is not gated the way .law and .cpa are.
+
+### Does a .esq domain affect SEO?
+
+No. Google treats .esq as a generic top-level domain with no inherent ranking advantage or penalty. As a new gTLD it carries no geographic targeting, so rankings depend on content, backlinks, and user experience rather than the suffix.
+
+### Who should register a .esq domain?
+
+Practicing attorneys, solo lawyers, and law firms who want a domain that signals their profession at a glance. It suits legal professionals building a personal brand around their own name, using the `firstname.esq` pattern early adopters popularized.
+
+### Why do .esq sites always need HTTPS?
+
+Charleston Road Registry placed the entire .esq namespace on the HSTS preload list, so browsers force HTTPS on every .esq site. You must install a valid TLS certificate or the site will refuse to load in modern browsers, with no opt-out.
+
+### Is .esq better than .law or .attorney for a law firm?
+
+.esq is the shortest and most recognizable legal extension, but unlike .law it is open to anyone, which slightly dilutes its credentialing value. .law requires verified bar membership; .attorney is longer but also open. The best choice depends on your name, branding goals, and budget.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [Top TLDs to secure for your law firm](/en/blog/top-tlds-to-secure-for-your-law-firm)
+- [Domain terminology guide](/en/blog/domain-terminology-guide)
+- [.com domain](/en/tld/com)
+- [ICANN (glossary)](/en/glossary/icann)
+- [DNSSEC (glossary)](/en/glossary/dnssec)

--- a/content/tld/en/estate.md
+++ b/content/tld/en/estate.md
@@ -1,0 +1,154 @@
+---
+title: 'What Is the .estate Domain? A Guide for Real Estate'
+date: '2026-06-15'
+language: 'en'
+tags: ['tld']
+authors: ['namefiteam']
+draft: false
+description: 'The .estate domain is an open generic extension built for real estate agents, brokerages, and property businesses. Learn who uses it, how it is priced, and whether it fits.'
+keywords: ['.estate domain', 'what is .estate', 'estate TLD', 'real estate domain', 'estate domain registration', 'property domain', 'new gTLD', 'Binky Moon']
+faqs:
+  - question: 'Can anyone register a .estate domain?'
+    answer: 'Yes. .estate is an open generic top-level domain with no eligibility restrictions. You do not need a real estate license, a brokerage, or any credential, so individuals, agents, and companies worldwide can register an available name on a first-come, first-served basis.'
+  - question: 'Does a .estate domain affect SEO?'
+    answer: 'No. Google treats .estate as a generic top-level domain with no inherent ranking advantage or penalty. Rankings depend on content quality, links, and user experience, not the suffix. A well-built .estate site can rank as well as a .com one.'
+  - question: 'Who should register a .estate domain?'
+    answer: 'Real estate agents, brokerages, property managers, developers, and estate-planning firms that want a descriptive, exact-match name. It also suits luxury or boutique property brands that want the address itself to signal the industry.'
+  - question: 'Is .estate good for a real estate business?'
+    answer: 'It can be a strong fit. The word directly names the industry, so a .estate address reads as on-topic and exact-match. For a large agency that prizes maximum familiarity and resale value, a matching .com may still be the safer default.'
+---
+
+The **.estate domain** is a descriptive generic top-level domain (gTLD) aimed squarely at the property world: real estate agents, brokerages, property managers, developers, and estate-planning firms. Where a neutral suffix says nothing about what you do, `.estate` puts the industry directly in the web address, turning the domain itself into a plain-language statement of business.
+
+For agents, founders, and marketing managers weighing a niche extension over a crowded `.com`, the practical questions are: who runs this suffix, who actually uses it, and is it worth registering? This page answers all three with verifiable registry facts and an honest look at the trade-offs.
+
+## .estate at a glance
+
+| Fact | Detail |
+| --- | --- |
+| TLD type | New generic top-level domain (gTLD) |
+| Registry operator | Binky Moon, LLC (an Identity Digital subsidiary) |
+| Year launched | 2014 (general availability; delegated to the root in 2013) |
+| IDN support | Yes (varies by registrar) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility requirements |
+| Best for | Real estate agents, brokerages, property managers, estate-planning firms |
+
+## What is .estate?
+
+`.estate` is a dictionary-word gTLD created under ICANN's New gTLD Program, the 2012-era expansion that introduced hundreds of word-based suffixes alongside the legacy set like `.com` and `.net`. The string is the English word *estate* — which carries two complementary meanings useful to the domain: a large property or landholding (as in "real estate"), and a person's total assets and affairs (as in "estate planning"). Both senses map cleanly onto property, wealth, and the businesses that serve them.
+
+That dual meaning is the suffix's value proposition. The address communicates "property and real estate" before a visitor reads a word of copy, which is exactly the kind of self-evident framing a descriptive extension is meant to provide.
+
+As a generic gTLD, `.estate` is **not tied to any country** and carries no geographic targeting signal. Per [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites), new gTLDs like this are treated as generic and are not used to infer a target country, so a `.estate` site competes globally rather than being boxed into one region. You can confirm the registry details on the official [IANA root-zone entry for .estate](https://www.iana.org/domains/root/db/estate.html).
+
+## History of .estate
+
+`.estate` was part of the first waves of the 2012 New gTLD Program to reach the internet root, with delegation recorded in late 2013 and general availability following in 2014. It originally launched within the Donuts portfolio, the operator that applied for and rolled out one of the largest collections of word-based gTLDs, many of them industry verticals like `.estate`.
+
+Over the following years the operating entity consolidated under **Binky Moon, LLC**, the registry-operator subsidiary that today holds the contracts for a large share of Identity Digital's portfolio. (Identity Digital is the rebranded successor to Donuts following its merger with Afilias.) So while registrar-facing branding usually says "Identity Digital," the contracted registry operator of record for `.estate` is Binky Moon, LLC — the name you will see on the IANA entry and the ICANN registry agreement.
+
+Adoption has been steady rather than explosive. `.estate` sits among Identity Digital's industry-vertical gTLDs — recognizable to real estate and property buyers without the headline volumes of mainstream suffixes. Registration counts fluctuate with promotions and renewals, so treat any single figure with caution.
+
+## How people use .estate
+
+Real, specific niches where `.estate` fits naturally:
+
+- **Real estate agents and brokerages** wanting an exact-match address for a personal brand or firm.
+- **Property management companies** handling rentals, maintenance, and tenant services.
+- **Developers and home builders** marketing new communities or individual projects.
+- **Estate-planning and wealth advisors** leaning into the "estate" sense of assets and inheritance.
+- **Luxury and boutique property brands** that want the suffix to underline an upmarket, specialist positioning.
+
+**Who it is not ideal for:** general-purpose businesses outside property, mass-market consumer brands, or anyone who needs a short, universally familiar address. The word "estate" is firmly on-topic, which is a strength for property and a poor fit for everything else.
+
+## Notable sites using .estate
+
+`.estate` is a niche industry suffix used mostly by agents, agencies, and property firms rather than household-name internet brands, so its footprint is built from many independent real estate businesses rather than a few famous flagship sites. Typical active use is an exact-match brand or location name — a firm, agent, or development putting its name directly on the suffix (for example a name of the form `yourbrand.estate`). Rather than invent a marquee example, the honest picture is this: it is a working extension for the property trade, not a suffix you will routinely see on a top global homepage.
+
+## .estate vs other domains
+
+| Feature | .estate | .realty | .properties | [.com](/en/tld/com) |
+| --- | --- | --- | --- | --- |
+| Meaning | Property / estates | Real estate trade | Properties / listings | Neutral, universal |
+| Best fit | Agents, property firms | Brokers, realty firms | Listing and portfolio sites | Anything |
+| Restrictions | Open to all | Open to all | Open to all | Open to all |
+| Recognition | Moderate | Moderate | Moderate | Universal |
+
+Pick `.estate` when you want the address itself to say "property" and an exact-match name is available. Related vertical suffixes like `.realty` and `.properties` send a similar signal — choose by which word matches your brand best — while [.com](/en/tld/com) remains the default when maximum familiarity and resale liquidity outweigh a descriptive suffix. Broad, flexible alternatives like [.online](/en/tld/online) or [.site](/en/tld/site) work if you would rather not pin the brand to one industry.
+
+## Why choose .estate?
+
+- **Built-in meaning:** the address communicates "real estate and property" before a visitor reads a single word of copy.
+- **Exact-match availability:** because demand is narrower than `.com`, the agent name, firm name, or location you want is far more likely to be free.
+- **Industry framing:** the suffix reads as on-topic to property buyers and sellers, reinforcing relevance at a glance.
+- **Open registration:** no license, no paperwork, no local-presence rule — anyone can register an available name.
+
+## Things to consider
+
+Be honest with yourself about the trade-offs:
+
+- **Industry lock-in:** "estate" firmly signals property. If your business may pivot beyond real estate, the name can feel mismatched later.
+- **Recognition gap:** mainstream users still default to `.com`, and some may not immediately register a `.estate` address as a "real" website.
+- **Premium pricing on some names:** short or high-demand terms may be classed as premium, with elevated registration and renewal fees (see pricing below).
+- **Spelling length:** "estate" is six letters and easy to spell, but the whole address is still longer than a tight `.com`, which matters for word-of-mouth.
+
+## Who can register a .estate domain?
+
+**Registration restrictions: none.** `.estate` is an open generic gTLD with no eligibility gate — you do not need a real estate license, a brokerage affiliation, or any credential. Any individual or organization worldwide can register an available `.estate` name on a first-come, first-served basis. This is unlike credential-gated industry suffixes such as `.realtor`, which requires membership in the National Association of Realtors; `.estate` imposes no such requirement.
+
+Standard new-gTLD policies apply. Trademark holders could claim matching names during the original Sunrise period, and ICANN's Trademark Clearinghouse Claims notices apply to flagged strings. Names follow common length and IDN rules, and DNSSEC is supported for registrants who want signed zones. WHOIS privacy availability, transfer, renewal, and redemption-grace handling are set by your [registrar](/en/glossary/registrar) within the registry's framework. The authoritative rules live in the [ICANN Registry Agreement for .estate](https://www.icann.org/en/registry-agreements/details/estate) and the operator's policies at [Identity Digital](https://identity.digital/).
+
+## .estate pricing and value
+
+This page never quotes live prices, but the **pricing dynamics** are worth understanding. `.estate` is a descriptive vertical gTLD, so standard names typically sit in the mid-range for word-based extensions — usually above bargain-bin suffixes but in line with comparable Identity Digital verticals.
+
+Two cost factors matter most. First, **first-year and renewal pricing differ**: introductory or promotional first-year rates do not carry over, and `.estate` renews at its standard rate every year, so budget for the recurring figure rather than the entry price. Second, the registry classes some desirable strings — short words, common surnames, prime location terms — as **premium names** with elevated registration and renewal fees that persist for the life of the registration. Always check whether a specific name is standard or premium before committing, since premium status follows the name, not the registrar.
+
+## Reputation and email deliverability
+
+New gTLDs as a class once carried a mild "unfamiliar suffix" perception, and a handful of cheap, abuse-prone extensions earned a poor reputation that occasionally spilled over into spam-filter heuristics. `.estate` is **not** one of the abuse-magnet suffixes: it is mid-priced, runs under a major, well-governed operator (Identity Digital / Binky Moon), and is dominated by legitimate property-industry use, which keeps its standing solid.
+
+For email deliverability, the suffix itself is rarely the deciding factor. What matters is correct authentication — SPF, DKIM, and DMARC properly configured, plus a warmed sending reputation. A `.estate` domain with clean authentication and good sending practices reaches inboxes reliably; skip the setup on any suffix and you will land in spam regardless.
+
+## Branding and naming tips
+
+- **Lead with the brand or location, let the suffix do the framing:** `riverside.estate` or `lumen.estate` reads as a property brand far more than `lumenrealty.com` would.
+- **Avoid redundancy:** you rarely need "realty," "properties," or "homes" in front of `.estate` — the suffix already places you in the industry.
+- **Use it for a domain hack where it fits:** location and surname names ("[town].estate", "[family].estate") can read cleanly as an exact-match address.
+- **Test it out loud:** because it is a real word, "[name] dot estate" should sound natural when spoken — say it before you buy it.
+
+## How to register a .estate domain at Namefi
+
+1. Search your desired name on [Namefi](https://namefi.io) to check availability and whether it is a standard or premium `.estate` string.
+2. Choose the exact name that matches your brand or location, keeping it short and clear.
+3. Complete registration and configure DNS — Namefi offers transparent pricing, fast DNS, and optional Web3 tokenization for owners who want on-chain control of their domain.
+
+Ready to claim your name? Start at [Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .estate domain?
+
+Yes. `.estate` is an open generic top-level domain with no eligibility restrictions. There is no requirement to hold a real estate license, run a brokerage, or prove any credential, so individuals, agents, and companies worldwide can register an available name on a first-come, first-served basis.
+
+### Does a .estate domain affect SEO?
+
+No. Google treats `.estate` as a generic top-level domain with no inherent ranking advantage or penalty. Search rankings depend on content quality, backlinks, and user experience, not on the suffix. A well-built `.estate` site can rank just as well as a `.com` one.
+
+### Who should register a .estate domain?
+
+Real estate agents, brokerages, property managers, developers, and estate-planning firms that want a descriptive, exact-match name. It also suits luxury or boutique property brands that want the address itself to signal the industry at a glance.
+
+### Is .estate good for a real estate business?
+
+It can be a strong fit. The word directly names the industry, so a `.estate` address reads as on-topic and exact-match, and desirable names are far more available than on `.com`. For a large agency that prizes maximum familiarity and resale value, a matching `.com` may still be the safer default.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [Top TLDs to secure for your real estate business](/en/blog/top-tlds-to-secure-for-your-real-estate-business)
+- [.com domain](/en/tld/com) — the universal default alternative
+- [.online domain](/en/tld/online) and [.site domain](/en/tld/site) — broad, flexible options
+- [Registrar](/en/glossary/registrar) and [ICANN](/en/glossary/icann) in the glossary

--- a/content/tld/en/fashion.md
+++ b/content/tld/en/fashion.md
@@ -1,0 +1,160 @@
+---
+title: 'What Is the .fashion Domain? The Style & Apparel TLD Explained'
+date: '2026-06-15'
+language: 'en'
+tags: ['tld']
+authors: ['namefiteam']
+draft: false
+description: 'The .fashion domain is an open gTLD for designers, apparel labels, and style brands who want a name that says exactly what they do — here is who it suits and why.'
+keywords: ['.fashion domain', 'what is .fashion', 'fashion TLD', 'fashion brand domain', 'apparel domain name', 'style domain extension', 'register .fashion', 'GoDaddy Registry']
+faqs:
+  - question: 'Can anyone register a .fashion domain?'
+    answer: 'Yes. The .fashion domain is an open generic TLD with no credential, industry, or local-presence requirements, so individuals and businesses anywhere can register one on a first-come, first-served basis. Some labels, such as most two-character names, are reserved by the registry.'
+  - question: 'Does a .fashion domain affect SEO?'
+    answer: 'No. Google treats .fashion as a generic top-level domain and ranks it on the same signals as .com. The extension itself gives no ranking boost or penalty, though a clear, relevant name can help click-through from search results.'
+  - question: 'Who should register a .fashion domain?'
+    answer: 'It suits clothing labels, independent designers, stylists, fashion bloggers, modeling agencies, and retailers who want a self-describing name. It works best as a primary brand identity or a memorable campaign and lookbook address.'
+  - question: 'Is .fashion good for an online clothing store?'
+    answer: 'It can be. The keyword sits in the domain itself, which reinforces the brand at a glance. Many stores still pair it with a shorter brand domain and redirect, because shoppers and email tools are more familiar with .com.'
+  - question: 'Does .fashion support WHOIS privacy?'
+    answer: 'Yes. As an open gTLD under ICANN policy, .fashion registrations support WHOIS privacy/redaction through most registrars, so personal contact details are not exposed in public WHOIS lookups.'
+---
+
+The **.fashion domain** is a generic top-level domain (gTLD) built for the style industry — clothing labels, independent designers, stylists, modeling agencies, fashion media, and apparel retailers. Where a generic extension says nothing about what a site does, a name like `summer.fashion` or `studio.fashion` puts the category in the address itself. For a sector that lives on identity and first impressions, that legibility is the whole pitch.
+
+This page covers what .fashion is, who runs it, who can register it, how it tends to be used, and the honest trade-offs to weigh before you buy.
+
+## .fashion at a glance
+
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (new gTLD) |
+| Registry operator | Registry Services, LLC (GoDaddy Registry) |
+| Year launched | Delegated 2014; general availability 2015 |
+| IDN support | Yes (varies by registrar) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no credential or local presence required |
+| Best for | Clothing labels, designers, stylists, fashion media, apparel retail |
+
+## What is .fashion?
+
+.fashion is a **generic top-level domain**, part of the new gTLD program that ICANN opened in 2012 to expand the namespace beyond legacy extensions like .com, .net, and .org. Unlike a country-code TLD such as `.fr` or `.it`, it carries no geographic meaning and is not tied to any nation. The string is plain English: the word "fashion" appears after the dot, so the domain reads as a complete phrase — `vintage.fashion`, `mens.fashion`, `slow.fashion`.
+
+Because it is a generic extension, Google does **not** geo-target .fashion to any country. The [IANA root-zone entry for .fashion](https://www.iana.org/domains/root/db/fashion.html) lists it as a global gTLD, and Google's documentation classifies new gTLDs as generic — meaning a .fashion site competes worldwide on the same footing as a .com, with no regional ranking advantage or disadvantage from the extension itself.
+
+## History of .fashion
+
+.fashion was **delegated to the DNS root in December 2014** and reached general availability in 2015, during the first major wave of new gTLD launches. It was originally introduced by Minds + Machines (MMX), a registry operator that ran a portfolio of lifestyle and interest-based extensions.
+
+Operational control later consolidated under **GoDaddy Registry** as part of GoDaddy's acquisition of the MMX portfolio. Today the [IANA record](https://www.iana.org/domains/root/db/fashion.html) names the sponsoring organization as Registry Services, LLC, with administrative contact details at GoDaddy Registry in Tempe, Arizona. The shift to a large, well-capitalized registry operator gave the extension more stable long-term backing than many niche new gTLDs received.
+
+As a focused vertical extension, .fashion has a smaller registration base than mass-market strings like .com, .xyz, or .shop. Its growth has tracked the broader appetite for keyword-in-domain branding among independent labels and digital-first brands rather than any single breakout adoption event.
+
+## How people use .fashion
+
+The extension works best when the second-level name and the suffix combine into a phrase the audience already searches for:
+
+- **Clothing and apparel labels** building a brand around a single descriptive word
+- **Independent and emerging designers** who want an affordable, on-topic identity
+- **Stylists and fashion consultants** marketing a personal practice
+- **Lookbooks, campaigns, and seasonal microsites** that need a memorable standalone URL
+- **Fashion blogs, magazines, and editorial projects**
+- **Modeling agencies and casting platforms**
+- **Sustainable / "slow fashion" projects** where the category word reinforces the mission
+
+**Who it is not ideal for:** anyone outside the style and apparel world, where the word "fashion" would confuse rather than clarify. It is also a weaker fit for a business that depends on customers typing the address from memory or dictating it over the phone, since audiences still default to assuming .com.
+
+## Notable sites using .fashion
+
+.fashion is used mainly by independent labels, designers, and campaign microsites rather than by household-name luxury houses, most of which sit on long-established .com domains. Rather than name a specific site that may change hands or lapse, it is more honest to describe the real pattern: the typical .fashion registrant is a small-to-mid apparel brand, a stylist, or an editorial project that wants the category embedded in its address. If you are evaluating the extension, judge it on how cleanly your chosen word reads before the dot, not on a marquee reference site.
+
+## .fashion vs other domains
+
+| Extension | Meaning | Restrictions | Typical use |
+| --- | --- | --- | --- |
+| [.fashion](/en/tld/fashion) | Style and apparel keyword | Open to all | Labels, designers, stylists, fashion media |
+| [.com](/en/tld/com) | Generic / commercial | Open to all | Default for almost any business |
+| [.store](/en/tld/store) | Retail / e-commerce | Open to all | Online shops of any category |
+| [.shop](/en/tld/shop) | Retail / shopping | Open to all | E-commerce and storefronts |
+
+Pick **.com** when you want the most universally trusted, familiar address and the matching name is available or affordable. Choose **.store** or **.shop** when commerce is the headline and the catalog spans categories. Reach for **.fashion** when style *is* the identity — when the apparel context is the point you most want to communicate the instant someone reads the name.
+
+## Why choose .fashion?
+
+- **Instant context.** The extension states the category, so the name reads as a self-describing phrase with no tagline required.
+- **Availability.** Short, brandable second-level names that are long gone in .com are often still open in .fashion.
+- **Brandable phrasing.** It enables clean domain hacks where the brand word and the suffix form a natural pair — `wear.fashion`, `street.fashion`.
+- **Backed by a major registry.** Operation under GoDaddy Registry gives the extension stable, long-term infrastructure rather than uncertain niche backing.
+- **Generic, global reach.** No geo-targeting and no eligibility gate means anyone, anywhere can build on it.
+
+## Things to consider
+
+- **Familiarity gap.** Most people still assume a brand "lives" at .com. You may need to educate customers or hold the matching .com defensively.
+- **Pricing tier.** Vertical new gTLDs like .fashion typically cost more per year than a baseline .com, and premium names cost more still (see below).
+- **Voice/dictation friction.** A two-word address is slightly harder to convey out loud than a single .com word.
+- **Smaller ecosystem.** Fewer registrations means occasionally less complete support in older tools that hardcode legacy extensions.
+
+## Who can register a .fashion domain?
+
+**Registration restrictions: open to all.** .fashion is an unrestricted generic TLD. There is no credential requirement, no industry-membership check, and no local-presence rule — you do **not** need to work in fashion to register one. Names are allotted first-come, first-served, like .com.
+
+A few standard registry rules still apply. Most two-character labels and certain reserved or premium strings are held back by the registry and are not openly available. Standard ICANN trademark protections governed a sunrise period at launch, and the Trademark Clearinghouse still underpins claims notices. Length and IDN rules follow normal gTLD conventions, and registrations support **DNSSEC** and **WHOIS privacy/redaction** through most registrars. Transfer, renewal, and redemption-grace behavior follow ICANN's standard gTLD lifecycle.
+
+The authoritative source for the rules governing this extension is its [ICANN Registry Agreement for .fashion](https://www.icann.org/en/registry-agreements/details/fashion), which sets out the operator's obligations, reserved names, and policy commitments.
+
+## .fashion pricing and value
+
+This page does not quote prices, because they change constantly and vary by registrar and promotion. What is durable is the **pricing structure**. Like most new gTLDs, .fashion uses tiered pricing: standard names sit at one rate, while the registry designates a set of shorter, dictionary, or high-demand names as **premium**, carrying higher first-year and often higher recurring fees. First-year and **renewal** prices commonly differ — an introductory first year can renew at a higher standard rate — so always check the renewal figure before committing. Cost is driven mainly by whether a name is standard or premium, the registry's wholesale rate, and any registrar margin or promotion. Budget for the long-term renewal price, not just the first year.
+
+## Reputation and email deliverability
+
+New gTLDs as a class once carried a mild trust discount because some cheap extensions attracted spam, and a few aggressive spam filters historically scored unfamiliar TLDs more harshly. .fashion sits on the **legitimate, brand-oriented end** of the new-gTLD spectrum — it is a vertical, mid-priced extension used by real labels, not a bargain string mass-registered for abuse, so it does not carry the worst of that baggage.
+
+For email, deliverability depends far more on your **authentication and sending practices than on the extension**. A .fashion sending domain with correctly configured SPF, DKIM, and DMARC, warmed up and kept off blocklists, reaches inboxes reliably. The honest mitigation is the same for any non-.com domain: authenticate properly, send to engaged recipients, and monitor your domain reputation.
+
+## Branding and naming tips
+
+- **Make the dot do work.** The strongest .fashion names read as a phrase: `fast.fashion`, `kids.fashion`, `house.fashion`. Let the suffix complete the idea.
+- **Keep it short and speakable.** A single, clear word before the dot is easiest to remember and to dictate.
+- **Avoid awkward splits.** Test that your name still reads cleanly if someone drops or mishears the dot.
+- **Consider defensive registrations.** If the brand matters, hold the matching .com (even as a redirect) and any obvious misspellings.
+- **Watch trademarks.** Confirm your chosen word does not collide with an existing apparel brand before you build on it.
+
+## How to register a .fashion domain at Namefi
+
+1. **Search** your desired name on [Namefi](https://namefi.io) to check availability across .fashion and alternatives.
+2. **Choose** the name that reads best — confirm whether it is a standard or premium registration, and check the renewal price.
+3. **Register** and complete checkout, then point DNS at your site or store.
+
+Namefi is an ICANN-accredited registrar with transparent pricing and fast DNS management, and it also supports Web3 domain tokenization for owners who want on-chain control of their names.
+
+## Frequently asked questions
+
+### Can anyone register a .fashion domain?
+
+Yes. The .fashion domain is an open generic TLD with no credential, industry, or local-presence requirements, so individuals and businesses anywhere can register one on a first-come, first-served basis. Some labels, such as most two-character names and certain premium strings, are reserved by the registry.
+
+### Does a .fashion domain affect SEO?
+
+No. Google treats .fashion as a generic top-level domain and ranks it on the same signals as .com. The extension itself gives no ranking boost or penalty, though a clear, relevant name can help click-through from search results.
+
+### Who should register a .fashion domain?
+
+It suits clothing labels, independent designers, stylists, fashion bloggers, modeling agencies, and retailers who want a self-describing name. It works best as a primary brand identity or a memorable campaign and lookbook address.
+
+### Is .fashion good for an online clothing store?
+
+It can be. The keyword sits in the domain itself, which reinforces the brand at a glance. Many stores still pair it with a shorter brand domain and redirect, because shoppers and email tools are more familiar with .com.
+
+### Does .fashion support WHOIS privacy?
+
+Yes. As an open gTLD under ICANN policy, .fashion registrations support WHOIS privacy/redaction through most registrars, so personal contact details are not exposed in public WHOIS lookups.
+
+## Related resources
+
+- [Top TLDs to Secure for Your Fashion Brand](/en/blog/top-tlds-to-secure-for-your-fashion-brand)
+- [Top TLDs to Secure for Your E-commerce Store](/en/blog/top-tlds-to-secure-for-your-ecommerce-store)
+- [What Is a TLD?](/en/blog/what-is-a-tld)
+- [How to Name Your Project](/en/blog/how-to-name-your-project)
+- [Registrar (glossary)](/en/glossary/registrar)
+- [Compare with .store](/en/tld/store) and [.shop](/en/tld/shop)

--- a/content/tld/en/finance.md
+++ b/content/tld/en/finance.md
@@ -1,0 +1,168 @@
+---
+title: 'What Is the .finance Domain? Uses, Rules and Value'
+date: '2026-06-15'
+language: 'en'
+tags: ['tld']
+authors: ['namefiteam']
+draft: false
+description: 'The .finance domain is an open generic gTLD run by Binky Moon (Identity Digital), built for banks, fintech, advisors and finance media. Here is who it suits and why.'
+keywords: ['.finance domain', 'what is .finance', '.finance domains', 'finance TLD', 'fintech domain', 'finance domain name', 'Identity Digital', 'Binky Moon', 'register .finance']
+faqs:
+  - question: 'Can anyone register a .finance domain?'
+    answer: 'Yes. The .finance TLD is an open generic gTLD with no eligibility restrictions. You do not need a financial licence, professional credential, or local presence to register one. Standard registrar terms and acceptable-use rules still apply.'
+  - question: 'Does a .finance domain affect SEO?'
+    answer: 'No. Google treats new gTLDs like .finance the same as .com and gives no inherent ranking boost or penalty. Keywords in a domain are not a meaningful ranking signal; your content, links, and user experience determine search performance.'
+  - question: 'Who should register a .finance domain?'
+    answer: 'It suits banks, fintech startups, financial advisors, accounting and wealth-management firms, lenders, finance media, and personal-finance creators who want a descriptive, on-topic web address that signals their industry at a glance.'
+  - question: 'Is .finance a trusted extension for handling money or sign-ups?'
+    answer: 'The suffix itself carries no special trust or verification, and finance-themed names are a known target for phishing. Users still judge a site by HTTPS, brand consistency, and reputation, so pair a .finance domain with strong security and clear branding.'
+  - question: 'Does .finance support WHOIS privacy and DNSSEC?'
+    answer: 'Yes. As an Identity Digital gTLD, .finance supports DNSSEC for registrants who enable it, and most registrars including Namefi offer WHOIS privacy so personal contact details are not published publicly.'
+---
+
+The **.finance domain** is one of the most literal addresses on the internet: it says exactly what the site is about. It is an open generic top-level domain (gTLD) aimed at banks, fintech companies, financial advisors, lenders, accountants, and anyone publishing money-related content. For a sector where clarity and credibility matter, a name like `yourbrand.finance` puts the industry right in the URL.
+
+This page covers what .finance is, who operates it, who can register one, how pricing works, how the suffix is perceived, and the alternatives worth weighing before you buy.
+
+## .finance at a glance
+
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (new gTLD, 2012 application round) |
+| Registry operator | Binky Moon, LLC — an [Identity Digital](https://identity.digital/) company |
+| Year launched | Delegated April 2014 |
+| IDN support | Yes (internationalized domain names supported) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no credential, licence, or local presence required |
+| Best for | Banks, fintech, advisors, lenders, accountants, finance media |
+
+## What is .finance?
+
+`.finance` is a **descriptive generic gTLD** — a domain extension whose meaning is in the word itself. It was introduced through ICANN's New gTLD Program, the 2012 expansion that took the root zone beyond legacy endings like .com, .net, and .org and added hundreds of keyword TLDs. According to its [IANA root-zone entry](https://www.iana.org/domains/root/db/finance.html), .finance is classified as a generic top-level domain and is administered by Binky Moon, LLC.
+
+Because it is a generic rather than a country-code TLD, .finance is **not tied to any geography**. Google's guidance on [managing multi-regional sites](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites) treats generic TLDs as global by default, so a .finance site is not geo-targeted to a specific country the way a ccTLD such as `.de` or `.fr` would be. That makes it a fit for firms operating across borders.
+
+## History of .finance
+
+The .finance string was applied for during ICANN's 2012 new-gTLD round by Donuts Inc., the company that assembled the largest portfolio of new generic extensions. The registry agreement was executed in **March 2014**, and the TLD was delegated to the root zone in **April 2014**, among the first wave of keyword gTLDs to go live.
+
+Ownership has since consolidated. Donuts merged with Afilias and later rebranded as **Identity Digital**, the operator behind hundreds of gTLDs today. The contracting entity on .finance is **Binky Moon, LLC**, an Identity Digital subsidiary that holds many of these registry agreements. The extension sits alongside a family of finance-adjacent gTLDs from the same operator — `.money`, `.loans`, `.credit`, `.tax`, `.insure`, and `.fund` — forming a small thematic cluster of money-related namespaces.
+
+## How people use .finance
+
+The suffix self-selects for finance and money topics. Common, real-world uses include:
+
+- **Banks and credit unions** wanting a clear, on-topic address for a product line or regional brand.
+- **Fintech startups** — payments, lending, neobanking, budgeting, and investing apps — that want the category baked into the name.
+- **Financial advisors, planners, and wealth managers** building a professional presence.
+- **Accounting, bookkeeping, and tax firms** that prefer a descriptive name over a generic .com.
+- **Lenders, brokers, and mortgage firms** marketing a specific service.
+- **Finance media and personal-finance creators** publishing analysis, education, or commentary.
+- **Campaign and microsite names** where a `verb.finance` or `topic.finance` construction reads cleanly.
+
+**Who it's not ideal for:** brands outside the money space, anyone who needs the broadest possible mainstream recognition (where .com still wins), or projects where the literal "finance" framing is too narrow for the long term.
+
+## Notable sites using .finance
+
+.finance has not produced a roster of household-name flagship sites the way .com or .io has; adoption is steady but spread across smaller financial businesses, advisory practices, fintech projects, and finance-content publishers rather than concentrated in a few famous brands. It is best described as a **working, descriptive namespace** used by finance-sector operators who want the topic in the URL. Judge it on fit and availability for your specific name, not on borrowed prestige from a celebrity domain.
+
+## .finance vs other domains
+
+| Extension | Type | Positioning |
+| --- | --- | --- |
+| [.com](/en/tld/com) | Legacy gTLD | Universal default; maximum recognition, but premium finance names are scarce and costly |
+| .finance | New gTLD | Descriptive, on-topic, broader availability of exact-match names |
+| [.io](/en/tld/io) | Repurposed ccTLD | Tech/startup signal; popular with fintech but says nothing about money specifically |
+| [.app](/en/tld/app) | New gTLD | App-first signal with enforced HTTPS; good for a fintech product, not a firm's main brand |
+
+Pick **.com** when broad familiarity outranks everything and you can secure (or afford) the name. Pick **.finance** when you want the category stated plainly and a short, exact-match name that is unavailable in .com. Pick **.io** or **.app** when your identity is built around being a tech product rather than a financial institution.
+
+## Why choose .finance?
+
+- **Instant context.** The reader knows what the site is about before they click — useful in ads, search snippets, and word of mouth.
+- **Availability.** Exact-match and brand names that are long gone in .com are often still open in .finance.
+- **No eligibility hurdles.** Unlike gated professional TLDs (for example `.cpa`, which requires accountancy credentials), .finance is open to register immediately.
+- **Global reach.** As a generic gTLD it carries no country targeting, so it works for cross-border operations.
+- **A coherent cluster.** It sits alongside related Identity Digital extensions, making it easy to find a matching family of names for sub-brands.
+
+## Things to consider
+
+- **Mainstream recall still favors .com.** Some users instinctively type `.com`, so you may want to defensively hold the matching .com if it exists.
+- **Phishing-sensitive category.** Money-themed suffixes attract impersonation; you will need to lean on brand consistency and security to earn trust (see the reputation section below).
+- **Premium pricing on desirable names.** The registry reserves a tier of premium keywords that cost more than standard registrations.
+- **Renewal economics.** Like most new gTLDs, the first-year and renewal prices differ; budget for the ongoing rate, not just year one.
+- **Niche framing.** "Finance" is descriptive but also limiting if your scope later broadens beyond money.
+
+## Who can register a .finance domain?
+
+**Registration restrictions: open to all.** There are **no eligibility requirements** for .finance — no financial licence, professional accreditation, membership, or local-presence rule. Any individual, business, or organization can register an available name, subject to the registrar's standard terms and acceptable-use policies. This contrasts sharply with credential-gated TLDs such as `.cpa` or `.bank`, which verify the registrant.
+
+Other administrative facts:
+
+- **Length and characters:** standard label rules apply — 1–63 characters, letters, digits, and hyphens, not starting or ending with a hyphen.
+- **IDNs:** internationalized domain names are supported.
+- **Registration term:** typically 1–10 years.
+- **DNSSEC and WHOIS privacy:** DNSSEC is supported, and WHOIS privacy is offered by most registrars including Namefi.
+- **Trademark / sunrise:** like all new gTLDs, .finance went through a Trademark Clearinghouse sunrise period at launch; rights holders can use the Clearinghouse for ongoing claims protection.
+
+The authoritative rules live in the [.finance Registry Agreement](https://www.icann.org/en/registry-agreements/details/finance) on ICANN's site, which governs the operator's obligations and reserved-name policies.
+
+## .finance pricing and value
+
+.finance is a **mid-tier new gTLD**, and its pricing follows the usual dynamics rather than any fixed number:
+
+- **Standard vs premium names.** The registry designates a set of high-demand keyword names — short, generic, or obviously valuable terms — as **premium**, which carry higher registration and often higher renewal fees. Most ordinary names register at the standard rate.
+- **First-year vs renewal.** Promotional first-year pricing is common across the industry, but the **renewal rate is what matters long term**; always check it before committing.
+- **What drives cost.** Length, keyword desirability, and premium classification are the main levers. A two-word, specific name is usually standard-priced; a single generic finance keyword is more likely premium.
+
+Treat the domain as a multi-year cost and weigh the renewal price, not just the headline first-year figure.
+
+## Reputation and email deliverability
+
+Perception is the thing to get right with a money-themed suffix. .finance reads as **descriptive and professional**, but the "finance" framing is also attractive to bad actors, so the broader category of finance-keyword domains sees its share of phishing attempts. The suffix itself confers **no verification or trust** — users still judge a site on HTTPS, brand consistency, content quality, and reputation.
+
+For email, deliverability depends on **your sending practices, not the TLD**. New gTLDs are not blocklisted as a class, but a fresh domain with no sending history needs proper authentication — **SPF, DKIM, and DMARC** — and a gradual warm-up to land in inboxes. Configure these from day one and your .finance mail will deliver as reliably as any .com.
+
+## Branding and naming tips
+
+- **Use the suffix as the noun.** The cleanest .finance names read as a phrase: `personal.finance`, `green.finance`, `brand.finance`. Domain-hack constructions where the word before the dot completes "X finance" are the most memorable.
+- **Keep it pronounceable.** Avoid stacked consonants or numbers that force people to spell it out loud.
+- **Mind look-alikes.** Finance is a high-stakes category for typosquatting; consider registering close variants and the matching .com if budget allows.
+- **Don't over-narrow.** If you may expand beyond money services, pick a name that still works as a brand, not just a literal description.
+
+## How to register a .finance domain at Namefi
+
+1. **Search** your desired name on [Namefi](https://namefi.io) to check availability and see whether it is a standard or premium .finance name.
+2. **Choose** the registration term and add WHOIS privacy and DNSSEC as needed.
+3. **Register** and complete checkout with transparent pricing — no surprise renewal traps.
+
+As an ICANN-accredited registrar, Namefi also supports **Web3 tokenization**, so you can mint eligible domains as on-chain assets, plus fast DNS management from the same dashboard. Start your search at [Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .finance domain?
+
+Yes. The .finance TLD is an open generic gTLD with no eligibility restrictions. You do not need a financial licence, professional credential, or local presence to register one. Standard registrar terms and acceptable-use rules still apply.
+
+### Does a .finance domain affect SEO?
+
+No. Google treats new gTLDs like .finance the same as .com and gives no inherent ranking boost or penalty. Keywords in a domain are not a meaningful ranking signal; your content, links, and user experience determine search performance.
+
+### Who should register a .finance domain?
+
+It suits banks, fintech startups, financial advisors, accounting and wealth-management firms, lenders, finance media, and personal-finance creators who want a descriptive, on-topic web address that signals their industry at a glance.
+
+### Is .finance a trusted extension for handling money or sign-ups?
+
+The suffix itself carries no special trust or verification, and finance-themed names are a known target for phishing. Users still judge a site by HTTPS, brand consistency, and reputation, so pair a .finance domain with strong security and clear branding.
+
+### Does .finance support WHOIS privacy and DNSSEC?
+
+Yes. As an Identity Digital gTLD, .finance supports DNSSEC for registrants who enable it, and most registrars including Namefi offer WHOIS privacy so personal contact details are not published publicly.
+
+## Related resources
+
+- [.com](/en/tld/com) — the universal default to compare against and consider holding defensively
+- [.io](/en/tld/io) — the tech/startup extension popular with fintech teams
+- [.app](/en/tld/app) — HTTPS-enforced extension for a fintech product front end
+- [.org](/en/tld/org) — a fit for nonprofit financial-literacy and association sites

--- a/content/tld/en/homes.md
+++ b/content/tld/en/homes.md
@@ -1,0 +1,144 @@
+---
+title: 'What Is the .homes Domain? The Real Estate Web Extension'
+date: '2026-06-15'
+language: 'en'
+tags: ['tld']
+authors: ['namefiteam']
+draft: false
+description: 'The .homes domain is an open new gTLD run by XYZ Registry, ideal for real estate, property, and housing brands that want a clear, descriptive web address.'
+keywords: ['.homes domain', 'what is .homes', '.homes TLD', 'real estate domain', 'property domain name', 'XYZ Registry', 'new gTLD', 'homes domain registration']
+faqs:
+  - question: 'Can anyone register a .homes domain?'
+    answer: 'Yes. The .homes TLD is open to everyone with no eligibility checks. The original 2014 launch limited it to verified housing-industry professionals, but the registry removed those restrictions when it relaunched the extension, so any individual or business can register a .homes name today.'
+  - question: 'Does a .homes domain affect SEO?'
+    answer: 'No. Google treats .homes like any other generic top-level domain and does not rank it higher or lower because of the suffix. As a non-geographic gTLD it carries no country targeting, so your rankings depend on content, links, and site quality, not the extension.'
+  - question: 'Who should register a .homes domain?'
+    answer: 'It suits real estate agents, brokerages, property developers, home builders, interior and home-improvement brands, and rental or listing platforms. The word "homes" is instantly understood, so the suffix works best when housing or property is central to your offering.'
+  - question: 'Who operates the .homes registry?'
+    answer: 'The .homes registry is operated by XYZ.COM LLC, the same company behind the .xyz domain. The extension was first delegated in 2014 under Dominion Enterprises and transferred to XYZ Registry in 2021.'
+---
+
+The **.homes domain** is a descriptive new generic top-level domain (gTLD) built for the housing world: real estate agents, brokerages, builders, property managers, and any brand whose business revolves around where people live. Where a generic suffix forces you to spell out your category in the name itself, a .homes address puts the category in the extension, so `austin.homes` or `coastal.homes` reads as a complete, self-explanatory phrase.
+
+If you work in property and want a short, memorable web address that says what you do before a visitor even clicks, .homes is one of the clearest options available. This page covers who runs it, its unusual history, how Google treats it, who can register one, and how it compares to the alternatives.
+
+## .homes at a glance
+
+| Fact | Detail |
+| --- | --- |
+| TLD type | New generic top-level domain (gTLD) |
+| Registry operator | XYZ.COM LLC (XYZ Registry) |
+| Year launched | Delegated 2014; relaunched open in 2019 |
+| IDN support | Yes (internationalized domain names supported) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility verification |
+| Best for | Real estate, property, housing, and home brands |
+
+## What is .homes?
+
+The plural noun "homes" needs no translation: it signals residences, real estate, and the places people live. That makes .homes a *meaningful* extension rather than an arbitrary one — the suffix completes the brand instead of just sitting after it.
+
+Technically, .homes is a **new gTLD**, one of the hundreds of extensions introduced through ICANN's 2012 new-gTLD program. It is generic, not a country-code TLD, so it is not tied to any nation and carries no geographic meaning. According to [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites), most new gTLDs are treated as generic and are not used for automatic geo-targeting — they behave like `.com` for ranking purposes. In other words, choosing .homes will not, by itself, help or hurt your search visibility; your content and authority do the work.
+
+You can confirm the registry's status in the official [IANA root-zone database entry for .homes](https://www.iana.org/domains/root/db/homes.html), the authoritative record for every delegated top-level domain.
+
+## History of .homes
+
+The .homes extension has a more interesting backstory than most. It was first delegated in 2014 under **Dominion Enterprises** (through DERHomes, LLC), a Virginia-based publishing and media company. At launch it was a **restricted** TLD: names were available only to verified housing-industry registrants, and that verification could take one to two weeks. Combined with onerous registrar requirements, the restrictions throttled adoption — by early 2019 the zone reportedly held only a few hundred domains.
+
+Dominion reversed course. As [Domain Name Wire reported](https://domainnamewire.com/2019/01/10/registry-to-relaunch-homes-top-level-domain/), the registry **relaunched .homes in 2019 as an open, unrestricted TLD**, scrapping the eligibility checks, cutting prices sharply, and broadening registrar support (including GoDaddy). The move mirrored the same open-access reboot the company had used for its `.boats` extension.
+
+The final chapter came in 2021, when the .homes registry agreement was **transferred to XYZ.COM LLC** — the operator best known for the [.xyz](/en/tld/xyz) domain — which remains the registry operator today. Under XYZ's stewardship, .homes is distributed through mainstream registrars worldwide as a fully open extension.
+
+## How people use .homes
+
+- **Real estate agents and brokerages** — branded agent sites like `yourname.homes` or city-focused listing pages.
+- **Property developers and home builders** — project and community microsites (`riverside.homes`).
+- **Rental and listing platforms** — search portals where "homes" is the product.
+- **Property management firms** — tenant portals and leasing pages.
+- **Home services and improvement brands** — renovation, interiors, smart-home, and staging businesses.
+- **Domain hacks** — readable phrases where the brand flows into the suffix, e.g. `dream.homes` or `model.homes`.
+
+**Who it's not ideal for:** if housing or property isn't central to your business, the literal "homes" meaning will confuse visitors. Software companies, agencies, and general brands are better served by a neutral suffix such as [.com](/en/tld/com), [.io](/en/tld/io), or [.app](/en/tld/app).
+
+## Notable sites using .homes
+
+Because .homes spent its early years as a tiny restricted namespace and only opened up later, it does not yet have household-name flagship sites the way mature extensions do. Its real, current use is concentrated among independent **real estate agents, regional brokerages, property developers, and home-services businesses** that register descriptive, locally branded names. The registry promotes the extension through [nic.homes](https://nic.homes/), its official portal. Rather than name a site that may lapse, the honest picture is this: .homes is an adoption-stage extension whose value comes from the clarity of the word, not from a marquee tenant.
+
+## .homes vs other domains
+
+| Extension | Type | Meaning | Best for |
+| --- | --- | --- | --- |
+| **.homes** | New gTLD | Residences / real estate | Property and housing brands |
+| [.com](/en/tld/com) | Legacy gTLD | None (universal) | Any business, maximum trust |
+| [.club](/en/tld/club) | New gTLD | Community / group | Communities, memberships |
+
+Pick **.com** when you want the most universally trusted, default extension and the descriptive value of the suffix doesn't matter. Choose **.homes** when housing is your whole story and you want the address itself to say so. Other property-adjacent suffixes such as `.house`, `.realty`, and `.estate` exist too; among them, .homes is the most natural plural-noun reading for a listings or multi-property brand.
+
+## Why choose .homes?
+
+- **Instant clarity.** The suffix tells visitors exactly what the site is about before they read a word of content.
+- **Strong, short names available.** Because it's a younger namespace, exact-match and city-based names that are long gone in `.com` are often still open.
+- **No eligibility hoops.** Unlike credential-gated suffixes such as `.law` or `.cpa`, anyone can register a .homes name with no paperwork.
+- **Reputable operator.** It's run by [XYZ Registry](/en/tld/xyz), an established new-gTLD operator with broad registrar distribution.
+
+## Things to consider
+
+Be honest about the trade-offs. The suffix is **narrow** — it only fits housing and property, so it locks your brand into that category. New gTLDs also carry **lower default familiarity** than `.com`; some users instinctively type `.com`, so the matching `.com` may be worth defensively registering if available. Finally, **premium pricing** applies to many short or high-demand .homes names, and renewals typically sit above commodity suffixes — budget for the long term, not just year one.
+
+## Who can register a .homes domain?
+
+**Registration restrictions: open to all.** There are no eligibility requirements today — any individual, company, or organization in any country can register a .homes domain, with no verification and no proof of real-estate credentials. This is a meaningful change from the original 2014 launch, when names were limited to verified housing-industry registrants (agents, brokers, builders, appraisers, inspectors, and similar). Those Nexus-style restrictions were removed when the extension relaunched, and the open policy carried over to the current operator. You can review the governing rules in the official [ICANN Registry Agreement for .homes](https://www.icann.org/en/registry-agreements/details/homes).
+
+Standard new-gTLD administration applies: domains can be registered for one to ten years, internationalized domain names (IDNs) are supported, and [DNSSEC](/en/glossary/dnssec) is available for registrants who want cryptographic protection against DNS spoofing. Trademark holders can use the ICANN Trademark Clearinghouse for sunrise and claims protections. WHOIS privacy/proxy services are offered by most [registrars](/en/glossary/registrar), and the usual transfer, renewal, and redemption-grace-period lifecycle applies once a name expires.
+
+## .homes pricing and value
+
+The .homes pricing model follows the standard new-gTLD pattern. First-year and renewal prices differ — promotional first-year rates are common, while the standard renewal sits noticeably higher, so weigh the multi-year cost rather than the headline first-year figure. A subset of names is classified as **premium**, carrying elevated registration *and* renewal pricing that persists for the life of the domain; short, generic, or high-intent words (city names, single dictionary words) are the most likely to be flagged premium. Pricing varies by registrar and changes over time, so confirm the current rate at checkout.
+
+## Reputation and email deliverability
+
+As a registry-operated new gTLD run by an established operator, .homes does not carry the bargain-bin reputation of suffixes frequently abused for spam. It is perceived as a **descriptive, professional, industry-specific** extension rather than a cheap throwaway. That said, any newer gTLD can occasionally face cautious spam-filter treatment, and recipients are simply less familiar with it than `.com`. To keep email deliverability strong, authenticate your domain with SPF, DKIM, and DMARC, warm up new sending domains gradually, and maintain good list hygiene — these matter far more than the suffix itself.
+
+## Branding and naming tips
+
+The plural noun makes .homes ideal for **phrase-style domain hacks**: `dream.homes`, `model.homes`, `city.homes`, or `<region>.homes` all read as natural English. Lean into geography — local real estate is hyper-regional, and a `<neighborhood>.homes` name is both available and memorable in a way the equivalent `.com` rarely is. One pitfall: the singular `.home` is *not* a delegated public TLD, so people may mistype your name without the "s." Pick a name that still reads clearly, consider securing close variants, and say the full address aloud to be sure the suffix lands cleanly in speech.
+
+## How to register a .homes domain at Namefi
+
+1. **Search** for your desired name on [Namefi](https://namefi.io) to check .homes availability.
+2. **Choose** the .homes result (and any companion extensions you want to protect).
+3. **Register** and configure DNS — Namefi provisions records fast and supports DNSSEC.
+
+Namefi is an ICANN-accredited registrar with transparent pricing and optional Web3 tokenization, so you can later turn your domain into an on-chain asset if you choose. Ready to claim your name? Start your search at [Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .homes domain?
+
+Yes. The .homes TLD is open to everyone with no eligibility checks. The original 2014 launch limited it to verified housing-industry professionals, but the registry removed those restrictions when it relaunched the extension, so any individual or business can register a .homes name today.
+
+### Does a .homes domain affect SEO?
+
+No. Google treats .homes like any other generic top-level domain and does not rank it higher or lower because of the suffix. As a non-geographic gTLD it carries no country targeting, so your rankings depend on content, links, and site quality, not the extension.
+
+### Who should register a .homes domain?
+
+It suits real estate agents, brokerages, property developers, home builders, interior and home-improvement brands, and rental or listing platforms. The word "homes" is instantly understood, so the suffix works best when housing or property is central to your offering.
+
+### Who operates the .homes registry?
+
+The .homes registry is operated by XYZ.COM LLC, the same company behind the .xyz domain. The extension was first delegated in 2014 under Dominion Enterprises and transferred to XYZ Registry in 2021.
+
+## Related resources
+
+- [What is a domain name?](/en/blog/what-is-domain)
+- [Domain terminology guide](/en/blog/domain-terminology-guide)
+- [How to sell a domain name you own](/en/blog/how-to-sell-a-domain-name-you-own)
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains)
+- [Glossary: ICANN](/en/glossary/icann)
+- [Glossary: Registrar](/en/glossary/registrar)
+- [Glossary: DNSSEC](/en/glossary/dnssec)
+- [.xyz domain](/en/tld/xyz)
+- [.com domain](/en/tld/com)
+- [.club domain](/en/tld/club)

--- a/content/tld/en/house.md
+++ b/content/tld/en/house.md
@@ -1,0 +1,155 @@
+---
+title: 'What Is the .house Domain? Real Estate & Home Extension'
+date: '2026-06-15'
+language: 'en'
+tags: ['tld']
+authors: ['namefiteam']
+draft: false
+description: 'The .house domain is an open generic TLD run by Binky Moon (Identity Digital). See who it suits, how it ranks, registration rules, and pricing dynamics.'
+keywords: ['.house domain', 'what is .house', '.house TLD', 'real estate domain', 'home domain extension', 'Binky Moon', 'Identity Digital', 'generic TLD', 'domain registration']
+faqs:
+  - question: 'Can anyone register a .house domain?'
+    answer: 'Yes. The .house TLD is an open, unrestricted generic top-level domain. There are no credential, industry, or local-presence requirements, so any individual or organization worldwide can register an available .house name on a first-come, first-served basis.'
+  - question: 'Does a .house domain affect SEO?'
+    answer: 'No. Google treats .house as a generic gTLD with no built-in ranking advantage or penalty. It is not geo-targeted to any country, and a descriptive .house name can improve click-through, but rankings still depend on content, links, and user experience.'
+  - question: 'Who should register a .house domain?'
+    answer: 'Real estate agencies, property developers, home-improvement and construction businesses, interior designers, vacation-rental hosts, and house-music projects benefit most, because the word "house" describes their offering directly in the domain.'
+  - question: 'Is .house good for a real estate business?'
+    answer: 'Yes. The suffix reads as a complete word, so a name like a brokerage or a single-property site communicates the category instantly. It is best for residential and home-focused brands rather than commercial or land-only ventures.'
+  - question: 'Does .house support WHOIS privacy and DNSSEC?'
+    answer: 'Yes. As an Identity Digital (Binky Moon) gTLD, .house supports DNSSEC at the registry level, and most registrars including Namefi offer WHOIS privacy so your personal contact details are not published publicly.'
+---
+
+The .house domain is an open generic top-level domain (gTLD) built around one of the most universal words in the English language. For real estate brokerages, home-improvement firms, property developers, interior designers, and even house-music labels, the .house suffix turns the extension itself into part of the message: the domain reads as a complete phrase, like *bright.house* or *open.house*. Because the word "house" is concrete and emotionally familiar, the TLD lends itself to descriptive, brandable names that tell a visitor exactly what to expect before the page even loads.
+
+This page explains what .house is, who operates it, who can register it, how search engines treat it, and the trade-offs to weigh before you buy — so you can decide whether this extension fits your project.
+
+## .house at a glance
+
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (gTLD), 2012 new-gTLD round |
+| Registry operator | Binky Moon, LLC (part of Identity Digital) |
+| Year launched | Registered with IANA 2013-12-19; general availability 2014 |
+| IDN support | Yes (internationalized domain names supported) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no credential, industry, or local-presence requirement |
+| Best for | Real estate, home services, property listings, house music |
+
+## What is .house?
+
+The .house extension is a [generic top-level domain](/en/glossary/tld) delegated in ICANN's 2012 new-gTLD program, the expansion that introduced hundreds of dictionary-word suffixes alongside the legacy set like [.com](/en/tld/com) and [.net](/en/tld/net). Unlike a country-code TLD, .house carries no geographic meaning — it is not tied to any nation and is not geo-targeted by search engines.
+
+The authoritative record for the suffix is the [IANA .house delegation record](https://www.iana.org/domains/root/db/house.html). Because .house is generic rather than geographic, Google treats it like any other open gTLD: no automatic country association and no inherent ranking boost or penalty. The value of the suffix is semantic and human-facing — it signals a category — not algorithmic.
+
+## History of .house
+
+The .house string was entered into the IANA root with a registration date of 2013-12-19 and reached general availability in 2014, during the first wave of new-gTLD launches. It was applied for and originally delegated within the Donuts portfolio (the largest applicant in the 2012 round), and its registry back end is now operated by Binky Moon, LLC, the registry entity that sits under [Identity Digital](https://identity.digital/registry) following the consolidation of the Donuts and Afilias businesses.
+
+Identity Digital runs one of the largest portfolios of descriptive gTLDs in the world — well over a hundred suffixes — and .house belongs to a cluster of property- and place-themed extensions in that catalog (alongside names such as .properties, .estate, and .realty). Adoption has been steady rather than explosive: .house is a mid-sized niche TLD whose registrations skew toward real estate and home-related businesses that value the literal meaning of the word over raw volume.
+
+## How people use .house
+
+- **Real estate agencies and brokerages** — a short, category-defining name for residential sales and lettings.
+- **Single-property and listing sites** — a memorable URL for one home, a development, or an "open house" event.
+- **Home-improvement, construction, and renovation firms** — builders, remodelers, and trades whose work centers on houses.
+- **Interior design and home-decor brands** — studios and shops positioning around the home.
+- **Vacation rentals and hospitality** — guest houses, lodges, and short-stay hosts.
+- **House-music projects** — labels, club nights, and DJs playing on the genre's name.
+
+**Who it's not ideal for:** businesses that are not home-, property-, or house-related. For a generic startup, SaaS product, or commercial-real-estate or land venture, the literal word "house" can mislead visitors. A broad consumer brand is usually better served by a neutral suffix such as [.com](/en/tld/com), [.io](/en/tld/io), or [.xyz](/en/tld/xyz).
+
+## Notable sites using .house
+
+The .house TLD is used mainly by small and mid-sized real estate, home-services, and music ventures rather than household-name corporations, so there is no single globally famous flagship site to point to. In practice you will most often encounter .house on:
+
+- Local and boutique real estate brokerage sites that pair a place or brand name with the suffix.
+- Single-property or new-development marketing pages launched for one listing.
+- Home-renovation, design-studio, and trades portfolios.
+- Independent house-music labels and event brands.
+
+Rather than cite a specific third-party site that could change hands or lapse, the honest summary is this: .house is a working niche extension whose typical registrant is a home-focused small business.
+
+## .house vs other domains
+
+| Extension | Meaning | Best fit | Availability of short names |
+| --- | --- | --- | --- |
+| [.house](/en/tld/house) | Literal "house" | Residential property, home services, house music | Good |
+| [.com](/en/tld/com) | Generic, universal | Any business; default trust signal | Very limited |
+| [.online](/en/tld/online) | Generic web presence | Broad, non-specific projects | Good |
+| [.store](/en/tld/store) | Retail / commerce | Online shops selling goods | Moderate |
+
+Pick [.com](/en/tld/com) when you want the most universally trusted suffix and can find or afford the name. Choose .house when the literal meaning works in your favor and you want a short, descriptive name that a generic suffix like [.online](/en/tld/online) can't deliver. If you are selling products rather than describing a home, [.store](/en/tld/store) or [.shop](/en/tld/shop) communicates commerce more directly.
+
+## Why choose .house?
+
+- **Descriptive by default** — the suffix is a real word, so the domain reads as a phrase and tells visitors the category instantly.
+- **Stronger name availability** — short, meaningful names that are long gone in [.com](/en/tld/com) are frequently still open in .house.
+- **Brandable domain hacks** — pairings like *open.house*, *full.house*, or *your.house* turn the extension into the second half of the brand.
+- **Reputable operator** — run by Binky Moon under Identity Digital, an established registry with reliable infrastructure and DNSSEC support.
+- **No geo-lock** — as a generic gTLD it works for an audience anywhere, with no country targeting baked in.
+
+## Things to consider
+
+- **Niche meaning** — the literal word narrows your audience. It is a strength for home brands and a liability for unrelated businesses.
+- **Recognition gap** — many mainstream users still default to [.com](/en/tld/com), so you may need to reinforce the full address in marketing and spoken contexts.
+- **Type-in leakage** — visitors may instinctively append ".com" to your name; consider whether a defensive [.com](/en/tld/com) registration is worth it.
+- **Renewal economics** — like most descriptive new gTLDs, .house typically renews at a higher standard rate than legacy suffixes, and premium names carry their own pricing.
+
+## Who can register a .house domain?
+
+**Registration restrictions: open to all.** The .house TLD has no eligibility gating — there is no credential check, no industry membership, and no local-presence requirement. Any person or organization anywhere in the world can register an available .house name on a first-come, first-served basis, the same way you would register a [.com](/en/tld/com).
+
+As a 2012-round gTLD operated by Binky Moon, .house follows standard new-gTLD policy, including Trademark Clearinghouse–based sunrise and claims protections at launch and the usual Uniform Domain-Name Dispute-Resolution Policy ([UDRP](/en/glossary/udrp)) for trademark disputes. Standard administrative rules apply: normal length and character limits, internationalized domain names, available DNSSEC, and — through most registrars including Namefi — [WHOIS](/en/glossary/whois) privacy plus the usual transfer, renewal, and redemption-grace lifecycle. You can read the registry operator's overview at [Identity Digital](https://identity.digital/registry).
+
+## .house pricing and value
+
+This page never quotes live prices, but it helps to understand the dynamics. Like most descriptive new gTLDs, .house generally has a higher standard registration and renewal price than legacy suffixes such as [.com](/en/tld/com) or [.net](/en/tld/net), and — importantly — the first-year and renewal prices usually differ, so budget for the recurring rate, not just the initial cost. The registry also designates some short, high-demand names as **premium** domains, which carry elevated registration and sometimes elevated renewal pricing set by the registry rather than the registrar. What drives cost is therefore a mix of the registry's wholesale tier for the specific name, whether it is flagged premium, and the registrar's own margin and services. Always check the renewal price before you commit.
+
+## Reputation and email deliverability
+
+Because .house is a descriptive, real-world suffix tied to a legitimate industry, it does not carry the heavy spam reputation that has dogged some ultra-cheap promotional TLDs. It reads as professional and purposeful, especially for property and home brands. That said, any newer gTLD is less universally recognized than [.com](/en/tld/com), and a small number of strict spam filters and form validators still apply mild caution to less-common extensions. The honest mitigation is straightforward: warm up your sending domain, publish proper SPF, DKIM, and DMARC records, and avoid bulk unsolicited mail. Done right, .house delivers reliably and presents as a credible, on-brand address.
+
+## Branding and naming tips
+
+The .house sweet spot is the **domain hack**, where the suffix completes a phrase: *open.house*, *full.house*, *the.house*, or *bright.house*. Because "house" is a common, easy-to-spell word, your names stay memorable and pronounceable — a real advantage over invented or heavily abbreviated strings. Keep the part before the dot short and concrete, and read the whole address aloud to make sure it scans as a phrase rather than two random words. The main pitfall is the type-in habit: people may reflexively add ".com," so reinforce the full ".house" address in your marketing and consider a defensive [.com](/en/tld/com) if the budget allows.
+
+## How to register a .house domain at Namefi
+
+1. **Search** for your desired name on [Namefi](https://namefi.io) to check availability and see whether it is a premium name.
+2. **Choose** the exact .house domain that fits your brand, and review the renewal terms, not just the first-year cost.
+3. **Register** and complete checkout, then manage DNS and settings from your dashboard.
+
+As an ICANN-accredited registrar, Namefi offers transparent pricing, fast DNS, WHOIS privacy, and optional Web3 [tokenization](/en/glossary/tokenize) so your domain can become an on-chain asset. Secure your .house name with [Namefi](https://namefi.io) today.
+
+## Frequently asked questions
+
+### Can anyone register a .house domain?
+
+Yes. The .house TLD is an open, unrestricted generic top-level domain. There are no credential, industry, or local-presence requirements, so any individual or organization worldwide can register an available .house name on a first-come, first-served basis.
+
+### Does a .house domain affect SEO?
+
+No. Google treats .house as a generic gTLD with no built-in ranking advantage or penalty. It is not geo-targeted to any country, and a descriptive .house name can improve click-through, but rankings still depend on content, links, and user experience.
+
+### Who should register a .house domain?
+
+Real estate agencies, property developers, home-improvement and construction businesses, interior designers, vacation-rental hosts, and house-music projects benefit most, because the word "house" describes their offering directly in the domain.
+
+### Is .house good for a real estate business?
+
+Yes. The suffix reads as a complete word, so a name for a brokerage or a single-property site communicates the category instantly. It is best for residential and home-focused brands rather than commercial or land-only ventures.
+
+### Does .house support WHOIS privacy and DNSSEC?
+
+Yes. As an Identity Digital (Binky Moon) gTLD, .house supports DNSSEC at the registry level, and most registrars including Namefi offer WHOIS privacy so your personal contact details are not published publicly.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [Top TLDs to secure for your real estate business](/en/blog/top-tlds-to-secure-for-your-real-estate-business)
+- [Domain terminology guide](/en/blog/domain-terminology-guide)
+- [Glossary: ICANN](/en/glossary/icann)
+- [Glossary: registrar](/en/glossary/registrar)
+- [.com domain](/en/tld/com) · [.store domain](/en/tld/store) · [.online domain](/en/tld/online)

--- a/content/tld/en/law.md
+++ b/content/tld/en/law.md
@@ -1,0 +1,146 @@
+---
+title: 'What Is the .law Domain? The Verified TLD for Lawyers'
+date: '2026-06-15'
+language: 'en'
+tags: ['tld']
+authors: ['namefiteam']
+draft: false
+description: 'The .law domain is a restricted, credential-gated extension reserved for licensed lawyers, law firms, law schools, and legal regulators, verified at registration and renewal.'
+keywords: ['.law domain', 'what is .law', 'law domain registration', 'restricted TLD', 'lawyer domain', 'law firm domain', 'legal domain name', 'credential-gated TLD']
+faqs:
+  - question: 'Can anyone register a .law domain?'
+    answer: 'No. .law is a restricted, credential-gated TLD. Only qualified lawyers licensed to practice, law firms, law schools, and legal regulators may register, and an independent validation provider verifies your legal credentials both at registration and on an ongoing basis throughout the domain lifecycle.'
+  - question: 'Does a .law domain affect SEO?'
+    answer: 'A TLD choice is not a direct Google ranking factor, so .law neither helps nor hurts rankings on its own. Its value is trust: a .law address signals a verified legal professional, which can lift click-through and reduce impersonation, indirectly helping performance.'
+  - question: 'Who should register a .law domain?'
+    answer: 'Practicing lawyers, law firms, law schools, and bar associations that want a verified, profession-specific web and email identity. It suits practices that value a credibility signal and anti-impersonation security over a short generic name.'
+  - question: 'What happens to my .law domain if I lose my license to practice?'
+    answer: 'Eligibility must be maintained for the life of the registration, not just at purchase. A lawyer with inactive, suspended, or non-practicing status who is no longer authorized to provide legal services may fail re-verification and be unable to keep or renew the domain.'
+---
+
+The **.law domain** is one of the internet's genuinely restricted extensions: a credential-gated top-level domain reserved for the legal profession. Unlike open suffixes that anyone can buy, .law is sold only to people and organizations that can prove they are qualified to practice or regulate law — licensed lawyers, law firms, law schools, and legal regulators. Every registrant's credentials are validated before a name is issued and re-checked over time. For the legal community, that verification is the entire point: a .law address tells prospective clients, at a glance, that there is a real, licensed practitioner or firm behind it.
+
+This page explains what .law is, exactly who can register it, how the eligibility checks work, and where it fits relative to mainstream alternatives like [.com](/en/tld/com) and other legal or professional extensions.
+
+## .law at a glance
+
+| Fact | Detail |
+| --- | --- |
+| TLD type | New gTLD (restricted / professional) |
+| Registry operator | Registry Services, LLC (GoDaddy Registry; originally Minds + Machines / MMX) |
+| Year launched | 2015 (Sunrise mid-2015; general availability 12 October 2015) |
+| IDN support | Not a marketed feature; standard ASCII names |
+| DNSSEC | Supported at the registry level |
+| Registration restrictions | Credential-gated — qualified lawyers, law firms, law schools, and legal regulators only; verified at registration **and** throughout the registration lifecycle |
+| Best for | Practicing lawyers and law firms wanting a verified, trusted web and email identity |
+
+## What is .law?
+
+.law is a **new generic top-level domain (gTLD)** delegated under ICANN's new gTLD program, but it belongs to the restricted, profession-specific category rather than the open commercial one. The string was secured by Minds + Machines (MMX) after a private auction in 2014, delegated to the DNS root in 2015, and aimed squarely at the global legal community. You can confirm the delegation and sponsoring organization on the [IANA root-zone entry for .law](https://www.iana.org/domains/root/db/law.html), which lists the operator as Registry Services, LLC and a 2015 registration date.
+
+Because it is a generic (not country-code) TLD, Google treats .law as a generic extension with no built-in geo-targeting. As [Google Search Central](https://developers.google.com/search/docs/crawling-indexing/managing-multi-regional-sites) explains, generic TLDs are not tied to a single country for ranking purposes, so a .law name does not signal "US-only" the way a ccTLD would — useful given that eligible lawyers come from many jurisdictions. The defining characteristic is the restriction itself: most extensions sell to whoever pays, but .law sells only to whoever can prove a legal credential, which makes the suffix function less like a marketing label and more like a verifiable professional badge.
+
+## History of .law
+
+Minds + Machines Group Limited (MMX) won the rights to .law (and its Spanish-language sibling .abogado) at a private auction in September 2014. The registry opened a Sunrise phase for trademark holders in mid-2015, with general availability to credentialed legal practitioners beginning **12 October 2015**.
+
+The operator changed hands in 2021: GoDaddy Registry acquired the portfolio of TLDs operated by Minds + Machines, and the .law registry was absorbed into **Registry Services, LLC**, the GoDaddy Registry entity now listed as the sponsoring organization. The restriction policy survived intact — .law remains a verified, lawyers-only namespace. Adoption skews toward practices that specifically want the credibility signal: solo attorneys, large firms, law schools, and bar associations, though the restricted model keeps total volume far below open suffixes.
+
+## How people use .law
+
+- **Solo and boutique practitioners** wanting a name that doubles as a credential, e.g. a firm at `smith.law`.
+- **Established and large law firms** using .law for a primary site, a campaign microsite, or matched verified email.
+- **Practice-area and specialty branding** — descriptive names like `[city]injury.law` or `[topic].law` that read as plain English.
+- **Law schools and legal-education programs** that qualify as eligible institutions.
+- **Bar associations, legal regulators, and professional bodies** establishing a verified presence.
+
+**Who it's not ideal for:** anyone outside the legal profession. Legal-tech startups, paralegals, legal marketers, bloggers, and non-lawyers cannot register .law and should look at [.com](/en/tld/com), [.io](/en/tld/io), or a neutral professional suffix instead.
+
+## Notable sites using .law
+
+Because .law is restricted, public examples are concentrated in the legal sector rather than household consumer brands. [Join.Law](https://www.join.law/) is the registry's dedicated .law marketing and registration channel, itself a .law domain, and reports the namespace in active use across thousands of legal practices — from solo attorneys to large firms, law schools, and bar associations. The most representative real-world pattern is a firm or practitioner using a `firmname.law` or `practicearea.law` address for both website and verified email, rather than a single famous flagship site.
+
+## .law vs other domains
+
+| Feature | .law | [.com](/en/tld/com) | [.info](/en/tld/info) |
+| --- | --- | --- | --- |
+| TLD type | New gTLD (restricted) | Legacy gTLD | Legacy gTLD |
+| Who can register | Verified lawyers / firms only | Anyone | Anyone |
+| Built-in trust signal | Strong (credential-verified) | Neutral | Neutral |
+| Availability of names | High (small namespace) | Very low (crowded) | Moderate |
+| Recognition | Growing, niche | Universal | Familiar |
+
+Pick **.com** if you want maximum universal recognition and do not need a credential signal. Pick **.law** when you are an eligible legal professional and want the address itself to prove that — a value no open suffix can match. **.info** sits between the two as an open, widely available alternative with no verification.
+
+## Why choose .law?
+
+- **Built-in credibility.** The restriction means a .law address can only belong to a verified lawyer, firm, school, or regulator — a trust signal an open suffix cannot replicate.
+- **Anti-impersonation.** Scammers and fake "law firms" cannot obtain a .law name, which makes it harder to spoof a legitimate practice.
+- **Clear, descriptive naming.** "Law" is a plain English word, so names like `tax.law` or `family.law` read naturally and are easy to say and remember.
+- **Plentiful availability.** Because the namespace is small and gated, good short names are far easier to secure than on .com.
+
+## Things to consider
+
+.law is not a casual purchase. It is **typically priced as a premium professional TLD**, well above commodity suffixes, and it carries an ongoing eligibility obligation rather than a one-time check. If your credentials lapse, you risk losing the name. It is also a niche extension: while recognition among legal audiences is solid and growing, general consumers are still more conditioned to expect .com, so some firms register both and redirect. Finally, eligibility is the hard gate — if you are adjacent to but not inside the regulated legal profession, .law is simply not available to you.
+
+## Who can register a .law domain?
+
+**Registration restrictions: this is a restricted, credential-gated TLD.** Per the registry's eligibility policy, only the following may register a .law domain:
+
+- **A qualified lawyer** — a professional licensed by a legal regulator to practice law and identifiable as a currently licensed practitioner in that regulator's public records.
+- **A law firm** — a partnership or incorporated entity formed by one or more qualified lawyers to engage in the practice of law.
+- **A law school** — an institution approved by a legal regulator or recognized education regulator to provide academic or vocational legal education toward becoming a qualified lawyer.
+- **A legal regulator** — an institution enacted or approved by legislation to regulate the provision of legal services in a jurisdiction.
+
+A lawyer with inactive, suspended, or non-practicing status who is not authorized to provide regulated legal services is **not** eligible. The registry uses an **independent validation provider** to verify that registrants meet these requirements, and may request additional documentation. Critically, eligibility applies **throughout the domain's lifecycle**, not only at first registration — so the credential must be maintained to keep and renew the name. You can review the binding rules in the [ICANN Registry Agreement for .law](https://www.icann.org/en/registry-agreements/details/law) and the operator's own program at [Join.Law](https://www.join.law/). Standard new-gTLD administrative behaviors apply: a Sunrise phase protected trademark holders at launch, names use standard ASCII, and the registry supports [DNSSEC](/en/glossary/dnssec); WHOIS privacy availability depends on your [registrar](/en/glossary/registrar).
+
+## .law pricing and value
+
+.law is positioned as a **premium professional TLD**, and its pricing dynamics differ from commodity suffixes. Expect first-year and renewal pricing to be set higher than open extensions, reflecting the verification overhead and the value of an exclusive, credential-gated namespace. As with most TLDs, some short, generic, or high-demand names (think single common words like `family.law`) may be designated **premium-tier** by the registry and carry their own elevated pricing and renewal terms. First-year promotional pricing and standard renewal pricing commonly differ, so factor the long-term renewal cost — not just the entry price — into your decision. What ultimately drives cost here is exclusivity and ongoing validation rather than raw scarcity.
+
+## Reputation and email deliverability
+
+.law enjoys a **clean, premium reputation**. Because nobody can register it without passing credential verification, the namespace has not become a haven for spam or throwaway domains the way some cheap open suffixes have. That helps email: a verified, established .law domain is generally treated as trustworthy by spam filters, and the suffix carries no inherent "spammy" baggage. Deliverability still depends on the basics — configure SPF, DKIM, and DMARC, warm up new sending domains gradually, and keep good list hygiene. The TLD helps your credibility; it does not exempt you from email authentication.
+
+## Branding and naming tips
+
+The big advantage is that **"law" is a real English word**, so the suffix completes naturally: `family.law`, `tax.law`, `injury.law`, or simply `firmname.law`. Lean into descriptive practice-area or geography names that read as a phrase — they are memorable and self-explanatory. Spelling and pronunciation are rarely an issue since the word is universally understood. Two cautions: make sure clients can find you even if they default to typing `.com`, and remember that the name must always belong to an eligible registrant, so avoid building a brand around a name you may not be able to keep if your status changes.
+
+## How to register a .law domain at Namefi
+
+1. **Search** your desired name to confirm it is available.
+2. **Choose** the exact `.law` name that matches your firm or practice.
+3. **Register** and complete the registry's legal-credential verification.
+
+Note that, because .law is restricted, you will need to satisfy the registry's eligibility verification before the name is issued. [Namefi](https://namefi.io) offers transparent pricing, fast DNS setup, and optional Web3 tokenization so you can hold your verified .law name as an on-chain asset alongside conventional management.
+
+## Frequently asked questions
+
+### Can anyone register a .law domain?
+
+No. .law is a restricted, credential-gated TLD. Only qualified lawyers licensed to practice, law firms, law schools, and legal regulators may register. An independent validation provider verifies your legal credentials at registration, and eligibility must be maintained throughout the domain's lifecycle, not just at purchase.
+
+### Does a .law domain affect SEO?
+
+A TLD choice is not a direct Google ranking factor, so .law neither helps nor hurts rankings on its own. Its real value is trust and credibility: a verified .law address signals a genuine legal professional, which can improve click-through and reduce impersonation — indirect benefits rather than a ranking boost.
+
+### Who should register a .law domain?
+
+Practicing lawyers, law firms, law schools, and bar associations that want a verified, profession-specific web and email identity. It suits practices that value a credibility signal and anti-impersonation security more than a short, generic name, and that can maintain their legal credentials over time.
+
+### What happens to my .law domain if I lose my license to practice?
+
+Eligibility must be maintained for the life of the registration, not only at purchase. A lawyer with inactive, suspended, or non-practicing status who is no longer authorized to provide legal services may fail re-verification and be unable to keep or renew the domain.
+
+### Does .law support WHOIS privacy and DNSSEC?
+
+DNSSEC is supported at the registry level. WHOIS privacy availability depends on your registrar's policy and applicable rules; many firms choose to publish accurate contact details anyway, since a verified professional presence is the point of the suffix.
+
+## Related resources
+
+- [What is a domain?](/en/blog/what-is-domain)
+- [Domain terminology guide](/en/blog/domain-terminology-guide)
+- [ccTLD market share by registration volume](/en/blog/cctld-market-share-by-registration-volume)
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains)
+- Glossary: [ICANN](/en/glossary/icann), [registrar](/en/glossary/registrar), [DNSSEC](/en/glossary/dnssec)
+- Compare TLDs: [.com](/en/tld/com), [.io](/en/tld/io), [.info](/en/tld/info)

--- a/content/tld/en/lawyer.md
+++ b/content/tld/en/lawyer.md
@@ -1,0 +1,147 @@
+---
+title: 'What Is the .lawyer Domain? Open Legal gTLD Explained'
+date: '2026-06-15'
+language: 'en'
+tags: ['tld']
+authors: ['namefiteam']
+draft: false
+description: 'The .lawyer domain is an open generic gTLD for legal professionals and firms. Learn who can register it, how it compares to .law and .attorney, and whether it fits.'
+keywords: ['lawyer domain', 'what is .lawyer', '.lawyer domains', '.lawyer vs .law', 'legal domain extensions', 'domains for law firms', 'lawyer TLD', 'register .lawyer']
+faqs:
+  - question: 'Can anyone register a .lawyer domain?'
+    answer: 'Yes. .lawyer is an open generic top-level domain sold first-come, first-served, with no bar membership, law license, or credential check required to register. This is the main practical difference from .law, which verifies that the registrant is a licensed legal professional.'
+  - question: 'Does a .lawyer domain affect SEO?'
+    answer: 'No. Google treats new generic TLDs like .lawyer the same as .com and applies no inherent ranking penalty or boost. Rankings depend on content, links, and user experience, not on the suffix itself.'
+  - question: 'Who should register a .lawyer domain?'
+    answer: 'It suits individual attorneys, solo practitioners, small law firms, and legal marketers who want a descriptive, profession-specific address. It is less suited to brands that want a non-legal identity or a strictly verified credential signal.'
+  - question: 'What is the difference between .lawyer and .law?'
+    answer: 'Both target legal professionals, but .law (operated by GoDaddy Registry) restricts registration to verified licensed practitioners, while .lawyer is open to anyone. .lawyer is therefore easier to obtain but carries no built-in proof of credentials.'
+---
+
+The **.lawyer domain** is a generic top-level domain (gTLD) built for the legal profession — individual attorneys, law firms, legal marketers, and anyone who wants a web address that says, plainly, what they do. Unlike the credential-gated `.law` extension, `.lawyer` is an **open gTLD**: anyone can register one on a first-come, first-served basis, with no bar membership or license verification at the point of sale.
+
+That openness is the most important thing to understand before buying one. It makes `.lawyer` easy to acquire and broadly available, but it also means the suffix itself is not proof that the owner is a licensed legal professional.
+
+## .lawyer at a glance
+
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (new gTLD, 2012 round) |
+| Registry operator | Dog Beach, LLC (an [Identity Digital](https://identity.digital/) registry; the former Donuts/Afilias group) |
+| Year launched | Delegated in 2014 |
+| IDN support | Yes |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no credential, license, or bar membership required |
+| Best for | Attorneys, solo practitioners, small firms, legal marketers |
+
+## What is .lawyer?
+
+`.lawyer` is one of hundreds of new generic top-level domains introduced under ICANN's 2012 new-gTLD program, the expansion that took the domain name system far beyond `.com`, `.net`, and `.org`. It is an English-language, profession-descriptive suffix: the word on the right of the dot tells a visitor exactly what kind of business sits behind the address.
+
+According to the [IANA root zone database entry for .lawyer](https://www.iana.org/domains/root/db/lawyer.html), the TLD is a generic top-level domain delegated in 2014. As a generic suffix — not a country-code TLD like `.uk` — it is **not tied to any geography**. Google treats new gTLDs such as `.lawyer` as generic, with no geo-targeting baked in, so a `.lawyer` site can rank globally just like a `.com`. For the basics of how suffixes work, see [what a TLD is](/en/blog/what-is-a-tld).
+
+## History of .lawyer
+
+`.lawyer` went live for general availability in 2014 through the registry portfolio then operated by Donuts Inc. That portfolio later merged with Afilias and rebranded as **Identity Digital** in 2022, which is why the registry-of-record on the IANA entry appears as Dog Beach, LLC — one of the holding entities Identity Digital uses across its stable of TLDs.
+
+`.lawyer` arrived alongside a small family of legal suffixes — `.attorney`, `.law`, and the Spanish-language `.abogado` — that gave the legal sector its own corner of the namespace. Adoption has been steady rather than explosive: legal extensions occupy a focused professional niche, valued for clarity and relevance more than for raw registration volume.
+
+## How people use .lawyer
+
+`.lawyer` works best where the address itself should signal "legal services":
+
+- **Solo attorneys and personal brands** — e.g. a `firstname-lastname.lawyer` address for an individual practitioner.
+- **Small and boutique law firms** that want a descriptive, memorable web home.
+- **Practice-area landing pages** — `injury.lawyer`, `divorce.lawyer`, or city-plus-practice combinations used in legal marketing.
+- **Lead-generation and referral sites** in the legal vertical.
+
+**Who it's not ideal for:** large established firms with strong `.com` brand equity, non-legal businesses (the suffix is unambiguously about law), and anyone who specifically wants a *verified* credential signal — for that, the gated `.law` extension is the better fit.
+
+## Notable sites using .lawyer
+
+`.lawyer` is used primarily by individual attorneys, boutique firms, and legal marketers rather than by household-name brands, so there is no roster of globally famous `.lawyer` sites comparable to the big `.com` names. In practice you encounter it most as personal-brand addresses for solo practitioners and as keyword-rich landing pages (practice area plus city) built by legal-marketing agencies. Rather than name a site we cannot independently verify is still active, the honest summary is this: `.lawyer` is a working professional suffix in steady niche use, not a marquee consumer TLD.
+
+## .lawyer vs other domains
+
+| Suffix | Restriction | Operator | Signal |
+| --- | --- | --- | --- |
+| [.lawyer](/en/tld/lawyer) | Open to all | Dog Beach, LLC (Identity Digital) | Descriptive, easy to get |
+| [.attorney](/en/tld/attorney) | Open to all | Dog Beach, LLC (Identity Digital) | Near-synonym, same openness |
+| .law | Verified license required | GoDaddy Registry | Credential-backed, premium |
+| [.com](/en/tld/com) | Open to all | Verisign | Universal default |
+
+Pick `.lawyer` (or its near-twin `.attorney`) when you want a clear, profession-specific address that anyone can register. Choose `.law` when the *verified-credential* signal matters and you are a licensed practitioner willing to pass the registry's checks. Keep `.com` in mind as the universal fallback when you want maximum familiarity and the matching name is available. For a deeper comparison across the legal namespace, read our guide to the [top TLDs to secure for your law firm](/en/blog/top-tlds-to-secure-for-your-law-firm).
+
+## Why choose .lawyer?
+
+- **Instant relevance.** The suffix communicates "legal services" before a visitor reads a single word.
+- **Availability.** Far less saturated than `.com`, so exact-match names — personal names and practice-area keywords — are much easier to find.
+- **No gatekeeping.** Open registration means no waiting on credential verification; register and launch the same day.
+- **Descriptive combinations.** `practicearea.lawyer` and `city.lawyer` patterns read naturally and support keyword-led campaigns.
+
+## Things to consider
+
+- **No built-in credibility check.** Because anyone can register `.lawyer`, the suffix alone does not prove the owner is a licensed attorney — clients who care will still look for credentials on the page.
+- **Niche meaning.** The word "lawyer" locks the address into a single profession; it cannot be repurposed for an unrelated brand later.
+- **Easy to confuse with siblings.** `.lawyer`, `.attorney`, and `.law` are close enough that visitors (and word-of-mouth referrals) may type the wrong one. Many firms defensively register more than one.
+- **Premium and renewal pricing.** Like most new gTLDs, `.lawyer` typically costs more per year than a bargain `.com`, and standout keyword names may carry premium pricing.
+
+## Who can register a .lawyer domain?
+
+**Registration restrictions: open to all.** `.lawyer` has **no eligibility gate** — no bar membership, law license, or professional credential is required to register, and names are sold first-come, first-served. This is the defining contrast with `.law`, where the registry uses an independent verification agency to confirm that registrants are qualified, licensed legal professionals before granting the name.
+
+A common point of confusion: some registrars collect an "accrediting body" contact field if you intend to advertise regulated legal services on a `.lawyer` site, but this is a service-disclosure detail, not a barrier to registration — the domain remains available to anyone. Standard administrative rules apply: names may be 1–63 characters using letters, digits, and hyphens (not in the 3rd–4th position together), IDNs are supported, DNSSEC is available, and WHOIS privacy is generally offered by registrars. Trademark holders should note the usual sunrise/TMCH protections at launch and the ongoing [UDRP](/en/glossary/udrp) dispute process. Authoritative policy is maintained by Dog Beach, LLC under Identity Digital; the ICANN-accredited [registrar](/en/glossary/registrar) you buy through implements those rules. For the official policy chain, start from the [IANA root entry](https://www.iana.org/domains/root/db/lawyer.html) and [ICANN](/en/glossary/icann) records.
+
+## .lawyer pricing and value
+
+`.lawyer` is priced as a premium professional gTLD rather than a commodity suffix, so expect it to sit above a basic `.com`. A few dynamics drive the cost:
+
+- **First-year vs. renewal pricing differ.** Promotional first-year rates are common; the steady-state renewal price is what matters for a long-lived firm site, so check it before committing.
+- **Premium-tier names exist.** Short, generic, high-value strings (broad practice-area or single-word names) are often flagged by the registry as premium and carry higher, sometimes recurring, pricing.
+- **Defensive multi-registration adds up.** Firms that also grab `.attorney` or `.law` should budget for several renewals.
+
+We don't quote live prices here — they change and vary by registrar — but the value case is straightforward: you are paying for relevance and availability a crowded `.com` market cannot offer.
+
+## Reputation and email deliverability
+
+New gTLDs once carried a faint "is this legit?" perception simply because they were unfamiliar, but legal suffixes like `.lawyer` are now well established in the profession. Because registration is open, a small minority of mail servers may apply marginally stricter filtering to *any* newer TLD. In practice this is easily managed: authenticate your email with SPF, DKIM, and DMARC, warm up new sending domains gradually, and keep content clean. A properly configured `.lawyer` address delivers just as reliably as a `.com`. The reputation that ultimately matters is your own — built through real content, not chosen for you by the suffix.
+
+## Branding and naming tips
+
+The strongest `.lawyer` names read as a complete phrase across the dot. `injury.lawyer`, `tax.lawyer`, and `denver.lawyer` are clean domain hacks that turn the suffix into part of the message, and personal-brand patterns like `janesmith.lawyer` suit solo practitioners building a name-based reputation. Watch two pitfalls: the close similarity to `.attorney` and `.law` means you should consider registering siblings defensively so referrals aren't lost to a mistyped suffix; and keep the left-of-dot label short and unambiguous, since legal clients often arrive by word of mouth. For broader strategy, see [how to name your project](/en/blog/how-to-name-your-project).
+
+## How to register a .lawyer domain at Namefi
+
+1. **Search** for your desired name — try your firm name, your personal name, or a `practicearea.lawyer` combination — on [Namefi](https://namefi.io).
+2. **Choose** the available option that best fits your brand, and add it to your cart.
+3. **Register** and complete checkout; your domain is provisioned and ready to point at your site.
+
+As an ICANN-accredited registrar, Namefi offers transparent pricing, fast DNS configuration, and optional Web3 tokenization so you can hold your domain as an on-chain asset. No credential verification is needed to register `.lawyer`.
+
+## Frequently asked questions
+
+### Can anyone register a .lawyer domain?
+
+Yes. `.lawyer` is an open generic top-level domain sold first-come, first-served, with no bar membership, law license, or credential check required to register. This is the main practical difference from `.law`, which verifies that the registrant is a licensed legal professional.
+
+### Does a .lawyer domain affect SEO?
+
+No. Google treats new generic TLDs like `.lawyer` the same as `.com` and applies no inherent ranking penalty or boost. Rankings depend on content, links, and user experience, not on the suffix itself.
+
+### Who should register a .lawyer domain?
+
+It suits individual attorneys, solo practitioners, small law firms, and legal marketers who want a descriptive, profession-specific address. It is less suited to brands that want a non-legal identity or a strictly verified credential signal.
+
+### What is the difference between .lawyer and .law?
+
+Both target legal professionals, but `.law` (operated by GoDaddy Registry) restricts registration to verified licensed practitioners, while `.lawyer` is open to anyone. `.lawyer` is therefore easier to obtain but carries no built-in proof of credentials.
+
+## Related resources
+
+- [.attorney domain](/en/tld/attorney) — the closest open-registration alternative to `.lawyer`.
+- [.abogado domain](/en/tld/abogado) — the Spanish-language legal suffix.
+- [.cpa domain](/en/tld/cpa) — a credential-gated professional TLD, for contrast.
+- [.com domain](/en/tld/com) — the universal default to weigh against any niche suffix.
+- [Top TLDs to secure for your law firm](/en/blog/top-tlds-to-secure-for-your-law-firm) — a strategy guide across the legal namespace.
+- [What is a TLD?](/en/blog/what-is-a-tld) — background on how domain suffixes work.
+- [Registrar](/en/glossary/registrar) and [ICANN](/en/glossary/icann) — the institutions behind every domain.

--- a/content/tld/en/legal.md
+++ b/content/tld/en/legal.md
@@ -1,0 +1,159 @@
+---
+title: 'What Is the .legal Domain? An Open Legal-Sector TLD'
+date: '2026-06-15'
+language: 'en'
+tags: ['tld']
+authors: ['namefiteam']
+draft: false
+description: 'The .legal domain is an open generic TLD for the legal field. Learn who runs it, who can register, how it compares to .law, and whether it suits your firm.'
+keywords: ['.legal domains', 'what is .legal', '.legal TLD', 'legal domain extension', 'law firm domain names', 'lawyer website domain', 'Identity Digital TLD', 'Binky Moon registry']
+faqs:
+  - question: 'Can anyone register a .legal domain?'
+    answer: 'Yes. The .legal domain is an open generic TLD with no credential, license, or bar-membership requirement, so anyone can register one. This is the key difference from .law, which verifies that the registrant is part of the legal profession before it activates the name.'
+  - question: 'Does a .legal domain affect SEO?'
+    answer: 'Google treats .legal like any other generic TLD, so the extension itself gives no ranking boost or penalty. Rankings come from content, links, and user experience. A descriptive .legal name can lift click-through by signaling at a glance that the site is legal-related.'
+  - question: 'Is .legal the same as .law?'
+    answer: 'No. Both signal a legal focus, but .law is credential-gated and verifies the registrant before the name goes live, while .legal is open to everyone with no verification. So .legal proves nothing about licensure, whereas .law is designed to.'
+  - question: 'Who should register a .legal domain?'
+    answer: 'It suits law firms, solo practitioners, legal-tech startups, legal marketers, and even non-lawyer legal services that want a clear, available, legal-signaling name. It is especially useful when the matching .com is taken, expensive, or less self-explanatory.'
+  - question: 'Who operates the .legal registry?'
+    answer: 'The .legal registry is operated by Binky Moon, LLC, a subsidiary of Identity Digital (formerly Donuts), under an ICANN registry agreement. The TLD was delegated to the DNS root zone in November 2014.'
+---
+
+The **.legal** domain is a new generic top-level domain (new gTLD) built around one of the most recognizable words in professional services. For law firms, legal-tech companies, and anyone publishing legal information, it offers a web address that announces its subject before a visitor reads a single line. If the matching `.com` is taken or generic, a `.legal` name is one of the most direct ways to claim a descriptive, on-brand presence.
+
+The single most important fact to understand about `.legal` is that it is **open**. Despite its professional meaning, the registry does **not** check bar membership, licensure, or any credential — so it is positioned very differently from the credential-gated `.law` extension. That openness is its biggest strength and its biggest caveat, and this page covers both.
+
+## .legal at a glance
+
+| Fact | Detail |
+| --- | --- |
+| TLD type | New gTLD (generic) |
+| Registry operator | Binky Moon, LLC (an [Identity Digital](https://www.identity.digital/) company, formerly Donuts) |
+| Year launched | Delegated to the root zone in November 2014 |
+| IDN support | Supported (varies by registrar) |
+| DNSSEC | Supported |
+| Registration restrictions | **Open to all** — no credential, license, or bar-membership requirement |
+| Best for | Law firms, legal-tech, legal marketers, and legal-information publishers wanting a descriptive name |
+
+## What is .legal?
+
+"Legal" is a plain-English adjective that frames anything it touches as relating to the law. As a domain suffix it instantly signals that a site deals with legal matters — advice, services, compliance, documents, or information — which is exactly why it appeals to a profession that depends on clear communication.
+
+`.legal` is a **generic** new gTLD, not a country-code extension. According to its [IANA root-zone entry](https://www.iana.org/domains/root/db/legal.html), it was delegated to the DNS root in November 2014 as part of ICANN's New gTLD Program. Because it is generic rather than geographic, Google does not tie it to any single country. As [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites) explains, many newer gTLDs are treated as generic and can be geo-targeted in Search Console just like a `.com`. In practice a `.legal` site can rank globally and target whatever market you choose.
+
+## History of .legal
+
+`.legal` emerged from the 2012 round of ICANN's New gTLD Program, the expansion that introduced hundreds of new suffixes beyond legacy options like `.com` and `.net`. It came out of the **Donuts** portfolio — the prolific operator behind dozens of profession- and interest-themed extensions — and was delegated to the root zone in November 2014.
+
+Donuts later rebranded as **Identity Digital**, and the registry agreement for `.legal` is held by its subsidiary **Binky Moon, LLC**, which holds the contracts for a large share of the former Donuts portfolio. The same operator runs a cluster of legal-adjacent open extensions — including [`.attorney`](/en/tld/attorney), `.lawyer`, and [`.abogado`](/en/tld/abogado) — so `.legal` sits inside a coherent family of legal suffixes rather than standing alone.
+
+## How people use .legal
+
+`.legal` is used wherever a descriptive, law-signaling name adds value:
+
+- **Law firms** wanting `firmname.legal` as a clear address that states the practice up front.
+- **Legal-tech startups** building contract tools, e-signature platforms, document automation, or research products who want to stand out from generic `.com` tech branding.
+- **In-house and compliance teams** publishing policy, terms, or compliance microsites.
+- **Descriptive service names** — `divorce.legal`, `immigration.legal`, or `tax.legal` that double as marketing keywords for a specific practice area.
+- **Brand-protection registrations** by firms that already own the `.com` and grab the `.legal` match defensively.
+
+**Who it's not ideal for:** anyone outside the legal field, since the suffix is so semantically loaded that a non-legal business would confuse visitors. It is also a weaker fit if your brand is already strongly tied to its existing `.com`. And because it is open, it is not the right choice if you specifically want a suffix that *proves* licensure — that is what `.law` is for.
+
+## Notable sites using .legal
+
+`.legal` adoption is concentrated among independent and regional firms, legal-tech companies, and corporate legal/compliance microsites rather than household-name consumer brands, so there is no single dominant public flagship to point to. A common real-world pattern is a company hosting its policy and compliance hub on a descriptive legal-themed address, or a practice using a keyword-rich name to capture intent for a specific service. Rather than name a site that may change hands, it is more accurate to describe the use: descriptive, legal-focused names where the suffix itself does part of the communicating.
+
+## .legal vs other domains
+
+| Feature | .legal | [.com](/en/tld/com) | .law | [.attorney](/en/tld/attorney) |
+| --- | --- | --- | --- | --- |
+| Type | New gTLD (generic) | Legacy gTLD | New gTLD (generic) | New gTLD (generic) |
+| Restrictions | Open to all | Open to all | Credential-verified (legal) | Open to all |
+| Legal signal | Strong | None | Strong + verified | Strong |
+| Audience | Legal field broadly | Everyone | Verified legal pros | Lawyers / firms |
+
+Choose `.com` when broad familiarity and resale value matter most and your brand is not strictly legal. Choose `.law` when you want the suffix to *prove* you are a verified practitioner, since it gates registration on credentials. Choose [`.attorney`](/en/tld/attorney) when you specifically mean a lawyer rather than the legal field in general. Choose `.legal` when you want the broadest legal-signaling word, open availability, and no verification hurdle — it reads as "about the law" rather than "I am a licensed attorney."
+
+## Why choose .legal?
+
+- **Instant clarity.** The suffix tells visitors and search engines the site is law-related before they read the content.
+- **Broadest legal word.** "Legal" covers more ground than "attorney" or "lawyer" — it fits firms, legal-tech, compliance, and information sites alike.
+- **Strong availability.** Short, keyword-rich names long gone in `.com` are often still open in `.legal`, and names like `compliance.legal` work as both a brand and a keyword phrase.
+- **No gatekeeping and easy brand protection.** You can register without submitting credentials, and firms can secure the `.legal` match to keep impersonators away from an obvious variant.
+
+## Things to consider
+
+`.legal` is not the right tool for every situation, and an honest buyer should weigh the trade-offs:
+
+- **Openness cuts both ways.** Because it does not verify credentials, the suffix signals a legal focus but does not *prove* licensure the way `.law` does — visitors who care about that distinction get no assurance from `.legal` alone.
+- **Lower recognition than .com.** Some users still default to typing `.com`, so you may want to own the `.com` defensively or use redirects.
+- **Niche by design.** Outside the legal field the name makes no sense, which is the point but also a hard constraint.
+
+## Who can register a .legal domain?
+
+**Registration restrictions: open to all.** `.legal` is an unrestricted, open generic TLD. There is **no requirement** to be a licensed attorney, bar member, accredited firm, or legal professional of any kind — any individual or organization may register one. This is the defining difference from `.law`, which is **credential-gated** and verifies that the registrant is part of the legal sector before the name is activated. With `.legal`, no such verification takes place: the suffix communicates a legal focus, but it is an open marketplace, not a vetted registry. The same openness distinguishes it from gated professional suffixes such as `.cpa`, which requires accounting credentials.
+
+Standard new gTLD rules apply. Registrations went through the usual sunrise and trademark-claims phases at launch via ICANN's Trademark Clearinghouse, giving trademark holders a window to secure matching names first. Names follow normal length and IDN conventions, and the registry supports **DNSSEC**. WHOIS privacy, transfer, renewal, and the redemption grace period follow the operator's and your registrar's policies. The authoritative rules live in the [ICANN .legal Registry Agreement](https://www.icann.org/en/registry-agreements/details/legal), held by Binky Moon, LLC, with operator-level policy published by [Identity Digital](https://www.identity.digital/).
+
+## .legal pricing and value
+
+`.legal` sits toward the upper-mid tier of new gTLD pricing — generally above commodity extensions like `.com` and in line with other premium profession-themed suffixes. A few dynamics are worth understanding before you buy:
+
+- **Premium names exist.** The registry reserves high-demand generic terms — single-word practice areas or broad legal concepts — as premium domains that carry higher registration and sometimes higher recurring renewal fees.
+- **First-year and renewal pricing differ.** An introductory first-year rate is not the same as the recurring renewal rate; always check the renewal figure before committing long-term.
+- **Cost drivers** include premium tiering, the registrar you choose, and any multi-year or bundle terms.
+
+This page intentionally avoids quoting figures, because prices and promotions change constantly across registrars.
+
+## Reputation and email deliverability
+
+`.legal` is perceived as a credible, professional suffix — its meaning is unambiguous and tied to a respected field, which helps it avoid the "cheap" or "spammy" reputation that has dogged some bargain-priced new gTLDs. Because it is a meaningful, mid-priced extension rather than a giveaway, it has not become a magnet for bulk spam registration.
+
+That said, deliverability depends far more on how you configure email than on the suffix itself. Newer gTLDs occasionally face slightly stricter spam-filter scrutiny simply because they are less familiar than `.com`. Mitigate this the standard way: set up correct **SPF, DKIM, and DMARC** records, warm up new sending domains gradually, and keep list hygiene tight. Done properly, a `.legal` domain delivers mail as reliably as any legacy extension.
+
+## Branding and naming tips
+
+- **Lead with the keyword.** Practice-area or topic names like `compliance.legal` or `divorce.legal` turn the suffix into part of the message.
+- **Keep the left side short** so the full address stays readable and easy to type and say aloud.
+- **Mind the read-out.** "Legal" is easy to spell and pronounce, but confirm the full domain reads naturally when spoken, since legal services rely heavily on word-of-mouth and phone referrals.
+- **Pair defensively.** If budget allows, hold both the `.legal` and the matching `.com`.
+
+## How to register a .legal domain at Namefi
+
+1. **Search** for your desired name on [Namefi](https://namefi.io) to check availability.
+2. **Choose** the exact `.legal` name that fits your firm, product, or practice area.
+3. **Register** and configure DNS — Namefi provides fast, reliable DNS management out of the box.
+
+Namefi is an ICANN-accredited registrar with transparent pricing, and it also supports Web3 tokenization, so you can optionally tokenize your domain for easier transfer and on-chain liquidity. [Search and register your .legal domain at Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .legal domain?
+
+Yes. The `.legal` domain is an open generic TLD with no credential, license, or bar-membership requirement, so anyone can register one. This is the key difference from `.law`, which verifies that the registrant is part of the legal profession before it activates the name.
+
+### Does a .legal domain affect SEO?
+
+Google treats `.legal` like any other generic TLD, so the extension itself gives no ranking boost or penalty. Rankings come from content, links, and user experience. A descriptive `.legal` name can lift click-through by signaling at a glance that the site is legal-related.
+
+### Is .legal the same as .law?
+
+No. Both signal a legal focus, but `.law` is credential-gated and verifies the registrant before the name goes live, while `.legal` is open to everyone with no verification. So `.legal` proves nothing about licensure, whereas `.law` is designed to.
+
+### Who should register a .legal domain?
+
+It suits law firms, solo practitioners, legal-tech startups, legal marketers, and even non-lawyer legal services that want a clear, available, legal-signaling name. It is especially useful when the matching `.com` is taken, expensive, or less self-explanatory.
+
+### Who operates the .legal registry?
+
+The `.legal` registry is operated by Binky Moon, LLC, a subsidiary of Identity Digital (formerly Donuts), under an ICANN registry agreement. The TLD was delegated to the DNS root zone in November 2014.
+
+## Related resources
+
+- [.com domain](/en/tld/com) — the legacy benchmark to compare against.
+- [.attorney domain](/en/tld/attorney) — the open legal counterpart focused on lawyers.
+- [.abogado domain](/en/tld/abogado) — the Spanish-language legal extension from the same operator.
+- [What is a domain?](/en/blog/what-is-domain) — the fundamentals, if you are new to domains.
+- [Domain terminology guide](/en/blog/domain-terminology-guide) — a glossary of the terms used above.
+- [ICANN](/en/glossary/icann), [registrar](/en/glossary/registrar), [DNS](/en/glossary/dns), and [DNSSEC](/en/glossary/dnssec) glossary entries.

--- a/content/tld/en/properties.md
+++ b/content/tld/en/properties.md
@@ -1,0 +1,148 @@
+---
+title: 'What Is the .properties Domain? The Real Estate Web Extension'
+date: '2026-06-15'
+language: 'en'
+tags: ['tld']
+authors: ['namefiteam']
+draft: false
+description: 'The .properties domain is an open generic gTLD run by Binky Moon (Identity Digital), built for real estate listings, brokers, and property portfolios worldwide.'
+keywords: ['.properties domain', 'what is .properties', '.properties TLD', 'real estate domain', 'property domain name', 'Binky Moon properties', 'Identity Digital real estate gTLD', 'register .properties']
+faqs:
+  - question: 'Can anyone register a .properties domain?'
+    answer: 'Yes. The .properties TLD is an open generic gTLD with no eligibility restrictions. Anyone worldwide — agents, developers, property managers, or businesses outside real estate — can register an available name, subject to standard trademark and acceptable-use rules.'
+  - question: 'Does a .properties domain affect SEO?'
+    answer: 'No. Google treats .properties as a generic, non-geographic gTLD, so it carries no inherent ranking advantage or penalty. Rankings depend on content, links, and user experience, not the suffix itself.'
+  - question: 'Who should register a .properties domain?'
+    answer: 'It suits real estate agencies, brokers, property managers, developers, and listing portals that want a descriptive, keyword-rich web address. It is less ideal for brands outside real estate or projects needing a short, single-word name.'
+  - question: 'Are .properties domains more expensive than .com?'
+    answer: 'Often yes. As a niche new gTLD, .properties usually carries higher standard and renewal pricing than .com, and many sought-after real estate keywords are classified as premium names with elevated fees.'
+  - question: 'Does .properties support WHOIS privacy and DNSSEC?'
+    answer: 'Yes. Registrations are managed through ICANN-accredited registrars that typically offer WHOIS privacy, and the registry supports DNSSEC for cryptographically signed DNS, so you get the same security posture as other Identity Digital TLDs.'
+---
+
+The **.properties domain** is a descriptive web extension built for the real estate world — listings, brokerages, property management firms, and investment portfolios. Where a generic suffix forces you to qualify your name (`acme-realty.com`), `.properties` lets the address itself say what the site is about: `downtown.properties` or `coastal.properties`. The result reads like a complete phrase rather than a brand bolted onto a generic suffix.
+
+For anyone whose business *is* property, that clarity is the whole appeal. This page covers what `.properties` is, who runs it, who can register it, how it is priced, and how it compares to the alternatives.
+
+## .properties at a glance
+
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (new gTLD) |
+| Registry operator | Binky Moon, LLC (Identity Digital, formerly Donuts) |
+| Year launched | Delegated 2014 |
+| IDN support | Yes (via accredited registrars) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility requirement |
+| Best for | Real estate agencies, brokers, property managers, listing portals |
+
+## What is .properties?
+
+`.properties` is a [generic top-level domain](/en/glossary/tld) (gTLD) introduced through ICANN's 2012 New gTLD Program — the expansion that added hundreds of descriptive suffixes such as `.guru`, `.realty`, and `.homes` to the root zone. The word "properties" maps directly onto the real estate vocabulary, where a "property" is a parcel of land or a building and "properties" is the everyday plural a broker uses to describe a portfolio of listings.
+
+You can confirm its delegation in the official [IANA root-zone database entry for .properties](https://www.iana.org/domains/root/db/properties.html), which lists Binky Moon, LLC as the sponsoring organization.
+
+Because `.properties` is a generic, non-geographic gTLD, Google does **not** tie it to any country. Unlike a country-code TLD such as `.uk` or `.de`, it carries no built-in geo-targeting signal, so a `.properties` site is treated as global by default — useful if you list real estate across multiple regions. Google treats newer gTLDs like any other generic domain for ranking purposes, so the suffix neither helps nor hurts SEO on its own.
+
+## History of .properties
+
+`.properties` was one of many descriptive strings applied for by Donuts Inc., the portfolio applicant that secured more new gTLDs than any other company in the 2012 round. The string passed ICANN evaluation and was delegated to the root zone in early 2014, going live for general registration shortly afterward.
+
+The operator's corporate identity changed over the years even though the registry behind `.properties` stayed consistent. Donuts consolidated its many single-purpose registry companies under one entity, **Binky Moon, LLC**, and the parent later rebranded from Donuts to **Identity Digital** after merging with Afilias. Today `.properties` sits inside Identity Digital's large real-estate portfolio alongside suffixes like `.realty`, `.estate`, `.house`, and `.homes`. That scale matters for buyers: stable registry infrastructure and broad registrar distribution rather than a boutique operator that might disappear.
+
+## How people use .properties
+
+The suffix is most natural for businesses whose entire identity revolves around real estate:
+
+- **Brokerages and agencies** — a firm name plus the suffix reads as a self-describing brand, e.g. `summit.properties`.
+- **Property management companies** — managers of residential or commercial portfolios who want listings under one descriptive roof.
+- **Developers and new-build projects** — a single development or a portfolio of projects marketed on a memorable address.
+- **Listing portals and search sites** — directories where "properties" literally describes the inventory.
+- **Investors and REIT-style portfolios** — owners presenting a collection of holdings to partners or buyers.
+
+**Who it's not ideal for:** brands with no real estate connection (the word will confuse visitors), projects that need an ultra-short single word, or businesses that depend on walk-in recognition where a `.com` is still the default people type from memory.
+
+## Notable sites using .properties
+
+`.properties` is a working niche extension rather than a home for globally famous consumer brands. Its real-world use is concentrated among regional brokerages, individual development projects, and property portfolios that adopt the keyword-rich format. The honest picture: you will find it on agency and listing sites worldwide, but it has not produced a household-name flagship the way `.io` did in tech. The value of `.properties` is the instantly readable category, not borrowed fame — weigh that trade-off if mega-site recognition matters to you.
+
+## .properties vs other domains
+
+| Feature | .properties | [.com](/en/tld/com) | [.io](/en/tld/io) | [.xyz](/en/tld/xyz) |
+| --- | --- | --- | --- | --- |
+| Type | New gTLD | Legacy gTLD | ccTLD (used generically) | New gTLD |
+| Meaning | Real estate / property | Universal commercial | Tech / startup connotation | Neutral, all-purpose |
+| Geo-targeting | None (generic) | None (generic) | None (treated generically) | None (generic) |
+| Typical price tier | Higher, premium-heavy | Standard | Higher | Low |
+| Best fit | Property businesses | Any business | Tech and Web3 | Budget, creative, Web3 |
+
+Pick `.com` when universal recognition and resale value outweigh everything else, `.io` for a tech or [tokenized-domain](/en/blog/what-are-tokenized-domains) product chasing the startup vibe, and `.xyz` for a low-cost neutral name. Pick `.properties` when your business is real estate and you want the address itself to communicate the category.
+
+## Why choose .properties?
+
+- **Instant category clarity.** The suffix does marketing work for you: a visitor knows it is about real estate before reading a single line of copy.
+- **Better available inventory.** Short, descriptive `.com` real estate names were exhausted years ago. On `.properties` you can still register clean keywords like a city or neighborhood name.
+- **Clean, phrase-style branding.** `coastal.properties` reads as a unit, supporting memorable domain-hack-style names where the suffix completes the thought.
+- **Stable, well-distributed registry.** Run by Binky Moon under Identity Digital, one of the largest registry operators, with wide registrar availability and dependable infrastructure.
+
+## Things to consider
+
+`.properties` is one of the longer suffixes in the namespace — eleven characters — so the full address runs long and demands a short, typo-resistant second-level name. As a niche gTLD it also lacks the reflexive recognition of `.com`; some users still assume "dot-com" and may need the address spelled out. Pricing skews higher than legacy options, and many desirable real estate keywords are flagged as premium names with elevated fees. None of these is disqualifying, but they are real trade-offs.
+
+## Who can register a .properties domain?
+
+**Registration restrictions: open to all.** `.properties` is an unrestricted generic gTLD. There is no credential, license, local-presence, or community-membership requirement — anyone worldwide can register an available name, including businesses outside real estate. This contrasts with credential-gated suffixes such as `.law` (bar membership) or `.cpa` (accounting credentials).
+
+The rules that do apply are the standard ICANN registry obligations: a sunrise period ran at launch to let trademark holders claim matching names first, and the Trademark Clearinghouse claims process still warns registrants who take a name matching a recorded mark. Standard length and IDN rules apply, the registry supports DNSSEC, and accredited registrars generally offer WHOIS privacy plus the usual transfer, renewal, and redemption-grace lifecycle. The authoritative source for these obligations is the [ICANN Registry Agreement for .properties](https://www.icann.org/en/registry-agreements/details/properties), and the operator of record is verifiable in the [IANA root database](https://www.iana.org/domains/root/db/properties.html).
+
+## .properties pricing and value
+
+Pricing on `.properties` follows the typical new-gTLD pattern rather than a flat rate. Most names register at a standard tier set by the registry and passed through by your [registrar](/en/glossary/registrar), and that tier generally sits above legacy `.com` pricing because it is a specialized extension with a smaller market.
+
+Two dynamics matter most. First, **first-year and renewal pricing usually differ** — a promotional first year does not lock in your long-term cost, so always check the renewal rate before committing to a name you intend to keep. Second, **premium names exist**: the registry classifies many high-demand real estate keywords (common city names, generic terms like "luxury" or "rental") as premium, with higher recurring fees. What drives cost is desirability and keyword value, not the length of the name alone.
+
+## Reputation and email deliverability
+
+New gTLDs as a class once carried a faint "cheap or spammy" perception in their early years, but that has faded as legitimate businesses adopted descriptive suffixes. `.properties` is a relatively low-volume, business-oriented extension without the bulk-registration patterns that get a TLD onto spam blocklists, so it does not carry a notably bad reputation. Deliverability depends far more on your own setup than on the suffix: configure SPF, DKIM, and DMARC correctly, warm up sending gradually, and keep clean list hygiene. A well-authenticated `.properties` address lands in inboxes just as reliably as a `.com`.
+
+## Branding and naming tips
+
+The most effective `.properties` names treat the suffix as the final word of a phrase: `oceanview.properties`, `metro.properties`, `heritage.properties`. Lead with a place, a quality, or a short brand word and let "properties" finish the thought — that domain-hack-style construction is where the extension shines. Because the suffix is long, keep the second-level label tight and easy to spell aloud; avoid hyphens and numbers that get lost when spoken over the phone. Real estate is referral-heavy, so test your full address out loud.
+
+## How to register a .properties domain at Namefi
+
+1. **Search** your desired name on [Namefi](https://namefi.io) to check availability and see whether it is a standard or premium name.
+2. **Choose** the exact `.properties` address that reads best as a complete phrase.
+3. **Register** and complete checkout, then point the domain using Namefi's fast DNS.
+
+Namefi is an [ICANN-accredited registrar](/en/glossary/icann) with transparent pricing and optional Web3 [tokenization](/en/glossary/tokenize), so you can hold your `.properties` name as a standard domain or as an on-chain asset. Get started at [Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .properties domain?
+
+Yes. `.properties` is an open generic gTLD with no eligibility restrictions. Anyone worldwide — agents, developers, property managers, or businesses outside real estate — can register an available name, subject only to standard trademark protections and acceptable-use rules.
+
+### Does a .properties domain affect SEO?
+
+No. Google treats `.properties` as a generic, non-geographic gTLD, so it carries no inherent ranking advantage or penalty. Your rankings depend on content quality, backlinks, and user experience — not on the suffix you choose.
+
+### Who should register a .properties domain?
+
+Real estate agencies, brokers, property managers, developers, and listing portals that want a descriptive, keyword-rich web address. It is less suitable for brands outside real estate or projects that need a short, single-word name.
+
+### Are .properties domains more expensive than .com?
+
+Often yes. As a niche new gTLD, `.properties` typically carries higher standard and renewal pricing than `.com`, and many desirable real estate keywords are classified as premium names with elevated fees.
+
+### Does .properties support WHOIS privacy and DNSSEC?
+
+Yes. Registrations run through ICANN-accredited registrars that usually offer WHOIS privacy, and the registry supports DNSSEC, giving you the same security baseline as other Identity Digital TLDs.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld) — how top-level domains work
+- [What is a domain?](/en/blog/what-is-domain) — domain-name fundamentals
+- [Top TLDs to secure for your real estate business](/en/blog/top-tlds-to-secure-for-your-real-estate-business)
+- [Registrar](/en/glossary/registrar) and [ICANN](/en/glossary/icann) glossary terms
+- Compare alternatives: [.com](/en/tld/com), [.io](/en/tld/io), and [.xyz](/en/tld/xyz)

--- a/content/tld/en/realtor.md
+++ b/content/tld/en/realtor.md
@@ -1,0 +1,171 @@
+---
+title: 'What Is the .realtor Domain? The TLD for NAR Members'
+date: '2026-06-15'
+language: 'en'
+tags: ['tld']
+authors: ['namefiteam']
+draft: false
+description: 'The .realtor domain is a restricted real-estate TLD limited to NAR and CREA members. Learn who can register, who runs it, and how it works for agents.'
+keywords: ['.realtor domains', 'what is .realtor', '.realtor TLD', 'realtor domain extension', 'real estate domain names', 'NAR domain', 'realtor website domain', 'Real Estate Domains LLC']
+faqs:
+  - question: 'Can anyone register a .realtor domain?'
+    answer: 'No. The .realtor domain is restricted to members of the National Association of REALTORS (NAR), members of the Canadian Real Estate Association (CREA), their member boards and associations, and NAR affiliates and licensees in good standing. The general public cannot register one, and NAR determines eligibility at its sole discretion.'
+  - question: 'Does a .realtor domain affect SEO?'
+    answer: 'Google treats .realtor as a generic TLD, so the suffix itself gives no inherent ranking boost or penalty. Rankings come from content, links, and user experience. A descriptive .realtor name can improve click-through by clearly signaling a verified real-estate professional.'
+  - question: 'Who should register a .realtor domain?'
+    answer: 'It suits individual REALTORS, brokerages, teams, and real-estate associations who are NAR or CREA members and want a credential-signaling web address. It is a strong fit when you want the suffix itself to prove membership in an organized real-estate body.'
+  - question: 'Do you actually own a .realtor domain?'
+    answer: 'No. Under the Real Estate Domain License Agreement you license rather than own a .realtor domain. Real Estate Domains LLC remains the registered holder, and your rights are those of a licensee tied to maintaining eligibility and good standing.'
+  - question: 'Who operates the .realtor registry?'
+    answer: 'The .realtor registry is operated by Real Estate Domains LLC, which is also the sole registrar. It runs the TLD under the direction of the National Association of REALTORS, which sponsors the extension and controls eligibility.'
+---
+
+The **.realtor** domain is a restricted top-level domain (TLD) reserved for members of organized real estate. Unlike open extensions that anyone can buy, a `.realtor` name is a credential in itself: it can only be licensed by members of the National Association of REALTORS® (NAR), the Canadian Real Estate Association (CREA), and their affiliated members in good standing. For an agent or brokerage, that exclusivity is the whole point — the suffix tells clients you belong to a recognized professional body.
+
+This page explains who is eligible, who runs the registry, how the licensing model differs from normal domain ownership, and whether a `.realtor` address is worth it. Because the eligibility rules are strict and enforced, getting them right matters more here than for almost any other suffix.
+
+## .realtor at a glance
+
+| Fact | Detail |
+| --- | --- |
+| TLD type | New gTLD (generic, sponsored / community-style) |
+| Registry operator | [Real Estate Domains LLC](https://www.get.realestate/) (also the sole registrar) |
+| Sponsor | National Association of REALTORS® (NAR) |
+| Year launched | Delegated to the root zone in 2014 |
+| IDN support | Limited (varies by registry policy) |
+| DNSSEC | Supported |
+| Registration restrictions | **Community-restricted** — NAR / CREA members and affiliates in good standing only |
+| Best for | REALTORS, brokerages, teams, and real-estate associations |
+
+## What is .realtor?
+
+"REALTOR®" is not a generic word for a real-estate agent — it is a registered trademark of the National Association of REALTORS®, applied only to members who subscribe to NAR's Code of Ethics. The `.realtor` domain extends that trademark into the domain namespace, so the suffix carries the same membership meaning a real address. That is what separates it from generic real-estate suffixes.
+
+`.realtor` is a **generic** new gTLD, not a country-code extension, but it functions as a sponsored, community-restricted TLD: NAR sponsors it and controls who may use it. According to its [IANA root-zone entry](https://www.iana.org/domains/root/db/realtor.html), it was delegated to the DNS root in 2014 under ICANN's New gTLD Program. Because it is generic rather than geographic, Google does not tie it to any single country. As [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites) explains, many newer gTLDs are treated as generic and carry no built-in country signal — so a `.realtor` site can rank and target markets like a `.com`, even though it spans the US and Canadian membership bases.
+
+## History of .realtor
+
+`.realtor` came out of the 2012 round of ICANN's New gTLD Program. Rather than let a third party control a suffix built around its trademark, NAR pursued the extension itself, and it was delegated to the root zone in 2014. The launch was notable for an aggressive adoption push: NAR offered the first `.realtor` domain free for an introductory period to its membership, which drove a large initial wave of registrations.
+
+The registry and exclusive registrar role sits with **Real Estate Domains LLC**, operating under NAR's direction. A companion extension, `.realestate`, was later introduced under the same umbrella for the broader real-estate audience that does not qualify for the membership-gated `.realtor`. Both share the same Real Estate Domain License Agreement and operator: one credential-gated, one broader.
+
+## How people use .realtor
+
+`.realtor` is used wherever proving organized-real-estate membership adds value:
+
+- **Individual agents** using a personal-name address like `janedoe.realtor` as a professional digital business card.
+- **Brokerages and teams** that want a branded `.realtor` site distinct from a generic `.com`.
+- **Member boards and associations** (local, state, or provincial) operating under the NAR/CREA umbrella.
+- **Email-first use** — many members adopt the matching `.realtor` email address as much as the website, since it signals membership in every message.
+- **Brand-protection registrations** by members who already hold the `.com` and want the matching `.realtor`.
+
+**Who it's not ideal for:** anyone who is not an NAR or CREA member — the rules simply bar non-members. It is also a poor fit for general real-estate businesses (mortgage, staging, photography) that are not REALTORS; those firms should look at open alternatives instead.
+
+## Notable sites using .realtor
+
+Adoption is concentrated among individual members, brokerage teams, and association sites rather than a single household-name flagship, so the most accurate picture is the typical pattern. NAR promotes the extension through its `get.realtor` member portal, and a large share of usage is personal-name agent sites (`firstnamelastname.realtor`) and matching member email addresses. Because registrations are tied to a named member in good standing, the namespace skews toward many small, individually branded sites rather than a few large public destinations.
+
+## .realtor vs other domains
+
+| Feature | .realtor | [.com](/en/tld/com) | .realestate | .homes |
+| --- | --- | --- | --- | --- |
+| Type | New gTLD (sponsored) | Legacy gTLD | New gTLD (generic) | New gTLD (generic) |
+| Restrictions | Members only (NAR/CREA) | Open to all | Open (real-estate focus) | Open to all |
+| Real-estate signal | Strong + verified membership | None | Strong | Strong |
+| Ownership model | Licensed, not owned | Owned | Owned | Owned |
+
+Choose `.com` when broad familiarity and resale value matter most and you do not need a membership signal. Choose `.realestate` or `.homes` when you want a real-estate signal but are not an NAR/CREA member, or want a name you fully own and can resell. Choose `.realtor` when you *are* a member and want the suffix to verify that membership — a signal no open extension can replicate.
+
+## Why choose .realtor?
+
+- **Built-in credential.** The suffix proves NAR or CREA membership, which open real-estate TLDs cannot do.
+- **Trust signal to clients.** Buyers and sellers who recognize the REALTOR® mark see immediate professional affiliation.
+- **Strong availability for members.** Because the pool is limited to members, the name you want is far likelier to be free than in `.com`.
+- **Consistent agent branding.** A matching `.realtor` website and email address present a unified professional identity.
+- **Backed by the association.** The extension is sponsored and promoted by NAR, tying it to an established institution rather than a speculative registry.
+
+## Things to consider
+
+`.realtor` is powerful only within its niche, and an honest buyer should weigh the trade-offs:
+
+- **You must stay eligible.** The address depends on continued membership in good standing — eligibility, not a one-time purchase, governs your rights.
+- **You license, not own.** Real Estate Domains LLC remains the registered holder; you cannot freely resell a `.realtor` name the way you could a `.com`.
+- **Single registrar.** Because the operator is the sole registrar, you do not get the competitive registrar marketplace that open TLDs enjoy.
+- **Niche by design.** Outside organized real estate the suffix is meaningless, and even within it some clients still default to typing `.com`.
+- **Not for adjacent businesses.** Mortgage, title, and other real-estate-adjacent firms generally do not qualify.
+
+## Who can register a .realtor domain?
+
+**Registration restrictions: community-restricted to organized-real-estate members.** A `.realtor` domain is **not open to the public**. Per the official [Real Estate Domain License Agreement](https://www.get.realestate/license-agreement), eligibility is limited to:
+
+- REALTORS® (NAR members);
+- members of the Canadian Real Estate Association (CREA);
+- NAR or CREA member boards and associations;
+- NAR affiliates and NAR licensees; and
+- parties otherwise in a contractual relationship with NAR relating to use of the REALTOR® mark.
+
+Crucially, **NAR determines eligibility at its sole discretion** — it decides who qualifies as an affiliate and which `.realtor` names a member may license. Anyone who does not meet the criteria may not license a `.realtor` domain, and losing membership in good standing can affect the license.
+
+Two points further distinguish `.realtor`. First, it is a **license, not ownership**: the agreement states you do not "own" the domain, and Real Estate Domains LLC remains the registered holder while you hold a licensee's usage rights. Second, registration runs through the operator's `.realtor` system rather than the open registrar market. The registry supports **DNSSEC**, and WHOIS, transfer, and renewal behavior follow the operator's and NAR's policies rather than generic gTLD defaults. The authoritative rules are the [ICANN .realtor Registry Agreement](https://www.icann.org/en/registry-agreements/details/realtor) and NAR's license terms.
+
+## .realtor pricing and value
+
+`.realtor` pricing works differently from open TLDs because there is a single operator-registrar and a membership context. A few dynamics are worth understanding before you commit:
+
+- **Membership-linked offers exist.** Historically NAR has used promotional offers (including a free first domain) to drive member adoption; introductory and recurring terms can differ, so confirm the renewal basis.
+- **First-year and renewal pricing differ.** As with most TLDs, any introductory rate is not the same as the recurring renewal rate — check the renewal figure before committing long term.
+- **Cost drivers** include membership status, the specific name, and the single-registrar model, which removes the price competition you would see across an open TLD's many registrars.
+
+This page intentionally avoids quoting figures, because prices and promotions change. Check live pricing through the official `.realtor` channel at registration time.
+
+## Reputation and email deliverability
+
+`.realtor` enjoys a credible, professional reputation precisely because it is gated: you cannot register one without verified membership, so it has not become a magnet for bulk spam the way some cheap open TLDs have. The suffix is associated with an established trade body, which lends it trust within its audience.
+
+As always, deliverability depends far more on configuration than on the suffix. Newer gTLDs can face slightly stricter spam-filter scrutiny simply because they are less familiar than `.com`. Mitigate this the standard way: publish correct **SPF, DKIM, and DMARC** records, warm up new sending domains gradually, and keep list hygiene tight. Done properly, `.realtor` email delivers as reliably as any legacy extension — and the membership signal can even help recipients trust it.
+
+## Branding and naming tips
+
+- **Use your real name.** Personal-name addresses like `firstnamelastname.realtor` are the natural pattern and reinforce that the suffix maps to a named member.
+- **Match website and email.** Adopting both the `.realtor` site and email maximizes the membership signal across every touchpoint.
+- **Keep the left side short.** "realtor" is seven characters, so a concise second-level label keeps the full address readable.
+- **Don't rely on it alone.** Some clients still type `.com`; hold the matching `.com` defensively where practical.
+
+## How to register a .realtor domain at Namefi
+
+1. **Search** for your desired name to check availability and confirm you meet NAR/CREA eligibility.
+2. **Choose** the exact `.realtor` name that fits you, your team, or your brokerage.
+3. **Register** and configure DNS — fast, reliable DNS management comes built in.
+
+Note that `.realtor` is a membership-gated TLD administered by its sponsor, so eligibility verification is part of the process. [Namefi](https://namefi.io) is an ICANN-accredited registrar with transparent pricing that also supports Web3 tokenization for eligible domains. [Explore domains and register at Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .realtor domain?
+
+No. The `.realtor` domain is restricted to members of the National Association of REALTORS® (NAR), members of the Canadian Real Estate Association (CREA), their member boards and associations, and NAR affiliates and licensees in good standing. The general public cannot register one, and NAR determines eligibility at its sole discretion.
+
+### Does a .realtor domain affect SEO?
+
+Google treats `.realtor` like any other generic TLD, so the extension itself gives no inherent ranking boost or penalty. Rankings come from content, links, and user experience. A descriptive `.realtor` name can improve click-through by clearly signaling a verified real-estate professional.
+
+### Who should register a .realtor domain?
+
+It suits individual REALTORS, brokerages, teams, and real-estate associations who are NAR or CREA members and want a credential-signaling web address. It is a strong fit when you want the suffix itself to prove membership in an organized real-estate body.
+
+### Do you actually own a .realtor domain?
+
+No. Under the Real Estate Domain License Agreement you license rather than own a `.realtor` domain. Real Estate Domains LLC remains the registered holder, and your rights are those of a licensee tied to maintaining eligibility and good standing.
+
+### Who operates the .realtor registry?
+
+The `.realtor` registry is operated by Real Estate Domains LLC, which is also the sole registrar. It runs the TLD under the direction of the National Association of REALTORS®, which sponsors the extension and controls eligibility.
+
+## Related resources
+
+- [.com domain](/en/tld/com) — the open benchmark to compare against.
+- [What is a domain?](/en/blog/what-is-domain) — the fundamentals, if you are new to domains.
+- [Domain terminology guide](/en/blog/domain-terminology-guide) — a glossary of the terms used above.
+- [ICANN](/en/glossary/icann), [registrar](/en/glossary/registrar), [DNS](/en/glossary/dns), and [DNSSEC](/en/glossary/dnssec) glossary entries.
+</content>
+</invoke>

--- a/content/tld/en/realty.md
+++ b/content/tld/en/realty.md
@@ -1,0 +1,145 @@
+---
+title: 'What Is the .realty Domain? The Open Real Estate TLD'
+date: '2026-06-15'
+language: 'en'
+tags: ['tld']
+authors: ['namefiteam']
+draft: false
+description: 'The .realty domain is an open generic TLD for property professionals. No NAR membership needed, unlike .realtor. See who can register, pricing, and SEO.'
+keywords: ['.realty domains', 'what is .realty', '.realty TLD', '.realty vs .realtor', 'real estate domain names', 'property website domain', 'Internet Naming Co', 'new gTLD for realtors']
+faqs:
+  - question: 'Can anyone register a .realty domain?'
+    answer: 'Yes. .realty is an open generic TLD with no eligibility restrictions. Any individual, business, or organization can register one without proving membership, a license, or local presence. This is the key difference from .realtor, which requires National Association of Realtors or Canadian Real Estate Association membership.'
+  - question: 'Is .realty the same as .realtor?'
+    answer: 'No. .realtor is restricted to members of the National Association of Realtors or the Canadian Real Estate Association and enforces naming rules. .realty is unrestricted and open to anyone selling, leasing, or renting property, with no membership requirement.'
+  - question: 'Does a .realty domain affect SEO?'
+    answer: 'Google treats new gTLDs like .realty the same as legacy endings such as .com, with no inherent ranking penalty or boost. Rankings come from content, links, and user experience. A descriptive ending like .realty can lift click-through by signaling the niche.'
+  - question: 'Who should register a .realty domain?'
+    answer: 'Real estate agencies, brokers, property managers, listing portals, and developers who want a clear, on-topic name. It suits anyone whose preferred .com is taken, and who wants a short, descriptive address without the membership gate that .realtor imposes.'
+---
+
+The **.realty** domain is an open generic top-level domain built for the property world: agencies, brokers, listing portals, property managers, and developers who want a web address that says exactly what they do. If your ideal `.com` is taken or priced out of reach, a `.realty` name lets you keep a short, descriptive brand while signaling your niche in a single word.
+
+Crucially, `.realty` is open to everyone. It is often confused with [.realtor](https://en.wikipedia.org/wiki/.realtor), which is gated behind trade-association membership — but `.realty` carries no such restriction, which makes it the more flexible choice for most real estate businesses.
+
+## .realty at a glance
+
+| Fact | Detail |
+| --- | --- |
+| TLD type | New gTLD |
+| Registry operator | Internet Naming Co. (backend: Tucows) |
+| Year launched | Delegated 2015 |
+| IDN support | Yes |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no credential or membership required |
+| Best for | Real estate agencies, brokers, property portals, developers |
+
+## What is .realty?
+
+The word "realty" is a long-standing English term for real property — land and the buildings on it — so the suffix reads instantly as "real estate" to an English-speaking audience. It is a **generic** top-level domain, not a country-code or geographic one, which means [Google](https://developers.google.com/search/docs/specialty/international/locale-adult) treats it as global rather than tied to any single country for geo-targeting. There is no built-in SEO advantage or penalty for choosing it; it behaves like any other generic ending in search.
+
+You can confirm the delegation and current operator on the authoritative [IANA root-zone record for .realty](https://www.iana.org/domains/root/db/realty.html), which lists the sponsoring organization, technical backend, and WHOIS server (`whois.nic.realty`).
+
+## History of .realty
+
+`.realty` was delegated to the DNS root in 2015 as part of ICANN's new gTLD program, the largest expansion of top-level domains in internet history. Its operator history is worth knowing, because the registry has changed hands more than once:
+
+- It was originally run by **Fegistry, LLC** from 2015.
+- It transferred to **Dog Beach, LLC** in 2021.
+- Since **February 2024** it has been operated by **Internet Naming Co.**, with Tucows providing the technical registry backend.
+
+This lineage matters mainly for due diligence: the rules and pricing tier of a TLD can evolve when stewardship changes, so always check the current operator's policies rather than older third-party write-ups. The transitions have been administrative; `.realty` has remained an open, unrestricted namespace throughout.
+
+## How people use .realty
+
+`.realty` is a literal, on-topic suffix, so the strongest uses are ones where the name plus the ending reads as a complete phrase:
+
+- **Brokerages and agencies** — `citygate.realty`, `summit.realty`, and similar names that pair a brand with the category.
+- **Independent agents** — a personal brand site that is clearly real estate without spelling out "realestate" in the second level.
+- **Property management firms** — letting and management companies that want a memorable, sector-specific address.
+- **Listing and search portals** — sites aggregating homes for sale or rent.
+- **Developers and new-build projects** — a dedicated microsite for a single development or community.
+
+**Who it's *not* ideal for:** anyone outside property and housing, since the meaning is narrow; businesses that specifically need the trust signal of trade-association branding (those should look at `.realtor`); and brands whose audience is non-English-speaking, where the word "realty" may not resonate.
+
+## Notable sites using .realty
+
+Adoption of `.realty` is led by working real estate firms and brokerages rather than household-name consumer brands, which is typical for a niche professional suffix. In practice you will most often see it used by regional agencies, independent brokers, and property-management companies that wanted a short, descriptive address when their `.com` equivalent was unavailable. Rather than name a specific site that may change hands, the honest summary is: this is a working-professional namespace, used day-to-day by real estate businesses, not a vanity extension.
+
+## .realty vs other domains
+
+| | .realty | [.realtor](https://en.wikipedia.org/wiki/.realtor) | [.com](/en/tld/com) |
+| --- | --- | --- | --- |
+| Type | New gTLD | New gTLD | Legacy gTLD |
+| Restrictions | Open to all | NAR / CREA membership required | Open to all |
+| Meaning | "Real estate" generic | Certified Realtor identity | Universal / no niche |
+| Best for | Any property business | Association members | Broadest recognition |
+
+Pick `.realty` when you want a clear real estate signal without joining a trade body. Choose `.realtor` only if you are a credentialed Realtor and want that specific badge. Choose `.com` when maximum mainstream recognition outweighs having a descriptive ending. Other generic options like [.io](/en/tld/io), [.app](/en/tld/app), or [.xyz](/en/tld/xyz) are better suited to tech and general brands than to property.
+
+## Why choose .realty?
+
+- **Instant relevance.** The suffix tells visitors and search users the site is about property before they click.
+- **No membership gate.** Unlike `.realtor`, anyone can register, so you are not blocked by association eligibility.
+- **Better availability.** Short, brandable names that are long gone in `.com` are often still open in `.realty`.
+- **Clean branding.** You can avoid awkward prefixes and hyphens by letting the ending carry the "real estate" meaning.
+
+## Things to consider
+
+`.realty` is a niche ending, and that cuts both ways. The meaning is narrow, so the name has little value outside property. Public recognition of the suffix is still lower than `.com`, so some visitors may instinctively type `.com` instead — consider defensively registering the matching `.com` if it exists. New gTLDs can also sit in a higher pricing tier than legacy endings, and renewal costs can differ from the first year (see pricing below). Finally, because the registry has changed operators, confirm current policies with the active operator before committing a brand to it.
+
+## Who can register a .realty domain?
+
+**Registration restrictions: open to all.** There is no credential, license, local-presence, or community requirement. Any individual, business, or organization may register a `.realty` domain — including people who rent, lease, sell, or simply work adjacent to property. This is the defining contrast with `.realtor`, which is limited to members of the National Association of Realtors or the Canadian Real Estate Association and enforces specific naming rules.
+
+Standard new gTLD practices apply: a sunrise period gave trademark holders early access at launch, and trademark claims are handled through ICANN's Trademark Clearinghouse. Names follow ordinary length rules, internationalized domain names (IDNs) are supported, and DNSSEC is available for registrants who want cryptographic integrity for their DNS. WHOIS privacy, transfer, renewal, and redemption-grace behavior follow the operator's policies and your registrar's settings. Because `.realty` is a gTLD, it is governed by an [ICANN Registry Agreement for .realty](https://www.icann.org/en/registry-agreements/details/realty), the authoritative source for the binding rules; the [IANA record](https://www.iana.org/domains/root/db/realty.html) lists the current operator and technical contacts.
+
+## .realty pricing and value
+
+This page never quotes live prices, but the **dynamics** are worth understanding. As a new gTLD, `.realty` typically sits in a higher pricing tier than legacy endings, and like most TLDs it can carry **premium** names — short, dictionary, or high-demand terms that the registry prices above the standard rate. Expect **first-year and renewal pricing to differ**, so budget for the ongoing renewal, not just the promotional first year. Cost is driven by the registry's wholesale tier, whether the specific name is flagged premium, and your registrar's margin and term length. Always check the renewal rate before registering a name you intend to keep long term.
+
+## Reputation and email deliverability
+
+`.realty` is a legitimate, professionally used suffix without a notable history of abuse, so it is not broadly flagged as spam-prone the way some ultra-cheap endings are. That said, newer and less-recognized gTLDs collectively get slightly more scrutiny from aggressive spam filters than long-established ones. The practical mitigation is the same hygiene any domain needs: authenticate your mail with SPF, DKIM, and DMARC, warm up a new sending domain gradually, and maintain a clean sending reputation. Done properly, `.realty` delivers mail reliably.
+
+## Branding and naming tips
+
+The strongest `.realty` names treat the suffix as the second half of a phrase: `harbor.realty`, `nextstep.realty`, `peak.realty`. Keep the second-level label short and easy to say aloud, since real estate is a word-of-mouth and signage business. Avoid pairing it with "real estate" or "homes" in the name itself — that is redundant given the suffix. One pitfall to watch: people may mishear or mistype `.realty` as `.realtor` or `.realestate`, so pick a left-hand label distinctive enough that the full name is unambiguous when spoken.
+
+## How to register a .realty domain at Namefi
+
+1. **Search** for your preferred name with the `.realty` ending.
+2. **Choose** an available label, checking whether it is flagged premium and reviewing the renewal rate.
+3. **Register** and configure DNS, with DNSSEC available if you want it.
+
+As an ICANN-accredited registrar, [Namefi](https://namefi.io) offers transparent pricing, fast DNS, and the option to tokenize your domain as a Web3 asset — bridging traditional registration with on-chain ownership. Start your search at [Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .realty domain?
+
+Yes. `.realty` is an open generic TLD with no eligibility restrictions. Any individual, business, or organization can register one without proving membership, a license, or local presence. This is the key difference from `.realtor`, which requires National Association of Realtors or Canadian Real Estate Association membership.
+
+### Is .realty the same as .realtor?
+
+No. `.realtor` is restricted to members of the National Association of Realtors or the Canadian Real Estate Association and enforces naming rules. `.realty` is unrestricted and open to anyone selling, leasing, or renting property, with no membership requirement.
+
+### Does a .realty domain affect SEO?
+
+Google treats new gTLDs like `.realty` the same as legacy endings such as `.com`, with no inherent ranking penalty or boost. Rankings come from content, links, and user experience. A descriptive ending like `.realty` can lift click-through by signaling the niche.
+
+### Who should register a .realty domain?
+
+Real estate agencies, brokers, property managers, listing portals, and developers who want a clear, on-topic name. It suits anyone whose preferred `.com` is taken, and who wants a short, descriptive address without the membership gate that `.realtor` imposes.
+
+## Related resources
+
+- [What is a domain name?](/en/blog/what-is-domain)
+- [Domain terminology guide](/en/blog/domain-terminology-guide)
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains)
+- [ICANN explained](/en/glossary/icann)
+- [What is a registrar?](/en/glossary/registrar)
+- [DNSSEC explained](/en/glossary/dnssec)
+- [.com domain](/en/tld/com)
+- [.io domain](/en/tld/io)
+- [.xyz domain](/en/tld/xyz)

--- a/content/tld/en/shopping.md
+++ b/content/tld/en/shopping.md
@@ -1,0 +1,155 @@
+---
+title: 'What Is the .shopping Domain? The E-Commerce Extension Explained'
+date: '2026-06-15'
+language: 'en'
+tags: ['tld']
+authors: ['namefiteam']
+draft: false
+description: 'The .shopping domain is an open e-commerce gTLD from Binky Moon (Identity Digital). Learn who it suits, how it compares to .shop and .store, and how to register it.'
+keywords: ['.shopping domains', 'what is .shopping', '.shopping TLD', '.shopping domain', 'e-commerce domain', 'retail domain name', 'Binky Moon', 'Identity Digital', 'shopping domain extension', 'buy .shopping domain']
+faqs:
+  - question: 'Can anyone register a .shopping domain?'
+    answer: 'Yes. The .shopping TLD is an open generic domain with no eligibility restrictions. Any individual or business in any country can register an available name on a first-come, first-served basis, with no credential, trademark, or local-presence requirement.'
+  - question: 'Does a .shopping domain affect SEO?'
+    answer: 'No. Google treats new gTLDs like .shopping the same as legacy extensions such as .com, and the suffix carries no inherent ranking penalty or boost. A descriptive extension can lift click-through rates on shopping-intent searches, but content, links, and user experience still drive rankings.'
+  - question: 'Who should register a .shopping domain?'
+    answer: 'Online retailers, marketplaces, deal and coupon sites, product-review publishers, and brands that want a clear, transactional web address. It also suits anyone whose ideal .com is taken, since the .shopping namespace still has short, exact-match names available.'
+  - question: 'How is .shopping different from .shop and .store?'
+    answer: 'All three are open e-commerce gTLDs. The word "shopping" frames the activity of browsing and buying rather than a single storefront, making it natural for marketplaces, aggregators, and review or deals sites. The right choice depends on which exact-match name you can secure.'
+  - question: 'Does .shopping support DNSSEC and WHOIS privacy?'
+    answer: 'Yes. The .shopping registry supports DNSSEC for cryptographic DNS integrity and internationalized domain names. WHOIS privacy is offered by most registrars, including Namefi, so personal contact details are not published in public records.'
+---
+
+If you sell products online, your web address is the first thing a customer reads. The **.shopping** domain is a generic Top-Level Domain (gTLD) built for exactly that moment: it names the activity of browsing and buying, and tells visitors and search engines what your site is for before they click. This page explains what .shopping is, who operates it, how it stacks up against the better-known .shop and .store, and what to weigh before you register.
+
+It is a descriptive, open extension — no credentials, no membership, no local presence required — which makes it a practical option for retailers, marketplaces, and content sites whose ideal .com is long gone.
+
+## .shopping at a glance
+
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic TLD (new gTLD, 2012 application round) |
+| Registry operator | Binky Moon, LLC, operated by [Identity Digital](https://www.identity.digital/) |
+| Year launched | Delegated to the DNS root in 2016 |
+| IDN support | Yes (internationalized domain names) |
+| DNSSEC | Yes |
+| Registration restrictions | Open to all — no eligibility requirements |
+| Best for | E-commerce stores, marketplaces, deal/coupon sites, product-review publishers |
+
+## What is .shopping?
+
+The **.shopping** TLD is a generic, non-sponsored extension delegated to the internet's root zone in 2016 as part of [ICANN's New gTLD Program](https://newgtlds.icann.org/), the expansion that introduced hundreds of word-based suffixes alongside the legacy set of .com, .net, and .org. Where .com is a catch-all for any commercial entity, .shopping is semantic: the label itself describes a purpose, so a name like `vintage.shopping` or `compare.shopping` communicates intent at a glance.
+
+Because .shopping is a generic gTLD rather than a country-code TLD, it is not tied to any nation and is not geo-targeted. Google's guidance is explicit that its systems treat new gTLDs the same as any other generic extension — a .shopping site is not pinned to a region and competes globally on the usual signals of content and links. You can confirm the suffix's root-zone status on its [IANA delegation record](https://www.iana.org/domains/root/db/shopping.html).
+
+## History of .shopping
+
+The .shopping string was applied for during ICANN's 2012 new-gTLD round and signed a Base Registry Agreement in 2016, the standard contract for non-sponsored generic extensions. It was delegated to the DNS root the same year and entered general availability shortly after, opening to registrants worldwide without restriction.
+
+Operationally, .shopping sits inside one of the largest new-gTLD portfolios on the market. Its registry, Binky Moon, LLC, holds dozens of descriptive extensions, and the back-end is run by Identity Digital — the company formed by the 2022 merger of Donuts and Afilias. That puts .shopping on mature registry infrastructure rather than a one-off operator. It remains a niche, descriptive TLD rather than a mass-market one, so registration volumes are modest compared with .shop, and the namespace still holds many short, exact-match names.
+
+## How people use .shopping
+
+The literal meaning of the word makes .shopping flexible across the retail funnel:
+
+- **Online stores** that want a transactional address customers immediately understand.
+- **Marketplaces and aggregators** where the experience is *browsing across sellers*, which the word "shopping" captures better than "store."
+- **Deal, coupon, and discount sites** built around the act of finding and comparing offers.
+- **Product-review and buying-guide publishers** whose content is shopping research rather than direct sales.
+- **Seasonal or campaign microsites** (for example a holiday gift hub) that need a memorable, on-theme address.
+- **Brand-protection registrations** by companies defending a trademark across e-commerce extensions.
+
+**Who it's not ideal for:** non-commercial projects, personal blogs, or B2B/SaaS products where "shopping" misframes what you do. A developer tool or a law firm gains nothing — and may confuse visitors — by sitting on a retail-flavored suffix.
+
+## Notable sites using .shopping
+
+.shopping is a smaller, descriptive namespace, and it does not yet have a roster of household-name flagship sites the way .shop does with high-profile merchandise stores. Rather than name a site we cannot verify is in active use, the honest picture is this: .shopping is most commonly adopted by independent e-commerce stores, niche marketplaces, deals and coupon sites, and brands registering it defensively alongside their primary domain. If a specific well-known .shopping site matters to your decision, verify it directly in a browser before relying on it.
+
+## .shopping vs other domains
+
+| Extension | Type | Framing | Registration |
+| --- | --- | --- | --- |
+| [.shopping](/en/tld/shopping) | Generic gTLD | The activity of browsing and buying | Open to all |
+| [.shop](/en/tld/shop) | Generic gTLD | A place that sells | Open to all |
+| [.store](/en/tld/store) | Generic gTLD | A storefront / retail outlet | Open to all |
+| [.com](/en/tld/com) | Legacy gTLD | Generic commercial catch-all | Open to all |
+
+All three retail extensions are open and SEO-equivalent, so the decision is mostly about meaning and availability. Choose **.shopping** when your value is *the act of shopping* — comparison, discovery, deals, marketplaces. Choose **.shop** or **.store** when you are framing a single storefront. Choose **.com** when the exact-match legacy name is available and affordable and you want the most universally recognized default. In practice, the deciding factor is which clean, exact-match name you can actually secure.
+
+## Why choose .shopping?
+
+- **Self-explanatory intent.** The suffix states your purpose, which can lift click-through rates on transactional searches where users want to buy.
+- **Availability of exact-match names.** Because the namespace is younger and smaller than .com, short keyword and brand names are far more likely to be open.
+- **Global and unrestricted.** No geographic targeting and no eligibility gate — register from anywhere for any lawful commercial use.
+- **Solid infrastructure.** Running on Identity Digital's registry platform means standard support for DNSSEC and internationalized domain names.
+
+## Things to consider
+
+- **Length.** At eight characters, `.shopping` is longer than `.shop` or `.com`; on packaging, ads, or spoken word it is more to type and say.
+- **Lower recognition.** It is less familiar to the general public than .com or even .shop, so some users may second-guess an unfamiliar suffix.
+- **Easy to confuse with .shop.** The two are close in meaning and spelling; if both your brand's .shop and .shopping are valuable, you may want to register both defensively.
+- **Niche fit.** Its strength — the retail meaning — is a liability for any non-commercial use.
+
+## Who can register a .shopping domain?
+
+**Registration restrictions: open to all.** There are no eligibility requirements for .shopping — no credential, trademark, community membership, or local-presence rule. Any person or organization, anywhere, can register an available name on a first-come, first-served basis.
+
+Standard generic-gTLD policies apply. A Trademark Clearinghouse–backed sunrise period ran at launch to let trademark holders claim matching names first; that window has long closed, so today registration is ordinary general availability. Names follow the usual DNS rules (broadly 1–63 characters, letters, digits, and hyphens, with IDN support for non-Latin scripts). The registry supports DNSSEC, and registrars including Namefi offer WHOIS privacy. Renewal, transfer, and redemption-grace handling follow ICANN's standard gTLD lifecycle. For the authoritative rules, see the [ICANN Registry Agreement for .shopping](https://www.icann.org/en/registry-agreements/details/shopping).
+
+## .shopping pricing and value
+
+.shopping is priced as a descriptive new gTLD, which generally sits above the cheapest commodity extensions but is not a luxury tier. A few dynamics are worth understanding rather than any specific figure:
+
+- **Premium names.** The registry classifies certain short or high-demand keyword domains as premium, which carry higher standing registration and renewal fees set by the registry, not the registrar.
+- **First-year vs. renewal.** Introductory or promotional first-year pricing does not predict the renewal rate — always check the standard renewal price before you commit to a name you plan to keep.
+- **What drives cost.** Registry wholesale pricing, premium tiering, and registrar margin together determine the final price; resale value depends on the quality and brevity of the keyword.
+
+We do not quote live prices here; check Namefi's current rate at registration time.
+
+## Reputation and email deliverability
+
+New gTLDs as a class once carried a faint association with spam, because abusers gravitated to cheap, lightly policed namespaces. .shopping has not been a notable offender, and its retail framing attracts commercial registrants rather than throwaway abuse. Still, some aggressive spam filters apply slightly more scrutiny to less-common extensions than to .com. The mitigation is the same as for any domain: authenticate mail with SPF, DKIM, and DMARC, warm up new sending domains gradually, and keep good list hygiene. Done properly, a .shopping address delivers reliably; deliverability is governed by sender reputation, not the suffix.
+
+## Branding and naming tips
+
+The word "shopping" is the asset — lean into it. The strongest .shopping names read as a natural two-word phrase: a category or brand on the left and the activity on the right, such as `smart.shopping`, `green.shopping`, or `yourbrand.shopping`. This domain-hack pattern lets you drop filler words a .com would force ("smartshoppingonline.com" becomes `smart.shopping`). Keep the left label short and unambiguous, since the suffix already adds eight characters. Spelling is rarely a pitfall — "shopping" is high-frequency and easy to dictate — but be mindful that listeners may hear ".shop" and miss the longer form, so confirm the full extension in spoken contexts.
+
+## How to register a .shopping domain at Namefi
+
+1. **Search** your desired name on [Namefi](https://namefi.io) to check availability across .shopping and related extensions.
+2. **Choose** the best match — and consider grabbing the .shop or .store version to protect your brand.
+3. **Register** and complete checkout with transparent pricing and no hidden add-ons.
+
+As an ICANN-accredited registrar, Namefi gives you straightforward DNS management and fast propagation, plus the option to tokenize your domain as an on-chain asset for true Web3 ownership and easy transfer. [Register your .shopping domain at Namefi](https://namefi.io) and put a clear, transactional address to work.
+
+## Frequently asked questions
+
+### Can anyone register a .shopping domain?
+
+Yes. The .shopping TLD is an open generic domain with no eligibility restrictions. Any individual or business in any country can register an available name on a first-come, first-served basis, with no credential, trademark, or local-presence requirement.
+
+### Does a .shopping domain affect SEO?
+
+No. Google treats new gTLDs like .shopping the same as legacy extensions such as .com, and the suffix carries no inherent ranking penalty or boost. A descriptive extension can lift click-through rates on shopping-intent searches, but content, links, and user experience still drive rankings.
+
+### Who should register a .shopping domain?
+
+Online retailers, marketplaces, deal and coupon sites, product-review publishers, and brands that want a clear, transactional web address. It also suits anyone whose ideal .com is taken, since the .shopping namespace still has short, exact-match names available.
+
+### How is .shopping different from .shop and .store?
+
+All three are open e-commerce gTLDs. The word "shopping" frames the activity of browsing and buying rather than a single storefront, making it natural for marketplaces, aggregators, and review or deals sites. The right choice depends on which exact-match name you can secure.
+
+### Does .shopping support DNSSEC and WHOIS privacy?
+
+Yes. The .shopping registry supports DNSSEC for cryptographic DNS integrity and internationalized domain names. WHOIS privacy is offered by most registrars, including Namefi, so personal contact details are not published in public records.
+
+## Related resources
+
+- [.shop](/en/tld/shop) — the most popular open e-commerce extension
+- [.store](/en/tld/store) — a storefront-framed retail alternative
+- [.com](/en/tld/com) — the legacy commercial default
+- [What is a TLD?](/en/glossary/tld) — the basics of top-level domains
+- [Registrar](/en/glossary/registrar) — how domain registration works
+- [DNSSEC](/en/glossary/dnssec) — securing DNS with cryptographic signatures
+- [Top TLDs to secure for your e-commerce store](/en/blog/top-tlds-to-secure-for-your-ecommerce-store) — a buyer's checklist

--- a/content/tld/en/style.md
+++ b/content/tld/en/style.md
@@ -1,0 +1,160 @@
+---
+title: 'What Is the .style Domain? A Guide to the Fashion TLD'
+date: '2026-06-15'
+language: 'en'
+tags: ['tld']
+authors: ['namefiteam']
+draft: false
+description: 'The .style domain is an open generic TLD for fashion, design, and lifestyle brands. Learn who runs it, who can register, pricing dynamics, and how to buy one.'
+keywords: ['.style domains', 'what is .style', '.style TLD', '.style domain', 'fashion domain extension', 'design domain name', 'lifestyle TLD', 'register .style domain', 'Identity Digital', 'new gTLD']
+faqs:
+  - question: 'Can anyone register a .style domain?'
+    answer: 'Yes. .style is an open generic top-level domain with no eligibility restrictions, so individuals, businesses, and organizations anywhere in the world can register one on a first-come, first-served basis. No credential, trademark, or local presence is required.'
+  - question: 'Does a .style domain affect SEO?'
+    answer: 'No. Google treats new generic TLDs like .style the same as legacy extensions such as .com, with no inherent ranking penalty or boost. Rankings depend on content, links, and user experience, not the suffix itself.'
+  - question: 'Who should register a .style domain?'
+    answer: 'Fashion labels, designers, stylists, salons, interior and architecture studios, lifestyle bloggers, and creators who want a short, on-theme name. It also suits brand owners protecting a trademark and domain investors holding descriptive fashion terms.'
+  - question: 'Is .style a good domain for a fashion brand?'
+    answer: 'It can be. The word "style" reads clearly and signals fashion, beauty, and design intent, and short on-brand names are far easier to find than in .com. The trade-off is lower public familiarity than legacy extensions.'
+  - question: 'Does .style support WHOIS privacy and DNSSEC?'
+    answer: 'Yes. As a standard Identity Digital generic TLD, .style supports DNSSEC, and most registrars including Namefi offer WHOIS privacy so personal contact details are not published publicly.'
+---
+
+The **.style** domain is an open generic top-level domain (gTLD) built for the world of fashion, beauty, design, and lifestyle. Where a legacy suffix like .com says nothing about what a site does, **.style** puts the theme right in the address — a clear signal that the brand behind it cares about aesthetics, trends, and self-expression.
+
+If you are a designer, stylist, label, salon, or lifestyle creator, this guide covers what **.style** is, who operates it, who can register one, how its pricing works, and how it compares to the alternatives — so you can decide whether it belongs in your brand.
+
+## .style at a glance
+
+| Fact | Detail |
+| --- | --- |
+| TLD type | New generic TLD (gTLD) |
+| Registry operator | Binky Moon, LLC (an [Identity Digital](https://www.identity.digital/) company, formerly Donuts) |
+| Year launched | 2015 (delegated February 2015; general availability May 2015) |
+| IDN support | Yes |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility requirement |
+| Best for | Fashion, beauty, design, interiors, and lifestyle brands |
+
+## What is .style?
+
+**.style** is a [new generic top-level domain](/en/blog/what-is-a-tld) — one of the hundreds of themed extensions introduced under ICANN's 2012 new gTLD program, which expanded the domain name system far beyond the original handful of suffixes like .com, .net, and .org. Unlike a country-code TLD such as .uk or .de, **.style** is not tied to any nation, so it carries no geographic meaning and is not geo-targeted by search engines.
+
+The string itself is plain English: *style*. That makes it instantly readable to a global audience and naturally evocative of fashion, grooming, interior design, architecture, and personal taste. You can confirm its delegation details in the authoritative [IANA root zone database entry for .style](https://www.iana.org/domains/root/db/style.html), which lists Binky Moon, LLC as the sponsoring organization.
+
+Because it is a generic rather than a country-code extension, **.style** is governed by an ICANN Registry Agreement and administered like other Identity Digital TLDs, with standardized policies for disputes, transfers, and abuse handling.
+
+## History of .style
+
+**.style** was one of many descriptive-word strings Donuts applied for during the new gTLD expansion. After a private auction resolved the contention set in late 2014, the string was delegated to the DNS root zone in February 2015 and reached general availability in May 2015.
+
+Donuts — which ran one of the largest portfolios of new gTLDs — later merged with Afilias to form **Identity Digital**, the company that operates **.style** today through its **Binky Moon, LLC** registry subsidiary. This matters for buyers: it means **.style** sits inside a large, professionally run registry alongside hundreds of sibling extensions, with consistent, well-documented policies rather than the patchwork rules that smaller standalone registries sometimes have.
+
+## How people use .style
+
+**.style** is a thematic extension, so its best uses are ones where the word reinforces the brand's purpose:
+
+- **Fashion and apparel brands** wanting a name that reads as on-trend (e.g. `label.style`).
+- **Stylists, makeup artists, and salons** building a portfolio or booking site.
+- **Interior design, architecture, and home-decor studios** where "style" speaks to aesthetic taste.
+- **Lifestyle bloggers and creators** covering fashion, beauty, and trends.
+- **Brand-protection registrations**, where an established label secures the .style version of its trademark defensively.
+- **Domain investors** holding descriptive terms (e.g. `street.style`, `life.style`) as digital assets.
+
+**Who it's not ideal for:** businesses outside the design and lifestyle space, or anyone whose audience expects the reassurance of a conventional .com. If your customers are unlikely to associate "style" with what you sell, the thematic advantage disappears.
+
+## Notable sites using .style
+
+There is no single household-name flagship on **.style** the way some extensions have an anchor tenant. In practice the suffix is used most by independent fashion and design studios, personal-stylist portfolios, lifestyle blogs, and creators who value a short, on-theme name, plus defensive registrations by larger apparel and beauty brands. Rather than name a site that may change hands, treat **.style** as a working extension for the design and lifestyle niche — a verifiable description of its real-world use, not an invented endorsement.
+
+## .style vs other domains
+
+| Extension | Positioning | Restrictions |
+| --- | --- | --- |
+| [.style](/en/tld/style) | Thematic name for fashion, design, and lifestyle | Open to all |
+| [.com](/en/tld/com) | Universal default; maximum familiarity and trust | Open to all |
+| [.shop](/en/tld/shop) | E-commerce intent; signals "buy here" | Open to all |
+| [.store](/en/tld/store) | Retail and online-store focus | Open to all |
+
+Pick **.com** when broad recognition matters more than theme. Choose [.shop](/en/tld/shop) or [.store](/en/tld/store) when the priority is signaling a place to buy. Reach for **.style** when the brand identity itself is about taste, fashion, and aesthetics, and you want the suffix to carry that meaning.
+
+## Why choose .style?
+
+- **Meaning built in.** The suffix communicates fashion and design before anyone clicks, which can lift relevance and click-through for the right brand.
+- **Availability.** Short, single-word names that are long gone in .com are often still open in **.style**, letting you build `name.style` instead of settling for a hyphenated or padded .com.
+- **Memorable domain hacks.** "Style" completes many phrases cleanly — `life.style`, `free.style`, `my.style` — for names that are easy to say and recall.
+- **Neutral SEO footing.** Per [Google Search Central](https://developers.google.com/search/docs/crawling-indexing/site-names), new gTLDs are treated like any other domain; the extension neither helps nor hurts rankings on its own.
+- **Stable registry.** Operated by Identity Digital, **.style** benefits from mature, consistent policies and broad registrar support.
+
+## Things to consider
+
+- **Lower familiarity.** Mainstream users still default to .com, and some may not immediately recognize **.style** as a real address.
+- **Niche by design.** Its thematic strength is a weakness outside fashion, beauty, and design.
+- **Premium names cost more.** The most desirable single-word **.style** domains are classified as premium and priced well above standard names (see below).
+- **Brand confusion.** Audiences habituated to .com may type the .com version of your name, so a defensive .com registration can still be worth it.
+
+## Who can register a .style domain?
+
+**Registration restrictions: open to all.** **.style** has no eligibility gate — there is no credential, professional-membership, trademark, or local-presence requirement. Any individual, business, or organization worldwide can register an available name on a first-come, first-served basis, exactly as with .com.
+
+As a standard Identity Digital generic TLD, **.style** follows ICANN's consensus policies: it supported a sunrise period at launch for trademark holders, supports internationalized domain names (IDNs), and supports DNSSEC for cryptographic integrity of DNS responses. Most registrars, including Namefi, offer WHOIS privacy to keep personal contact details off the public record. Transfers use the standard authorization-code process, and registrations follow ICANN's normal renewal and redemption-grace lifecycle. Domain disputes are handled through ICANN's [UDRP](/en/glossary/udrp). For the operator's own policies and full registry details, see the official [Identity Digital](https://www.identity.digital/) site.
+
+## .style pricing and value
+
+This page does not quote prices, but it helps to understand what drives them. **.style** registrations come in two tiers. **Standard** names are priced at the registry's regular rate, while **premium** names — short, common, high-demand words like `street.style` or `wedding.style` — are flagged by the registry and carry higher, sometimes recurring, premium pricing.
+
+As with most new gTLDs, **first-year and renewal pricing usually differ**: an introductory or promotional first year does not necessarily reflect what you pay annually thereafter, so check the standard renewal rate before committing to a name you intend to keep long term. The main cost drivers are the name's tier (standard vs premium), its length and keyword desirability, and whether you add services like WHOIS privacy. To learn how names trade on the secondary market, see [how to sell a domain name you own](/en/blog/how-to-sell-a-domain-name-you-own).
+
+## Reputation and email deliverability
+
+New gTLDs as a category once drew extra scrutiny from spam filters, because cheap, lightly regulated extensions attracted abuse early in the program. **.style** is a thematic, moderately priced Identity Digital extension rather than a bargain-bin suffix, so it does not carry the worst of that reputation — but it is still less established than .com in the eyes of some recipients and filters.
+
+If you send email from a **.style** domain, deliverability depends far more on your configuration than on the suffix. Set up SPF, DKIM, and DMARC correctly, warm up new sending domains gradually, and keep your list clean. Done properly, a **.style** domain reaches inboxes reliably; the extension is not a meaningful obstacle.
+
+## Branding and naming tips
+
+The strength of **.style** is the domain hack: let the suffix finish the phrase. `life.style`, `free.style`, and `my.style` read as natural words, which is more memorable than bolting "style" onto an unrelated brand. Keep the second-level label short and easy to spell aloud — you want a name that survives being shared verbally without confusion.
+
+Because some users still assume .com, say and show your full domain (suffix included) in marketing, and consider registering the .com equivalent defensively if it is available. Avoid names that only make sense in writing or that invite the wrong .com to capture your traffic.
+
+## How to register a .style domain at Namefi
+
+1. **Search** your desired name at [Namefi](https://namefi.io) to check availability across the .style namespace.
+2. **Choose** your exact name, noting whether it is a standard or premium registration.
+3. **Register** and configure DNS, WHOIS privacy, and renewals from one dashboard.
+
+As an ICANN-accredited [registrar](/en/glossary/registrar), Namefi offers transparent pricing and fast DNS management, plus something most registrars do not: the option to [tokenize your domain](/en/blog/what-are-tokenized-domains) as an on-chain asset, bridging your Web2 name into Web3. Whether you are launching a label or building a portfolio of fashion names, Namefi gives you the tools to manage and move them.
+
+[Register your .style domain at Namefi](https://namefi.io) and put your aesthetic right in the address.
+
+## Frequently asked questions
+
+### Can anyone register a .style domain?
+
+Yes. **.style** is an open generic top-level domain with no eligibility restrictions, so individuals, businesses, and organizations anywhere in the world can register one on a first-come, first-served basis. No credential, trademark, or local presence is required.
+
+### Does a .style domain affect SEO?
+
+No. Google treats new generic TLDs like **.style** the same as legacy extensions such as .com, with no inherent ranking penalty or boost. Rankings depend on content, links, and user experience, not the suffix itself.
+
+### Who should register a .style domain?
+
+Fashion labels, designers, stylists, salons, interior and architecture studios, lifestyle bloggers, and creators who want a short, on-theme name. It also suits brand owners protecting a trademark and domain investors holding descriptive fashion terms.
+
+### Is .style a good domain for a fashion brand?
+
+It can be. The word "style" reads clearly and signals fashion, beauty, and design intent, and short on-brand names are far easier to find than in .com. The trade-off is lower public familiarity than legacy extensions.
+
+### Does .style support WHOIS privacy and DNSSEC?
+
+Yes. As a standard Identity Digital generic TLD, **.style** supports DNSSEC, and most registrars including Namefi offer WHOIS privacy so personal contact details are not published publicly.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [How to sell a domain name you own](/en/blog/how-to-sell-a-domain-name-you-own)
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains)
+- [Registrar (glossary)](/en/glossary/registrar)
+- [UDRP (glossary)](/en/glossary/udrp)
+- [.shop domain](/en/tld/shop) · [.store domain](/en/tld/store) · [.com domain](/en/tld/com)

--- a/content/tld/en/tax.md
+++ b/content/tld/en/tax.md
@@ -1,0 +1,156 @@
+---
+title: 'What Is the .tax Domain? The Extension for Tax & Accounting'
+date: '2026-06-15'
+language: 'en'
+tags: ['tld']
+authors: ['namefiteam']
+draft: false
+description: 'The .tax domain is an open generic gTLD run by Binky Moon. Learn who uses it, the registration rules, pricing dynamics, reputation, and whether it fits your firm.'
+keywords: ['.tax domain', 'what is .tax', '.tax TLD', 'tax domain extension', '.tax registration', 'accounting domain', 'tax preparer website', 'new gTLD']
+faqs:
+  - question: 'Can anyone register a .tax domain?'
+    answer: 'Yes. The .tax registry is open to everyone with no credential, license, or local-presence requirement. You do not need to be an accountant, tax preparer, or registered firm. Names are sold first-come, first-served, subject only to standard syntax rules and any reserved or premium names the registry holds back.'
+  - question: 'Does a .tax domain affect SEO?'
+    answer: 'No. Google treats .tax as a generic top-level domain with no inherent ranking advantage or penalty. Search engines weigh content, links, and user experience, not the suffix. A descriptive .tax name can improve click-through because the extension signals the topic, but it does not change crawling or indexing.'
+  - question: 'Who should register a .tax domain?'
+    answer: 'It suits tax preparers, CPAs, enrolled agents, bookkeeping and accounting firms, tax-software products, and educational sites about taxation. It works well as an exact-match or descriptive name where the desired .com is taken or expensive. It is a poor fit for unrelated businesses, since the suffix strongly implies tax content.'
+  - question: 'Is .tax a restricted or community domain?'
+    answer: 'No. Despite the professional-sounding name, .tax is an unrestricted generic gTLD under a standard ICANN base registry agreement. Unlike .cpa, which requires CPA credentials, .tax has no eligibility gate, sunrise-only access, or membership verification. Trademark holders did get a sunrise period at launch.'
+---
+
+The **.tax domain** is a topic-specific generic extension built for the world of taxation: preparers, accountants, bookkeepers, tax-software makers, and the educational sites that explain it all. The word *tax* is short, universally understood, and unambiguous, which makes the suffix one of the clearer professional alternatives to a crowded .com landscape.
+
+If you run a tax practice or build tools for one, a .tax name puts your specialty directly in the address bar. This page covers what the suffix is, who operates it, who can register it, how its pricing works, and how it compares to the alternatives, so you can decide whether it belongs in your brand.
+
+## .tax at a glance
+
+| Fact | Detail |
+| --- | --- |
+| TLD type | New gTLD (generic, 2012 application round) |
+| Registry operator | Binky Moon, LLC (c/o [Identity Digital](https://www.identity.digital/)) |
+| Year launched | Delegated 2014 |
+| IDN support | Yes, via the registry's supported scripts |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no credential, license, or local presence required |
+| Best for | Tax preparers, CPAs, accounting firms, tax-software products, tax education |
+
+## What is .tax?
+
+.tax is a **new generic top-level domain (gTLD)** introduced through ICANN's 2012 New gTLD Program, the expansion that brought hundreds of word-based suffixes to the root zone. It is not a country-code TLD, so it carries no national association and is not geo-targeted. According to [Google Search Central](https://developers.google.com/search/docs/crawling-indexing/international/managing-multi-regional-sites), generic new gTLDs like .tax are treated as global, with no geographic targeting applied by default.
+
+The string itself does the marketing. Where a generic suffix like .com or [.net](/en/tld/net) tells a visitor nothing, *tax* names the subject before the page loads. That self-describing quality is the whole point of topic gTLDs, and it is why the extension concentrates among firms and products in one clear niche.
+
+You can confirm the official delegation record on the [IANA root database entry for .tax](https://www.iana.org/domains/root/db/tax.html).
+
+## History of .tax
+
+.tax was applied for during the 2012 round and **delegated to the root zone in 2014**, originally under the Donuts portfolio of generic gTLDs. The registry function for these strings now sits with **Binky Moon, LLC**, the registry-operator entity of [Identity Digital](https://www.identity.digital/) (formed from the merger of Donuts and Afilias), which operates one of the largest gTLD portfolios in the industry.
+
+Like other Identity Digital extensions, .tax launched with a trademark sunrise phase before general availability. Adoption has been steady rather than explosive: it serves a defined professional audience, so registration volume is modest compared with mass-market suffixes, but it has a durable, on-topic user base.
+
+## How people use .tax
+
+Real, specific uses of .tax cluster tightly around the obvious theme:
+
+- **Tax preparation services** — independent preparers and seasonal firms using a name like `yourname.tax`.
+- **CPA and accounting practices** — firms wanting a suffix that names their core service line.
+- **Bookkeeping and payroll providers** whose work centers on tax compliance.
+- **Tax software and SaaS** products that file, calculate, or optimize taxes.
+- **Tax education and reference** — guides, courses, and explainer sites about filing, deductions, and codes.
+- **Enrolled agents and tax attorneys** marketing a tax-focused practice area.
+
+**Who it's not ideal for:** any business outside the tax and accounting world. Because *tax* so strongly implies the subject, using it for an unrelated brand confuses visitors and wastes the suffix's main advantage. General firms that do far more than tax may prefer a broader name; see our guide on the [top TLDs to secure for your accounting firm](/en/blog/top-tlds-to-secure-for-your-accounting-firm).
+
+## Notable sites using .tax
+
+.tax is a working niche extension rather than a home to famous consumer brands, so its typical use is best described honestly: tax-preparation practices, accounting firms, and tax-software landing pages register exact-match or descriptive names. Many registrations are defensive, held by tax businesses alongside their primary .com. Rather than name a site we cannot independently verify as actively published, the accurate summary is that the suffix lives squarely inside the professional tax sector.
+
+## .tax vs other domains
+
+| Extension | Type | Meaning | Eligibility |
+| --- | --- | --- | --- |
+| [.com](/en/tld/com) | Legacy gTLD | Generic, universal default | Open to all |
+| .tax | New gTLD | Names the tax/accounting niche | Open to all |
+| [.info](/en/tld/info) | Legacy gTLD | Informational, generic | Open to all |
+
+Pick **.com** when you want the most recognized, trust-by-default address and the exact name is available. Pick **.tax** when the matching .com is taken or pricey and you want the suffix itself to advertise your specialty. **[.info](/en/tld/info)** is a broader, cheaper generic option for reference content, but it does not signal the tax niche the way .tax does. For credential-locked alternatives, note that .cpa exists but is restricted to licensed CPAs — .tax has no such gate.
+
+## Why choose .tax?
+
+- **Instant relevance.** The suffix states your industry, which can lift click-through from search results and read cleanly on a business card.
+- **Availability.** Short, exact-match names that are long gone in .com are often still open in .tax.
+- **Open eligibility.** No license or membership check, so any tax-adjacent business can register immediately.
+- **Standard infrastructure.** Backed by Identity Digital's established registry platform with DNSSEC support.
+
+## Things to consider
+
+- **Narrow meaning.** The niche clarity that helps a tax firm becomes a liability if your business ever broadens; the name boxes you into one topic.
+- **Lower recognition than .com.** Some visitors still reflexively type `.com`, so you may want to defensively register the matching .com and redirect it.
+- **Premium tiers.** The most desirable short or high-value words are often classified as premium by the registry and priced well above standard names.
+- **Niche familiarity.** New gTLDs are widely supported, but a small share of users and legacy systems are less accustomed to non-.com suffixes.
+
+## Who can register a .tax domain?
+
+**Registration restrictions: open to all.** .tax is an **unrestricted generic gTLD**. There is no credential, license, professional-membership, or local-presence requirement — you do not need to be a CPA, enrolled agent, or registered firm to hold a .tax name. This sets it apart from gated professional TLDs such as .cpa (CPA license required) or .law (bar admission required). Registration is first-come, first-served, subject only to standard domain syntax and any names the registry reserves or prices as premium.
+
+At launch, trademark holders had a **sunrise** window to claim matching strings before general availability, the standard practice for new gTLDs. Standard administrative behaviors apply: DNSSEC is supported, WHOIS privacy is typically offered through your registrar, and the suffix follows the usual transfer, renewal, and redemption-grace lifecycle.
+
+The authoritative source for the rules is the [.tax Registry Agreement on ICANN's site](https://www.icann.org/en/registry-agreements/details/tax), governing the operator as a base, non-sponsored gTLD. For background, see our glossary entries on [ICANN](/en/glossary/icann) and the [registrar](/en/glossary/registrar) role.
+
+## .tax pricing and value
+
+.tax is priced as a **mid-tier topic gTLD**, generally above commodity legacy suffixes but well below scarce extensions. A few pricing dynamics matter when you budget:
+
+- **Premium names exist.** The registry classifies short, common, or high-demand tax words as premium, carrying higher standard pricing both to register and to renew.
+- **First-year and renewal pricing differ.** Registrars often discount the first year, while renewals revert to the standard rate, so check the multi-year cost.
+- **Cost drivers.** Wholesale registry fees, registrar margin, premium classification, and add-ons like privacy or DNS hosting all feed the final figure.
+
+We do not list specific prices here because they change and vary by registrar; compare the all-in renewal cost, not just a first-year promo.
+
+## Reputation and email deliverability
+
+.tax reads as **professional and topical** rather than cheap or spammy. Because it is a paid, industry-specific suffix tied to a regulated profession, it has not become a haven for throwaway or abuse registrations the way some ultra-cheap suffixes have, which is good for trust.
+
+For email, mail providers treat the suffix like any other new gTLD: deliverability depends on your sending reputation and authentication, not the extension. Configure **SPF, DKIM, and DMARC** correctly, warm up new sending domains gradually, and your .tax mail will land as reliably as .com mail. Topic gTLDs can face slightly more scrutiny from conservative spam filters, so proper authentication is the honest mitigation.
+
+## Branding and naming tips
+
+- **Lean into the hack.** The suffix is a verb-like noun, so descriptive names read naturally: `acme.tax`, `file.tax`, `smart.tax`.
+- **Keep it short and spellable.** Avoid hyphens and ambiguous spellings; the value of .tax is clarity, so don't undercut it with a hard-to-type stem.
+- **Confirm the .com.** Check whether the matching .com is taken before you commit; if it points at a competitor, that can dilute your brand even with a strong .tax name.
+- **Watch premium flags.** Your dream one-word name may be a premium asset with a higher recurring cost — confirm the renewal price before you fall in love with it.
+
+## How to register a .tax domain at Namefi
+
+1. **Search** your desired name with the `.tax` suffix.
+2. **Choose** an available standard or premium name that fits your brand.
+3. **Register** and configure DNS to point at your site or landing page.
+
+[Namefi](https://namefi.io) is an ICANN-accredited registrar with transparent pricing, fast DNS management, and optional Web3 tokenization that lets you hold a domain as an on-chain asset. Start your .tax search at [Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .tax domain?
+
+Yes. The .tax registry is open to everyone with no credential, license, or local-presence requirement. You do not need to be an accountant, tax preparer, or registered firm. Names are sold first-come, first-served, subject only to standard syntax rules and any reserved or premium names the registry holds back.
+
+### Does a .tax domain affect SEO?
+
+No. Google treats .tax as a generic top-level domain with no inherent ranking advantage or penalty. Search engines weigh content, links, and user experience, not the suffix. A descriptive .tax name can improve click-through because the extension signals the topic, but it does not change crawling or indexing.
+
+### Who should register a .tax domain?
+
+It suits tax preparers, CPAs, enrolled agents, bookkeeping and accounting firms, tax-software products, and educational sites about taxation. It works well as an exact-match or descriptive name where the desired .com is taken or expensive. It is a poor fit for unrelated businesses, since the suffix strongly implies tax content.
+
+### Is .tax a restricted or community domain?
+
+No. Despite the professional-sounding name, .tax is an unrestricted generic gTLD under a standard ICANN base registry agreement. Unlike .cpa, which requires CPA credentials, .tax has no eligibility gate, sunrise-only access, or membership verification. Trademark holders did get a sunrise period at launch.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [Top TLDs to secure for your accounting firm](/en/blog/top-tlds-to-secure-for-your-accounting-firm)
+- [Glossary: ICANN](/en/glossary/icann)
+- [Glossary: DNSSEC](/en/glossary/dnssec)
+- [.com domain](/en/tld/com)
+- [.info domain](/en/tld/info)

--- a/prompts/tld-listicle.md
+++ b/prompts/tld-listicle.md
@@ -1,0 +1,79 @@
+<!--
+  "Top 10 TLDs to Secure for Your <X>" listicle authoring prompt.
+  Companion to tld-page.md (which authors the per-TLD detail pages this listicle links to).
+  Fill in {{vertical}} (e.g. "Law Firm", "SaaS") and {{date}} (yyyy-mm-dd) before use.
+-->
+
+# Role
+
+You are an expert SEO and domain-industry copywriter for Namefi (ICANN-accredited registrar
+that also supports Web3 tokenized domains). Write one English blog listicle recommending the
+top TLDs a **{{vertical}}** should register, and why.
+
+# Hard Rules
+
+1. NEVER fabricate facts, prices, stats, ratings, or registry details. Verify registry
+   operator and registration restrictions (open vs credential/membership-gated) before stating
+   them. Restricted examples: `.law`, `.cpa`, `.realtor`, `.bank` are gated; most new gTLDs
+   (`.legal`, `.attorney`, `.lawyer`, `.realty`, `.shop`, …) are open — do not guess, verify.
+2. No live prices, promos, or availability.
+3. Professional, objective, buyer-focused tone.
+
+# Internal-first linking (the most important rule)
+
+This listicle's #1 job is to send readers to **our own TLD docs**, not off-site.
+
+- **Every TLD in the list MUST link to our own detail page `/en/tld/<tld>` at least once**, on
+  its **first mention** in the body prose. This is the primary link for that TLD.
+- IANA / ICANN / registry-operator links are **secondary** — include them as supporting
+  citations *in addition to* the internal link, never instead of it. (Our TLD doc is where the
+  deep IANA/registry citations live; the listicle points to the doc.)
+- If a TLD does **not** yet have a `/en/tld/<tld>` doc, that's a signal to **create the doc**
+  (use `tld-page.md`) rather than linking only to IANA. Don't ship a listicle entry whose only
+  link is external when an internal page could exist.
+- **Link format:** site-relative `/en/tld/<tld>` — NO `/r` prefix (the app's `basePath: '/r'`
+  is added automatically; writing `/r/en/...` produces a broken `/r/r/...` URL). Same for
+  `/en/blog/<slug>` and `/en/glossary/<slug>`.
+- Link each TLD's first mention only (don't link every occurrence); don't link inside the
+  `### N. .tld` headings.
+
+# Citations (E-E-A-T)
+
+Beyond the internal links, include ≥8 inline links to authoritative/primary sources where they
+back a claim: IANA root DB, ICANN registry agreements, registry operators, official bodies
+(NAR, AICPA, etc.), and Google Search Central for any SEO claim.
+
+# Structure (Markdown)
+
+```yaml
+---
+title: 'Top 10 TLDs You Should Secure for Your {{vertical}}'
+date: '{{date}}'
+language: en
+tags: ['tld', 'domains']
+authors: ['namefiteam']
+draft: false
+description: '<150-160 char meta description with the primary keyword>'
+keywords: ['<8-12 real, human-readable keyword phrases>']
+---
+```
+
+Body:
+- Opening (2 short paragraphs): why a {{vertical}} should secure multiple TLDs — brand
+  protection, defensive registration against typosquatters/competitors, future flexibility.
+- `## How to choose TLDs for your {{vertical}}` — one short paragraph of criteria.
+- `## The top 10 TLDs to secure for your {{vertical}}` — ten `### N. .<tld> — <angle>`
+  subsections, 2–4 sentences each: what the suffix is, why it fits the vertical, and any
+  registration restriction stated accurately. **First mention of `.<tld>` in each subsection's
+  body links to `/en/tld/<tld>`.**
+- `## Defensive registration strategy` — secure exact-match brand across the top few + the
+  category TLD; watch renewals.
+- `## Register your {{vertical}} domains at Namefi` — CTA linking `[Namefi](https://namefi.io)`;
+  may mention transparent pricing / Web3 tokenization / fast DNS, but quote NO price.
+- `## Frequently asked questions` — 3–4 real Q&As; include one on whether a TLD affects SEO
+  (answer accurately, cite Google Search Central).
+
+# Output Constraints
+
+- Return ONLY the raw Markdown file content, starting with `---`. No code fences.
+- No images/image references.


### PR DESCRIPTION
## Why
The 'Top 10 TLDs to secure for your \<X\>' listicles linked many TLDs to **IANA** because we had **no internal doc** for them — two articles (law-firm, real-estate) had **zero** internal TLD links. Principle: a listicle should send readers to **our own TLD doc** first; IANA/registry belongs on the doc itself.

## What
- **23 new TLD detail pages** (authored via `prompts/tld-page.md`, ~1,500-1,800 words each, verified registry/restriction facts, FAQ schema): `.co .biz .company .cpa .tax .accountant .finance .shopping .deals .fashion .boutique .style .law .esq .legal .attorney .lawyer .realtor .realty .estate .homes .properties .house`
- **Relinked all 8 listicles** — every listed TLD now links to its own `/en/tld/<x>` doc on first mention; IANA/registry citations kept as **secondary**.
- **Accuracy fix:** `.esq` is **open**, not credential-gated (common misconception) — corrected in the law-firm listicle. (`.law`/`.cpa`/`.realtor` confirmed restricted.)
- **`prompts/tld-listicle.md`** — documents the internal-first linking convention for future listicles.

## Verified
- Every listed TLD internally linked ✅ · no malformed/double links ✅ · all `/en/tld/<x>` targets exist ✅
- `data:validate` ✅ · `lint:mdx` ✅
- Subagents verified registry operators/restrictions against IANA/ICANN/official bodies and corrected several of my hints (e.g. `.esq` open; `.lawyer`/`.attorney`/`.homes`/`.realty` operators).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial and routing changes only—no application code, auth, or data pipelines.
> 
> **Overview**
> Adds **~23 new English TLD detail pages** under `content/tld/en/` (long-form guides with FAQs, registry facts, and internal cross-links) so listicles can point readers to Namefi-owned docs instead of only IANA.
> 
> **Relinks all eight “Top TLDs to secure…” listicles** so first mentions of listed extensions go to `/en/tld/<name>`; IANA/ICANN citations stay as secondary references. E-commerce and fashion posts also drop “not in allow-list” notes now that those TLDs have pages.
> 
> **Content accuracy:** the law-firm listicle (and related metadata/FAQs) now states **`.esq` is open**, not credential-gated, while **`.law`** remains the restricted legal TLD; real-estate and other vertical posts get matching internal links and small copy tweaks (e.g. `.biz` registry policy link).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d6a0a15db18490cddf8fcfbe24ffce1b38cba4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 19 new comprehensive TLD guides (accountant, attorney, biz, boutique, co, company, cpa, deals, esq, estate, fashion, finance, homes, house, law, lawyer, legal, properties, realtor, realty, shopping, style, tax) with detailed eligibility, pricing, and registration information

* **Documentation**
  * Improved blog articles with enhanced cross-references to TLD resource pages
  * Corrected information accuracy on legal TLDs (.law requires credentials; .esq is open)
  * Enhanced TLD guides with branding tips and deliverability best practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->