### PR TITLE
content(tld): upgrade 35 key TLD docs to the tld-page.md spec

### DIFF
--- a/content/tld/en/abogado.md
+++ b/content/tld/en/abogado.md
@@ -1,56 +1,146 @@
 ---
-title: "What is the .abogado TLD and why choose it?"
-date: '2025-12-10'
+title: 'What Is the .abogado Domain? The Verified Lawyer Extension'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: "Establish trust in the Hispanic legal market with a .abogado domain. Discover the benefits, SEO advantages, and usage of this professional TLD for lawyers."
-keywords: [".abogado domains", ".abogado TLD", "top-level domain", "what is .abogado", "why choose .abogado", "what is the .abogado domain", "why choose the .abogado domain", "legal domain names", "lawyer domains", "spanish legal domains", "law firm branding", "domain investing", "blockchain domain management", "tokenized domains", "legal tech domains"]
+description: 'The .abogado domain is a credential-gated TLD for verified lawyers, meaning "abogado" (lawyer) in Spanish — ideal for Hispanic-market legal branding.'
+keywords: ['.abogado domains', 'what is .abogado', '.abogado TLD', 'lawyer domain extension', 'legal domain names', 'Spanish lawyer domain', 'abogado domain registration', 'verified legal TLD']
+faqs:
+  - question: 'Can anyone register a .abogado domain?'
+    answer: 'No. The .abogado TLD is credential-gated. You must be a licensed lawyer or an authorized legal institution (law firm, law school, court, or bar association), and an independent third party verifies your status against public legal records before registration is approved.'
+  - question: 'Does a .abogado domain affect SEO?'
+    answer: 'A .abogado extension carries no inherent ranking boost or penalty. Google treats it as a generic top-level domain, so it is not geo-targeted to any single country. Rankings still depend on content quality, links, and technical health.'
+  - question: 'Who should register a .abogado domain?'
+    answer: 'Verified lawyers, attorneys, and law firms serving Spanish-speaking clients, especially immigration, family, and personal-injury practices in the United States, Spain, and Latin America. The verified extension signals an authentic licensed practitioner.'
+  - question: 'What does the word abogado mean?'
+    answer: 'Abogado is the Spanish word for lawyer or attorney. The .abogado extension is the Spanish-language counterpart to the English .law and .attorney domains, aimed at practitioners serving Hispanic and Latin American audiences.'
+  - question: 'Does .abogado support WHOIS privacy?'
+    answer: 'Generally no. Because eligibility depends on verified identity, the registry requires the qualified lawyer or legal institution name to appear in the registration record, so standard WHOIS/RDAP privacy redaction is typically not available.'
 ---
 
-## **What is .abogado?**
+The **.abogado** domain is one of the few top-level domains where you cannot simply buy a name — you have to prove you are a lawyer first. "Abogado" is the Spanish word for *lawyer* or *attorney*, and the extension is the Spanish-language sibling of restricted legal TLDs like [.law](/en/tld/law) and [.attorney](/en/tld/attorney). For verified attorneys and firms serving Hispanic and Latin American clients, a .abogado address is a built-in trust badge: the suffix itself certifies that a real legal regulator has the registrant on record.
 
-The **.abogado** Top-Level Domain (TLD) is a specialized domain extension explicitly designed for the legal profession. In Spanish, the word *"abogado"* translates directly to "lawyer" or "attorney." Launched as part of the [ICANN New gTLD Program](https://newgtlds.icann.org/en/about/program), this extension provides a dedicated digital space for legal practitioners, law firms, and legal educational institutions that serve Spanish-speaking communities.
+If you are not a licensed legal professional, you will not be able to register one — and that scarcity is exactly what gives the namespace its credibility. This page covers who runs .abogado, who qualifies, how it compares to other legal extensions, and what to weigh before registering.
 
-Unlike generic domains such as .com or .net, .abogado is a verified and restricted TLD in many contexts. Its intended purpose is to provide immediate categorization and trust. When a user sees a URL ending in .abogado, they immediately understand two things: the website is related to legal services, and it is likely tailored to Spanish speakers or operates within a Hispanic market.
+## .abogado at a glance
 
-As the internet becomes more segmented, professionals are moving away from crowded legacy domains in favor of industry-specific extensions that communicate authority instantly.
+| Fact | Detail |
+| --- | --- |
+| TLD type | new gTLD (generic, not country-specific) |
+| Registry operator | Registry Services, LLC (GoDaddy Registry); legal policy administered via the .law/.abogado registry program |
+| Year delegated | 2014 |
+| IDN support | Limited — Latin-script names; check registrar at registration |
+| DNSSEC | Supported |
+| Registration restrictions | **Credential-gated** — verified Qualified Lawyer or authorized legal institution only |
+| Best for | Spanish-speaking lawyers, immigration/family/PI firms, Hispanic-market legal branding |
 
-## **How People Are Using .abogado**
+## What is .abogado?
 
-The usage of .abogado is highly targeted, making it a powerful tool for branding within the legal sector. Here is how it is currently being utilized:
+.abogado is a **generic top-level domain (gTLD)** introduced under [ICANN's New gTLD Program](https://newgtlds.icann.org/en/about/program). The word means "lawyer" in Spanish, which positions the extension squarely at the Spanish-speaking legal market — the United States' large Hispanic population, Spain, Mexico, and the rest of Latin America.
 
-*   **Hispanic Market Targeting:** Law firms in the United States, Spain, and Latin America use this TLD to specifically target Spanish-speaking clients. It signals linguistic capability and cultural relevance.
-*   **Immigration Law:** Attorneys specializing in immigration often use .abogado to create a welcoming and clearly understood entry point for clients seeking assistance in their native language.
-*   **International Law Firms:** Global firms often register the .abogado version of their brand to protect their intellectual property and create dedicated landing pages for their LATAM divisions.
-*   **Legal Education and Advice:** Blogs and portals offering legal advice or exam preparation for law students in Spanish-speaking countries utilize the extension to build authority.
-*   **Personal Branding:** Independent practitioners are securing `FirstnameLastname.abogado` to establish a professional digital business card.
+Technically, .abogado is delegated in the root zone to **Registry Services, LLC** (GoDaddy Registry), as recorded in the [IANA root database entry for .abogado](https://www.iana.org/domains/root/db/abogado.html). It runs alongside the English-language [.law](/en/tld/law) namespace under a shared verified-legal registry policy.
 
-## **Notable Entities Using .abogado**
+Because it is a generic gTLD rather than a ccTLD, Google does **not** geo-target .abogado to any single country. Per [Google Search Central's guidance on generic TLDs](https://developers.google.com/search/docs/specialty/international/locale-specific-urls), the suffix is treated as global, and you signal geographic intent through content, language, and hreflang — not the extension.
 
-While many .abogado domains are held by private practices and local firms, several types of entities leverage this TLD effectively:
+## History of .abogado
 
-*   **Regional Law Firms:** Many boutique firms in regions like California, Texas, and Florida utilize these domains (e.g., `TuDefensa.abogado` or similar descriptive names) to capture local search traffic.
-*   **Legal Tech Startups:** New platforms offering automated legal services or consultations for the Spanish-speaking market are adopting this TLD to stand out from generic tech startups.
-*   **Domain Investors:** Investors recognize the value of keyword-rich domains in the legal vertical (which traditionally has high Cost-Per-Click values) and hold premium generic terms like `Divorcio.abogado` (Divorce Lawyer) or `Accidentes.abogado` (Accident Lawyer).
+.abogado was delegated in **2014**, in the first wave of New gTLD Program launches. It was originally delegated to Top Level Domain Holdings Limited, the registry group later known as Minds + Machines, and the delegation subsequently transferred to **Registry Services, LLC (GoDaddy Registry)**, which holds the IANA record today.
 
-## **Why Choose .abogado?**
+From the outset, .abogado was positioned as a **restricted, verified** namespace rather than an open land-rush extension. That deliberate gating kept registration volumes modest compared with open gTLDs, but it preserved the suffix's core promise: every .abogado holder is a checked, licensed practitioner. Adoption has been steady within the Spanish-speaking legal niche rather than explosive.
 
-Choosing a .abogado domain offers distinct advantages, particularly if your business model touches upon the Hispanic legal market.
+## How people use .abogado
 
-*   **Instant Credibility and Trust:** The domain acts as a digital badge of honor. It immediately identifies you as a legal professional, helping to bridge the trust gap with potential clients.
-*   **SEO and Semantic Relevance:** Search engines prioritize relevance. If a user searches for "abogado de familia" (family lawyer), a domain name containing the keyword extension can provide a strong signal of relevance to search algorithms.
-*   **Superior Availability:** Finding a short, memorable name on .com is nearly impossible today. With .abogado, you have a much higher chance of securing your exact firm name or a high-value keyword.
-*   **Clear Audience Targeting:** It filters your traffic effectively. Visitors clicking on a .abogado link are almost certainly looking for legal help in Spanish, resulting in higher quality leads.
-*   **Brand Protection:** For larger firms, registering the .abogado equivalent of your primary domain is a defensive move to prevent competitors or bad actors from capitalizing on your brand name in the Hispanic market.
+- **Immigration attorneys** serving Spanish-first clients, who recognize the word instantly.
+- **Family-law and divorce practices** (e.g., descriptive names like *divorcio.abogado*) targeting Spanish-language search.
+- **Personal-injury and accident firms** in U.S. markets with large Hispanic populations (California, Texas, Florida).
+- **Solo practitioners** registering `nombreapellido.abogado` as a professional digital business card.
+- **Law firms with LATAM divisions** running dedicated Spanish-language landing pages.
 
-## **Register Your .abogado Domain at Namefi**
+**Who it's not ideal for:** anyone who is not a verified lawyer (you cannot register), English-only practices with no Spanish-speaking audience, and non-legal businesses — the word is unambiguous and would confuse visitors.
 
-Whether you are a solo practitioner looking to expand your client base or a forward-thinking investor eyeing the legal sector, securing a **.abogado** domain is a strategic move.
+## Notable sites using .abogado
 
-At **Namefi**, we make domain registration seamless and future-proof. Not only are we an ICANN-accredited registrar, but we also bridge the gap between Web2 and Web3. When you register with us, you can easily manage your domain portfolio, and even tokenize your domains for easier transfer and liquidity on the blockchain.
+.abogado is a small, restricted namespace, so it has no household-name flagship sites the way [.io](/en/tld/io) or [.ai](/en/tld/ai) do. In practice it is used by individual verified attorneys and boutique Spanish-speaking firms for practice websites and keyword-descriptive landing pages (family law, immigration, accident claims). The registry's own policy and information hub operates at nic.abogado. Rather than invent well-known examples, the honest description is: this is a working professional namespace for verified lawyers, not a consumer-brand showcase.
 
-Don't wait until your preferred legal brand is taken. Establish your authority in the global legal market today.
+## .abogado vs other domains
 
-[**Search and Register Your .abogado Domain at Namefi**](https://namefi.io)
+| Extension | Restriction | Language / audience | Page |
+| --- | --- | --- | --- |
+| .abogado | Verified lawyers only | Spanish-speaking legal market | — |
+| .law | Verified lawyers only | English-language legal market | [/en/tld/law](/en/tld/law) |
+| .attorney | Open to all | General / U.S. legal | [/en/tld/attorney](/en/tld/attorney) |
+| .com | Open to all | Global, generic | [/en/tld/com](/en/tld/com) |
+
+Choose **.abogado** when your clients search and think in Spanish and you want a verified credential built into the address. Choose **[.law](/en/tld/law)** for the same verified prestige in English. Choose **[.attorney](/en/tld/attorney)** if you want a legal-sounding name without the verification step, and keep a **[.com](/en/tld/com)** as your defensive flagship.
+
+## Why choose .abogado?
+
+- **Built-in verification.** The suffix certifies that an independent party checked your license — a trust signal open extensions cannot match.
+- **Instant language and niche clarity.** Spanish-speaking clients understand "abogado" without translation, filtering for high-intent legal traffic.
+- **Availability.** Short, descriptive names long gone on [.com](/en/tld/com) are often still open here, because the pool is restricted to verified lawyers.
+- **Defensible brand.** Competitors and bad actors cannot squat your name in this namespace without passing verification themselves.
+
+## Things to consider
+
+- **You must qualify.** Non-lawyers are excluded entirely, and verification adds a step and lead time before your name goes live.
+- **Niche recognition.** Outside Spanish-speaking audiences, fewer users instantly recognize the extension; pair it with a mainstream domain.
+- **Pricing.** Verified legal TLDs typically sit in a higher price band than open gTLDs (see below).
+- **Privacy limits.** Identity verification means your verified name appears in the record; WHOIS/RDAP privacy is usually unavailable.
+- **Renewal eligibility.** You generally must remain a licensed practitioner; lapsed eligibility can affect renewal.
+
+## Who can register a .abogado domain?
+
+**Registration restrictions: credential-gated.** .abogado is **not** open to the general public. Eligibility is limited to a **Qualified Lawyer** — an individual verified as a currently licensed legal professional in an appropriately regulated jurisdiction — or an **authorized legal institution** such as a law firm, law school, court of law, or bar association. The registry engages an **independent third party** to verify each applicant against public records kept by legal regulators before a name is activated.
+
+This mirrors the verification model of [.law](/en/tld/law); both run under the same verified-legal registry program (see the [Join.Law eligibility and FAQ pages](https://www.join.law/faq.htm) for the operator's current policy). Practically, you should expect to supply documentation of your bar admission or institutional status, and the registrant name on record must match your verified legal identity. Standard sunrise/trademark protections applied at launch, names follow normal length and Latin-script rules, DNSSEC is supported, and — because identity is the point — WHOIS/RDAP privacy redaction is typically not offered. Because eligibility can be tied to continued licensure, keep your credentials current to avoid renewal complications.
+
+## .abogado pricing and value
+
+.abogado sits in the **premium professional tier** of the domain market, alongside other verified legal extensions, rather than in the budget range of open gTLDs. Expect first-year and renewal pricing to differ, and note that some short, high-demand keyword names (think the Spanish equivalents of "divorce" or "accident lawyer") may be classified as **premium** and priced above standard registrations. Cost is driven by the restricted, verified nature of the namespace, the third-party verification overhead, and the commercial value of keyword-rich legal terms. We do not quote specific prices here — always check live pricing at registration time.
+
+## Reputation and email deliverability
+
+Because every .abogado holder is a verified lawyer, the namespace carries an inherently **clean, professional reputation** — it is the opposite of the cheap, high-volume gTLDs that mail filters scrutinize for spam. There is no notable history of the suffix being blocklisted. That said, newer and less-common extensions are still less familiar to some recipients and spam systems than [.com](/en/tld/com), so deliverability depends far more on your own setup than on the suffix. Authenticate your mail with SPF, DKIM, and DMARC, warm up new sending domains, and maintain good list hygiene; do that, and a .abogado address should land reliably.
+
+## Branding and naming tips
+
+The strongest .abogado names read as a natural Spanish phrase: `apellido.abogado` (surname) or descriptive practice terms like `inmigracion.abogado` or `accidentes.abogado`. The extension itself supplies the word "lawyer," so avoid redundant names that repeat "abogado" in the second level. Watch spelling pitfalls for non-Spanish speakers — it is *abogado* (Spanish), not *advogado* (the Portuguese form). Keep names short and phonetic so they survive being spoken over the phone or in a radio ad.
+
+## How to register a .abogado domain at Namefi
+
+1. **Search** your desired name on [Namefi](https://namefi.io) to check availability.
+2. **Choose** the exact name or keyword-descriptive variant that fits your practice.
+3. **Complete verification** of your status as a qualified lawyer or legal institution, then register.
+
+[Namefi](https://namefi.io) is an ICANN-accredited registrar with transparent pricing and fast DNS, and it also supports Web3 tokenization — so once registered, you can manage your portfolio and optionally tokenize domains for easier transfer and liquidity on-chain.
+
+## Frequently asked questions
+
+### Can anyone register a .abogado domain?
+
+No. The .abogado TLD is credential-gated. You must be a licensed lawyer or an authorized legal institution (law firm, law school, court, or bar association), and an independent third party verifies your status against public legal records before registration is approved.
+
+### Does a .abogado domain affect SEO?
+
+A .abogado extension carries no inherent ranking boost or penalty. Google treats it as a generic top-level domain, so it is not geo-targeted to any single country. Rankings still depend on content quality, backlinks, and technical health.
+
+### Who should register a .abogado domain?
+
+Verified lawyers, attorneys, and law firms serving Spanish-speaking clients — especially immigration, family, and personal-injury practices across the United States, Spain, and Latin America. The verified extension signals an authentic licensed practitioner.
+
+### What does the word abogado mean?
+
+Abogado is the Spanish word for lawyer or attorney. The .abogado extension is the Spanish-language counterpart to the English [.law](/en/tld/law) and [.attorney](/en/tld/attorney) domains, aimed at practitioners serving Hispanic and Latin American audiences.
+
+### Does .abogado support WHOIS privacy?
+
+Generally no. Because eligibility depends on verified identity, the registry requires the qualified lawyer or legal institution name to appear in the registration record, so standard WHOIS/RDAP privacy redaction is typically not available.
+
+## Related resources
+
+- [.law domain](/en/tld/law) — the English-language verified legal extension.
+- [.attorney domain](/en/tld/attorney) — an open legal alternative with no verification step.
+- [.legal domain](/en/tld/legal) — another legal-sector option to compare.
+- [.com domain](/en/tld/com) — the mainstream default worth holding defensively.

--- a/content/tld/en/academy.md
+++ b/content/tld/en/academy.md
@@ -1,64 +1,163 @@
 ---
-title: "What is the .academy TLD and Why Choose It for Your Educational Brand?"
-date: '2025-12-10'
+title: 'What Is the .academy Domain? Education TLD Explained'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: "Discover the .academy TLD: the perfect domain extension for schools, courses, and educational platforms. Learn why .academy boosts credibility and branding."
-keywords: [".academy domains", ".academy TLD", ".academy top-level domain", "what is .academy", "why choose .academy", "what is the .academy domain", "why choose the .academy domain", "educational domains", "online course naming", "domain investing", "digital asset domains", "education blockchain projects", "tokenized education domains", "academic web address", "school domain names", ".academy registration"]
+description: 'The .academy domain is an open gTLD for schools, courses, training centers and coaching brands. Learn who uses it, the rules, pricing dynamics and how to register.'
+keywords: ['.academy domain', 'what is .academy', '.academy TLD', 'academy domain registration', 'education domain extension', 'online course domain', 'training website domain', 'new gTLD']
+faqs:
+  - question: 'Can anyone register a .academy domain?'
+    answer: 'Yes. The .academy domain is an open generic TLD with no eligibility requirements. There is no residency, business-type, accreditation, or credential check, so individuals and organizations alike can register names on a first-come, first-served basis.'
+  - question: 'Does a .academy domain affect SEO?'
+    answer: 'No. Google treats .academy like any other generic top-level domain, so it carries no inherent ranking advantage or penalty. Rankings depend on content, links, and user experience, not the suffix. A descriptive .academy name can modestly improve click-through by signaling intent.'
+  - question: 'Who should register a .academy domain?'
+    answer: 'It suits schools, online course creators, coding and trading bootcamps, sports and arts academies, corporate training portals, and any brand whose identity centers on teaching. It is less ideal for general businesses, e-commerce stores, or projects with no educational angle.'
+  - question: 'Who operates the .academy registry?'
+    answer: 'The .academy registry is operated by Binky Moon, LLC, a subsidiary in the Identity Digital portfolio (formerly Donuts). It was delegated in the root zone in December 2013 and reached general availability in March 2014 as part of ICANN new gTLD program.'
+  - question: 'Does .academy support WHOIS privacy and DNSSEC?'
+    answer: 'Yes. Because .academy has no special verification rules, most registrars offer WHOIS privacy on it like any standard gTLD, and the registry supports DNSSEC for cryptographic protection of DNS responses.'
 ---
 
-## **What is .academy?**
+The **.academy domain** is one of the clearest "does-what-it-says" extensions on the internet: the suffix itself names the product. For anyone building a school, an online course, a coaching brand, or a corporate training hub, a .academy address tells visitors what they're getting before they read a word of copy. It is an open generic top-level domain, so the only real question is whether the name fits your brand — not whether you qualify.
 
-The **.academy** domain extension is a generic Top-Level Domain (gTLD) specifically designed for the education sector. Unlike traditional extensions like .com or .net, which are broad and undefined, **.academy** clearly communicates the purpose of a website before a visitor even clicks on it.
+This page covers what .academy is, who runs it, how people use it, the registration rules, pricing dynamics, and how it compares to the alternatives.
 
-Launched as part of the massive expansion of the domain namespace by [ICANN](https://www.icann.org/) (Internet Corporation for Assigned Names and Numbers), this TLD was introduced to solve the problem of overcrowding in traditional domain spaces. It is currently managed by [Identity Digital](https://identity.digital/), a leading domain registry services provider.
+## .academy at a glance
 
-The primary purpose of the .academy TLD is to serve institutions, organizations, and individuals dedicated to learning, training, and specialized instruction. As the e-learning market continues to explode globally, this TLD has seen steady adoption by entities wanting to establish immediate authority in their specific niche.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (new gTLD, 2013 round) |
+| Registry operator | Binky Moon, LLC (Identity Digital portfolio) |
+| Year launched | Delegated 2013; general availability March 2014 |
+| IDN support | Yes (registrar-dependent) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility requirements |
+| Best for | Schools, courses, bootcamps, coaching, corporate training |
 
-## **How People Are Using .academy**
+## What is .academy?
 
-The versatility of the .academy TLD allows it to be used across a wide spectrum of industries. It is not limited to traditional K-12 schools or universities. Here is how different sectors are utilizing it:
+The .academy domain is a [generic top-level domain (gTLD)](/en/glossary/tld) introduced during ICANN's new gTLD program — the same expansion that delivered hundreds of descriptive suffixes like `.app`, `.dev`, and `.shop`. Where a [.com](/en/tld/com) name is neutral and says nothing about purpose, .academy carries built-in meaning: a place of structured learning, instruction, and expertise. That semantic clarity is the entire value proposition.
 
-*   **Online Course Creators:** Solo experts selling masterclasses in cooking, coding, marketing, or fitness use it to brand their instructional hubs.
-*   **Corporate Training:** Businesses create internal portals (e.g., `training.companyname.academy`) to host employee onboarding and skill development resources.
-*   **Sports and Arts:** Martial arts dojos, dance studios, and football clinics use it to distinguish themselves from general clubs.
-*   **Tech Bootcamps:** Coding schools and data science workshops use the extension to signal intensive learning environments.
-*   **Web3 and Crypto Education:** With the rise of complex blockchain technologies, many educational platforms are using .academy to teach users about DeFi, NFTs, and tokenomics.
+You can confirm the delegation in the [IANA root zone database entry for .academy](https://www.iana.org/domains/root/db/academy.html), which lists it as a generic TLD with a registration date of 2013-12-12. Because it is generic and not a [country-code TLD](/en/blog/cctld-market-share-by-registration-volume), it has no geographic association — Google treats it as a neutral suffix with no geo-targeting, the same way it treats .com or [.org](/en/tld/org). Per [Google Search Central](https://developers.google.com/search/docs/crawling-indexing/site-name), new gTLDs like .academy carry no built-in ranking advantage or disadvantage; the suffix is just a label.
 
-## **Notable Entities Using .academy**
+## History of .academy
 
-While many massive institutions still rely on legacy .edu or .org domains, .academy has become the go-to choice for specialized modern training centers and digital-first educational brands.
+The .academy string was delegated on 2013-12-12 and entered general availability in March 2014, an early mover in the new gTLD program. It launched under Donuts Inc., the registry that pioneered a large portfolio of descriptive "vertical" extensions. Through consolidation that portfolio became Identity Digital, and the registry-of-record for .academy today is **Binky Moon, LLC**, the Identity Digital entity holding many of its dot-word agreements.
 
-*   **Code Academy (Generic Concept):** While famous sites like Codecademy often started with .com, many regional coding schools have adopted names like `london.academy` or `tech.academy` to secure exact-match branding.
-*   **Sports Organizations:** Various specialized sports training facilities, such as tennis or golf clinics, utilize the domain to highlight their focus on coaching rather than just facility rental.
-*   **The Academy of Motion Picture Arts and Sciences:** While they own various domains, the word "Academy" is synonymous with prestige, and using the TLD allows for shorter, punchier URLs for specific campaigns or sub-brands.
-*   **Language Learning Platforms:** Niche language schools offering specific dialects (e.g., `mandarin.academy`) use the TLD to dominate niche search results.
+Adoption has tracked the boom in online education and the creator economy. As independent instructors, bootcamps, and corporate L&D teams moved learning online, an exact-match .academy name became an easy way to stake out a category-defining address without paying premium aftermarket prices for a crowded .com. There are no verified blockbuster public sales to report for this suffix — its strength is everyday utility, not speculative resale.
 
-## **Why Choose .academy?**
+## How people use .academy
 
-Choosing the right domain name is critical for your brand's digital identity. Here is why .academy is a smart investment for your next project:
+Real, common niches for .academy include:
 
-*   **Instant Credibility:** The word "academy" implies a place of higher learning, authority, and structure. It instantly positions your brand as an expert resource.
-*   **Superior Availability:** Finding a short, memorable name on .com is nearly impossible without spending a fortune. With .academy, you are far more likely to find your first choice (e.g., `YourName.academy` vs. `TheYourNameAcademyOnline.com`).
-*   **SEO Relevance:** Search engines look for relevance. If your business is about teaching, having the keyword "academy" directly in the URL sends a strong signal to Google and Bing about your content's intent.
-*   **Memorable Branding:** It allows for creative domain hacks and concise branding. It turns your URL into a descriptive call to action.
-*   **Future-Proofing:** As the internet moves toward more semantic and descriptive URLs, owning a category-defining TLD places you ahead of the curve.
+- **Online course creators and e-learning platforms** — experts and small teams branding a masterclass, cohort course, or membership.
+- **Coding, data, and trading bootcamps** — intensive skills programs that want "academy" to signal rigor.
+- **Sports and performance academies** — football, tennis, martial-arts, and esports programs, a genuinely heavy user category here.
+- **Arts and music schools** — dance studios, language schools, and conservatory-style brands.
+- **Corporate training portals** — internal "Acme Academy" learning hubs, often on a subdomain.
+- **Certification and professional development** — short-course providers and upskilling brands.
 
-## **Register Your .academy Domain at Namefi**
+**Who it's not ideal for:** general retailers, [e-commerce stores](/en/tld/shop), SaaS products with no teaching angle, or any brand where "academy" misrepresents what you sell. If learning is not central to your identity, a neutral suffix will serve you better.
 
-Ready to establish your educational platform as an authority in your field? There is no better place to start than by securing your **.academy** domain today.
+## Notable sites using .academy
 
-At **Namefi**, we make domain registration simple, secure, and future-ready. As an ICANN-accredited registrar, we offer standard Web2 ease of use combined with cutting-edge Web3 integration. When you register with us, you aren't just buying a name; you are securing a digital asset that can be easily managed or tokenized for maximum flexibility.
+The .academy suffix is used broadly by training brands rather than a handful of household-name flagships, so the honest picture is wide, niche adoption. In active use you'll find sports-training academies (football and tennis academies favor exact-match names like `internationalfootball.academy`), independent trading and finance education brands, language and coding schools, and corporate learning portals. Rather than name a single "famous" site that could mislead, the accurate description is: many education-first operators who want the category word baked into the address. Always verify a specific site is live before relying on it as an example.
 
-**Why register with Namefi?**
-*   Transparent pricing with no hidden fees.
-*   Seamless integration with blockchain technology for advanced users.
-*   Instant setup and easy DNS management.
+## .academy vs other domains
 
-Don't let your perfect educational brand name get taken by someone else.
+| Suffix | Meaning signal | Typical use | Restrictions |
+| --- | --- | --- | --- |
+| **.academy** | Strong — "place of learning" | Schools, courses, coaching | Open to all |
+| [.com](/en/tld/com) | None (neutral) | Anything | Open to all |
+| [.org](/en/tld/org) | "Organization / nonprofit" | Institutions, NGOs | Open to all |
+| [.club](/en/tld/club) | "Community / membership" | Cohorts, communities | Open to all |
 
-**[Search and Register Your .academy Domain at Namefi](https://namefi.io)**
+Pick **.academy** when teaching is your core identity and you want the address to say so. Pick [.com](/en/tld/com) for a universally recognized, resale-friendly default. Pick [.org](/en/tld/org) if institutional trust matters more than the "learning" signal, and [.club](/en/tld/club) if you're building a community rather than a curriculum.
 
-Start building your legacy of learning today.
+## Why choose .academy?
+
+- **Self-describing brand.** The suffix names your category, lifting click-through and recall for an education product.
+- **Far better availability.** Short, exact-match names are realistically obtainable on .academy, unlike the exhausted [.com](/en/tld/com) space.
+- **Memorable domain hacks.** Names like `code.academy`, `chess.academy`, or `[yourbrand].academy` read cleanly and need no explanation.
+- **Standard infrastructure.** Run by an established registry with DNSSEC and broad registrar support — no exotic setup.
+
+## Things to consider
+
+- **Niche by design.** The semantic strength that helps an education brand works against an unrelated business.
+- **Less defaulted-to than .com.** Some users still type ".com" by reflex, so consider defensively holding the matching [.com](/en/tld/com) if affordable.
+- **Renewal differs from first-year.** Like most descriptive new gTLDs, renewal can sit above legacy-TLD levels — budget for it.
+- **Possible confusion with .edu.** The accredited, restricted [.edu](https://www.educause.edu/policies/eligibility) space carries institutional weight that .academy does not; don't imply accreditation you lack.
+
+## Who can register a .academy domain?
+
+**Registration restrictions: open to all.** The .academy domain has no eligibility requirements — no accreditation, no proof that you run a real school, no residency or local-presence rule, and no community membership. Anyone, individual or organization, can register an available name on a first-come, first-served basis. This is unlike credential-gated suffixes such as `.cpa` or `.law`, where verification is mandatory.
+
+As a new gTLD, .academy is governed by an [ICANN Registry Agreement](https://www.icann.org/en/registry-agreements?first-letter=a) rather than a country-manager policy, and it ran the standard sunrise and trademark-claims processes (via the Trademark Clearinghouse) at launch. Administratively, the registry supports **DNSSEC**, most registrars offer **WHOIS privacy** on it, and transfers, renewals, and the redemption-grace period follow normal ICANN gTLD lifecycle rules. Label-length and IDN support are standard and registrar-dependent.
+
+## .academy pricing and value
+
+The .academy domain sits in the mid-tier of descriptive new gTLDs on pricing **dynamics** — not a budget throwaway, but not a luxury suffix. A few patterns to understand instead of any specific number:
+
+- **First-year vs renewal differ.** Promotional first-year rates are common across the industry, while the standard renewal is what you actually live with long-term — always check the renewal, not the headline.
+- **Premium names exist.** The registry reserves a tier of short, generic, high-demand labels (e.g. one-word category names) that carry elevated registration and sometimes renewal pricing.
+- **Cost drivers** are the registry wholesale fee plus your registrar's margin and whether the specific name is flagged premium.
+
+For a fuller primer on how the namespace and pricing are structured, see [what is a TLD](/en/blog/what-is-a-tld).
+
+## Reputation and email deliverability
+
+Among the new gTLDs, .academy enjoys a relatively clean reputation. Because it is descriptive and tied to a legitimate use case (education), it does not carry the spam baggage that dogs some ultra-cheap or promo-driven suffixes that spammers register in bulk. That said, it has less trust history than [.com](/en/tld/com) or [.org](/en/tld/org), so a brand-new .academy domain can occasionally see slightly more cautious filtering when sending cold email at volume.
+
+Mitigation is the same as for any domain: authenticate mail with SPF, DKIM, and DMARC; warm up a new sending domain gradually; keep [DNSSEC](/en/glossary/dnssec) enabled; and avoid spammy patterns. Done properly, .academy delivers as reliably as any mainstream suffix.
+
+## Branding and naming tips
+
+- **Lean into the hack.** The suffix is a noun, so `chess.academy` or `sales.academy` reads as a phrase — exploit that.
+- **Keep it short and literal.** Single-word topic names (the subject you teach) are the strongest pattern.
+- **Avoid double "academy."** `myacademy.academy` is redundant; let the suffix do the work.
+- **Mind spelling.** "Academy" is often misspelled (acadamy, accademy); pick a label that doesn't compound the risk.
+
+## How to register a .academy domain at Namefi
+
+1. Search your desired name on [Namefi](https://namefi.io) to check availability and see whether it's a standard or premium label.
+2. Choose the exact .academy name that fits your brand and confirm the term.
+3. Register and complete checkout — then manage DNS, enable DNSSEC, and connect your site.
+
+As an [ICANN-accredited registrar](/en/glossary/registrar), Namefi offers transparent pricing, fast DNS management, and the option to [tokenize your domain](/en/blog/what-are-tokenized-domains) as a Web3 asset for portable, on-chain ownership. Start at [Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .academy domain?
+
+Yes. The .academy domain is an open generic TLD with no eligibility requirements. There is no residency, business-type, accreditation, or credential check, so individuals and organizations alike can register names on a first-come, first-served basis.
+
+### Does a .academy domain affect SEO?
+
+No. Google treats .academy like any other generic top-level domain, so it carries no inherent ranking advantage or penalty. Rankings depend on content, links, and user experience, not the suffix. A descriptive .academy name can modestly improve click-through by signaling intent.
+
+### Who should register a .academy domain?
+
+It suits schools, online course creators, coding and trading bootcamps, sports and arts academies, corporate training portals, and any brand whose identity centers on teaching. It is less ideal for general businesses, e-commerce stores, or projects with no educational angle.
+
+### Who operates the .academy registry?
+
+The .academy registry is operated by Binky Moon, LLC, a subsidiary in the Identity Digital portfolio (formerly Donuts). It was delegated in the root zone in December 2013 and reached general availability in March 2014 as part of ICANN's new gTLD program.
+
+### Does .academy support WHOIS privacy and DNSSEC?
+
+Yes. Because .academy has no special verification rules, most registrars offer WHOIS privacy on it like any standard gTLD, and the registry supports DNSSEC for cryptographic protection of DNS responses.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [Domain terminology guide](/en/blog/domain-terminology-guide)
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains)
+- [Glossary: registrar](/en/glossary/registrar)
+- [Glossary: DNSSEC](/en/glossary/dnssec)
+- [Glossary: ICANN](/en/glossary/icann)
+- [.com domain](/en/tld/com)
+- [.org domain](/en/tld/org)
+- [.club domain](/en/tld/club)

--- a/content/tld/en/accountants.md
+++ b/content/tld/en/accountants.md
@@ -1,60 +1,148 @@
 ---
-title: "The Professional Choice: What is the .accountants TLD and Why Choose It?"
-date: '2025-12-10'
+title: 'What Is the .accountants Domain? A Guide for Finance Pros'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: "Elevate your financial brand with the .accountants TLD. Learn why CPAs, firms, and tax pros are choosing this domain for better branding and availability."
-keywords: [".accountants domains", ".accountants TLD", "top-level domain", "what is .accountants", "why choose .accountants", "what is the .accountants domain", "why choose the .accountants domain", "CPA domain names", "accounting firm website", "tax professional domains", "financial services TLD", "bookkeeping website", "domain investing", "tokenized domain", "blockchain domains"]
+description: 'The .accountants domain is an open gTLD for CPAs, bookkeepers, and accounting firms. Learn who can register it, how it is priced, and how it affects trust.'
+keywords: ['.accountants domain', 'what is .accountants', '.accountants TLD', 'accounting firm domain', 'CPA domain name', 'Identity Digital gTLD', 'bookkeeping website domain', 'niche TLD for accountants']
+faqs:
+  - question: 'Can anyone register a .accountants domain?'
+    answer: 'Yes. The .accountants extension is an open generic top-level domain with no credential check. You do not need to be a licensed CPA, a registered firm, or a member of any professional body to register one, so accountants and non-accountants alike are eligible.'
+  - question: 'Does a .accountants domain affect SEO?'
+    answer: 'No. Google treats new gTLDs like .accountants the same as .com and gives no inherent ranking boost or penalty for the suffix. Rankings come from content, links, and user experience, not from the keyword in the extension.'
+  - question: 'Who should register a .accountants domain?'
+    answer: 'It suits accounting firms, solo CPAs, bookkeepers, tax preparers, and auditing or fintech businesses that want a descriptive, on-topic web address. It is a strong fit when the matching .com is taken or expensive, or as a defensive registration for an established brand.'
+  - question: 'Is .accountants more expensive than .com?'
+    answer: 'Usually yes. As a niche new gTLD it typically carries higher standard registration and renewal fees than .com, and the most desirable keyword names may be classified as premium with elevated recurring pricing set by the registry.'
+  - question: 'Does .accountants support WHOIS privacy and DNSSEC?'
+    answer: 'Yes. The registry supports DNSSEC for signed, tamper-resistant DNS, and registrars including Namefi offer WHOIS privacy so your personal contact details are not exposed in public records, subject to standard registrar policy.'
 ---
 
-## **What is .accountants?**
+The **.accountants domain** is a descriptive new generic top-level domain (gTLD) built for the accounting and financial-services world. Where a generic suffix like `.com` says nothing about what you do, a web address such as `clarity.accountants` or `riverside.accountants` states the profession before a visitor reads a single word of your homepage. That clarity is the whole pitch, and it is why CPAs, bookkeepers, tax preparers, and audit firms consider it.
 
-The **.accountants** domain extension is a generic Top-Level Domain (gTLD) specifically dedicated to the accounting and financial services industry. Unlike the traditional `.com` or `.net`, which are open to everyone and serve general purposes, `.accountants` is a specialized namespace designed to instantly communicate professional expertise in finance, tax preparation, bookkeeping, and auditing.
+This page covers what the suffix is, who actually runs it, who is allowed to register it, how its pricing behaves, and how it is perceived for trust and email — so you can decide whether it belongs on your shortlist or whether a mainstream alternative serves you better.
 
-Launched as part of [ICANN’s New gTLD Program](https://newgtlds.icann.org/en/about/program), this extension was created to offer a dedicated digital space for financial professionals. As the internet became crowded, finding short, memorable domain names under legacy TLDs became nearly impossible. The `.accountants` extension solves this by opening up a vast inventory of highly relevant, keyword-rich names.
+## .accountants at a glance
 
-It is unrestricted, meaning anyone can register it, but it is predominantly used by certified public accountants (CPAs), accounting firms, tax consultants, and financial software developers to establish immediate credibility.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (new gTLD) |
+| Registry operator | Binky Moon, LLC — operated by [Identity Digital](https://www.identity.digital/) (formerly Donuts) |
+| Year launched | Delegated 2014 |
+| IDN support | Yes (varies by registrar) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no CPA license or firm membership required |
+| Best for | Accounting firms, solo CPAs, bookkeepers, tax and audit practices |
 
-## **How People Are Using .accountants**
+## What is .accountants?
 
-This TLD serves as a digital business card that tells visitors exactly what to expect before they even click the link. Here is how various groups are utilizing this domain:
+`.accountants` is a new gTLD — one of the hundreds of descriptive suffixes introduced through ICANN's New gTLD Program in the 2010s, rather than a country code like `.uk` or a legacy extension like `.com` or `.net`. Its meaning is self-evident: it signals an accounting or financial-services context directly in the domain name.
 
-*   **CPA Firms and Solo Practitioners:** Professionals are moving away from long, hyphenated `.com` addresses (e.g., `smith-jones-accounting-services.com`) to sleek, modern addresses like `SmithJones.accountants`.
-*   **Tax Preparation Services:** Seasonal and year-round tax professionals use the domain to highlight their specialty, often creating landing pages for tax season marketing.
-*   **Fintech and Software Companies:** Developers creating bookkeeping software or financial tools use the extension to target their specific user base directly.
-*   **Educational Platforms:** Blogs, forums, and educational sites offering study materials for CPA exams or financial literacy courses use the domain to signal authority.
-*   **Recruitment Agencies:** Headhunters specializing in financial talent use it to host job boards specific to the accounting sector.
+The official delegation record is held by [IANA](https://www.iana.org/domains/root/db/accountants.html), which lists the technical and administrative facts for the suffix. Importantly, search engines do **not** treat `.accountants` as tied to any country. [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites) confirms that most new gTLDs are handled as generic, non-geographic domains, so using `.accountants` does not geo-target your site to one nation the way a ccTLD can.
 
-## **Notable Entities Using .accountants**
+A practical note on confusables: there is a separate, singular **`.accountant`** suffix run by a different operator, plus credential-oriented options like `.cpa`. They are easy to mix up in conversation and on a business card, which is worth keeping in mind when you pick one.
 
-While many Fortune 500 companies secure their brand names across all TLDs for brand protection (defensive registration), the true power of `.accountants` is seen in the Small to Medium Business (SMB) sector.
+## History of .accountants
 
-*   **Modern Accounting Firms:** Forward-thinking firms like *Cloud.accountants* or *Fusion.accountants* (hypothetical examples of common usage patterns) utilize the TLD to signal a tech-savvy approach to finance.
-*   **Local Businesses:** You will often see domains structured as `[CityName].accountants` or `[Region]Tax.accountants`. This strategy helps local firms capture high-intent search traffic from clients looking for services in their specific area.
-*   **Specialized Consultants:** Forensic accountants and niche auditors often use the extension to differentiate themselves from general financial planners.
+`.accountants` was delegated to the root zone in 2014 as part of the first major wave of the New gTLD Program. It originated under Donuts Inc., the company that launched one of the largest portfolios of descriptive gTLDs. Through corporate consolidation, the registry contract now sits with **Binky Moon, LLC**, and the day-to-day registry services are run by **Identity Digital**, the successor brand to Donuts. You can confirm the current operator on the [IANA delegation record](https://www.iana.org/domains/root/db/accountants.html), which is updated as registry details change.
 
-For a look at the technical registry information and delegation of this TLD, you can view the [IANA delegation record](https://www.iana.org/domains/root/db/accountants.html).
+Adoption has followed the pattern typical of profession-specific gTLDs: steady, niche, and concentrated among small and mid-sized firms and independent practitioners rather than large public brands. It is a working professional suffix, not a viral consumer one, and registration volumes reflect that focused audience.
 
-## **Why Choose .accountants?**
+## How people use .accountants
 
-Choosing the right domain is critical for your digital identity. Here is why `.accountants` is a superior choice for the industry:
+- **Solo CPAs and small practices** who want a short, on-topic address instead of a long hyphenated `.com`.
+- **Bookkeeping and payroll services** positioning around a clear specialty.
+- **Tax-preparation businesses** spinning up seasonal landing pages and campaigns.
+- **Audit, forensic, and advisory firms** that want the suffix to do the explaining.
+- **Local firms** using a `[city].accountants` or `[region]tax.accountants` pattern to read as locally relevant.
+- **Established brands** registering defensively to keep the matching name out of others' hands.
 
-*   **Immediate Credibility:** The extension acts as a label. It builds trust instantly, assuring the user that they are visiting a site dedicated to professional financial services.
-*   **Superior Availability:** Because `.com` has been around for decades, most good names are taken or cost thousands of dollars. With `.accountants`, you are far more likely to find your exact business name or a premium keyword without paying a premium price.
-*   **Built-in SEO Keywords:** Having the keyword "accountants" in your URL ensures that your domain is semantically relevant to search queries. It creates a cleaner URL structure that looks great on business cards and social media.
-*   **Memorable Branding:** `YourName.accountants` is easier to remember and type than `YourNameCPAandAssociates.com`.
+**Who it is not ideal for:** businesses that serve audiences far beyond accounting, anyone who already owns a strong, well-known `.com`, or brands that rely on customers typing the address from memory — many people still default to `.com` and may misremember a niche suffix.
 
-## **Register Your .accountants Domain at Namefi**
+## Notable sites using .accountants
 
-Ready to establish a professional digital presence that commands respect? Securing your `.accountants` domain is the first step toward building a trustworthy brand in the financial sector.
+`.accountants` is used mainly by independent firms and regional practices rather than household-name companies, so there is no large, instantly recognizable public flagship site to point to. The honest picture is a long tail of small accounting, bookkeeping, and tax businesses using the suffix as a descriptive home for their practice. Rather than name a site that might lapse or change hands, the accurate description is that typical real-world usage is a working firm's main or campaign site, not a mass-market consumer brand.
 
-At **Namefi**, we make domain registration simple, secure, and future-proof.
-*   **ICANN Accredited:** We are a fully compliant and trusted registrar.
-*   **Web3 Integration:** We are pioneering the future of digital assets. At Namefi, your domain can be minted as an NFT, allowing for seamless transfers, enhanced liquidity, and integration with blockchain technologies.
-*   **Easy Management:** Our user-friendly dashboard makes managing your DNS settings and renewals effortless.
+## .accountants vs other domains
 
-Don't let your perfect domain name get snapped up by a competitor.
+| Suffix | Type | Eligibility | Best fit |
+| --- | --- | --- | --- |
+| [.accountants](/en/tld/accountants) | Niche new gTLD | Open to all | Firms wanting a descriptive, on-topic address |
+| [.com](/en/tld/com) | Legacy gTLD | Open to all | Maximum recognition and default trust |
+| [.cpa](/en/tld/cpa) | Restricted gTLD | Verified CPA credential required | Licensed CPAs signalling validated status |
+| [.tax](/en/tld/tax) | Niche new gTLD | Open to all | Tax-focused practices and content |
 
-**[Search and Register your .accountants domain at Namefi today](https://namefi.io)**.
+Pick `.com` when broad recognition and instant familiarity matter most. Choose `.accountants` or `.tax` when the matching `.com` is taken or costly and you want the suffix itself to describe the service. Choose `.cpa` only if you hold the credential and want that verification baked into your address. Several of these also have dedicated guides — see [.com](/en/tld/com), [.cpa](/en/tld/cpa), and [.tax](/en/tld/tax).
+
+## Why choose .accountants?
+
+- **Instant context.** The suffix tells visitors your field before they read any copy.
+- **Better availability.** Exact-match and keyword names that are long gone under `.com` are often still open under `.accountants`.
+- **Clean, descriptive branding.** `yourfirm.accountants` reads cleanly on a card, an invoice, or an email signature.
+- **No credential barrier.** Unlike `.cpa`, you can register without proving a license, which suits bookkeepers and advisory firms outside the CPA designation.
+
+## Things to consider
+
+- **Higher cost than `.com`.** Niche gTLDs generally cost more to register and renew, and standout keyword names can be premium-priced.
+- **Lower familiarity.** Many users still assume `.com`; a niche suffix can be misremembered or mistyped.
+- **Easy to confuse.** The singular `.accountant`, plus `.cpa` and `.tax`, sit nearby — people may reach the wrong one.
+- **"Open" cuts both ways.** Because anyone can register, the suffix alone does not certify professional qualifications; your own credentials still carry the trust.
+
+## Who can register a .accountants domain?
+
+**Registration restrictions: open to all.** This is the single most important eligibility fact: `.accountants` is an unrestricted gTLD with no credential gate. You do **not** need a CPA license, firm registration, or membership in any accounting body to register one — it is genuinely open to the public. That is the key difference from a credential-gated suffix like `.cpa`, which requires verified CPA status.
+
+Standard new-gTLD rules apply: domains run from 1 to 63 characters, internationalized domain names (IDNs) are supported subject to your registrar, and trademark holders had a Sunrise window at launch via the Trademark Clearinghouse. The registry supports **DNSSEC** for signed DNS, registrars including Namefi offer **WHOIS privacy**, and renewal, transfer, and redemption-grace handling follow standard ICANN-accredited registrar practice. A subset of high-value keyword names is reserved or classified as premium by the registry. For the authoritative rules, see the suffix's [ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/accountants) and the operator's site, [Identity Digital](https://www.identity.digital/).
+
+## .accountants pricing and value
+
+Pricing for `.accountants` follows the usual niche-gTLD pattern rather than a single flat rate. Expect three dynamics. First, **standard names cost more than `.com`** — descriptive professional gTLDs typically carry higher base fees because they serve a focused audience. Second, **first-year and renewal pricing can differ**, so weigh the long-term renewal cost, not just the entry price. Third, **premium names exist**: the registry classifies short, high-demand keyword terms into elevated price categories, and those premium names usually renew at the premium rate every year. The drivers of cost are name desirability, length, and premium classification — a generic keyword sits at the top of the range while a longer, specific firm name sits at standard pricing.
+
+## Reputation and email deliverability
+
+Niche new gTLDs occasionally face the perception that "anything but `.com` is less established," and a small number of poorly configured spam filters historically scored unfamiliar suffixes more cautiously. In practice, `.accountants` is a professional, low-abuse suffix, and modern mail systems judge senders on authentication and sending behavior, not on the TLD. The reliable mitigation is technical hygiene: publish correct **SPF, DKIM, and DMARC** records, warm up new sending domains gradually, and keep list quality high. Pair that with a real, content-rich website, and the suffix carries professional weight without deliverability friction.
+
+## Branding and naming tips
+
+The most effective `.accountants` names read as a natural phrase: a firm name, a city, or a clear specialty immediately followed by the suffix — `riverside.accountants`, `claritytax.accountants`. Because the word "accountants" is long and plural, avoid stacking another long word in front of it; short, punchy roots keep the whole address memorable and easy to say aloud. Watch the confusable trap: spell out clearly whether you are the singular `.accountant` or the plural `.accountants`, since saying it aloud is ambiguous. As with any non-`.com` suffix, registering the matching `.com` defensively (where affordable) catches visitors who type the wrong ending out of habit.
+
+## How to register a .accountants domain at Namefi
+
+1. **Search** your preferred name on [Namefi](https://namefi.io) to check availability.
+2. **Choose** the best available option — and consider grabbing a defensive `.com` alongside it.
+3. **Register** and configure DNS from one dashboard.
+
+As an ICANN-accredited registrar, Namefi offers transparent pricing, fast DNS management, and — uniquely — the option to **tokenize your domain** as an on-chain asset for Web3 use cases. You can read more in [What Are Tokenized Domains?](/en/blog/what-are-tokenized-domains) and [Why Tokenize Domains?](/en/blog/why-tokenize-domains).
+
+## Frequently asked questions
+
+### Can anyone register a .accountants domain?
+
+Yes. `.accountants` is an open generic top-level domain with no credential check. You do not need to be a licensed CPA, a registered firm, or a member of any professional body to register one, so accountants and non-accountants alike are eligible. This contrasts with credential-gated suffixes such as `.cpa`.
+
+### Does a .accountants domain affect SEO?
+
+No. Google treats new gTLDs like `.accountants` the same as `.com` and gives no inherent ranking boost or penalty for the suffix. Rankings come from content, links, and user experience — not from having the keyword in your extension.
+
+### Who should register a .accountants domain?
+
+It suits accounting firms, solo CPAs, bookkeepers, tax preparers, and auditing or fintech businesses that want a descriptive, on-topic web address. It is a strong fit when the matching `.com` is taken or expensive, or as a defensive registration for an established brand.
+
+### Is .accountants more expensive than .com?
+
+Usually yes. As a niche new gTLD it typically carries higher standard registration and renewal fees than `.com`, and the most desirable keyword names may be classified as premium with elevated recurring pricing set by the registry.
+
+### Does .accountants support WHOIS privacy and DNSSEC?
+
+Yes. The registry supports DNSSEC for signed, tamper-resistant DNS, and registrars including Namefi offer WHOIS privacy so your personal contact details are not exposed in public records, subject to standard registrar policy.
+
+## Related resources
+
+- [What Is a TLD?](/en/blog/what-is-a-tld)
+- [What Is a Domain?](/en/blog/what-is-domain)
+- [Top TLDs to Secure for Your Accounting Firm](/en/blog/top-tlds-to-secure-for-your-accounting-firm)
+- [What Are Tokenized Domains?](/en/blog/what-are-tokenized-domains)
+- [ICANN](/en/glossary/icann) and [Registrar](/en/glossary/registrar) glossary terms
+- Compare suffixes: [.com](/en/tld/com), [.cpa](/en/tld/cpa), and [.tax](/en/tld/tax)

--- a/content/tld/en/agency.md
+++ b/content/tld/en/agency.md
@@ -1,60 +1,153 @@
 ---
-title: 'Unlock Professional Credibility: What is the .agency TLD and Why Choose It?'
-date: '2025-12-10'
+title: 'What Is the .agency Domain? A Guide for Service Firms'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: 'Discover the power of the .agency domain. Perfect for service firms, creative studios, and consultancies. Learn why .agency boosts credibility and register yours today.'
-keywords: ['.agency domains', '.agency TLD', '.agency top-level domain', 'what is .agency', 'why choose .agency', 'what is the .agency domain', 'why choose the .agency domain', 'tokenized .agency domains', 'blockchain domain investing', 'marketing agency domains', 'creative agency URL', 'real estate agency website', 'recruitment agency domains', 'new gTLD investment', 'buy .agency domain']
+description: 'The .agency domain is an open new gTLD from Identity Digital, ideal for marketing, creative, real-estate, and consulting firms wanting a descriptive, brandable web address.'
+keywords: ['.agency domain', 'what is .agency', '.agency TLD', '.agency domains', 'agency domain name', 'new gTLD for agencies', 'marketing agency domain', 'creative agency website', 'Identity Digital TLD', 'register .agency']
+faqs:
+  - question: 'Can anyone register a .agency domain?'
+    answer: 'Yes. The .agency domain is an open, unrestricted new gTLD with no credential, membership, or local-presence requirement. Anyone in the world can register an available .agency name through an accredited registrar on a first-come, first-served basis.'
+  - question: 'Does a .agency domain affect SEO?'
+    answer: 'No. Google treats new gTLDs like .agency the same as legacy extensions such as .com. Rankings depend on content, links, and user experience, not on the suffix. A keyword-relevant URL can modestly help click-through, but it is not a direct ranking factor.'
+  - question: 'Who should register a .agency domain?'
+    answer: 'It suits marketing, advertising, PR, creative, design, talent, real-estate, recruitment, and consulting firms that describe themselves as agencies. It is a strong fit when a short, exact-match name is taken on .com but available as a .agency.'
+  - question: 'Is .agency good for email and deliverability?'
+    answer: 'Yes, when configured properly. As an established 2014-era Identity Digital extension, .agency carries no inherent spam stigma. Set up SPF, DKIM, and DMARC, warm up new domains gradually, and deliverability is comparable to other professional gTLDs.'
 ---
 
-## **What is .agency?**
+If your business is an agency, the .agency domain lets you say so in the URL itself. Instead of stacking the word "agency" on the left of a legacy suffix — as in *brightagency.com* — you can move it to the right of the dot and register the cleaner, more descriptive *bright.agency*. For marketing, creative, real-estate, recruitment, and consulting firms, that single change turns the web address into a plain-language label of what the company does.
 
-The **.agency** domain is a generic Top-Level Domain (gTLD) specifically designed to serve the vast ecosystem of service-based businesses that identify as agencies. Unlike the saturated .com or .net namespaces, .agency offers a clear, descriptive, and professional identity right in the URL.
+This is a reference for the **.agency domain**: who runs the registry, who can register, how the suffix is perceived, what drives its pricing, and how it compares to the alternatives — so you can decide whether it belongs on your shortlist.
 
-Launched as part of [ICANN's new gTLD program](https://newgtlds.icann.org/en/about/program), .agency was created to provide a dedicated digital space for businesses ranging from advertising and marketing to real estate, insurance, and recruitment. It allows companies to shorten their web addresses by moving the word "agency" from the left side of the dot (e.g., *smithagency.com*) to the right side (e.g., *smith.agency*).
+## .agency at a glance
 
-Managed by [Identity Digital](https://identity.digital/), this TLD has seen steady adoption because it immediately communicates the nature of the business to visitors before they even load the website.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (new gTLD, 2012 round) |
+| Registry operator | Binky Moon, LLC (an [Identity Digital](https://www.identity.digital/) company) |
+| Year launched | Delegated 2014 |
+| IDN support | Yes (internationalized domain names supported) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no credential, membership, or local presence required |
+| Best for | Marketing, creative, real-estate, recruitment, and consulting agencies |
 
-## **How People Are Using .agency**
+## What is .agency?
 
-The versatility of the word "agency" makes this TLD applicable to a wide variety of industries. Here is how different sectors are leveraging this domain extension:
+The **.agency domain** is a generic top-level domain (gTLD) introduced through ICANN's New gTLD Program, the 2012 expansion round that added hundreds of descriptive word-based suffixes to the root zone. According to its [IANA root-zone record](https://www.iana.org/domains/root/db/agency.html), .agency was delegated in 2014 and is sponsored by Binky Moon, LLC, the registry-operator entity of [Identity Digital](https://www.identity.digital/) (formerly Donuts), which runs one of the largest portfolios of new gTLDs in the world.
 
-*   **Marketing and Advertising:** Digital marketing firms, SEO consultants, and PR houses use .agency to establish authority and creative flair.
-*   **Real Estate:** Brokers and property management groups use it to differentiate themselves from general listing sites.
-*   **Talent and Modeling:** Casting directors and talent management firms use it to create sleek, portfolio-focused websites.
-*   **Travel and Tourism:** Boutique travel planners utilize the extension to suggest a personalized service approach.
-*   **Government and Non-Profits:** Local government bodies and environmental protection groups often use it to designate official departments.
-*   **Web3 and Tech:** Development shops and blockchain consultancy firms are increasingly adopting .agency to signify high-level service in the decentralized space.
+Because .agency is a generic gTLD rather than a country-code TLD, it is not tied to any nation or region. [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites) treats most new gTLDs as generic — they carry no built-in geo-targeting, so a .agency site can rank globally just like a .com.
 
-## **Notable Entities Using .agency**
+## History of .agency
 
-While many Fortune 500 companies protect their brand by registering their .agency domains, the TLD truly shines among specialized service providers who want memorable branding.
+.agency was part of the first wave of Identity Digital's (then Donuts') professional and business-oriented strings. After delegation in 2014, the .agency name was held under Steel Falls, LLC before the portfolio consolidated; in 2018 the IANA record was updated to reflect Binky Moon, LLC as the sponsoring organization, the standard registry entity Identity Digital now uses across its TLDs.
 
-1.  **Creative Studios:** Many award-winning design boutiques have migrated to .agency addresses to secure short, one-word domain names that would be impossible to acquire on legacy TLDs.
-2.  **Specialized Insurance Firms:** Niche insurance providers often use the extension to highlight their specific focus (e.g., *cybersecurity.agency* or *travel.agency*).
-3.  **Digital Consultancies:** As the gig economy grows, collectives of freelancers and consultants are forming "micro-agencies" and using this TLD to project a corporate, unified front.
+Adoption has been steady rather than explosive. The suffix found a durable niche among service firms that wanted an exact-match, on-brand address when the equivalent short .com names had long since been taken. Unlike speculative or meme-driven extensions, .agency's growth has been tied to genuine business use.
 
-*Note: Due to the specific nature of this TLD, the "stars" of the .agency world are often local market leaders in real estate and marketing rather than global consumer goods brands.*
+## How people use .agency
 
-## **Why Choose .agency?**
+The word "agency" spans many industries, which is precisely what gives the suffix its range. Common real-world uses include:
 
-Choosing the right domain extension is critical for your digital strategy. Here is why .agency is a smart investment:
+- **Marketing, advertising, and PR firms** — establishing a descriptive, professional brand URL.
+- **Creative and design studios** — securing a short, one-word name impossible to get on legacy TLDs.
+- **Real-estate and property agencies** — differentiating from generic listing portals.
+- **Recruitment and staffing agencies** — signaling a service-and-representation business.
+- **Talent, modeling, and casting agencies** — pairing a portfolio site with a sleek address.
+- **Travel and boutique consultancies** — implying a personalized, managed-service approach.
 
-*   **Immediate Recognition:** It describes exactly what you do. When a user sees a link ending in .agency, they expect professional services, consultation, or representation.
-*   **Superior Availability:** Finding a short, catchy name on .com is becoming increasingly difficult and expensive. The .agency namespace offers a vast inventory of premium, short names that are still available for registration.
-*   **Better Branding:** It allows for shorter URLs. Instead of registering `TheCreativeDesignAgency.com`, you can simply register `CreativeDesign.agency`. This is easier for clients to remember and type.
-*   **SEO Relevance:** Search engines like Google treat new gTLDs just like traditional ones. However, having a relevant keyword in your TLD can improve click-through rates (CTR) because users perceive the link as highly relevant to their search query.
+**Who it's not ideal for:** product companies, SaaS apps, e-commerce stores, personal blogs, or any business that does not actually present itself as an "agency." For those, a [.com](/en/tld/com), [.app](/en/tld/app), [.shop](/en/tld/shop), or [.store](/en/tld/store) communicates the offering far more accurately. Forcing the word "agency" onto a non-agency brand creates confusion rather than clarity.
 
-## **Register Your .agency Domain at Namefi**
+## Notable sites using .agency
 
-Ready to professionalize your web presence? Whether you are launching a new digital marketing firm, a real estate brokerage, or a Web3 consultancy, the .agency domain is the perfect foundation for your brand.
+.agency is used primarily by independent service firms and the agency arms of larger organizations rather than by household-name consumer brands, so its strongest examples are working business sites rather than global landmarks. Typical patterns include marketing and creative shops adopting a *brandname.agency* address as their primary site, and larger companies pointing a .agency at a sub-brand or holding it defensively. Rather than name a specific site that could later lapse or change hands: when you see a .agency URL in the wild, it almost always belongs to a marketing, creative, real-estate, or recruitment firm using the suffix exactly as intended.
 
-At **Namefi**, we make domain registration simple, secure, and future-proof.
-*   **ICANN Accredited:** We are a fully compliant and trusted registrar.
-*   **Web3 Integrated:** Namefi allows you to bridge the gap between Web2 and Web3. You can easily mint your .agency domain as a tokenized asset, giving you true ownership and flexibility.
+## .agency vs other domains
 
-Don't let your perfect agency name get snapped up by a competitor.
+| Feature | .agency | [.com](/en/tld/com) | [.io](/en/tld/io) | [.xyz](/en/tld/xyz) |
+| --- | --- | --- | --- | --- |
+| Type | New gTLD | Legacy gTLD | ccTLD (tech-repurposed) | New gTLD |
+| Descriptive meaning | "we are an agency" | none (universal) | "input/output", techy | none (universal) |
+| Short-name availability | High | Very low | Low–medium | High |
+| Typical price tier | Mid | Low | High | Low |
+| Best audience | Service firms | Everyone | Startups, dev tools | Generalists, Web3 |
 
-**[Register your .agency domain at Namefi today](https://namefi.io)** and start building your legacy.
+Pick [.com](/en/tld/com) when universal familiarity outweighs everything else and a suitable name is available. Pick **.agency** when the word genuinely describes your business and the matching .com is taken or overpriced. Pick [.io](/en/tld/io) for tech or developer products, and [.xyz](/en/tld/xyz) when you want a low-cost, flexible generalist suffix without an industry label.
+
+## Why choose .agency?
+
+- **Built-in description.** The suffix tells visitors what you do before the page even loads — useful for a category defined by its service.
+- **Short, exact-match names.** Names long gone on .com are frequently still available as .agency, letting you register *yourbrand.agency* instead of a padded compromise.
+- **Cleaner branding.** Moving "agency" to the right of the dot produces a shorter, more memorable, easier-to-type address.
+- **Reputable registry.** Identity Digital operates a large, well-maintained portfolio with standard registrar support, DNSSEC, and IDN handling.
+- **Global and generic.** No geo-targeting penalty and no eligibility hoops.
+
+## Things to consider
+
+No suffix is free of trade-offs. Honest points to weigh:
+
+- **Niche meaning.** The descriptive nature that helps an agency actively hurts a non-agency brand. The word narrows your perceived category.
+- **Lower default recognition.** Some non-technical visitors still assume "the .com" and may mistype the address. Securing the matching .com defensively, if affordable, reduces that leakage.
+- **Pricing above bargain TLDs.** As a descriptive professional extension, .agency typically sits in a mid price tier, above the cheapest generic suffixes (see pricing below).
+- **Premium names.** The most desirable single keywords may be reserved as premium registrations with higher fees.
+
+## Who can register a .agency domain?
+
+**Registration restrictions: open to all.** .agency is an unrestricted new gTLD. There is no credential gate (unlike [.law](/en/tld/law) or [.cpa](/en/tld/cpa)), no membership requirement, and no local-presence rule. Any individual or organization worldwide can register an available .agency name on a first-come, first-served basis through any accredited registrar.
+
+Standard policies apply. At launch it ran the usual ICANN Sunrise period giving trademark holders (via the Trademark Clearinghouse) first claim, but that phase is long closed. Names follow conventional length and character rules and support IDNs. The registry supports DNSSEC, registrars commonly offer WHOIS privacy, and transfer, renewal, and redemption-grace handling follow standard ICANN gTLD lifecycle rules. The governing rules are set out in the [ICANN Registry Agreement for .agency](https://www.icann.org/en/registry-agreements/details/agency); for registrar-level policies, check your registrar's terms.
+
+## .agency pricing and value
+
+This page never quotes live prices, but the pricing **dynamics** are worth understanding. .agency generally sits in a mid price tier: more than the cheapest generic suffixes, less than premium tech extensions. Expect first-year and renewal pricing to differ — introductory rates are common, while the renewal is the true long-term cost, so always check the standing renewal before you commit.
+
+A subset of the most sought-after one-word names are classified as **premium** registrations by the registry and carry higher, sometimes recurring, fees. Cost is driven by the registry's wholesale rate, premium tiering, your registrar's markup, and any promotional first-year offer. Budget on the renewal figure, not the headline first-year price.
+
+## Reputation and email deliverability
+
+.agency is a mature, professionally positioned suffix without the spam stigma attached to some ultra-cheap, free, or promo-driven TLDs. Because it has been operated by a reputable registry since 2014 and is widely used by legitimate service businesses, mailbox providers and spam filters treat it on its merits rather than penalizing the extension itself.
+
+Deliverability ultimately depends on configuration, not the suffix. To land in the inbox: publish correct **SPF**, **DKIM**, and **DMARC** records; warm up a brand-new domain gradually rather than blasting a large first send; keep list hygiene tight; and avoid spammy content. Done properly, a .agency address performs comparably to other professional gTLDs for both web trust and email.
+
+## Branding and naming tips
+
+- **Read the whole string as a phrase.** The best .agency names work as a left-of-dot brand plus the word: *north.agency*, *frame.agency*, *summit.agency*.
+- **Keep it short and speakable.** The suffix already adds syllables, so a tight root keeps the full address easy to say and type.
+- **Avoid awkward keyword stuffing.** *marketingmarketing.agency* reads as spam. Let the suffix carry the category and keep the root clean.
+- **Mind the assumption gap.** Some people will hear your URL and reach for ".com" — choose a root distinctive enough to find, and consider holding the .com defensively.
+
+## How to register a .agency domain at Namefi
+
+1. **Search** for your desired name on [Namefi](https://namefi.io) to check availability across .agency and alternatives.
+2. **Choose** the exact .agency name (and any defensive variants) you want to secure.
+3. **Register** and complete checkout to lock it in.
+
+As an ICANN-accredited registrar, Namefi offers transparent pricing and fast DNS management. Namefi also bridges Web2 and Web3: you can mint your .agency as a [tokenized domain](/en/blog/what-are-tokenized-domains), giving you on-chain ownership and transfer flexibility alongside the conventional registration. [Register your .agency domain at Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .agency domain?
+
+Yes. The .agency domain is an open, unrestricted new gTLD with no credential, membership, or local-presence requirement. Anyone in the world can register an available .agency name through an accredited registrar on a first-come, first-served basis.
+
+### Does a .agency domain affect SEO?
+
+No. Google treats new gTLDs like .agency the same as legacy extensions such as .com. Rankings depend on content, links, and user experience, not on the suffix. A keyword-relevant URL can modestly help click-through, but it is not a direct ranking factor.
+
+### Who should register a .agency domain?
+
+It suits marketing, advertising, PR, creative, design, talent, real-estate, recruitment, and consulting firms that describe themselves as agencies. It is a strong fit when a short, exact-match name is taken on .com but available as a .agency.
+
+### Is .agency good for email and deliverability?
+
+Yes, when configured properly. As an established 2014-era Identity Digital extension, .agency carries no inherent spam stigma. Set up SPF, DKIM, and DMARC, warm up new domains gradually, and deliverability is comparable to other professional gTLDs.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld) — the basics of top-level domains.
+- [What is a domain?](/en/blog/what-is-domain) — how domain names work end to end.
+- [Top TLDs to secure for your business](/en/blog/top-tlds-to-secure-for-your-business) — which extensions to register defensively.
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains) — bringing your domain on-chain.
+- [Registrar](/en/glossary/registrar) and [ICANN](/en/glossary/icann) — key terms in the glossary.
+- Compare with [.com](/en/tld/com), [.io](/en/tld/io), and [.xyz](/en/tld/xyz).

--- a/content/tld/en/ai.md
+++ b/content/tld/en/ai.md
@@ -1,122 +1,158 @@
 ---
-title: "What is the .ai Domain? Country, Owner & Why Choose .ai (2026)"
-date: '2025-12-10'
-updated: '2026-06-10'
+title: 'What Is the .ai Domain? Anguilla ccTLD for AI Explained'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: "What country is .ai? It's Anguilla's ccTLD. Learn who owns the .ai TLD, why it's the top domain for AI startups, its SEO value, and how to register .ai at Namefi."
-keywords: [".ai domain", ".ai TLD", "ai tld", "what is .ai domain", "what country is .ai", "what country has the .ai domain", "which country has the .ai domain", "is .ai a country code", "is .ai a ccTLD", "ai country code", "who owns .ai tld", "where does .ai come from", "Anguilla domain name", "Anguilla ccTLD", "artificial intelligence domains", ".ai vs .io", "why choose .ai", "buy .ai domain", "register .ai domain", "tech startup branding", "tokenized domains", "blockchain domain assets", "AI startup domain", "gccTLD", "Namefi .ai registration"]
+description: '.ai is Anguilla''s country-code domain turned global AI branding extension. Learn who runs it, registration rules, SEO impact, and how to register .ai at Namefi.'
+keywords: ['.ai domain', 'what is .ai', '.ai TLD', 'Anguilla ccTLD', 'register .ai domain', 'AI startup domain', '.ai vs .io', 'who owns .ai']
+faqs:
+  - question: 'Can anyone register a .ai domain?'
+    answer: 'Yes. The .ai registry is open to anyone worldwide with no local-presence or credential requirement. The main difference from most TLDs is that .ai is sold in a minimum two-year term rather than one-year increments.'
+  - question: 'Does a .ai domain affect SEO?'
+    answer: 'No. Google treats .ai as a generic top-level domain rather than geo-targeting it to Anguilla, so a .ai site can rank globally. The extension itself is neither a ranking boost nor a penalty; content and links still decide rankings.'
+  - question: 'Who should register a .ai domain?'
+    answer: 'It suits artificial-intelligence startups, machine-learning products, AI agents, and developer tools that want the meaning of "AI" built into the name. It is less ideal for budget projects or local non-tech businesses, given the higher price and two-year minimum.'
+  - question: 'Who owns and operates the .ai registry?'
+    answer: 'The Government of Anguilla holds the IANA delegation for .ai. Since January 2025 the technical registry back-end is operated by Identity Digital. Each individual .ai domain you register is owned by you, the registrant.'
+  - question: 'Why is the minimum .ai registration two years?'
+    answer: 'The Anguilla registry sets the policy: .ai domains register and renew in terms of two to ten years, not the single-year cycle common to .com. This raises the upfront cost but reduces the risk of accidentally losing a name to a missed one-year renewal.'
 ---
 
-## **What is .ai?**
+The **.ai** domain is the rare extension whose two letters are also one of the most valuable acronyms on the internet. Technically it is the country-code top-level domain (ccTLD) for Anguilla, a British Overseas Territory in the Eastern Caribbean. In practice it has become the default address for the artificial-intelligence industry, from frontier model labs to indie AI tools.
 
-At first glance, the **.ai** extension seems tailor-made for the booming industry of Artificial Intelligence. However, technically speaking, **.ai** is the **country code Top-Level Domain (ccTLD)** for **Anguilla**, a British Overseas Territory in the Eastern Caribbean.
+This page covers what .ai really is, who runs it, the registration rules that make it different from .com, how it affects SEO and email trust, and how it compares with alternatives like [.io](/en/tld/io/) so you can decide whether it fits your project.
 
-Originally delegated in 1995, the domain was intended for entities connected to Anguilla. However, much like the famous .io (Indian Ocean) or .tv (Tuvalu) domains, .ai has transcended its geographic roots. Because "AI" is the global acronym for Artificial Intelligence, tech companies began adopting the extension to signal their focus on machine learning, robotics, and data science.
+## .ai at a glance
 
-Today, major search engines like Google treat .ai as a **gccTLD** (generic country code Top-Level Domain). This means that despite being a country code, Google [treats it as generic for search results](https://developers.google.com/search/docs/crawling-indexing/manage-multiregional-site#geotargeting), ensuring that .ai websites can rank globally rather than just within the Caribbean. This distinction has turned .ai into one of the most valuable and sought-after digital assets in the modern web economy.
+| Fact | Detail |
+| --- | --- |
+| TLD type | ccTLD (country code for Anguilla); treated as generic by Google |
+| Registry operator | Government of Anguilla; technical back-end by Identity Digital (since Jan 2025) |
+| Year delegated | 1995 |
+| IDN support | Limited — primarily ASCII a–z, 0–9, and hyphen |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all; minimum two-year registration term |
+| Best for | AI/ML startups, agent products, developer tools, premium tech brands |
 
-## **What country is .ai? (Anguilla)**
+## What is .ai?
 
-**The short answer: .ai is the country code for Anguilla**, a small British Overseas Territory in the Eastern Caribbean. If you only need a one-line answer, that's it — but the details below explain why this matters.
+.ai is the [ccTLD](/en/glossary/tld/) assigned to Anguilla. The two letters "AI" are simply Anguilla's ISO 3166-1 country code — the same coincidence that turned .io (Indian Ocean Territory) and .tv (Tuvalu) into tech favorites. The extension was delegated in 1995, decades before the modern AI boom, as confirmed by the [IANA root-zone record for .ai](https://www.iana.org/domains/root/db/ai.html).
 
-Here are the facts behind the most common country-origin questions about .ai:
+What makes .ai unusual is how search engines treat it. Although it is officially a ccTLD, [Google does not geo-target it to Anguilla](https://developers.google.com/search/docs/crawling-indexing/managing-multi-regional-sites). Google maintains a list of ccTLDs it treats as generic ("gccTLDs"), and .ai is one of them. That means a .ai site can rank worldwide rather than being nudged toward Caribbean audiences — a key reason global AI companies are comfortable building their primary brand on it.
 
-*   **What country is .ai?** Anguilla.
-*   **Is .ai a country code?** Yes. .ai is a **ccTLD** (country code Top-Level Domain), the same category as .uk, .de, or .jp. The two letters "AI" are Anguilla's ISO 3166-1 country code.
-*   **Is .ai a ccTLD?** Yes — officially a ccTLD, even though the wider tech world uses it for "Artificial Intelligence" and search engines treat it as generic.
-*   **Where does .ai come from?** It was delegated to Anguilla in 1995, long before the modern AI boom.
-*   **Why does it look like "AI"?** Pure coincidence. Anguilla's two-letter code happens to spell the global acronym for Artificial Intelligence — the same lucky accident that made .io ("Input/Output") a tech favorite.
+## History of .ai
 
-So when someone asks "**which country has the .ai domain**" or "**where does .ai come from**," the answer is always Anguilla — a Caribbean island that now lends its identity to the entire global AI industry.
+.ai was delegated to Anguilla in 1995 and spent its first two decades as a sleepy ccTLD. The turning point came with the deep-learning and then the generative-AI wave: as "AI" became the defining label of the technology era, demand for the matching domain exploded.
 
-### **Who owns the .ai TLD?**
+The financial impact on Anguilla has been striking. Public reporting indicates the territory earned roughly $2.9 million from domain fees in 2018, climbing to about $32 million in 2023 — a sum equal to more than 10% of its GDP — with officials projecting .ai revenue would account for close to half of government income by 2025. On the secondary market, premium one-word names command serious prices: `fin.ai` reportedly sold for about $1 million in March 2025.
 
-Ownership of a ccTLD and ownership of an individual domain are two different things:
+In January 2025, the Government of Anguilla moved the registry's technical operations to **Identity Digital**, one of the largest domain back-end operators, modernizing the platform that had previously been run more locally. The government still owns the namespace and sets policy.
 
-*   **The .ai registry (the TLD itself)** is administered on behalf of the **Government of Anguilla**, which holds the delegation for its country code as recorded by [IANA](https://www.iana.org/domains/root/db/ai.html). Anguilla manages registry policy for the extension, and the surge in .ai registrations has become a meaningful source of revenue for the territory.
-*   **An individual .ai domain** (for example, `yourbrand.ai`) is owned by **you**, the registrant, once you register it through an accredited registrar. You control where it points, how it renews, and whether you sell or transfer it.
+## How people use .ai
 
-In other words, Anguilla owns the *namespace*, but every registered .ai domain is owned by the person or company who registered it. For more on how registries and registrars differ, see our glossary entries on [registrar](/en/glossary/registrar/) and [ICANN](/en/glossary/icann/).
+- **AI and ML startups:** companies whose product *is* artificial intelligence, using the URL to state the value proposition directly.
+- **AI agents and assistants:** conversational agents, copilots, and autonomous tools where "AI" is the category.
+- **Developer tooling and infrastructure:** APIs, model-hosting, and data platforms targeting technical buyers.
+- **Premium brand and redirect names:** large companies securing a short, memorable `brand.ai` even when their main site is `.com`.
+- **Domain investors:** short, dictionary-word .ai names treated as a high-value asset class.
 
-## **How People Are Using .ai**
+**Who it's not ideal for:** budget side-projects, purely local non-tech businesses, or anyone who needs the cheapest possible one-year registration — the two-year minimum and premium pricing make .ai a deliberate choice, not a default.
 
-The usage of .ai has exploded alongside the advancement of Large Language Models (LLMs) and generative tech. It is no longer just a niche extension; it is a brand statement.
+## Notable sites using .ai
 
-*   **Tech Startups and SaaS:** New companies use it to instantly communicate that their product is powered by smart algorithms. It saves marketing effort by putting the value proposition directly in the URL.
-*   **Creative Portfolios:** Designers and artists utilizing generative AI tools use .ai domains to showcase synthetic media and digital art collections.
-*   **Domain Investors:** Due to the high demand and higher price floor compared to standard domains, investors see .ai as a "digital gold" asset class, often holding premium names for future resale.
-*   **Web3 and Blockchain Projects:** As the lines between AI and blockchain blur, many decentralized projects are adopting .ai to highlight automated, smart-contract-driven protocols.
+- **character.ai** — consumer platform for chatting with AI characters.
+- **perplexity.ai** — widely used AI answer engine and search product.
+- **x.ai** — the company behind the Grok models.
+- **stability.ai** — the team behind the Stable Diffusion image models.
+- **scale.ai** — data-labeling and AI infrastructure company.
 
-If you're weighing how AI-era branding plays out across different extensions, our guide to [tokenized domain use cases in 2026](/en/blog/tokenized-domain-use-cases-2026/) covers how teams are pairing premium TLDs with on-chain ownership.
+These are established, high-traffic properties, which is part of why .ai now reads as a credible primary domain rather than a novelty.
 
-## **Notable Entities Using .ai**
+## .ai vs other domains
 
-The credibility of the .ai extension has been cemented by industry giants and unicorns who have adopted it as their primary digital home.
+| | **.ai** | **.io** | **.com** |
+| --- | --- | --- | --- |
+| Origin | Anguilla ccTLD | Indian Ocean ccTLD | Original generic gTLD |
+| Connotation | Artificial intelligence | Input/output, dev/SaaS | Universal, default |
+| Google treatment | Generic (gccTLD) | Generic (gccTLD) | Generic |
+| Typical price | High, premium | Mid-high | Low, but short names scarce |
+| Min. term | Two years | One year | One year |
 
-1.  **OpenAI (via redirects/sub-projects):** While their main site is .com, the entity behind ChatGPT helped popularize the association of "AI" with consumer tech, driving the TLD's popularity.
-2.  **Stability.ai:** The creators of Stable Diffusion, a leading open-source generative AI model, use this domain as their primary hub.
-3.  **X.ai:** Elon Musk's artificial intelligence company utilizes this short, premium domain, signaling the high-value nature of the extension.
-4.  **Jasper.ai:** A leading AI writing assistant that rebranded from a .com to a .ai to better align with its core technology.
-5.  **Character.ai:** A popular platform for conversational AI agents, showcasing the consumer-facing potential of the TLD.
+Pick **.ai** when artificial intelligence *is* your product and you want the meaning baked into the name. Choose **[.io](/en/tld/io/)** for broader developer, SaaS, or infrastructure plays where it reads as "input/output" and tends to be cheaper — see [why .io domains are expensive](/en/blog/why-are-io-domains-expensive/). Keep **[.com](/en/tld/com/)** in mind as the universal default; many teams secure the .com defensively alongside their .ai. For a deeper head-to-head, read [.ai vs .io: which domain is right for your startup?](/en/blog/ai-vs-io-domain/).
 
-## **Why Choose .ai?**
+## Why choose .ai?
 
-Choosing a domain extension is a strategic business decision. Here is why .ai stands out in a crowded digital landscape:
+- **Instant industry signal:** the moment someone reads your URL, they know your product involves AI — the value proposition is in the name.
+- **Global ranking, no geo-penalty:** because Google treats .ai as generic, you are not boxed into Anguilla.
+- **Short names still available:** unlike the saturated .com market, concise, brandable .ai names can still be registered or acquired.
+- **Credibility by association:** with leading AI companies on .ai, the extension now reads as serious rather than fringe.
 
-*   **Immediate Industry Relevance:** The moment a user sees your URL, they know your business involves innovation and technology. It establishes authority and relevance instantly.
-*   **Availability of Short Names:** The .com market is saturated. It is nearly impossible to find short, one-word, or two-word brandable .com domains without spending a fortune. The .ai namespace, while premium, still offers excellent availability for concise, punchy names.
-*   **SEO Advantage:** As mentioned, search engines treat .ai as generic. You are not penalized geographically, and you gain the semantic relevance of the keyword "AI" in your URL, which can be a signal of relevance to users.
-*   **Investment Value:** .ai domains generally carry a higher registration cost than .com or .net. This creates a "velvet rope" effect—having a .ai domain signals that a company is well-funded and serious about its technology.
+## Things to consider
 
-### **.ai vs .io for AI/tech startups**
+- **Two-year minimum term:** you cannot register or renew for a single year, raising the entry cost.
+- **Premium pricing:** .ai consistently costs more than .com or .net, both at registration and renewal.
+- **Niche meaning:** if your product is not actually AI-related, the extension can confuse visitors or feel like a stretch.
+- **Hype-cycle risk:** branding tightly to "AI" ties your identity to a fast-moving trend.
 
-The two most popular "tech" extensions both began as island country codes that happened to spell something meaningful — but they send different signals:
+## Who can register a .ai domain?
 
-*   **.ai** says *Artificial Intelligence* outright. It's the sharpest choice for LLM products, machine-learning tools, AI agents, and anything that wants the value proposition baked into the name. It carries a higher price floor, which doubles as a credibility signal.
-*   **.io** (the [British Indian Ocean Territory ccTLD](/en/tld/io/)) reads as *Input/Output* and has become the default for SaaS, developer tools, and infrastructure startups. It's typically cheaper and has deep, established recognition in engineering circles.
+**Registration restrictions: open to all.** There is no local-presence, citizenship, or credential requirement to register a .ai domain — anyone worldwide can register one through an accredited [registrar](/en/glossary/registrar/). The defining rule is the **two-year minimum term**: .ai names register and renew in increments of two to ten years rather than the one-year cycle common elsewhere.
 
-**Rule of thumb:** if AI *is* your product, lead with .ai; if you're a broader developer-facing or infrastructure play, .io is the safer, more economical pick. Many teams secure both to protect their brand. For a full head-to-head — pricing, SEO, resale value, and real examples — read our dedicated breakdown: **[.ai vs .io: which domain is right for your startup?](/en/blog/ai-vs-io-domain/)**
+Names use standard ASCII characters (a–z, 0–9, and hyphens, not at the start or end), with limited support for internationalized domain names. The registry supports [DNSSEC](/en/glossary/dnssec/) for cryptographic integrity, and modern WHOIS/RDAP lookups are provided through the registry. Authoritative policy and registration rules are published by the Anguilla registry at the official site, [nic.ai](https://nic.ai/). Because .ai is a ccTLD, it is not governed by an [ICANN](/en/glossary/icann/) registry agreement; Anguilla sets its own policy.
 
-## **Frequently Asked Questions about .ai**
+## .ai pricing and value
 
-### What country has the .ai domain?
-Anguilla, a British Overseas Territory in the Eastern Caribbean. The two letters "AI" are Anguilla's official ISO 3166-1 country code.
+.ai is a premium extension, and a few dynamics drive its cost. Every registration spans a **minimum of two years**, so the upfront total is inherently higher than a one-year .com. **First-year and renewal pricing can differ**, so budget for both. And short, dictionary, or category-defining names are often classified as **premium** and priced well above standard registration. Demand from the AI sector keeps the price floor elevated. This page does not quote prices — check current rates when you register.
 
-### What country is .ai?
-.ai belongs to **Anguilla**. It was delegated as Anguilla's country code Top-Level Domain (ccTLD) in 1995 — decades before "AI" became shorthand for Artificial Intelligence.
+## Reputation and email deliverability
 
-### Is .ai a country code?
-Yes. .ai is a country code, specifically a ccTLD for Anguilla. It only *looks* like a generic "AI" extension because Anguilla's country code coincidentally matches the acronym for Artificial Intelligence.
+.ai is perceived as a **premium, serious, tech-forward** extension — close to .io in prestige and arguably ahead of it for AI-specific brands. It does not carry the spam-prone reputation associated with some cheap new gTLDs, so legitimate .ai senders are generally not at a structural disadvantage in spam filters.
 
-### Is .ai a ccTLD or a gTLD?
-Technically, .ai is a **ccTLD** (tied to Anguilla). In practice, search engines like Google treat it as a generic, non-geotargeted TLD — sometimes called a **gccTLD** — so .ai sites can rank globally rather than just in the Caribbean.
+That said, no TLD guarantees inbox placement. As with any domain, deliverability depends on proper authentication. Configure **SPF, DKIM, and DMARC**, warm up new sending domains gradually, and maintain good list hygiene. A correctly authenticated .ai domain reaches inboxes as reliably as a .com.
 
-### Who owns the .ai TLD?
-The .ai registry is administered on behalf of the **Government of Anguilla**, which holds the IANA delegation for the extension. However, each individual .ai domain you register is owned by you, the registrant.
+## Branding and naming tips
 
-### Where does .ai come from?
-The extension comes from Anguilla, which received the .ai delegation in 1995. Its popularity with Artificial Intelligence companies is a modern phenomenon driven by the rise of machine learning and generative AI.
+The most powerful .ai pattern is the **domain hack**, where the extension completes a word or phrase — `fin.ai`, `scale.ai`, or any `verb.ai` / `noun.ai` that reads naturally. Aim for short, pronounceable names; the value of .ai is partly that it lets you own a concise, meaningful URL.
 
-### Is .ai good for SEO?
-Yes. Because Google treats .ai as generic rather than geotargeted to Anguilla, .ai websites can rank worldwide. You also gain semantic relevance from having "AI" in your URL.
+Watch two pitfalls. First, people may mishear "dot A-I" as "dot AI the word" — say it as letters when speaking aloud. Second, avoid hyphens and numbers, which undercut the clean, premium feel that makes .ai worth its price.
 
-### Can I tokenize a .ai domain?
-Yes. With a Web3-native registrar like Namefi, your .ai domain can be managed as an NFT, enabling instant transfers and on-chain ownership. Learn more in [What Are Tokenized Domains?](/en/blog/what-are-tokenized-domains/).
+## How to register a .ai domain at Namefi
 
-## **Register Your .ai Domain at Namefi**
+1. **Search** your desired name on Namefi to check availability.
+2. **Choose** the registration term (remember the two-year minimum) and review whether the name is standard or premium.
+3. **Register** and complete checkout.
 
-Whether you are launching the next big LLM, building a portfolio of high-value digital assets, or simply securing your brand for the future, the time to register your .ai domain is now.
+[Namefi](https://namefi.io) is an ICANN-accredited registrar that also supports Web3 tokenized domains, so your .ai can be managed as an on-chain [NFT](/en/glossary/nft/) for easier transfer and verifiable ownership — see [what are tokenized domains](/en/blog/what-are-tokenized-domains/). You get transparent pricing, reliable DNS, and optional tokenization in one place.
 
-At **Namefi**, we go beyond traditional registration. We are an ICANN-accredited registrar that bridges the gap between Web2 and Web3. When you register a domain with us, you aren't just renting a name; you are securing a tokenized asset that offers easier transferability, enhanced security, and seamless integration with blockchain technologies.
+## Frequently asked questions
 
-**Why Namefi?**
-*   **Transparent Pricing:** Competitive rates for premium TLDs.
-*   **Tokenized Ownership:** Your domain can be managed as an NFT, allowing for instant liquidity and transfers without bureaucratic friction.
-*   **Seamless Management:** An intuitive dashboard for both DNS management and asset tracking.
+### Can anyone register a .ai domain?
 
-Don't wait until your perfect brand name is taken by a competitor.
+Yes. The .ai registry is open to anyone worldwide with no local-presence or credential requirement. The main difference from most TLDs is that .ai is sold in a minimum two-year term rather than one-year increments, which raises the upfront cost.
 
-**[Secure your .ai domain at Namefi today](https://namefi.io)** and stake your claim in the future of intelligence.
+### Does a .ai domain affect SEO?
+
+No. Google treats .ai as a generic top-level domain rather than geo-targeting it to Anguilla, so a .ai site can rank globally. The extension itself is neither a ranking boost nor a penalty; content, links, and user experience still decide rankings.
+
+### Who should register a .ai domain?
+
+It suits artificial-intelligence startups, machine-learning products, AI agents, and developer tools that want the meaning of "AI" built into the name. It is less ideal for budget projects or local non-tech businesses, given the higher price and two-year minimum term.
+
+### Who owns and operates the .ai registry?
+
+The Government of Anguilla holds the IANA delegation for .ai. Since January 2025 the technical registry back-end is operated by Identity Digital. Each individual .ai domain you register, however, is owned by you, the registrant.
+
+### Why is the minimum .ai registration two years?
+
+The Anguilla registry sets the policy: .ai domains register and renew in terms of two to ten years, not the single-year cycle common to .com. This raises the upfront cost but reduces the risk of losing a name to a missed one-year renewal.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/)
+- [.ai vs .io: which domain is right for your startup?](/en/blog/ai-vs-io-domain/)
+- [Tokenized domain use cases in 2026](/en/blog/tokenized-domain-use-cases-2026/)
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains/)
+- [.io domain](/en/tld/io/) · [.com domain](/en/tld/com/) · [.dev domain](/en/tld/dev/)
+- Glossary: [registrar](/en/glossary/registrar/) · [ICANN](/en/glossary/icann/) · [DNSSEC](/en/glossary/dnssec/) · [SEO](/en/glossary/seo/)

--- a/content/tld/en/app.md
+++ b/content/tld/en/app.md
@@ -1,106 +1,155 @@
 ---
-title: "What is a .app Domain? The Secure TLD for Apps (HTTPS by Default)"
-date: '2025-12-10'
-updated: '2026-06-10'
+title: 'What Is a .app Domain? The HTTPS-Secure TLD Explained'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: "What is a .app domain and what is it used for? Learn why Google's .app TLD requires HTTPS (HSTS preload), who should use it, and how to register a tokenized .app at Namefi."
-keywords: ['.app domain', '.app TLD', 'app domain', 'app tld', 'app tlds', '.app top level domain', 'what is .app domain used for', 'what is a .app domain', 'why choose .app', 'Google Registry .app', '.app HTTPS required', '.app HSTS preload', 'secure domains HSTS', 'mobile app landing page', 'SaaS domain names', 'developer domains', 'tokenized domains', 'blockchain domains', 'buy .app domain', 'dominio .app', 'dominios app', 'dominio app', 'qué es un dominio .app', 'registrar dominio .app', 'Namefi .app']
+description: 'The .app domain is Google Registry''s gTLD for software and apps, with HTTPS required on every site. Learn who it suits, how it ranks, and how to register one.'
+keywords: ['.app domain', 'what is .app', '.app TLD', '.app domains', 'app domain extension', 'Google Registry .app', '.app HTTPS required', 'register .app domain', 'developer domains']
+faqs:
+  - question: 'Can anyone register a .app domain?'
+    answer: 'Yes. The .app TLD is an open generic top-level domain with no eligibility restrictions, so anyone can register an available name. The one practical condition is technical, not legal: a .app site needs a valid HTTPS certificate to load in browsers.'
+  - question: 'Does a .app domain affect SEO?'
+    answer: 'Google treats .app as a standard generic gTLD with no inherent ranking advantage or penalty. Because .app forces HTTPS, you automatically meet Google''s secure-connection best practice, which is a lightweight positive signal.'
+  - question: 'Who should register a .app domain?'
+    answer: 'Mobile app makers, SaaS and web-app builders, and developers showcasing projects are the natural fit. The suffix reads as "this is a working application," making it ideal for product hubs, download pages, and login portals.'
+  - question: 'Why does a .app domain require HTTPS?'
+    answer: 'Google Registry added the entire .app zone to the browser HSTS preload list before launch. Browsers therefore upgrade every .app request to HTTPS automatically, so the domain will not load without a valid TLS certificate. You cannot opt out.'
+  - question: 'Does .app support WHOIS privacy?'
+    answer: 'Yes. As a generic gTLD, .app supports standard registrar WHOIS privacy or proxy services, and most personal registrant data is already redacted in public WHOIS output under current ICANN policy.'
 ---
 
-## **What is a .app Domain?**
+The **.app** domain is a generic top-level domain (gTLD) built for the one corner of the web everyone now lives in: software. Operated by Google Registry, it carries a clear, universally understood meaning, and it is best known for one defining rule: every .app site must be served over HTTPS. If you build mobile apps, web apps, or developer tools, a `.app` address tells visitors exactly what they are about to open before they click.
 
-The **.app** domain is a generic Top-Level Domain (gTLD) designed for applications, software developers, and technology products. It launched to the general public in **May 2018** and is operated by **Google Registry**, the same operator behind sibling extensions like [.dev](/en/tld/dev/) and .page.
+This page covers what makes .app different from generic extensions like .com, who actually uses it, how Google treats it for ranking, the registration rules, and how to register one at Namefi.
 
-Unlike legacy extensions such as .com or .net, the .app TLD was created with a clear purpose: to give the booming app economy a secure, instantly recognizable home on the internet. Whether your product is a mobile application, a web-based tool, or a backend service, a `.app` address tells users exactly what to expect before they even click the link.
+## .app at a glance
 
-The single most important thing to know about .app is its **security model**: it was the first TLD to require **HTTPS for every site**, enforced through the **HSTS preload list**. We explain exactly how that works—and what it means for you as an owner—further down this page.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (gTLD) |
+| Registry operator | Charleston Road Registry Inc. (Google Registry) |
+| Year launched | Delegated 2015; general availability May 2018 |
+| IDN support | Yes |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility gating; valid HTTPS certificate required for the site to load |
+| Best for | Mobile apps, SaaS/web apps, developer projects |
 
-For background on how new extensions like this are introduced and governed, see our glossary entries on [ICANN](/en/glossary/icann/) and what a [registrar](/en/glossary/registrar/) actually does.
+## What is .app?
 
-## **What is a .app Domain Used For?**
+The word "app" needs no translation: it is global shorthand for an application, whether on a phone, in a browser, or on a desktop. That makes .app one of the most self-explanatory new gTLDs available. A name like `getproduct.app` communicates "functional software" instantly, in a way `getproduct.com` cannot.
 
-Because "app" is a universally understood term, .app bridges the gap between developers and everyday users. Here is how it is most commonly used:
+.app is a generic gTLD, not a country-code TLD, so it carries no geographic association. According to [Google Search Central](https://developers.google.com/search/docs/crawling-indexing/managing-multi-regional-sites), new gTLDs like .app are treated as generic by default and are not tied to any single country for geo-targeting — your audience can be global. You can confirm its delegation and operator details on the [IANA root-zone entry for .app](https://www.iana.org/domains/root/db/app.html).
 
-*   **Mobile App Landing Pages:** Companies with apps on the Apple App Store or Google Play use a `.app` domain (e.g., `getproduct.app`) as a central hub for download links, release notes, and support.
-*   **Web Applications (SaaS):** Modern software lives in the browser, so SaaS providers use .app for the actual product interface and login, separating it from a marketing site that often sits on a .com.
-*   **Developer Portfolios:** Engineers use `lastname.app` or `projectname.app` to showcase coding projects, side projects, and résumés.
-*   **Documentation and Support Portals:** Tech companies spin up dedicated .app sites to host API docs, user guides, and status pages.
-*   **Product Launches:** On platforms like [Product Hunt](https://www.producthunt.com/), a growing share of new tech launches now use .app addresses, in part because the short, brandable .com market is so saturated.
+The defining technical fact about .app is its security model. It was the first TLD made available for general registration with **HTTPS enforced for every site**, baked in at the registry level via the HSTS preload list. We cover the practical consequences in the eligibility and reputation sections below.
 
-## **Why Does .app Require HTTPS? (HSTS Preload Explained)**
+## History of .app
 
-This is the defining feature of the .app TLD, and it is worth understanding properly because it directly affects how you set up your site.
+Charleston Road Registry Inc. applied for .app during ICANN's new-gTLD program. The string was contested by multiple applicants, and Google won it at a 2015 ICANN auction with a reported bid of around $25 million — at the time one of the highest amounts paid for a new gTLD. IANA records show the delegation completed in 2015.
 
-**Every .app domain is on the HSTS preload list at the registry level.** Google Registry submitted the entire `.app` zone to the **HSTS (HTTP Strict Transport Security) preload list** *before* the TLD launched. That list is honored by Chrome, Firefox, Safari, Edge, and most other modern browsers. The practical consequences:
+The namespace opened to the public in 2018. After a sunrise period for trademark holders and an early-access window with descending fees, .app reached general availability in May 2018, when anyone could register an available name at standard pricing. Google marketed it as the first TLD with built-in HTTPS security to launch for general registration. It has since become a recognizable home for app-related products, though it remains niche relative to legacy extensions.
 
-*   **HTTP is disabled, automatically.** When a browser sees any address ending in `.app`, it upgrades the connection to **HTTPS before the request is even sent**—the user never touches an insecure HTTP connection.
-*   **No certificate means no website.** If you register a .app domain but do not configure a valid **TLS/SSL certificate**, browsers will simply refuse to load it (you'll see an error like "HTTP is disabled for this domain"). The domain can be *bought* like any other, but it will not *resolve* in a browser until HTTPS is in place.
-*   **You cannot opt out.** Because the requirement is baked into the TLD via the preload list, it applies to every `.app` site, and individual domains cannot be removed from it.
+## How people use .app
 
-### **What This Means for You as an Owner**
+- **Mobile app landing pages** — a central hub for App Store and Google Play links, release notes, and support, e.g. `yourapp.app`.
+- **Web apps and SaaS** — the product interface and login surface, often kept separate from a marketing `.com`.
+- **Developer portfolios and side projects** — `name.app` or `project.app` to show working tools rather than a static résumé.
+- **Documentation, status, and API portals** — dedicated `.app` subsites for docs and uptime pages.
+- **Product launches** — concise, brandable names that are still findable, unlike the saturated short-`.com` market.
 
-*   **You need a TLS certificate before going live.** The good news: certificates are typically free and automatic. Most hosts (Vercel, Netlify, Cloudflare, GitHub Pages) and tools like [Let's Encrypt](https://letsencrypt.org/) provision and renew them for you with no manual work.
-*   **You are secure by default.** Mandatory HTTPS protects your visitors from man-in-the-middle attacks, content injection by ISPs, and credential interception on public Wi-Fi. There is no "I forgot to turn on SSL" failure mode on .app.
-*   **It builds trust.** Users see the secure-connection indicator on every visit, with no insecure-page warnings—valuable for any product handling logins, payments, or personal data.
-*   **It's good for SEO.** Google has confirmed that HTTPS is a positive ranking signal. Because .app enforces HTTPS by design, you meet that best practice automatically from day one.
+**Who it's not ideal for:** content-first sites (blogs, news, editorial), local brick-and-mortar businesses that benefit from a familiar `.com`, or any project unwilling or unable to serve over HTTPS — a `.app` site simply will not load without a valid certificate.
 
-## **Notable Entities Using .app**
+## Notable sites using .app
 
-Since launch, many high-profile companies have adopted the extension to signal security and relevance:
+- **cash.app** — Block's peer-to-peer payments service, the highest-profile .app brand, with name and URL perfectly aligned.
+- **google.app** — Google Registry, the operator itself, uses the namespace for projects and redirects.
+- **ohdear.app** — a well-known website-monitoring service that Google Registry has featured as a flagship .app site.
 
-1.  **Cash App (cash.app):** Perhaps the most famous example—Block's peer-to-peer payment service, with the brand name and URL perfectly aligned.
-2.  **Google (google.app):** As the registry operator, Google uses the extension for projects and redirects that showcase the namespace.
-3.  **Oh Dear (ohdear.app):** A well-known website monitoring service, featured by Google Registry as a flagship .app site.
-4.  **Sitata (sitata.app):** A travel safety application that hosts its web-based services on the extension.
+These are products that handle real users, logins, and payments — a reasonable signal that .app is trusted for serious applications, not just experiments.
 
-These examples show .app is trusted by products handling real users, payments, and sensitive data.
+## .app vs other domains
 
-## **Why Choose a .app Domain?**
+| | .app | [.com](/en/tld/com) | [.dev](/en/tld/dev) | [.io](/en/tld/io) |
+| --- | --- | --- | --- | --- |
+| Meaning | Application / software | Generic, universal | Developer / engineering | Tech / startup connotation |
+| Registry | Google Registry | Verisign | Google Registry | Identity Digital |
+| HTTPS enforced | Yes (HSTS preload) | No | Yes (HSTS preload) | No |
+| Availability of short names | Good | Very poor | Good | Moderate |
 
-Choosing the right extension shapes your brand's digital identity. Here's why .app is a strong choice for developers and tech businesses:
+Choose **.app** when the thing you are publishing is itself an application and you want the URL to say so. Choose **[.com](/en/tld/com)** when broad familiarity outweighs descriptiveness. Choose **[.dev](/en/tld/dev)** for developer tooling and engineering audiences, and **[.io](/en/tld/io)** when you want a general tech-startup feel. Both .app and [.dev](/en/tld/dev) share the same registry and the same mandatory-HTTPS model.
 
-*   **Built-in Security:** Enforced HTTPS via HSTS preload means your users are protected by default—and so is your reputation.
-*   **Instant Recognition:** The extension describes your product immediately. A `.app` address tells visitors they're heading to a functional tool or application.
-*   **SEO Advantage by Default:** Mandatory HTTPS aligns you with Google's ranking best practices from the start.
-*   **Availability:** Short, one-word .com names are nearly impossible to find or wildly expensive. The .app namespace still offers excellent availability for concise, memorable, brandable names.
-*   **Trust Factor:** In an era of phishing and spoofed sites, a guaranteed secure connection raises user confidence.
+## Why choose .app?
 
-If you're weighing .app against other developer-friendly extensions, compare it with our guides to [.dev](/en/tld/dev/) and [.tech](/en/tld/tech/) to find the best fit for your project.
+- **Built-in security.** Enforced HTTPS via HSTS preload means there is no "I forgot to enable SSL" failure mode, and visitors never hit an insecure-page warning.
+- **Instant meaning.** The suffix describes the product, which is rare among extensions and useful for click-through and recall.
+- **Availability.** Short, one-word names that are long gone in `.com` are still attainable in .app.
+- **Generic, global treatment.** No country lock-in, so it suits an international audience.
 
-## **Frequently Asked Questions About .app Domains**
+## Things to consider
 
-**What is a .app domain used for?**
-It's used for anything app-related: mobile app landing pages, web apps and SaaS products, developer portfolios, documentation portals, and product launch sites. The extension signals "this is a functional application" at a glance.
+- **HTTPS is mandatory, not optional.** You must configure a valid TLS certificate before the site will resolve in any modern browser. This is trivial on hosts like Vercel, Netlify, Cloudflare, or GitHub Pages, but it is a hard requirement.
+- **Lower baseline familiarity than .com.** Some non-technical users still default to typing `.com`, so a `.app` brand may want to defend the matching `.com` if it is available.
+- **Narrower meaning.** The suffix's strength — "this is an app" — is also a limit: it fits software and products, but reads oddly for a blog, a charity, or a local shop.
+- **Single-operator namespace.** Both .app and .dev are run by Google Registry, so policy and roadmap decisions sit with one operator.
 
-**Why does .app require HTTPS?**
-Because Google Registry placed the entire .app TLD on the browser HSTS preload list before launch. Browsers automatically upgrade every .app connection to HTTPS, so a valid TLS/SSL certificate is mandatory for the site to load.
+## Who can register a .app domain?
 
-**Can I buy a .app domain without an SSL certificate?**
-Yes—you can register and own a .app domain without one. But it will not display in a browser until you add a valid TLS certificate. Most modern hosting providers supply these for free and automatically.
+**Registration restrictions: open to all.** .app is an unrestricted generic gTLD. There is no credential, membership, industry, or local-presence requirement — anyone, anywhere can register an available name. The only real condition is technical: because the zone is on the HSTS preload list, a .app domain will not display in a browser until you attach a valid HTTPS certificate. You can buy and own the name without one, but it will not resolve as a website.
 
-**Is .app good for SEO?**
-Yes. Google treats HTTPS as a ranking signal, and .app enforces HTTPS by default, so you satisfy that requirement automatically. The extension itself is treated neutrally for ranking, just like other gTLDs.
+Standard gTLD policies apply otherwise: a sunrise phase ran at launch for trademark holders, IDN names and DNSSEC are supported, and registrars offer WHOIS privacy or proxy services (with most personal data already redacted under current ICANN policy). Transfers, renewals, and the redemption grace period follow ordinary gTLD rules. The authoritative governing document is the [ICANN Registry Agreement for .app](https://www.icann.org/en/registry-agreements/details/app); launch and policy details are published by [Google Registry](https://www.registry.google/).
 
-**Who operates the .app TLD?**
-Google Registry operates .app. It is a generic Top-Level Domain (gTLD) available to anyone, not restricted to a specific country or industry.
+## .app pricing and value
 
-**Can I tokenize a .app domain?**
-Yes. With Namefi you can register a .app domain and mint it as an on-chain asset (an NFT), making it easy to transfer, trade, or use in Web3 applications while keeping full ICANN-compliant ownership. Learn more in [What Are Tokenized Domains?](/en/blog/what-are-tokenized-domains/)
+This static page lists no prices, but here is how .app pricing behaves. .app sits in the standard new-gTLD tier rather than the budget bracket, priced comparably to other premium-feel suffixes. Expect **first-year and renewal pricing to differ**, and remember that renewals recur for as long as you hold the name, so budget for the ongoing rate. A subset of short, dictionary, or otherwise desirable names are classified as **premium** and carry higher registry-set fees. The drivers of cost are name length, keyword desirability, and premium status — the extension itself, not any promotion, sets the floor.
 
-## **Register Your .app Domain at Namefi**
+## Reputation and email deliverability
 
-Ready to secure the perfect home for your application? At Namefi, registering your **.app** domain is simple, secure, and future-proof.
+.app is perceived as **modern, secure, and developer-credible** rather than cheap or spammy. Two factors help: it is run by Google, and its mandatory-HTTPS model means there is no such thing as an insecure .app site, which discourages some throwaway abuse patterns common to ultra-cheap TLDs.
 
-Namefi isn't just a standard registrar—we bridge Web2 and Web3. When you register with us, you don't just rent a name; you secure a digital asset that can be tokenized and easily managed or traded on the blockchain.
+That said, newer gTLDs sometimes draw slightly more cautious spam-filter treatment than long-established extensions, simply because they have a shorter track record. If you send email from a .app domain, the mitigation is the same as for any domain: publish correct **SPF, DKIM, and DMARC** records, warm up volume gradually, and keep your list clean. Done properly, .app deliverability is on par with mainstream extensions.
 
-**Why register with Namefi?**
-*   **ICANN Accredited:** Fully compliant, secure registration.
-*   **Seamless Web3 Integration:** Mint your domain as an NFT for easier transfer and liquidity.
-*   **Competitive Pricing:** Launch your project without breaking the budget.
+## Branding and naming tips
 
-Don't let your perfect app name get taken by a competitor. Secure your digital real estate today.
+The cleanest .app names are ones where "app" completes the brand, not just trails it — `cash.app` works because the result reads as a phrase. Use it when the suffix adds meaning (`tracker.app`, `notes.app`) rather than fighting it. Keep names short and easy to dictate aloud, since "dot app" is unambiguous to say. If your audience is non-technical, consider securing the matching `.com` as a safety net for direct-type traffic. Hyphens and tricky spellings hurt recall here just as anywhere.
 
-[**Register your .app domain at Namefi**](https://namefi.io)
+## How to register a .app domain at Namefi
+
+1. Search your desired name on [Namefi](https://namefi.io) to check .app availability.
+2. Choose the name and confirm whether it is a standard or premium registration.
+3. Register, then point the domain at your host and ensure HTTPS is configured so the site loads.
+
+Namefi is an ICANN-accredited registrar with transparent pricing, and it bridges Web2 and Web3: you can register a .app and optionally mint it as an on-chain asset (an NFT) for easier transfer and trading, while keeping full ICANN-compliant ownership and fast DNS. To understand tokenization first, see [What Are Tokenized Domains?](/en/blog/what-are-tokenized-domains)
+
+[Register your .app domain at Namefi](https://namefi.io)
+
+## Frequently asked questions
+
+### Can anyone register a .app domain?
+
+Yes. The .app TLD is an open generic top-level domain with no eligibility restrictions, so anyone can register an available name. The one practical condition is technical, not legal: a .app site needs a valid HTTPS certificate to load in browsers.
+
+### Does a .app domain affect SEO?
+
+Google treats .app as a standard generic gTLD with no inherent ranking advantage or penalty. Because .app forces HTTPS, you automatically meet Google's secure-connection best practice, which is a lightweight positive signal.
+
+### Who should register a .app domain?
+
+Mobile app makers, SaaS and web-app builders, and developers showcasing projects are the natural fit. The suffix reads as "this is a working application," making it ideal for product hubs, download pages, and login portals.
+
+### Why does a .app domain require HTTPS?
+
+Google Registry added the entire .app zone to the browser HSTS preload list before launch. Browsers therefore upgrade every .app request to HTTPS automatically, so the domain will not load without a valid TLS certificate. You cannot opt out.
+
+### Does .app support WHOIS privacy?
+
+Yes. As a generic gTLD, .app supports standard registrar WHOIS privacy or proxy services, and most personal registrant data is already redacted in public WHOIS output under current ICANN policy.
+
+## Related resources
+
+- [.dev domain](/en/tld/dev) — the sibling Google Registry gTLD with the same mandatory-HTTPS model.
+- [.com domain](/en/tld/com) — the universal default to compare against.
+- [.io domain](/en/tld/io) and [.tech domain](/en/tld/tech) — other tech-leaning extensions.
+- [What Are Tokenized Domains?](/en/blog/what-are-tokenized-domains) — how registering with Namefi lets you mint a domain on-chain.
+- [Domain Terminology Guide](/en/blog/domain-terminology-guide) — definitions for gTLD, DNSSEC, and more.
+- Glossary: [ICANN](/en/glossary/icann), [registrar](/en/glossary/registrar), [DNS](/en/glossary/dns), [DNSSEC](/en/glossary/dnssec).

--- a/content/tld/en/blog.md
+++ b/content/tld/en/blog.md
@@ -1,45 +1,165 @@
 ---
-title: What is .blog TLD and why choose it?
-date: '2025-12-10'
+title: 'What Is the .blog Domain? The Extension Built for Content'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: Explore the .blog TLD and learn how it can elevate your online presence. Secure your .blog domain today with Namefi!
-keywords: ['.blog', 'blog domain', 'domain name', 'tld', 'domain investing', 'web3 domains', 'blogging', 'domain registration', 'ICANN', 'Namefi', 'website', 'online presence', 'brand building', 'digital marketing', 'content creation']
+description: 'The .blog domain is an open gTLD run by Automattic that instantly signals a content site. Learn who it suits, how it is priced, and its email reputation.'
+keywords: ['.blog domain', 'what is .blog', '.blog TLD', 'blog domain name', 'Automattic .blog', 'gTLD for blogs', 'register .blog domain', 'content website domain']
+faqs:
+  - question: 'Can anyone register a .blog domain?'
+    answer: 'Yes. The .blog TLD is open to everyone with no eligibility, credential, or local-presence requirement. You do not need to run a blog or use WordPress to register one. The only exception is premium-tier names, which carry higher registry pricing but no extra qualification.'
+  - question: 'Does a .blog domain affect SEO?'
+    answer: 'No. Google treats .blog like any other generic top-level domain and does not rank it higher or lower than .com. A descriptive extension can lift click-through rates because the suffix tells searchers the site is a blog, but the suffix itself is not a ranking factor.'
+  - question: 'Who should register a .blog domain?'
+    answer: 'It suits bloggers, writers, journalists, marketing teams, and companies running a content or news hub who want the URL to state its purpose. It works especially well as a brandable second-level word, such as a company name followed by .blog.'
+  - question: 'Who operates the .blog registry?'
+    answer: 'The registry operator is Knock Knock WHOIS There, LLC, a subsidiary of Automattic, the company behind WordPress.com. The TLD was delegated in 2016 and reached general availability in November of that year. CentralNic provides the back-end registry services.'
+  - question: 'Is .blog good for email deliverability?'
+    answer: 'It is generally fine. As an established gTLD it is not broadly blocklisted, but any newer extension can draw slightly more scrutiny from spam filters than .com. Authenticate mail with SPF, DKIM, and DMARC and warm up a new sending domain gradually.'
 ---
 
-## **What is .blog?**
+The **.blog domain** is one of the few extensions that explains itself: the moment a reader sees it, they know the site publishes content. For writers, journalists, marketers, and companies running a news or insights hub, that clarity is the whole point of buying it. It is an open generic top-level domain (gTLD) operated by the company behind WordPress, which gives it unusual credibility in the publishing world.
 
-The .blog Top-Level Domain (TLD) is a generic TLD (gTLD) specifically designed for blogs, online journals, and content-driven websites. Launched in 2016, .blog provides a clear and recognizable domain extension for anyone looking to establish a strong online presence through blogging. Unlike generic TLDs like .com, .blog instantly communicates the nature of your website to visitors. It is managed by Automattic, the company behind WordPress.com, offering a relevant and focused domain space for bloggers of all kinds. You can learn more about gTLDs on [ICANN's website](https://www.icann.org/resources/pages/what-is-gtld-2012-02-25-en).
+This page covers what .blog is, who runs it, who can register it, how its pricing works, and how it is perceived for email and SEO — so you can decide whether it fits your project.
 
-## **How People Are Using .blog**
+## .blog at a glance
 
-*   **Individual Bloggers:** Sharing personal stories, passions, and expertise.
-*   **Businesses:** Publishing company news, industry insights, and customer testimonials.
-*   **Creative Professionals:** Showcasing portfolios, behind-the-scenes content, and project updates.
-*   **Organizations:** Sharing announcements, research, and advocacy efforts.
-*   **Podcasters:** Providing show notes, transcripts, and additional content for their audio content.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (gTLD) |
+| Registry operator | Knock Knock WHOIS There, LLC (an Automattic subsidiary) |
+| Year launched | 2016 (general availability November 2016) |
+| Back-end registry | CentralNic |
+| IDN support | Yes |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no credential or local presence required |
+| Best for | Blogs, content hubs, company news sites, personal brands |
 
-## **Notable Entities Using .blog**
+## What is .blog?
 
-While specific famous examples fluctuate, .blog is widely adopted across various sectors:
+.blog is a generic top-level domain, not a country-code extension, so it carries no geographic association. The word "blog" is itself a contraction of "weblog," and the suffix puts that meaning directly in the address bar. Because it is generic, [Google's Search Central documentation](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites) treats it the same as .com for international and geo-targeting purposes — it is not tied to any single country and can rank globally.
 
-*   **Tech Companies:** Sharing development updates and insights.
-*   **Marketing Agencies:** Offering blogging tips and industry best practices.
-*   **Lifestyle Brands:** Engaging audiences with lifestyle content and product features.
-*   **Food Bloggers:** Recipe blogs with easily identifiable domain names.
+The extension is unusual among new gTLDs because its registry operator is a recognizable name in publishing rather than a pure domain-industry company. You can confirm the delegation details in the [IANA root-zone database entry for .blog](https://www.iana.org/domains/root/db/blog.html).
 
-## **Why Choose .blog?**
+## History of .blog
 
-*   **Relevance:** Instantly communicate that your website is a blog, attracting the right audience.
-*   **Branding:** Create a memorable and consistent brand identity centered around your blog.
-*   **Availability:** Increase your chances of securing your desired domain name compared to more saturated TLDs like .com.
-*   **SEO potential:** Although not a direct ranking factor, a relevant domain name can improve click-through rates, potentially boosting SEO performance.
-*   **Memorability:** .blog is easy to remember and share, making it ideal for building a loyal readership.
+.blog was delegated in 2016 after Automattic — the parent company of WordPress.com — acquired the rights to operate it. The registry is formally held by a subsidiary, Knock Knock WHOIS There, LLC, which ICANN requires to operate at arm's length from the registrar business.
 
-## **Register Your .blog Domain at Namefi**
+Key milestones:
 
-Ready to launch your blog with a perfect domain name? Namefi makes it easy to register your .blog domain and get your content out there! As an ICANN-accredited registrar, we provide a secure and reliable platform for managing your domains. Plus, with our seamless Web3 integration, you can easily connect your domain to decentralized applications and explore the future of the internet. Check out our full list of features at [Namefi](https://namefi.io).
+- **2016** — Sunrise for trademark holders began in August, followed by a landrush phase, with general availability opening on 21 November 2016.
+- **2019** — The registry moved its back-end technical provider to CentralNic, having previously used Nominet, as reported by industry outlets such as [Domain Name Wire](https://domainnamewire.com/).
+- **Ongoing** — Adoption has grown into the hundreds of thousands of registrations, spread across personal, corporate, and news publishing.
 
-Don't wait! Secure your .blog domain today and start building your online presence.
+The registry's own informational site runs on the suffix at nic.blog, and WordPress's own news has been published under a wordpress.blog address — fitting, given the operator.
+
+## How people use .blog
+
+- **Personal blogs and creators** — writers who want a clean, on-topic URL instead of a long .com.
+- **Company content hubs** — businesses that host their articles on a dedicated `<brand>.blog` rather than a `/blog` subdirectory.
+- **News and niche publications** — sites covering finance, technology, beauty, music, politics, or travel.
+- **Multilingual publishing** — the word "blog" is understood across many languages, so it travels well internationally.
+- **Domain hacks** — short brand or word combinations that read naturally with the suffix.
+
+**Who it's not ideal for:** e-commerce stores, SaaS products, or brands whose audience expects a .com and may distrust an unfamiliar extension. If the site is not primarily about publishing, the suffix can mislead visitors.
+
+## Notable sites using .blog
+
+- **wordpress.blog** — WordPress.com has published company and product news under a .blog address, a natural fit given Automattic operates the registry.
+- **nic.blog** — the registry's own informational site about the extension and its policies.
+
+Beyond these, the suffix is widely used by independent creators and corporate content teams rather than by a small set of household-name sites; its strength is descriptive clarity rather than celebrity adoption. We avoid naming sites whose current status we cannot verify.
+
+## .blog vs other domains
+
+| Extension | Signal | Restrictions | Typical use |
+| --- | --- | --- | --- |
+| [.com](/en/tld/com) | Neutral, universal default | Open | Anything; the safe baseline |
+| .blog | "This is a blog/content site" | Open | Publishing, content hubs |
+| [.org](/en/tld/org) | Organization, non-profit feel | Open | Communities, causes, projects |
+| [.xyz](/en/tld/xyz) | Modern, generic, low-cost | Open | Startups, experiments |
+
+Choose .com when you want the most familiar, resale-friendly address. Choose **.blog** when the site's identity *is* content and you want the URL to say so. Consider [.org](/en/tld/org) for a community or mission-driven publication, and [.xyz](/en/tld/xyz) when you want a flexible, inexpensive modern suffix without a topical meaning.
+
+## Why choose .blog?
+
+- **Instant clarity** — the suffix tells visitors and searchers exactly what the site is.
+- **Better availability** — many short, memorable names that are long gone in .com remain open in .blog.
+- **Credible operator** — being run by Automattic ties the extension to the publishing ecosystem.
+- **Global readability** — "blog" is widely understood across languages, helping international audiences.
+
+## Things to consider
+
+- **Premium tiers exist** — short or high-demand names are classified as premium and cost more, sometimes at every renewal.
+- **Narrow meaning** — the suffix pigeonholes the site as a blog, which is limiting if you later pivot to a product or store.
+- **Less universal recognition** — some non-technical audiences still default to expecting .com and may mistype the address.
+- **Renewal differs from first year** — like most gTLDs, standard registration and renewal prices are not the same.
+
+## Who can register a .blog domain?
+
+**Registration restrictions: open to all.** There is no credential, membership, local-presence, or community requirement. You do not need to operate a blog, use WordPress, or prove any qualification — anyone worldwide can register an available .blog name.
+
+The TLD supports internationalized domain names (IDNs) and DNSSEC for signed, tamper-evident DNS. A trademark Sunrise phase ran at launch; today, brand owners can rely on the Trademark Clearinghouse for ongoing protections. Standard ICANN lifecycle rules apply, including the 60-day transfer lock after registration or registrar transfer and the redemption grace period for expired names. Because .blog is a gTLD, its rules are governed by an ICANN Registry Agreement, and the authoritative operator record is the [IANA root-zone entry for .blog](https://www.iana.org/domains/root/db/blog.html). WHOIS privacy is offered through registrars rather than mandated by the registry.
+
+## .blog pricing and value
+
+.blog uses a two-tier pricing model. Most names register at a standard rate, while a pool of short, common, or high-value words is reserved as **premium**, carrying higher registry fees. An important nuance: some premium .blog names renew at their premium price every year, not just in year one, so check a name's renewal tier before committing to it as a long-term brand.
+
+As with virtually all gTLDs, first-year and renewal pricing differ, and the registry — not the registrar — sets the wholesale and premium tiers. Cost drivers include the name's length, dictionary value, and premium classification. We do not list specific prices here because they vary by registrar and change over time.
+
+## Reputation and email deliverability
+
+.blog reads as a legitimate, purpose-built publishing extension rather than a bargain-bin suffix, which works in its favor for trust. As an established gTLD it is not broadly blocklisted. That said, any extension outside the .com/.net core can attract marginally more scrutiny from aggressive spam filters, particularly for a brand-new sending domain with no reputation history.
+
+The fix is standard email hygiene, not avoiding the suffix: publish SPF, DKIM, and DMARC records, send from a consistent domain, and warm up a new sender by gradually increasing volume. A correctly authenticated .blog domain delivers mail reliably.
+
+## Branding and naming tips
+
+- **Lead with the brand:** `acme.blog` reads cleanly and avoids the redundant `acmeblog.com`.
+- **Keep it short:** the suffix already adds five characters, so a concise second-level word stays memorable.
+- **Mind premium tiers:** the most brandable single words are often premium — budget for that or pick a compound.
+- **Avoid confusion:** since some users still type ".com" by reflex, make sure the spoken name is unambiguous.
+
+## How to register a .blog domain at Namefi
+
+1. Search your desired name on [Namefi](https://namefi.io) to check availability and tier.
+2. Choose the .blog result (watch for premium pricing on short names).
+3. Complete registration with transparent pricing and fast DNS setup.
+
+As an ICANN-accredited registrar, Namefi also lets you tokenize your domain for Web3 use, bridging traditional registration and on-chain ownership.
+
+## Frequently asked questions
+
+### Can anyone register a .blog domain?
+
+Yes. The .blog TLD is open to everyone with no eligibility, credential, or local-presence requirement. You do not need to run a blog or use WordPress to register one. The only exception is premium-tier names, which carry higher registry pricing but no extra qualification.
+
+### Does a .blog domain affect SEO?
+
+No. Google treats .blog like any other generic top-level domain and does not rank it higher or lower than .com. A descriptive extension can lift click-through rates because the suffix tells searchers the site is a blog, but the suffix itself is not a ranking factor.
+
+### Who should register a .blog domain?
+
+It suits bloggers, writers, journalists, marketing teams, and companies running a content or news hub who want the URL to state its purpose. It works especially well as a brandable second-level word, such as a company name followed by .blog.
+
+### Who operates the .blog registry?
+
+The registry operator is Knock Knock WHOIS There, LLC, a subsidiary of Automattic, the company behind WordPress.com. The TLD was delegated in 2016 and reached general availability in November of that year. CentralNic provides the back-end registry services.
+
+### Is .blog good for email deliverability?
+
+It is generally fine. As an established gTLD it is not broadly blocklisted, but any newer extension can draw slightly more scrutiny from spam filters than .com. Authenticate mail with SPF, DKIM, and DMARC and warm up a new sending domain gradually.
+
+## Related resources
+
+- [What is a domain?](/en/blog/what-is-domain)
+- [Domain terminology guide](/en/blog/domain-terminology-guide)
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains)
+- [Glossary: gTLD and TLD](/en/glossary/tld)
+- [Glossary: registrar](/en/glossary/registrar)
+- [Glossary: DNSSEC](/en/glossary/dnssec)
+- [.com domain](/en/tld/com)
+- [.org domain](/en/tld/org)
+- [.xyz domain](/en/tld/xyz)

--- a/content/tld/en/city.md
+++ b/content/tld/en/city.md
@@ -1,40 +1,157 @@
 ---
-title: What is .city TLD and why it's perfect for local businesses?
-date: '2025-06-21'
-language: en
+title: 'What Is the .city Domain? A Guide for Local Brands'
+date: '2026-06-15'
+language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: .city is the domain for local businesses, municipal services, and city-focused websites. Perfect for establishing local presence.
+description: '.city is an open generic top-level domain run by Identity Digital, built for local businesses, city guides, and community sites. Here is who it suits and why.'
+keywords: ['.city domain', 'what is .city', '.city TLD', 'local business domain', 'city domain name', 'Identity Digital', 'new gTLD', 'community website domain']
+faqs:
+  - question: 'Can anyone register a .city domain?'
+    answer: 'Yes. .city is an open generic top-level domain with no eligibility restrictions. Anyone in the world can register an available .city name without proving local presence, government ties, or any credential. Standard registry acceptable-use rules still apply.'
+  - question: 'Does a .city domain affect SEO?'
+    answer: 'No. Google treats .city as a generic domain, so it carries no inherent ranking penalty or boost. Search rankings depend on content, links, and user experience, not on the suffix you choose.'
+  - question: 'Who should register a .city domain?'
+    answer: 'Local businesses, city guides, tourism sites, community portals, neighborhood directories, and local events benefit most, especially when the exact .com is taken. It pairs a place name or keyword with the literal word city for an instantly clear address.'
+  - question: 'Is .city good for a local business website?'
+    answer: 'Yes, when the name reads naturally. A domain like yourtown.city or coffee.city signals local relevance at a glance. It works best for businesses, guides, and services tied to a specific place rather than global brands.'
+  - question: 'Does .city support WHOIS privacy and DNSSEC?'
+    answer: 'Yes. Most registrars offer free WHOIS privacy on .city, and the registry supports DNSSEC for cryptographic protection of DNS records. Availability of each depends on your chosen registrar.'
 ---
 
-## **What is .city?**
+The **.city domain** is one of the clearest descriptive web addresses available: it pairs any name with the literal word "city," producing addresses that read like a label. For local businesses, tourism boards, community projects, and city guides, it turns a domain into a tagline. If the exact .com you want is taken, a name like `yourtown.city` can be more memorable than a hyphenated alternative.
 
-**.city** is a location-focused top-level domain (TLD, a domain suffix that comes after the final dot in an internet address) designed for **local businesses, municipal services, and city-focused websites**. It emphasizes local presence and community connection.
+This page covers what .city is, who runs it, who can register one, how pricing works, and how it is perceived by people and spam filters.
 
----
+## .city at a glance
 
-## **How People Use .city**
+| Fact | Detail |
+| --- | --- |
+| TLD type | New gTLD (generic top-level domain) |
+| Registry operator | Binky Moon, LLC (an [Identity Digital](https://www.identity.digital/) company) |
+| Year launched | 2014 |
+| IDN support | Yes |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility requirements |
+| Best for | Local businesses, city guides, tourism, community and events sites |
 
-* **Local businesses** and services
-* **Municipal websites** and city services
-* **Tourism websites** and city guides
-* **Local news** and community information
-* **City events** and local directories
+## What is .city?
 
----
+`.city` is a **generic top-level domain (gTLD)** introduced during ICANN's 2012 new-gTLD expansion, which created hundreds of descriptive suffixes beyond the original handful like `.com` and `.org`. The meaning needs no explanation: the suffix is the English word "city," so a `.city` address instantly communicates a connection to a place, an urban community, or local life.
 
-## **Why Choose .city?**
+Because it is a generic suffix rather than a country-code domain, **Google does not geo-target `.city` to any single region**. A `.city` site is treated like any other generic domain for search; the suffix itself confers no ranking advantage or penalty, as Google's guidance on generic top-level domains makes clear. The local signal a buyer gets from `.city` is about human readability and branding, not an automatic search-engine boost. You can confirm the delegation record on the [IANA root-zone database entry for .city](https://www.iana.org/domains/root/db/city.html).
 
-* **Local Focus**: Perfect for location-based businesses
-* **Community Connection**: Emphasizes local presence
-* **SEO Benefits**: Good for local search optimization
-* **Clear Purpose**: Immediately understood meaning
+## History of .city
 
----
+The `.city` string was delegated to the root zone in **2014**, part of the wave of new gTLDs that operator Donuts Inc. applied for and launched in that era. Donuts rebranded as **Identity Digital** in 2022 and, following an earlier consolidation, holds its original gTLD contracts under the subsidiary **Binky Moon, LLC** — the entity now named as the registry operator for `.city`.
 
-## **Register Your .city Domain**
+Identity Digital runs one of the largest portfolios of descriptive gTLDs in the industry, which means `.city` sits alongside a consistent family of place- and topic-based extensions (`.town`, `.land`, `.house`, `.realty`, and many more) sharing the same registry policies and infrastructure. The suffix has settled into a steady niche role: it is not a mass-market giant like `.com`, but it has durable, ongoing use for local and community-oriented sites.
 
-Register your **.city domain at [Namefi](https://namefi.io)** today.
+## How people use .city
 
-👉 **Visit [namefi.io](https://namefi.io) and secure your .city domain.**
+`.city` works best when the name to the left of the dot makes the whole address read like a phrase:
+
+- **Local business sites** — a shop, restaurant, or service naming its town or trade, e.g. `coffee.city`.
+- **City guides and tourism** — travel, dining, and what-to-do sites for a specific place.
+- **Community and neighborhood portals** — residents' associations, local news, and directories.
+- **Local events and festivals** — a clean, on-theme address for an event tied to a place.
+- **Civic and public-interest projects** — initiatives organized around urban life and local issues.
+
+**Who it's not ideal for:** global brands, SaaS products, or anything with no geographic or community angle. For those, a generic startup-friendly suffix such as [.io](/en/tld/io) or [.xyz](/en/tld/xyz), or the default [.com](/en/tld/com), usually communicates intent more accurately than `.city`.
+
+## Notable sites using .city
+
+`.city` is used primarily by **local and regional projects** rather than household-name global brands, so its footprint is broad but distributed. In practice you will most often see it on city guides, local directories, neighborhood and tourism portals, and community or event sites — typically formed as `<place>.city` or `<topic>.city`. Rather than cite a high-profile example that may change hands, the honest picture is that `.city` lives in the long tail of the web: small, place-focused sites where the suffix does descriptive work a generic suffix cannot.
+
+## .city vs other domains
+
+| Feature | .city | [.com](/en/tld/com) | [.online](/en/tld/online) | [.club](/en/tld/club) |
+| --- | --- | --- | --- | --- |
+| Type | New gTLD | Legacy gTLD | New gTLD | New gTLD |
+| Core signal | Local / urban | Universal default | General web presence | Community / membership |
+| Availability of good names | High | Low | Moderate | Moderate |
+| Best fit | Place-based sites | Anything | Broad / generic | Groups, communities |
+
+Pick `.com` when it is available and the brand is global. Choose `.city` when your project is genuinely tied to a place and the descriptive suffix completes the name. [.club](/en/tld/club) overlaps for community-driven projects, while [.online](/en/tld/online) and [.site](/en/tld/site) are more neutral, general-purpose alternatives when "city" is too specific.
+
+## Why choose .city?
+
+- **Instant clarity.** The suffix is a common English word, so the address explains itself with zero learning curve.
+- **Strong availability.** Because the namespace is far less crowded than `.com`, short, exact-match local names are often still open.
+- **Brandable structure.** `<place>.city` or `<keyword>.city` reads as a complete phrase, which is memorable on signage, cards, and ads.
+- **Backed by a major registry.** Identity Digital operates a large, stable portfolio with consistent policies and DNSSEC support.
+
+## Things to consider
+
+- **It is descriptive, not universal.** A `.city` address signals "local," which is a strength for the right project and a limitation for a global brand.
+- **Renewal pricing differs from the first year.** Like most new gTLDs, `.city` renewals can be priced higher than an introductory first-year registration — budget for the renewal rate.
+- **Premium names exist.** Some sought-after `.city` strings are reserved as premium names with elevated, registry-set pricing.
+- **Lower recognition than `.com`.** Some non-technical visitors still assume every site ends in `.com`, so reinforce the full address in your branding.
+
+## Who can register a .city domain?
+
+**Registration restrictions: open to all.** `.city` has **no eligibility requirements** — you do not need to be a municipality, a resident, a local business, or hold any credential. Anyone worldwide can register an available `.city` name on a first-come, first-served basis, subject to the registry's standard acceptable-use rules. Unlike credential-gated suffixes such as `.law` or `.cpa`, there is no verification step.
+
+Standard practices apply: the registry's sunrise period for trademark holders closed long ago, IDN (internationalized domain name) registrations are supported, and the namespace follows normal length rules. On the administrative side, `.city` supports **DNSSEC**, most registrars offer **WHOIS privacy**, and the suffix follows the usual gTLD lifecycle for transfers, renewals, and the redemption grace period after expiry. The authoritative rules — including the Acceptable Use Policy and reserved-names policy — are published on [Identity Digital's policies page](https://www.identity.digital/policies/).
+
+## .city pricing and value
+
+This page never quotes live prices, but the **pricing dynamics** are worth understanding. `.city` is a mid-tier new gTLD: standard registrations are typically priced above the cheapest commodity suffixes but well below scarce legacy assets. Three factors drive what you pay:
+
+- **First-year vs. renewal.** Introductory first-year pricing is often lower than the ongoing renewal rate, which is the figure that matters over the life of a domain.
+- **Premium tier.** A subset of high-demand `.city` strings are designated as **premium names** with registry-set pricing — and sometimes premium renewals — well above standard.
+- **Registrar margin and add-ons.** Privacy, DNS hosting, and other services vary by registrar and affect total cost.
+
+Always check the **renewal** price, not just the headline first-year rate, before committing to a name.
+
+## Reputation and email deliverability
+
+New gTLDs as a category have occasionally drawn extra scrutiny from spam filters, because cheap, bulk-registered suffixes have been abused for throwaway domains. `.city` itself is **not a notorious spam suffix**, and its association with legitimate local businesses and civic projects works in its favor — but a brand-new domain on any newer suffix can start with a neutral-to-cautious reputation.
+
+The practical fix is the same as for any domain: **build sender reputation deliberately.** Authenticate your mail with SPF, DKIM, and DMARC, warm up new sending domains gradually, and avoid spammy content. Done properly, `.city` delivers reliably; deliverability problems trace back to sending practices far more often than to the suffix.
+
+## Branding and naming tips
+
+- **Make it read as a phrase.** The best `.city` names complete a thought: `explore<place>.city`, `<trade>.city`, `<neighborhood>.city`.
+- **Lead with the place or keyword.** Put the meaningful word first so the suffix lands as the natural ending.
+- **Watch for ambiguity.** Because "city" is a real word, double-check that the full string does not accidentally form an unintended phrase.
+- **Reinforce the full domain.** In voice and print, say and show the whole address so people don't default to typing `.com`.
+
+## How to register a .city domain at Namefi
+
+1. **Search** your desired `.city` name to check availability.
+2. **Choose** the exact string that best fits your brand or place.
+3. **Register** it and configure DNS.
+
+Namefi is an ICANN-accredited registrar with transparent pricing and fast DNS, and it can additionally **tokenize** your domain as a Web3 asset for on-chain ownership and transfer. Start your search at [Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .city domain?
+
+Yes. `.city` is an open generic top-level domain with no eligibility restrictions. Anyone in the world can register an available `.city` name without proving local presence, government ties, or any credential. Standard registry acceptable-use rules still apply.
+
+### Does a .city domain affect SEO?
+
+No. Google treats `.city` as a generic domain, so it carries no inherent ranking penalty or boost. Search rankings depend on content, links, and user experience, not on the suffix you choose.
+
+### Who should register a .city domain?
+
+Local businesses, city guides, tourism sites, community portals, neighborhood directories, and local events benefit most, especially when the exact `.com` is taken. It pairs a place name or keyword with the literal word "city" for an instantly clear address.
+
+### Is .city good for a local business website?
+
+Yes, when the name reads naturally. A domain like `yourtown.city` or `coffee.city` signals local relevance at a glance. It works best for businesses, guides, and services tied to a specific place rather than global brands.
+
+### Does .city support WHOIS privacy and DNSSEC?
+
+Yes. Most registrars offer free WHOIS privacy on `.city`, and the registry supports DNSSEC for cryptographic protection of DNS records. Availability of each depends on your chosen registrar.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [Domain terminology guide](/en/blog/domain-terminology-guide)
+- [ICANN](/en/glossary/icann) and [registrar](/en/glossary/registrar) glossary terms
+- Compare with [.com](/en/tld/com), [.online](/en/tld/online), and [.club](/en/tld/club)

--- a/content/tld/en/click.md
+++ b/content/tld/en/click.md
@@ -1,60 +1,143 @@
 ---
-title: "Drive Action with Your Link: What is the .click TLD and Why Choose It?"
-date: '2025-12-10'
+title: 'What Is the .click Domain? The Call-to-Action TLD Explained'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: "Explore the .click TLD: the perfect domain for calls-to-action, photography, and digital marketing. Learn why .click drives engagement and how to register yours."
-keywords: [".click domains", ".click TLD", "top-level domain", "what is .click", "why choose .click", "what is the .click domain", "why choose the .click domain", "buy .click domain", "call to action TLD", "marketing domains", "photography domains", "link shortener domains", "domain investing", "tokenized domains", "Namefi"]
+description: 'The .click domain is an open new gTLD built around the web''s core action. Learn who runs it, who it suits, its pricing dynamics, and how it compares.'
+keywords: ['.click domain', 'what is .click', '.click TLD', 'click domain extension', 'call to action domain', 'URL shortener domain', 'new gTLD', 'register .click domain']
+faqs:
+  - question: 'Can anyone register a .click domain?'
+    answer: 'Yes. .click is an open generic top-level domain with no eligibility restrictions. Anyone, anywhere can register an available .click name on a first-come, first-served basis, with no credential, trademark, or local-presence requirement.'
+  - question: 'Does a .click domain affect SEO?'
+    answer: 'No. Google treats .click like any other generic top-level domain and says new gTLDs carry no inherent ranking advantage or penalty. Your content, links, and user experience determine rankings, not the suffix.'
+  - question: 'Who should register a .click domain?'
+    answer: 'Marketers building branded short links, campaign landing pages, and tracking URLs benefit most, since the word itself is a call to action. It also suits photographers and anyone wanting a punchy, action-oriented brand.'
+  - question: 'Is .click good for URL shorteners and short links?'
+    answer: 'Yes. At five characters it keeps full URLs compact, and the word implies navigation, so branded short links like go.click read naturally. Many marketers use it precisely for this purpose.'
+  - question: 'Does .click support internationalized domain names?'
+    answer: 'Yes. The .click registry supports internationalized domain names, so you can register names using non-Latin scripts. Standard labels allow 1 to 63 characters using letters, numbers, and hyphens.'
 ---
 
-## **What is .click?**
+The **.click domain** turns the most universal action on the web into a web address. As a generic, unrestricted new gTLD, it reads as an instruction the moment someone sees it, which is why marketers, link-builders, and creators reach for it when they want a name that does something rather than just sits there. If you are weighing whether **.click** belongs in your stack, this page covers who runs it, who can register, how it is priced, how it is perceived, and where it fits against the alternatives.
 
-The **.click** extension is a generic Top-Level Domain (gTLD) that serves as a direct invitation for user interaction. Launched during the expansion of the domain namespace by [ICANN](https://www.icann.org/), it is part of the "New gTLD" program designed to offer more variety and specificity than traditional extensions like .com or .net.
+## .click at a glance
 
-Managed by [Identity Digital](https://identity.digital/) (formerly known as Donuts), the .click TLD was created with a clear purpose: to bridge the gap between content and action. In the digital world, the "click" is the fundamental unit of engagement—whether it is clicking a mouse, tapping a screen, or snapping a camera shutter.
+| Fact | Detail |
+| --- | --- |
+| TLD type | New gTLD (generic) |
+| Registry operator | Internet Naming Co. (formerly Uniregistry) |
+| Year launched | 2014 (delegated 2014-08-15) |
+| IDN support | Yes |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility requirement |
+| Best for | Call-to-action sites, branded short links, marketing campaigns, photography |
 
-Because of its linguistic versatility, .click is not restricted to a single industry. It has found a home among digital marketers looking to increase click-through rates (CTR), photographers highlighting the "click" of a shutter, and tech developers focusing on user interface interactions.
+## What is .click?
 
-## **How People Are Using .click**
+**.click** is a generic top-level domain (gTLD) introduced through ICANN's New gTLD Program, the 2012-onward expansion that added hundreds of new suffixes beyond legacy extensions like [.com](/en/tld/com) and [.net](/en/tld/net). The string was applied for to capture the single most common interaction on the internet: the click — a mouse press, a screen tap, or, fittingly, a camera shutter.
 
-The beauty of the .click domain lies in its ability to act as a verb. It creates an immediate subconscious call to action (CTA). Here is how various sectors are leveraging this TLD:
+Because it is a generic gTLD and not a country-code, **.click** carries no geographic meaning. Google does not geo-target it to any region; it is treated as a global, generic extension. Per [Google Search Central](https://developers.google.com/search/docs/crawling-indexing/managing-multi-regional-sites), new gTLDs are handled like any other generic domain for search, so the suffix neither helps nor hurts rankings on its own. You can confirm the delegation and operator details on the [IANA root-zone record for .click](https://www.iana.org/domains/root/db/click.html).
 
-*   **Digital Marketers and Affiliates:** Professionals use .click for landing pages, redirect links, and tracking URLs. A domain like `bestdeals.click` tells the user exactly what to do.
-*   **Link Shorteners:** Instead of using generic or random character strings, brands are creating custom URL shorteners (e.g., `brand.click/promo`) to maintain brand consistency while sharing links on social media.
-*   **Photographers:** The onomatopoeia of a camera shutter makes this TLD perfect for photography portfolios. A studio might use `capture.click` or `studio.click` to showcase their visual work.
-*   **Tech Support and UI/UX:** Software companies use it for help portals or tutorial sites where they guide users on where to "click" to solve problems.
-*   **Web3 and Domain Investors:** As the internet evolves towards decentralized identity, investors are looking for short, memorable domains. A .click domain represents high utility in a tokenized environment where ease of access is paramount.
+## History of .click
 
-## **Notable Entities Using .click**
+.click was delegated to the DNS root zone on 2014-08-15, one of the earlier strings to launch in the New gTLD Program. It was originally operated by Uniregistry, Corp., the registry founded by domain investor Frank Schilling, which built a portfolio of action- and keyword-oriented extensions.
 
-While many major corporations still rely on legacy TLDs for their primary headquarters, the .click extension is widely adopted for specific campaigns, tools, and creative projects.
+In 2020, GoDaddy [acquired Uniregistry's registrar, marketplace, and domain portfolio](https://www.prnewswire.com/news-releases/godaddy-acquires-uniregistrys-registrar-marketplace--portfolio-301003011.html), but the registry business followed a separate path. Per the IANA record, the .click registry was transferred to **Internet Naming Co.** on 2022-11-16, which is the operator of record today. Throughout these transitions the suffix has kept its open, no-restriction policy, which has made it a steady choice for marketing and short-link use rather than for marquee corporate homepages.
 
-*   **URL Shortening Services:** Various independent URL shortening services leverage the extension because it is short (5 characters) and implies navigation.
-*   **Ad Tracking Platforms:** Many backend advertising technologies use .click domains to route traffic effectively because the extension is semantically relevant to the "Pay-Per-Click" (PPC) industry.
-*   **Creative Agencies:** Modern design agencies often utilize .click for portfolio sub-domains or specific campaign landing pages to differentiate from their corporate .com sites.
+## How people use .click
 
-*Note: Due to the specific utility nature of this TLD, it is often the "unsung hero" operating in the background of marketing campaigns rather than the face of Fortune 500 homepages.*
+- **Branded URL shorteners and short links** — a short, action-named domain like `go.click` keeps shared links compact and on-brand.
+- **Campaign and landing pages** — names such as `subscribe.click` or `register.click` state the desired action directly.
+- **Ad tracking and redirect URLs** — semantically relevant to the pay-per-click world, so it slots naturally into marketing plumbing.
+- **Photography portfolios** — the camera-shutter "click" makes it a clever fit for studios and photographers.
+- **Help and tutorial sites** — UI/UX and support teams use it for "click here to fix it" walkthroughs.
 
-## **Why Choose .click?**
+**Who it's not ideal for:** established brands whose customers expect a [.com](/en/tld/com), regulated businesses that need maximum perceived permanence, or anyone whose audience would read "click" as throwaway or promotional rather than as a primary brand.
 
-If you are debating whether to register a .click domain, consider these distinct advantages:
+## Notable sites using .click
 
-*   **Built-in Call to Action:** The word itself is a command. Using a domain like `subscribe.click` or `buy.click` removes friction and encourages the user to engage immediately.
-*   **High Availability:** Unlike the saturated .com market, where finding a short, memorable name is nearly impossible without a high budget, .click offers a vast inventory of premium names at affordable standard registration rates.
-*   **Memorable Branding:** It is punchy, modern, and tech-savvy. It stands out in a list of search results or social media feeds.
-*   **Semantic Relevance for Photography:** For photographers, "click" is native to their craft, offering a clever alternative to the longer .photography or .studio.
-*   **SEO Neutrality:** Google and other search engines treat new gTLDs like .click exactly the same as .com regarding ranking potential. The advantage comes from user behavior—if the domain looks relevant, users are more likely to click it.
+.click is most visible in the background of marketing and link infrastructure rather than on Fortune 500 homepages, so its typical real-world use is in branded short links, redirect domains, and campaign-specific landing pages rather than flagship corporate sites. Many organizations register a memorable **.click** name purely as a short-link or redirect domain that funnels traffic to their primary site. Rather than name a specific site we cannot independently verify is still live, the honest description is this: **.click** thrives as a utility and campaign extension, prized for being short and action-oriented, and is frequently paired with a brand's main [.com](/en/tld/com) rather than replacing it.
 
-## **Register Your .click Domain at Namefi**
+## .click vs other domains
 
-Ready to drive action and secure a domain that commands attention? Whether you are building a marketing funnel, a photography portfolio, or investing in digital assets, .click is a dynamic choice.
+| Extension | Type | Core signal | Restrictions |
+| --- | --- | --- | --- |
+| [.click](/en/tld/click) | New gTLD | Action / call-to-action | Open to all |
+| [.com](/en/tld/com) | Legacy gTLD | Universal default | Open to all |
+| [.shop](/en/tld/shop) | New gTLD | Retail / commerce | Open to all |
+| [.online](/en/tld/online) | New gTLD | General-purpose web presence | Open to all |
 
-At **Namefi**, we make domain registration simple, secure, and future-proof.
-*   **ICANN Accredited:** We are a fully compliant and trusted registrar.
-*   **Web3 Integrated:** Namefi allows you to mint your domain as an NFT, giving you true ownership and the ability to trade your domain instantly on the blockchain without complex paperwork.
+Pick [.com](/en/tld/com) when you want the most trusted, default-recall extension for a primary brand. Choose **.click** when the action itself is the point — short links, CTAs, and campaigns where "click" reinforces the message. Consider [.shop](/en/tld/shop) if commerce is the headline, or [.online](/en/tld/online) for a broad, generic web presence.
 
-Don't let your perfect name get snapped up by someone else.
+## Why choose .click?
 
-**[Register your .click domain at Namefi today](https://namefi.io)** and start turning traffic into action.
+- **The name is a verb.** Few suffixes carry a built-in instruction; "click" tells visitors what to do before they read a word of copy.
+- **Short and clean.** At five characters it keeps full URLs tidy, which matters for short links and printed or spoken addresses.
+- **Wide availability.** Because the legacy [.com](/en/tld/com) space is saturated, exact-match and short names are far easier to find on **.click**.
+- **No eligibility hurdles.** It is open globally with no credential or local-presence requirement, so registration is immediate.
+
+## Things to consider
+
+**.click** carries a marketing, promotional connotation that can feel less weighty than a [.com](/en/tld/com) for a primary corporate identity. Some users may instinctively type ".com" out of habit, so a defensive [.com](/en/tld/com) registration (with a redirect) is worth considering. As with any newer gTLD, a small share of older email systems and spam filters historically scrutinize unfamiliar suffixes more closely — see the deliverability section below. None of these are blockers, but they are real trade-offs to weigh against the punchy branding upside.
+
+## Who can register a .click domain?
+
+**Registration restrictions: open to all.** There is no eligibility gate — no trademark, credential, profession, or local-presence requirement. Anyone, anywhere can register an available **.click** name on a first-come, first-served basis.
+
+On the rules and admin side: standard labels allow 1 to 63 characters using letters (a–z), numbers (0–9), and hyphens, with hyphens not permitted in the third and fourth positions simultaneously (the standard IDN-prefix rule). The registry supports internationalized domain names (IDN) and DNSSEC, and names can be registered for terms of 1 to 10 years. Like other New gTLD Program strings, **.click** launched with an ICANN-mandated Sunrise period giving trademark holders first opportunity to secure matching names. The suffix is governed by an [ICANN Registry Agreement for .click](https://www.icann.org/en/registry-agreements/details/click), the authoritative source for its operating rules.
+
+## .click pricing and value
+
+This page never quotes live prices, but the **dynamics** are worth understanding. **.click** is a standard-tier new gTLD, so everyday registrations typically sit in the normal range for such extensions. Two things shape what you pay. First, **first-year and renewal pricing differ** — an introductory first-year rate does not lock in the renewal, so always check the recurring price before committing to a brand. Second, **premium names exist**: short, dictionary, or high-demand strings are flagged by the registry as premium and carry higher registration and renewal fees set at the registry level. What drives cost is the name itself (length and keyword value), the registration term, and whether the registry has classified it as premium.
+
+## Reputation and email deliverability
+
+As a marketing-oriented suffix, **.click** is sometimes perceived as promotional, and like several newer gTLDs it has at times drawn extra scrutiny from spam filters and conservative mail systems, partly because cheap, action-named domains can be attractive to bulk senders. The practical impact is modest and very fixable. If you plan to send email from a **.click** domain, authenticate properly with SPF, DKIM, and DMARC, warm up sending gradually, and keep your mailing practices clean. For high-stakes transactional email, many teams send from a well-established [.com](/en/tld/com) while using **.click** for the click-through links themselves — the use case it was made for.
+
+## Branding and naming tips
+
+The strongest **.click** names are domain hacks where the suffix completes a phrase: `one.click`, `just.click`, `go.click`, or an imperative like `subscribe.click`. Keep the second-level label short so the full address stays compact and speakable. Watch for two pitfalls: people may default to typing ".com," so reinforce the full address in your branding; and avoid names that sound like throwaway clickbait if you want the domain to read as a real brand rather than a one-off promo link.
+
+## How to register a .click domain at Namefi
+
+1. Search your desired name on [Namefi](https://namefi.io) to check availability.
+2. Choose the **.click** name (and a defensive [.com](/en/tld/com) if you want one).
+3. Complete registration and configure DNS.
+
+[Namefi](https://namefi.io) is an ICANN-accredited registrar with transparent pricing and fast DNS, and it also lets you tokenize eligible domains as on-chain assets for true Web3 ownership — bridging conventional registration and tokenized domains in one place.
+
+## Frequently asked questions
+
+### Can anyone register a .click domain?
+
+Yes. .click is an open generic top-level domain with no eligibility restrictions. Anyone, anywhere can register an available .click name on a first-come, first-served basis, with no credential, trademark, or local-presence requirement.
+
+### Does a .click domain affect SEO?
+
+No. Google treats .click like any other generic top-level domain and says new gTLDs carry no inherent ranking advantage or penalty. Your content, links, and user experience determine rankings, not the suffix.
+
+### Who should register a .click domain?
+
+Marketers building branded short links, campaign landing pages, and tracking URLs benefit most, since the word itself is a call to action. It also suits photographers and anyone wanting a punchy, action-oriented brand.
+
+### Is .click good for URL shorteners and short links?
+
+Yes. At five characters it keeps full URLs compact, and the word implies navigation, so branded short links like go.click read naturally. Many marketers use it precisely for this purpose.
+
+### Does .click support internationalized domain names?
+
+Yes. The .click registry supports internationalized domain names, so you can register names using non-Latin scripts. Standard labels allow 1 to 63 characters using letters, numbers, and hyphens.
+
+## Related resources
+
+- [What is a domain name?](/en/blog/what-is-domain)
+- [Domain terminology guide](/en/blog/domain-terminology-guide)
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains)
+- [ICANN (glossary)](/en/glossary/icann)
+- [Registrar (glossary)](/en/glossary/registrar)
+- [DNS (glossary)](/en/glossary/dns)
+- [.com domain](/en/tld/com)
+- [.shop domain](/en/tld/shop)
+- [.online domain](/en/tld/online)

--- a/content/tld/en/cloud.md
+++ b/content/tld/en/cloud.md
@@ -1,47 +1,147 @@
 ---
-title: What is .cloud TLD and why choose it?
-date: '2025-12-10'
+title: 'What Is the .cloud Domain? The Cloud & Tech Extension Explained'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: Learn about the .cloud TLD, its benefits, and how it can enhance your online presence. Secure your .cloud domain with Namefi today!
-keywords: ['.cloud', 'domain name', 'TLD', 'cloud computing', 'domain registration', 'Namefi', 'web3', 'domain investing', 'branding', 'cloud services', 'domain extensions', 'ICANN']
+description: 'The .cloud domain is an open gTLD operated by Aruba PEC S.p.A., built for cloud, SaaS, and tech brands. Learn who it suits, its pricing dynamics, and reputation.'
+keywords: ['.cloud domain', 'what is .cloud', '.cloud TLD', 'cloud computing domain', 'SaaS domain name', 'Aruba .cloud registry', 'new gTLD', 'tech domain extension']
+faqs:
+  - question: 'Can anyone register a .cloud domain?'
+    answer: 'Yes. The .cloud TLD is an open generic top-level domain with no eligibility restrictions. Any individual, business, or organization worldwide can register an available .cloud name on a first-come, first-served basis, with no credential, industry, or local-presence requirement.'
+  - question: 'Does a .cloud domain affect SEO?'
+    answer: 'No. Google treats .cloud as a generic gTLD, so it carries no built-in ranking advantage or penalty and is not tied to any country. Search rankings depend on content, links, and user experience, not on the extension you choose.'
+  - question: 'Who should register a .cloud domain?'
+    answer: 'It suits cloud providers, SaaS and PaaS startups, DevOps and IT consultancies, and developer tools or status pages that want a name signaling cloud infrastructure. It is a weaker fit for local service businesses or brands where a literal cloud meaning could confuse visitors.'
+  - question: 'Is .cloud good for SaaS and developer products?'
+    answer: 'Yes. The suffix reads as modern and technical, and short, relevant names are still widely available compared with .com. Many teams use .cloud for product, infrastructure, or environment subdomains where the meaning reinforces what the service does.'
+  - question: 'Does .cloud support DNSSEC and WHOIS privacy?'
+    answer: 'Yes. The .cloud registry supports DNSSEC for cryptographically signed DNS, and WHOIS privacy is offered through registrars rather than the registry, so availability depends on the registrar you choose.'
 ---
 
-## **What is .cloud?**
+The **.cloud domain** is a generic top-level domain (gTLD) built for the era of cloud computing, SaaS, and distributed infrastructure. For founders shipping a developer tool, teams naming a platform, or providers who want a web address that says exactly what they do, **what .cloud offers** is a short, descriptive, globally available extension with an unmistakable technical meaning.
 
-The .cloud Top-Level Domain (TLD) is a generic TLD (gTLD) specifically designed for individuals, businesses, and organizations involved in cloud computing, technology, and related services. It signifies a strong association with cloud technology, offering a recognizable and relevant domain extension. Launched to meet the growing demand for cloud-related online identities, .cloud provides a clear and direct way to communicate expertise and innovation in the cloud space. You can learn more about gTLDs at [ICANN's website](https://www.icann.org/resources/pages/what-is-a-gtld-2012-02-25-en). It is maintained and operated by [ArvanCloud](https://www.arvancloud.com/).
+Unlike a country-code suffix, .cloud is open worldwide and carries no geographic baggage — which is part of why it has become a familiar sight on status pages, product subdomains, and infrastructure brands.
 
-## **How People Are Using .cloud**
+## .cloud at a glance
 
-The .cloud TLD is used by a variety of individuals and organizations, including:
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (new gTLD) |
+| Registry operator | Aruba PEC S.p.A. (Italy) |
+| Year launched | Delegated 2015 |
+| IDN support | Latin a–z, 0–9, and hyphen (3–63 characters) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility requirement |
+| Best for | Cloud providers, SaaS/PaaS, DevOps, developer tools, tech brands |
 
-*   **Cloud Service Providers:** Companies offering infrastructure, platform, or software as a service (IaaS, PaaS, SaaS).
-*   **Tech Startups:** New companies focused on cloud-based solutions and innovation.
-*   **IT Professionals:** Individuals working in cloud computing, DevOps, and related fields looking to establish a professional online presence.
-*   **Consulting Firms:** Businesses offering cloud migration, optimization, and security services.
-*   **Developers:** Software engineers and developers building applications and services for the cloud.
-*   **Educational Institutions:** Universities and training centers offering cloud computing courses and certifications.
+## What is .cloud?
 
-## **Notable Entities Using .cloud**
+The word "cloud" is the defining metaphor of modern computing — shorthand for services delivered over the internet rather than from a box under your desk. The **.cloud TLD** turns that metaphor into a web address, letting a brand signal at a glance that it lives in cloud, hosting, or distributed-infrastructure territory.
 
-While many organizations are adopting .cloud, here are some examples of notable entities:
+.cloud is a **generic gTLD**, not a country-code TLD. That distinction matters for international projects: per [Google Search Central's guidance on generic TLDs](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites), generic extensions like .cloud are not tied to any single country and are treated as global by default, so you can target audiences anywhere without the geo-targeting constraints that come with a ccTLD. You can verify its delegation details in the [IANA root-zone entry for .cloud](https://www.iana.org/domains/root/db/cloud.html).
 
-*   **Canva:** The popular online design platform uses [canva.cloud](https://www.canva.cloud) for internal tools and infrastructure.
-*   **SoundCloud:** The well-known music streaming platform uses cloud infrastructure for its operations, potentially benefitting from a .cloud domain for specific initiatives.
-*   **Organizations providing cloud infrastructure** This could include large companies like Amazon (AWS), Google (GCP), or Microsoft Azure, all of whom could benefit from the .cloud TLD to denote their cloud-specific offerings.
+## History of .cloud
 
-## **Why Choose .cloud?**
+.cloud was awarded through ICANN's New gTLD Program and **delegated to the DNS root zone in 2015**, with [Aruba PEC S.p.A.](https://www.aruba.it/) — a subsidiary of Aruba S.p.A., one of Europe's largest hosting and cloud providers — securing the registry after a private auction among applicants. The registry kicked off the launch with a "Pioneers" program that highlighted early adopters in the cloud-services space.
 
-*   **Relevance:** Instantly communicate your connection to cloud technology and services.
-*   **Branding:** Establish a strong and memorable brand identity in the cloud computing space.
-*   **Availability:** Increase your chances of finding a short, memorable domain name compared to more saturated TLDs like .com.
-*   **Trust:** Signal expertise and credibility to potential customers and partners.
-*   **SEO Potential:** While not a direct ranking factor, a relevant domain name can contribute to improved search engine visibility for cloud-related keywords.
+Aruba running the registry is itself a meaningful detail: the operator is a working cloud and hosting company, not a pure domain speculator, which has shaped how the extension is positioned toward genuine cloud and technology use rather than generic resale. Adoption has trended steadily as SaaS and infrastructure naming has matured and the supply of short, unregistered .com equivalents has thinned.
 
-## **Register Your .cloud Domain at Namefi**
+## How people use .cloud
 
-Ready to establish your presence in the cloud with a .cloud domain? [Namefi](https://namefi.io) makes it easy to register your desired .cloud domain name. As an ICANN-accredited registrar, Namefi offers secure and reliable domain registration services. Plus, we offer seamless Web3 integration, giving you the tools to build the future of the internet.
+Real, specific niches where .cloud fits naturally:
 
-Don't wait! Secure your .cloud domain today and start building your online presence in the cloud!
+- **Cloud and hosting providers** branding infrastructure, IaaS, or managed-service offerings.
+- **SaaS and PaaS startups** that want a product name reading as obviously software-delivered.
+- **DevOps and platform teams** using it for environment, status, or internal-tooling subdomains.
+- **IT consultancies** offering cloud migration, optimization, and security work.
+- **Developer tools and APIs** where the suffix reinforces the "runs in the cloud" promise.
+
+**Who it's not ideal for:** brick-and-mortar local businesses, personal brands, or companies whose audience expects a .com — and any project where a literal "cloud" reading would muddle the message (a bakery or a law firm, say) is better served elsewhere.
+
+## Notable sites using .cloud
+
+The most prominent .cloud address is the registry's own marketing and information hub at **get.cloud**, which Aruba operates to promote the extension (the registry's administrative contact is published at the `@get.cloud` domain in the IANA record). Beyond that, .cloud sees heavy real-world use on **product, infrastructure, and status subdomains** inside larger cloud and SaaS companies rather than as the primary brand domain.
+
+Because much of its adoption is operational rather than front-facing marketing, .cloud has fewer household-name flagship websites than older extensions — so rather than name a site that may not be in active public use, the honest picture is: it is widely deployed for technical and infrastructure purposes, and most prominently showcased by the registry itself.
+
+## .cloud vs other domains
+
+| Extension | Meaning signal | Restrictions | Typical fit |
+| --- | --- | --- | --- |
+| [.com](/en/tld/com) | Universal, commercial default | Open | Any brand wanting maximum familiarity |
+| [.cloud](/en/tld/cloud) | Cloud / infrastructure | Open | Cloud, SaaS, hosting, DevOps |
+| [.io](/en/tld/io) | Tech / startup convention | Open | Startups, developer tools, APIs |
+| [.tech](/en/tld/tech) | Broad technology | Open | Tech brands and communities |
+
+Pick **.com** when broad recognition outranks descriptiveness. Choose **.cloud** when your product genuinely lives in cloud or infrastructure and you want the name to say so. Reach for **.io** or **.tech** when you want a general tech or startup signal without committing to the specific "cloud" meaning.
+
+## Why choose .cloud?
+
+- **Exact-meaning descriptiveness.** The suffix communicates your category before a visitor reads a single word of copy.
+- **Global and unrestricted.** As a generic gTLD it has no country targeting and no eligibility gate, so anyone, anywhere can register.
+- **Availability.** Short, brandable names that are long gone in .com are frequently still open in .cloud.
+- **Operator credibility.** A real cloud company runs the registry, keeping the extension anchored to genuine technical use.
+
+## Things to consider
+
+.cloud is a niche-meaning extension, and that cuts both ways. Its literal reading is an asset for infrastructure brands but a liability for anything outside that lane. First-year promotional pricing and standard renewal pricing often differ, so model the long-term cost, not just the sign-up cost. And as with most newer gTLDs, a minority of users still default to assuming a .com exists — you may field occasional "is it dot-com?" questions and should secure your brand's .com defensively where you can.
+
+## Who can register a .cloud domain?
+
+**Registration restrictions: open to all.** There is no credential, membership, industry, or local-presence requirement. Any person or organization worldwide can register an available .cloud name on a first-come, first-served basis. Names must be **3 to 63 characters**, using letters a–z, digits 0–9, and hyphens (which cannot begin or end the name).
+
+Standard trademark protections apply: the extension launched with an ICANN-mandated sunrise period, and ongoing Trademark Clearinghouse claims and UDRP-based dispute resolution remain available to rights holders. Administratively, the registry **supports DNSSEC**; WHOIS privacy is provided at the registrar level rather than by the registry; and transfer, renewal, and redemption-grace behavior follows standard ICANN gTLD policy. The governing rules are set out in the [ICANN Registry Agreement for .cloud](https://www.icann.org/en/registry-agreements/details/cloud).
+
+## .cloud pricing and value
+
+.cloud pricing follows the usual new-gTLD dynamics rather than a single flat rate. Expect a distinction between **first-year and renewal pricing** — promotional intro rates frequently sit below the standard renewal — so budget on the renewal figure. The registry also designates a tier of **premium names** (short, dictionary, or high-demand strings) that carry higher registration and sometimes higher renewal pricing. What drives cost is name length and desirability, premium classification, the registrar's margin, and any add-ons like privacy. We deliberately quote no specific numbers here because prices change and vary by registrar.
+
+## Reputation and email deliverability
+
+.cloud reads as **modern and technical** rather than cheap or spammy. Because it is operated by an established hosting company and priced as a mid-tier professional extension rather than a giveaway, it has not acquired the bulk-spam reputation that has dogged some ultra-low-cost new gTLDs. That said, any newer extension can occasionally meet conservative spam filters or recipients who default to trusting .com. The honest mitigation is the same discipline that helps every domain: set up **SPF, DKIM, and DMARC** correctly, warm up new sending domains gradually, and keep list hygiene tight. Authentication and sender behavior, not the suffix, are what determine deliverability.
+
+## Branding and naming tips
+
+.cloud rewards names where "cloud" completes a phrase — `yourbrand.cloud`, `status.cloud`-style patterns, or product names that pun on weather and computing. It pairs especially well with infrastructure, platform, and environment naming. Watch two pitfalls: avoid stacking another redundant tech word in front of it (the suffix already says "cloud"), and confirm your audience won't reflexively type `.com` — secure that variant if the brand matters. Short, pronounceable, single-concept names travel best.
+
+## How to register a .cloud domain at Namefi
+
+1. **Search** for your preferred name using Namefi's domain search.
+2. **Choose** an available .cloud name (and grab the matching .com defensively if it's open).
+3. **Register** and configure DNS in minutes.
+
+As an ICANN-accredited registrar, [Namefi](https://namefi.io) offers transparent pricing, fast DNS, and optional Web3 tokenization so you can hold your domain as an on-chain asset. Search your .cloud name and register it in a few steps.
+
+## Frequently asked questions
+
+### Can anyone register a .cloud domain?
+
+Yes. The .cloud TLD is an open generic top-level domain with no eligibility restrictions. Any individual, business, or organization worldwide can register an available .cloud name on a first-come, first-served basis, with no credential, industry, or local-presence requirement.
+
+### Does a .cloud domain affect SEO?
+
+No. Google treats .cloud as a generic gTLD, so it carries no built-in ranking advantage or penalty and is not tied to any country. Search rankings depend on content, links, and user experience, not on the extension you choose.
+
+### Who should register a .cloud domain?
+
+It suits cloud providers, SaaS and PaaS startups, DevOps and IT consultancies, and developer tools or status pages that want a name signaling cloud infrastructure. It is a weaker fit for local service businesses or brands where a literal cloud meaning could confuse visitors.
+
+### Is .cloud good for SaaS and developer products?
+
+Yes. The suffix reads as modern and technical, and short, relevant names are still widely available compared with .com. Many teams use .cloud for product, infrastructure, or environment subdomains where the meaning reinforces what the service does.
+
+### Does .cloud support DNSSEC and WHOIS privacy?
+
+Yes. The .cloud registry supports DNSSEC for cryptographically signed DNS, and WHOIS privacy is offered through registrars rather than the registry, so availability depends on the registrar you choose.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [Domain terminology guide](/en/blog/domain-terminology-guide)
+- [Top TLDs to secure for your SaaS](/en/blog/top-tlds-to-secure-for-your-saas)
+- [Glossary: ICANN](/en/glossary/icann)
+- [Glossary: DNSSEC](/en/glossary/dnssec)
+- [.com domain](/en/tld/com) · [.io domain](/en/tld/io) · [.tech domain](/en/tld/tech)

--- a/content/tld/en/club.md
+++ b/content/tld/en/club.md
@@ -1,60 +1,157 @@
 ---
-title: 'What is the .club TLD and Why Choose It?'
-date: '2025-12-10'
+title: 'What Is the .club Domain? Community TLD Explained'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: 'Unlock the power of community with the .club TLD. Learn why this domain extension is ideal for businesses, DAOs, and groups, and how to register yours today.'
-keywords: ['.club domains', '.club TLD', '.club top-level domain', 'what is .club', 'why choose .club', 'what is the .club domain', 'why choose the .club domain', 'domain investing', 'tokenized domains', 'web3 community domains', 'blockchain domains', 'DAO domains', 'membership site domains', 'buy .club domain', 'new gTLD']
+description: 'The .club domain is an open gTLD for communities, memberships, and Web3 groups. Learn who uses it, its SEO standing, pricing dynamics, and how to register.'
+keywords: ['.club domain', '.club TLD', 'what is .club', 'register .club domain', 'community domain', 'membership domain', 'web3 club domain', 'new gTLD', 'club domain SEO']
+faqs:
+  - question: 'Can anyone register a .club domain?'
+    answer: 'Yes. The .club domain is an open generic top-level domain with no membership, credential, or local-presence requirement. Any individual or organization worldwide can register an available name on a first-come, first-served basis.'
+  - question: 'Does a .club domain affect SEO?'
+    answer: 'No. Google treats .club as a standard generic top-level domain with no inherent ranking penalty or bonus. Rankings depend on content quality, relevance, and links, not on the extension itself.'
+  - question: 'Who should register a .club domain?'
+    answer: 'It suits membership sites, subscription brands, sports teams, fan communities, associations, and Web3 or DAO communities. It is a strong fit whenever your name centers on belonging to a group rather than selling a single product.'
+  - question: 'Is .club good for email deliverability?'
+    answer: 'A .club address can send and receive normal email, but newer generic extensions sometimes face stricter spam filtering. Proper SPF, DKIM, and DMARC setup plus a warmed sending domain matter far more than the suffix for reaching inboxes.'
+  - question: 'Does .club support WHOIS privacy and DNSSEC?'
+    answer: 'Yes. As an open gTLD, .club registrations support standard registrar WHOIS privacy services and DNSSEC signing. Availability of each depends on the registrar you choose rather than registry policy.'
 ---
 
-## **What is .club?**
+The **.club domain** is a generic top-level domain built for one idea: belonging. Where most extensions describe what a site sells or where it lives, `.club` describes who it gathers — members, subscribers, fans, teammates, and communities. That makes it one of the more semantically expressive new gTLDs, and a natural fit for membership businesses and Web3 groups alike.
 
-The **.club** domain extension is a generic Top-Level Domain (gTLD) specifically designed to represent communities, groups, and membership-based organizations. Unlike country-specific domains (ccTLDs like .uk or .ca), .club is open to everyone regardless of location.
+Because the word "club" carries the same meaning across English, French, Spanish, German, and many other languages, the suffix reads clearly to a global audience. This page covers what `.club` is, who runs it, who actually uses it, how it is perceived, and what to weigh before you register one.
 
-Launched in 2014 as part of the [ICANN new gTLD program](https://newgtlds.icann.org/en/about/program), it quickly became one of the most successful and recognizable extensions on the internet. The word "club" is unique in linguistics; it is spelled the same and carries the same meaning—a group of people with a shared interest—in many languages, including English, French, Spanish, and German.
+## .club at a glance
 
-In the modern digital landscape, .club has evolved beyond traditional social clubs. It is now a primary choice for subscription businesses, loyalty programs, and increasingly, the Web3 ecosystem where Decentralized Autonomous Organizations (DAOs) and tokenized communities thrive.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (new gTLD) |
+| Registry operator | Registry Services, LLC (GoDaddy Registry) |
+| Year launched | 2014 (general availability May 7, 2014) |
+| IDN support | Yes |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no credential, membership, or local presence required |
+| Best for | Membership sites, subscriptions, fan communities, associations, DAOs |
 
-## **How People Are Using .club**
+## What is .club?
 
-The versatility of the .club TLD allows it to serve a wide variety of users, from traditional brick-and-mortar establishments to cutting-edge digital frontiers.
+`.club` is a [generic top-level domain](/en/glossary/tld) — not a country-code TLD — delegated to the DNS root in 2014 as part of ICANN's new gTLD program. Its meaning is plain and universal: a club is a group of people united by a shared interest, and the suffix signals community membership rather than a product or place.
 
-*   **Subscription Services:** E-commerce brands use it for "Box of the Month" services or exclusive membership tiers (e.g., `shaving.club` or `coffee.club`).
-*   **Web3 and DAOs:** In the blockchain space, community is everything. Projects use .club to denote governance forums, NFT collector groups, or DAO landing pages.
-*   **Sports and Hobbies:** Local sports teams, martial arts dojos, and fitness centers utilize the extension to emphasize the "team" aspect of their business.
-*   **Fan Communities:** Influencers and streamers register .club domains to host VIP content, merchandise stores, or discord landing pages for their followers.
-*   **Professional Networks:** Coding bootcamps, masterminds, and networking groups use it to imply exclusivity and shared professional growth.
+For search engines, this matters in a practical way. Because `.club` is a generic gTLD with no geographic association, Google does not tie it to any country for [geo-targeting](/en/glossary/seo). According to [Google Search Central](https://developers.google.com/search/docs/crawling-indexing/managing-multi-regional-sites), new gTLDs like `.club` are treated as generic by default, the same way `.com` is — so the extension neither helps nor hurts your ability to rank globally. You can confirm the delegation details in the [IANA root-zone entry for .club](https://www.iana.org/domains/root/db/club.html).
 
-## **Notable Entities Using .club**
+## History of .club
 
-Because of its broad appeal, several high-profile entities and innovative startups have adopted the .club extension.
+`.club` was one of the most anticipated names of the first new gTLD wave. The original applicant, .CLUB Domains, LLC, won the string at private auction in 2013 after raising several million dollars from a group of investors, then opened general availability on May 7, 2014. It quickly became one of the highest-volume new gTLDs by registrations, helped by aggressive marketing toward subscription and membership brands.
 
-1.  **Dollar Shave Club:** While they operate on a .com, the industry giant helped popularize the "club" model for e-commerce, leading many competitors to utilize the actual .club TLD for better branding.
-2.  **50 Cent:** The famous rapper and entrepreneur was an early adopter, launching `50inda.club` as a hub for his fans.
-3.  **Rotary International:** Many local chapters of this massive global service organization utilize .club to distinguish their specific city or region (e.g., `rotary[cityname].club`).
-4.  **Bored Ape Yacht Club (Community Projects):** Various derivative projects and community hubs surrounding major NFT collections often utilize .club to signify membership to the ecosystem.
+In 2021, GoDaddy Registry acquired .CLUB Domains, LLC along with several other extensions, and operation moved to its subsidiary [Registry Services, LLC](https://registry.godaddy/). The transfer of the registry to its current operator is reflected in the IANA record, dated August 2021. The extension has remained one of the more durable community-oriented gTLDs through that consolidation.
 
-## **Why Choose .club?**
+## How people use .club
 
-Selecting the right TLD is crucial for your brand's digital identity. Here is why .club stands out as a strong investment:
+`.club` works best when membership or community is the point of the name:
 
-*   **Immediate Recognition:** The word "club" implies community, passion, and belonging. When a user sees this URL, they immediately understand that the website is about bringing people together.
-*   **High Availability:** While .com is often saturated, finding short, memorable, and keyword-rich names is significantly easier with .club.
-*   **Global Appeal:** As mentioned earlier, "club" is a recognized term worldwide, making it excellent for international brands.
-*   **SEO Relevance:** Search engines like Google treat .club as a standard gTLD. However, semantically, if your business is a "book club" or a "fight club," having the keyword in the extension can help with click-through rates and brand recall.
-*   **Perfect for Web3:** For developers and investors in the blockchain space, .club aligns perfectly with the ethos of token-gated communities and decentralized governance.
+- **Subscription and "of-the-month" brands** — coffee, wine, books, and box services that frame the customer as a member.
+- **Fan and creator communities** — streamers, musicians, and influencers hosting VIP areas, Discord landing pages, or merch hubs.
+- **Sports teams and hobby groups** — local clubs, dojos, run crews, and gaming squads that literally are clubs.
+- **Associations and networks** — alumni groups, masterminds, and professional circles implying exclusivity.
+- **Web3 and DAOs** — token-gated communities and [DAO](/en/glossary/dao) front pages, where "club" maps neatly onto collective membership.
 
-## **Register Your .club Domain at Namefi**
+**Who it's not ideal for:** a single-product e-commerce store, a serious financial or legal institution, or any brand whose primary domain users will type from memory and expect on `.com`. If your offering is not built around a community, the suffix can feel like a stretch.
 
-Whether you are building a local sports team website, a global subscription business, or the next great DAO, a **.club** domain is the perfect foundation for your community.
+## Notable sites using .club
 
-At **Namefi**, we make domain ownership easier and more functional than ever before.
-*   **ICANN Accredited:** We are a fully compliant and trusted registrar.
-*   **Web3 Integration:** We bridge the gap between Web2 and Web3. When you register with us, you can manage your domain via traditional DNS or tokenize it to manage ownership on the blockchain.
-*   **Instant Setup:** Search, buy, and launch your idea in minutes.
+- **nic.club** — the registry's own informational site for the extension.
+- **Subscription and membership brands** broadly use `.club` for member portals and loyalty programs, where the word reinforces the value proposition.
 
-Don't let your community wait. Secure your digital identity today.
+`.club` is widely registered but, like most new gTLDs, its highest-traffic public examples shift over time, so the most reliable real example to point to is the registry's own `nic.club`. Treat the suffix as proven for community use rather than associating it with one flagship site.
 
-[**Search for your .club domain at Namefi**](https://namefi.io)
+## .club vs other domains
+
+| Extension | Type | Core association | Typical price tier |
+| --- | --- | --- | --- |
+| [.club](/en/tld/club) | new gTLD | Community / membership | Budget to mid |
+| [.com](/en/tld/com) | legacy gTLD | Universal default | Standard |
+| [.vip](/en/tld/vip) | new gTLD | Exclusivity / premium members | Mid |
+| [.org](/en/tld/org) | legacy gTLD | Nonprofits / associations | Standard |
+
+Pick [.com](/en/tld/com) when you want the universal default and the exact name is available. Choose `.club` when "club" is part of the meaning and the matching `.com` is taken or expensive. Reach for [.vip](/en/tld/vip) if exclusivity outranks community, and [.org](/en/tld/org) for established associations and nonprofits.
+
+## Why choose .club?
+
+- **The name does the explaining.** "club" tells visitors instantly that the site is about a group, which can lift click-through and recall for community brands.
+- **Strong availability.** Short, keyword-rich names long gone on `.com` are often still open on `.club`.
+- **Global readability.** The word travels across languages without translation.
+- **Web3 alignment.** It pairs naturally with token-gated communities and DAO branding.
+
+## Things to consider
+
+- **Type-in habit favors `.com`.** Some visitors will default to typing `.com`, so a defensive `.com` registration may be worth it.
+- **Niche framing.** The suffix only fits if community is genuinely central to your brand.
+- **Renewal awareness.** Like many new gTLDs, first-year promotional pricing can differ markedly from the standard renewal rate — budget for the renewal, not the intro.
+
+## Who can register a .club domain?
+
+**Registration restrictions: open to all.** `.club` is an unrestricted gTLD. There is no membership test, professional credential, community-eligibility check, or local-presence requirement — any person or organization worldwide can register an available `.club` name on a first-come, first-served basis. This is different from gated extensions such as `.law` (bar membership) or `.realtor` (NAR membership).
+
+Standard new-gTLD rules apply: trademark holders could claim names during the original sunrise period, and ongoing Trademark Clearinghouse claims notices apply at registration. The extension supports internationalized domain names (IDNs), DNSSEC signing, and registrar-provided WHOIS privacy, and follows ICANN's standard transfer, renewal, and redemption-grace lifecycle. For the authoritative rules, see the [ICANN Registry Agreement for .club](https://www.icann.org/en/registry-agreements/details/club) and the registry operator [Registry Services, LLC](https://registry.godaddy/).
+
+## .club pricing and value
+
+`.club` generally sits in the budget-to-mid pricing band among new gTLDs, but the dynamics matter more than any headline figure. Two pricing mechanics are worth understanding before you buy.
+
+First, **first-year and renewal pricing usually differ.** Promotional first-year rates are common on community extensions, while the standard renewal rate is what you actually pay year after year — always check the renewal before committing to a name you intend to keep.
+
+Second, **premium-tier names exist.** The registry classifies certain short, generic, or high-demand strings (for example one-word or category names) as premium, carrying higher registration and sometimes higher renewal fees set by the registry rather than the registrar. The bulk of `.club` names price at the standard tier. Aftermarket value, as with any TLD, depends on length, brandability, and keyword strength.
+
+## Reputation and email deliverability
+
+`.club` is perceived as a friendly, community-oriented extension rather than a premium corporate one — neutral to positive for its intended audience, but less authoritative-feeling than `.com` or `.org` for, say, a bank or law firm.
+
+On email, newer generic suffixes including `.club` have at times drawn slightly more cautious treatment from spam filters than legacy extensions, largely because low-cost TLDs attract some abuse. The practical reality: the suffix is a minor factor at most. Inbox placement is driven by [DNS](/en/glossary/dns) authentication — SPF, DKIM, and DMARC — plus sender reputation and warm-up. Configure those correctly and a `.club` address delivers reliably; skip them and any domain on any TLD will struggle.
+
+## Branding and naming tips
+
+`.club` rewards the domain-hack pattern where the suffix completes the phrase: `book.club`, `coffee.club`, `founders.club`, `chess.club`. When the second-level word plus "club" reads as a natural two-word concept, the name is memorable and self-describing. Avoid forcing it onto names where "club" adds no meaning. Spelling and pronunciation are low-risk — "club" is short, common, and unambiguous across audiences — which is part of why the extension travels so well internationally.
+
+## How to register a .club domain at Namefi
+
+1. Search your desired name to check `.club` availability.
+2. Choose the exact `.club` name (and consider a defensive `.com`).
+3. Register and configure DNS — or [tokenize](/en/glossary/tokenize) it for on-chain ownership.
+
+[Namefi](https://namefi.io) is an [ICANN](/en/glossary/icann)-accredited [registrar](/en/glossary/registrar) with transparent pricing, fast DNS, and optional Web3 [tokenization](/en/blog/what-are-tokenized-domains), so you can hold a `.club` name as a traditional domain or as an on-chain asset.
+
+## Frequently asked questions
+
+### Can anyone register a .club domain?
+
+Yes. The .club domain is an open generic top-level domain with no membership, credential, or local-presence requirement. Any individual or organization worldwide can register an available name on a first-come, first-served basis.
+
+### Does a .club domain affect SEO?
+
+No. Google treats .club as a standard generic top-level domain with no inherent ranking penalty or bonus. Rankings depend on content quality, relevance, and links, not on the extension itself.
+
+### Who should register a .club domain?
+
+It suits membership sites, subscription brands, sports teams, fan communities, associations, and Web3 or DAO communities. It is a strong fit whenever your name centers on belonging to a group rather than selling a single product.
+
+### Is .club good for email deliverability?
+
+A .club address can send and receive normal email, but newer generic extensions sometimes face stricter spam filtering. Proper SPF, DKIM, and DMARC setup plus a warmed sending domain matter far more than the suffix for reaching inboxes.
+
+### Does .club support WHOIS privacy and DNSSEC?
+
+Yes. As an open gTLD, .club registrations support standard registrar WHOIS privacy services and DNSSEC signing. Availability of each depends on the registrar you choose rather than registry policy.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains)
+- [.com domain](/en/tld/com)
+- [.vip domain](/en/tld/vip)
+- [.org domain](/en/tld/org)
+- [Glossary: ICANN](/en/glossary/icann)
+- [Glossary: DAO](/en/glossary/dao)

--- a/content/tld/en/com.md
+++ b/content/tld/en/com.md
@@ -1,61 +1,160 @@
 ---
-title: 'The Gold Standard: What is the .com TLD and Why Choose It?'
-date: '2025-12-10'
+title: 'What Is the .com Domain? The Internet Default Explained'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: 'Discover why .com remains the undisputed king of domains. Learn about its history, credibility, value for domain investing, and how to register yours at Namefi.'
-keywords: ['.com domains', '.com TLD', 'top-level domain', 'what is .com', 'why choose .com', 'what is the .com domain', 'why choose the .com domain', 'domain investing', 'commercial domains', 'tokenized domains', 'blockchain domains', 'buy .com domain', 'best domain for business', 'legacy TLD', 'high value domains']
+description: 'The .com domain is the default address of the commercial internet. Learn its history, who can register one, how pricing works, and why it still leads.'
+keywords: ['.com domains', 'what is .com', '.com TLD', '.com domain extension', 'register .com domain', 'com domain meaning', '.com vs .net', 'business domains']
+faqs:
+  - question: 'Can anyone register a .com domain?'
+    answer: 'Yes. The .com namespace is open to everyone worldwide with no local-presence, business, credential, or community requirement. The original commercial intent is no longer enforced, so individuals, nonprofits, and companies alike can register one.'
+  - question: 'Does a .com domain affect SEO?'
+    answer: 'Google treats .com as a generic top-level domain with no inherent ranking advantage or penalty. The practical benefit is human: users trust and click .com results more readily, which can lift real-world click-through rates.'
+  - question: 'Who should register a .com domain?'
+    answer: 'Almost any business, brand, or project that wants the most universally recognized and trusted address, especially companies serving a global or mainstream consumer audience and anyone protecting a brand long term.'
+  - question: 'Why are good .com domains so hard to find?'
+    answer: 'With over 160 million .com names registered, the supply of short, dictionary, and exact-match brand names is largely exhausted. Most premium .com names are already owned, so many are only available on the secondary market.'
 ---
 
-## **What is .com?**
+The **.com domain** is the closest thing the internet has to a default. Short for "commercial," it is the original generic top-level domain that, through decades of ubiquity, became the suffix people assume when they hear a website name. For most businesses and brands, **what is .com** really comes down to one thing: it is the address users expect, type, and trust without thinking.
 
-The **.com** extension is the absolute titan of the internet. Standing for **"commercial,"** it is a generic Top-Level Domain (gTLD) that was originally intended for commercial organizations. However, due to its unrestricted availability, it quickly became the default address for the vast majority of the internet, covering everything from personal blogs to Fortune 500 companies.
+If you are launching a company, protecting a brand, or building anything meant for a mainstream or global audience, .com remains the benchmark every other extension is measured against. This page covers where it came from, who can register one, how pricing works, and how it stacks up against the closest alternatives.
 
-Introduced in 1985, .com was one of the very first TLDs implemented in the Domain Name System (DNS). It is currently managed by [Verisign](https://www.verisign.com/), which reports that there are over 160 million .com domain name registrations worldwide, making it by far the most popular and widely recognized extension in existence.
+## .com at a glance
 
-While hundreds of [new gTLDs](https://icannwiki.org/New_gTLD_Program) (like .io, .xyz, or .ai) have emerged to cater to specific niches, .com retains a distinct status as the "Main Street" of the digital world.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic TLD (gTLD), treated as generic by Google |
+| Registry operator | Verisign (VeriSign Global Registry Services) |
+| Year delegated | 1985 |
+| IDN support | Yes |
+| DNSSEC | Yes |
+| Registration restrictions | Open to all — no local presence, credential, or business requirement |
+| Best for | Businesses, global brands, e-commerce, anyone wanting the default extension |
 
-## **How People Are Using .com**
+## What is .com?
 
-Because .com is the default mental association people have with websites, its usage spans every conceivable sector. Here is how different groups utilize this powerhouse TLD:
+The **.com top-level domain** is a [generic TLD (gTLD)](/en/blog/what-is-a-tld/) originally intended for commercial organizations. It was one of the very first TLDs created in 1985, alongside `.net`, `.org`, `.edu`, `.gov`, and `.mil`, as documented in the [IANA root-zone entry for .com](https://www.iana.org/domains/root/db/com.html). The registry operator is **Verisign**, which has run the authoritative .com infrastructure for decades.
 
-*   **Global Enterprises:** Almost every major multinational corporation uses a .com to signal global presence and authority.
-*   **eCommerce Stores:** Online retailers prioritize .com to build immediate consumer trust. Shoppers are often wary of entering credit card details on unfamiliar domain extensions.
-*   **Tech Startups:** While many startups flirt with trendy extensions like .ai or .io, the ultimate goal for many is to "graduate" to their matching .com once they have the budget, as it secures brand dominance.
-*   **Domain Investors:** In the world of domain investing and [digital assets](https://namefi.io), premium .com domains are considered "blue-chip" assets. They hold value better than almost any other extension and are frequently tokenized or traded for significant sums.
-*   **Portfolios and Blogs:** Professionals who want to be taken seriously often choose .com for their personal branding to appear established and credible.
+The "com" label points back to a commercial purpose, but that restriction was never meaningfully enforced, and the suffix is now used by everyone from Fortune 500 companies to personal blogs and nonprofits. For search, Google classifies .com as a **generic** rather than country-targeted extension, so a .com site is **not geo-targeted** to any single market and is a sound choice for global audiences.
 
-## **Notable Entities Using .com**
+## History of .com
 
-Listing notable entities using .com is essentially listing the history of the modern internet. However, a few examples highlight the gravity of this TLD:
+.com was delegated on **January 1, 1985**, making it one of the founding TLDs of the modern Domain Name System. The very first .com ever registered was **symbolics.com**, recorded on March 15, 1985 by the computer manufacturer Symbolics — a domain that still resolves today and is often cited as a piece of internet history.
 
-*   **Symbolics.com:** The very first domain ever registered (March 15, 1985). It still exists today and serves as a museum of internet history.
-*   **Google.com:** The world's most visited website.
-*   **Amazon.com:** The giant of eCommerce, proving the commercial viability of the web.
-*   **Apple.com:** A prime example of a short, dictionary-word .com that commands immense brand authority.
+The commercial web boom of the late 1990s turned .com into the default storefront of the internet. Verisign now reports more than **160 million .com registrations** worldwide, by far the largest single TLD. That scale has also made the .com aftermarket the most active in the industry: category-defining names such as voice.com and cars.com have changed hands for eight-figure sums, among the highest publicly reported domain sales on record.
 
-## **Why Choose .com?**
+## How people use .com
 
-In an era with thousands of domain extensions, why should you still strive for a .com?
+The suffix spans essentially every sector, but it concentrates where trust and recognition matter most:
 
-*   **Unmatched Credibility and Trust:** Internet users instinctively trust .com addresses. It signals longevity and legitimacy.
-*   **The "Radio Test":** If you tell someone your website name without mentioning the extension, they will automatically assume it ends in .com. Owning the .com prevents your traffic from leaking to competitors.
-*   **Mobile-Friendly:** Many smartphone keyboards have a dedicated ".com" key. No other TLD shares this level of user interface integration.
-*   **SEO & CTR Advantages:** While search engines like Google treat all TLDs fairly neutrally regarding ranking algorithms, human behavior is different. Users are more likely to click (Click-Through Rate) on a .com result because it looks like a "real" business.
-*   **Resale Value and Asset Tokenization:** If you are looking at domains as an investment, .com domains historically appreciate in value more consistently than other TLDs. They are prime candidates for [Real World Asset (RWA)](https://www.coindesk.com/learn/what-are-real-world-assets-rwas-in-defi/) tokenization on the blockchain.
+- **Established businesses and global brands** signaling permanence and authority
+- **E-commerce stores** where consumer trust at checkout is critical
+- **Startups** that want their primary brand on the most recognized extension
+- **Domain investors** treating premium .com names as blue-chip digital assets
+- **Personal brands and portfolios** that want to read as established and credible
 
-## **Register Your .com Domain at Namefi**
+**Who it's not ideal for:** budget buyers who only need a placeholder, projects that deliberately want a niche or techy signal (where [.io](/en/tld/io/) or [.ai](/en/tld/ai/) fit better), or anyone who cannot find an acceptable available name and is unwilling to consider the aftermarket.
 
-Whether you are launching a new venture, protecting your brand, or investing in digital real estate, securing a .com is the smartest move you can make.
+## Notable sites using .com
 
-At **Namefi**, we combine the reliability of a traditional, ICANN-accredited registrar with the innovation of Web3. When you register a domain with us, you don't just get a URL; you get a seamless digital asset that can be easily managed, transferred, or even used within DeFi applications.
+- **google.com** — the world's most visited website
+- **amazon.com** — the e-commerce giant that proved the commercial web at scale
+- **apple.com** — a short, dictionary-word .com with immense brand authority
+- **symbolics.com** — the first .com ever registered, now preserved as a piece of internet history
 
-*   **Transparent Pricing:** No hidden fees.
-*   **Web3 Integration:** Mint your domain as an NFT for instant transfers and enhanced security.
-*   **Trusted Service:** Built by experts in DNS and blockchain technology.
+These span search, retail, hardware, and history itself, illustrating why .com reads as the default for serious, public-facing brands.
 
-Don't let your perfect name be taken by someone else.
+## .com vs other domains
 
-**[Register your .com with Namefi today](https://namefi.io)** and build your legacy on the internet's most trusted foundation.
+| Feature | .com | .net | .org | .io |
+| --- | --- | --- | --- | --- |
+| Type | gTLD | gTLD | gTLD | ccTLD (generic) |
+| Primary signal | Universal / default | Network / tech (legacy) | Nonprofit / community | Tech / Input-Output |
+| Short-name availability | Very scarce | Scarce | Moderate | Good |
+| Typical price tier | Standard | Standard | Standard | Premium |
+
+Pick **.com** as the universal default whenever you can find or afford the name. Choose [.net](/en/tld/net/) as a classic fallback when the matching .com is taken, [.org](/en/tld/org/) when you want a community, nonprofit, or open-project connotation, or [.io](/en/tld/io/) when a technical, startup-flavored signal and short-name availability matter more than mainstream familiarity.
+
+## Why choose .com?
+
+- **Unmatched recognition.** .com is the suffix people assume by default — the "radio test" winner. Say a brand name aloud and listeners mentally append ".com," so owning it captures traffic that would otherwise leak elsewhere.
+- **Trust and credibility.** Decades of ubiquity make .com read as legitimate and established, which is especially valuable for e-commerce and any site asking for payment details.
+- **Interface integration.** Many mobile keyboards still include a dedicated ".com" key, a level of built-in convenience no other suffix shares.
+- **Global SEO.** Google treats it as generic, so your site can rank worldwide without being boxed into a single country.
+- **Resale value.** Premium .com names hold value more reliably than almost any other extension and anchor the most liquid segment of the domain [aftermarket](/en/blog/how-to-sell-a-domain-name-you-own/).
+
+## Things to consider
+
+- **Scarcity.** With 160 million-plus names registered, short, brandable, and exact-match .com names are largely gone; you may face a compromise spelling, a longer name, or an aftermarket purchase.
+- **Aftermarket cost.** The most desirable .com names are owned and resold, sometimes for substantial sums, rather than available at standard registration price.
+- **No niche signal.** .com says "everything," which is a strength for mainstream brands but offers none of the built-in meaning a category-specific suffix provides.
+- **Single-TLD risk.** Building a brand on one suffix without securing key alternates leaves room for copycats.
+
+## Who can register a .com domain?
+
+**Registration restrictions: open to all.** Anyone in the world can register a .com domain. There is **no local-presence requirement**, no business-eligibility check, and no credential or community gate. The original "commercial" intent has never been enforced, so individuals, nonprofits, and companies register .com names freely.
+
+Names run **1–63 characters**, allow letters, digits, and hyphens (not at the start or end), and **internationalized domain names (IDNs)** are supported for non-Latin scripts. The registry supports **DNSSEC**, and standard transfer, renewal, and redemption-grace-period behavior applies, including the usual auth-code transfer process and a 60-day post-transfer lock. Because .com is an ICANN gTLD, the binding rules are set out in the [.com Registry Agreement between ICANN and Verisign](https://www.icann.org/en/registry-agreements/details/com), and trademark holders can use ICANN dispute mechanisms such as the [UDRP](/en/blog/what-is-udrp/) against infringing registrations.
+
+## .com pricing and value
+
+This page never quotes live prices, but the pricing **dynamics** are worth understanding:
+
+- **A regulated wholesale floor.** Verisign's .com wholesale price is set under its ICANN registry agreement, which permits periodic increases, so registrar pricing tends to move within a predictable band rather than swinging freely.
+- **First-year vs. renewal pricing differ.** An introductory first-year rate can sit below the recurring renewal rate, so budget for the renewal — not just the signup price.
+- **The real premium is the aftermarket.** Standard registration covers any available .com, but most short, dictionary, and brandable names are already owned. Their cost is driven by secondary-market demand and can dwarf the base price.
+
+## Reputation and email deliverability
+
+.com carries the **most neutral and trusted reputation** of any TLD. To users, partners, and spam filters alike it reads as the established default — the opposite of the cheap, spam-prone new gTLDs that some aggressive mail filters treat with suspicion.
+
+Because .com is the home of countless legitimate businesses, it does not trigger the blanket suspicion that some bargain extensions attract, which makes it a strong foundation for business email. That said, deliverability depends far more on your own sending practices — properly configured SPF, DKIM, and DMARC records, a warmed-up sending domain, and clean list hygiene — than on the suffix itself.
+
+## Branding and naming tips
+
+Because the best one-word .com names are taken, modern .com branding usually means **coining a name** rather than finding a dictionary word: invented brandables (think made-up but pronounceable words), two-word compounds, and added prefixes or suffixes (`get-`, `try-`, `-app`, `-hq`). Keep the result short, easy to spell, and unambiguous when spoken aloud.
+
+Watch two pitfalls. First, avoid awkward hyphenation or number substitutions that are hard to dictate over a phone call. Second, check that your chosen .com is not a confusing near-match to an existing brand, which invites trademark trouble and lost traffic.
+
+## How to register a .com domain at Namefi
+
+1. **Search** for your desired name at [Namefi](https://namefi.io) to check availability.
+2. **Choose** the .com result (and any alternates worth securing).
+3. **Register** and configure DNS.
+
+As an [ICANN-accredited](/en/glossary/icann/) [registrar](/en/glossary/registrar/), Namefi bridges Web2 and Web3: transparent pricing, fast [DNS](/en/glossary/dns/) management, and the option to hold your name as a [tokenized domain](/en/blog/what-are-tokenized-domains/) for verifiable [domain ownership](/en/glossary/domain-ownership/) and easy transferability. You can even [tokenize an existing .com](/en/blog/how-to-tokenize-your-com/) you already own. Get started at [Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .com domain?
+
+Yes. The .com namespace is open to everyone worldwide with no local-presence, business, credential, or community requirement. The original commercial intent is no longer enforced, so individuals, nonprofits, and companies alike can register one, subject only to standard availability.
+
+### Does a .com domain affect SEO?
+
+Google treats .com as a generic top-level domain with no inherent ranking advantage or penalty. The practical benefit is human rather than algorithmic: users trust and click .com results more readily, which can lift real-world click-through rates.
+
+### Who should register a .com domain?
+
+Almost any business, brand, or project that wants the most universally recognized and trusted address. It is especially worthwhile for companies serving a global or mainstream consumer audience and for anyone protecting a brand over the long term.
+
+### Why are good .com domains so hard to find?
+
+With over 160 million .com names registered, the supply of short, dictionary, and exact-match brand names is largely exhausted. Most premium .com names are already owned, so they are typically available only through the secondary market rather than at standard registration price.
+
+### Does .com support WHOIS privacy and DNSSEC?
+
+DNSSEC is supported by the .com registry. WHOIS privacy availability depends on your registrar; most modern registrars, including Namefi, offer privacy protection on eligible registrations.
+
+## Related resources
+
+- [What is a domain?](/en/blog/what-is-domain/)
+- [What is a TLD?](/en/blog/what-is-a-tld/)
+- [Domain terminology guide](/en/blog/domain-terminology-guide/)
+- [How to tokenize your .com](/en/blog/how-to-tokenize-your-com/)
+- [How to sell a domain name you own](/en/blog/how-to-sell-a-domain-name-you-own/)
+- TLD guides: [.net](/en/tld/net/), [.org](/en/tld/org/), [.io](/en/tld/io/), [.ai](/en/tld/ai/), [.xyz](/en/tld/xyz/)
+- Glossary: [ICANN](/en/glossary/icann/), [registrar](/en/glossary/registrar/), [DNS](/en/glossary/dns/), [DNSSEC](/en/glossary/dnssec/)

--- a/content/tld/en/dev.md
+++ b/content/tld/en/dev.md
@@ -1,48 +1,159 @@
 ---
-title: What is .dev TLD and why developers love it?
-date: '2025-06-21'
-language: en
+title: 'What Is the .dev Domain? The Secure TLD for Developers'
+date: '2026-06-15'
+language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: .dev is Google's secure domain for developers and development projects. Learn why it's the top choice for programmers, tech companies, and development teams.
+description: '.dev is Google''s HTTPS-only top-level domain for developers, projects, and tech teams. Learn who can register it, how it affects SEO, and how to buy one.'
+keywords: ['.dev domain', 'what is .dev', 'dev TLD', 'Google Registry dev', 'HSTS preload', 'developer domain', 'register dev domain', 'dev domain SEO']
+faqs:
+  - question: 'Can anyone register a .dev domain?'
+    answer: 'Yes. The .dev TLD is open to everyone with no credential, profession, or local-presence requirement. You do not need to be a software developer or a registered company to buy one, though the suffix reads best for technical projects.'
+  - question: 'Does a .dev domain affect SEO?'
+    answer: 'No. Google treats .dev as a generic gTLD with no ranking advantage or penalty versus .com. It is not tied to a country, so it stays geo-neutral. Rankings depend on content, links, and performance, not the suffix.'
+  - question: 'Why do .dev sites require HTTPS?'
+    answer: 'The entire .dev TLD is on the browsers'' HSTS preload list, so Chrome, Firefox, Safari, and Edge refuse to load any .dev site over plain HTTP. Every .dev domain must serve a valid TLS certificate, which is free through providers like Let''s Encrypt.'
+  - question: 'Who should register a .dev domain?'
+    answer: 'Software engineers, dev tooling and API products, open-source projects, technical blogs, and engineering teams who want a name that instantly signals a developer audience and enforces a secure, HTTPS-only setup by default.'
 ---
 
-## **What is .dev?**
+The **.dev** domain is a generic top-level domain run by Google's registry and aimed squarely at the developer world: engineers, dev-tooling companies, open-source maintainers, and technical teams. What makes it unusual among extensions is a hard security rule baked into the TLD itself: every .dev site must be served over HTTPS, with no exceptions. That single property has shaped who adopts it and how.
 
-The **.dev** domain extension is a secure top-level domain (TLD, a domain suffix that comes after the final dot in an internet address) operated by **Google** and designed specifically for **developers, development projects, and tech companies**. Like `.app`, `.dev` requires **HTTPS encryption** for all websites, ensuring maximum security for development-related content.
+If you want a name that reads as "this is built by and for developers" and that forces a secure setup from day one, **.dev** is one of the few extensions purpose-built for that signal.
 
-The `.dev` extension is the **natural choice for developers**, immediately signaling that your website is related to software development, programming, or technology.
+## .dev at a glance
 
----
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (gTLD) |
+| Registry operator | Charleston Road Registry Inc. (Google) |
+| Year launched | Delegated 2014; general availability March 1, 2019 |
+| IDN support | Yes |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no credential or local presence required |
+| Notable rule | Entire TLD is HSTS-preloaded; HTTPS is mandatory |
+| Best for | Developers, dev tools, APIs, open-source, technical blogs |
 
-## **How People Are Using .dev**
+## What is .dev?
 
-`.dev` domains are perfect for:
+.dev is a new gTLD operated by **Charleston Road Registry Inc.**, the registry subsidiary Google uses to run its domain extensions. Its meaning is self-explanatory in software circles — "dev" is universal shorthand for *developer* and *development* — which is why it needs no localization to land with a technical audience worldwide.
 
-* **Software developers** showcasing their portfolios
-* **Development teams** and tech companies
-* **Open source projects** and code repositories
-* **Programming blogs** and tutorial sites
-* **Developer tools** and services
-* **Tech startups** and development agencies
+Because .dev is generic rather than country-coded, search engines treat it as geo-neutral. Per [Google Search Central](https://developers.google.com/search/docs/crawling-indexing/managing-multi-regional-sites), generic TLDs carry no built-in geographic association, so a .dev site is not pinned to any single market and ranks on its own merits. You can confirm the registry details on the [IANA root-zone entry for .dev](https://www.iana.org/domains/root/db/dev.html).
 
----
+## History of .dev
 
-## **Why Choose .dev?**
+Google applied for .dev during ICANN's new-gTLD program and the string was delegated to the root zone in 2014. For years afterward Google held it internally — many engineers knew `*.dev` as a popular local development hostname (e.g. `myapp.dev` on a developer's own machine), which created a quirky collision later on.
 
-* **Developer Community**: Built for and by developers
-* **Security First**: HTTPS required for all sites
-* **Professional Credibility**: Recognized in tech industry
-* **Google Infrastructure**: Reliable and fast
-* **Clear Purpose**: Instantly understood by tech audience
+When Google moved to open .dev to the public, it placed the entire TLD on the browser **HSTS preload list** before launch. That meant Chrome and other browsers began forcing HTTPS on anything ending in .dev — and broke countless local dev setups that had relied on plain-HTTP `.dev` hostnames. Developers migrated those local environments to `.test` or `.localhost`, and .dev was freed up as a real, public, secure-by-default extension. General availability opened on **March 1, 2019**, following a brief Early Access Period. The ICANN registry agreement for the string is listed at [icann.org](https://www.icann.org/en/registry-agreements/details/dev).
 
----
+## How people use .dev
 
-## **Register Your .dev Domain at Namefi**
+- **Personal developer portfolios** — `yourname.dev` is a clean, credible home for an engineer's resume and projects.
+- **Developer tools, SDKs, and APIs** — product and documentation sites for tooling aimed at builders.
+- **Open-source projects** — landing and docs pages where a technical audience is expected.
+- **Engineering blogs and tutorials** — content sites where the readership is developers.
+- **Internal and staging environments** — teams use .dev for dashboards and tools meant for their own engineers.
 
-Ready to establish your developer presence online?
+**Who it's not ideal for:** brands targeting a general consumer or non-technical audience. To most people outside software, "dev" is unfamiliar jargon, so a coffee shop or fashion label is better served by **.com** or a niche retail suffix.
 
-Register your **.dev domain today at [Namefi](https://namefi.io)** and join the developer community.
+## Notable sites using .dev
 
-👉 **Visit [namefi.io](https://namefi.io) and secure your .dev today.**
+- **web.dev** — Google's own resource for modern web development best practices.
+- **cloud.google.com** aside, Google publishes several developer surfaces on .dev, reflecting its registry ownership.
+- **dart.dev** and **flutter.dev** — official homes for the Dart language and Flutter framework.
+- **opensource.dev** — a Google hub for open-source guidance.
+
+These are real, active sites; the suffix is genuinely used by major engineering organizations rather than being a parked novelty.
+
+## .dev vs other domains
+
+| Extension | Positioning | HTTPS enforced | Best fit |
+| --- | --- | --- | --- |
+| [.dev](/en/tld/dev) | Developer-focused, secure by default | Yes (HSTS preload) | Engineers, dev tools, OSS |
+| [.app](/en/tld/app) | Apps and software products | Yes (HSTS preload) | Mobile/web app launches |
+| [.io](/en/tld/io) | Tech and startup default | No | Startups, SaaS, APIs |
+| [.tech](/en/tld/tech) | Broad technology branding | No | Tech media, events, hardware |
+
+Choose **.dev** when your audience is explicitly developers and you value the forced-HTTPS guarantee. Pick [.app](/en/tld/app) if you're shipping a consumer app, [.io](/en/tld/io) for a general startup or SaaS brand, and [.tech](/en/tld/tech) for wider, less code-specific technology positioning.
+
+## Why choose .dev?
+
+- **Unambiguous audience signal.** The suffix tells visitors immediately that the site is technical, which sharpens positioning for tools, docs, and portfolios.
+- **Security enforced at the TLD level.** Because .dev is HSTS-preloaded, browsers only load it over HTTPS. You cannot accidentally ship an insecure .dev site, and visitors never see a mixed-content downgrade.
+- **Strong availability of short names.** Compared with the crowded **.com** space, many concise, brandable .dev names are still registrable.
+- **Backed by Google's registry infrastructure.** The TLD runs on stable, well-resourced nameserver infrastructure.
+
+## Things to consider
+
+- **HTTPS is non-negotiable.** You must have a valid TLS certificate before launch. This is free and routine (e.g. via Let's Encrypt), but it is a hard prerequisite, not a nice-to-have.
+- **Niche meaning.** Outside software, "dev" carries little meaning and can confuse non-technical visitors.
+- **Pricing tends to run above commodity gTLDs.** Premium positioning and tiered names mean .dev is not the cheapest extension (see pricing below).
+- **Easy to conflate with internal hostnames.** Some developers still mentally associate `.dev` with old local-development conventions, though that practice is now discouraged.
+
+## Who can register a .dev domain?
+
+**Registration restrictions: open to all.** There is no credential check, profession requirement, trademark gate, or local-presence rule. Any individual or organization can register an available .dev name — you do not have to be a developer or a company.
+
+A few operational notes:
+
+- **Sunrise/trademark:** like other new gTLDs, .dev ran a Sunrise phase at launch for trademark holders via the Trademark Clearinghouse; that phase is long closed and general registration is now standard.
+- **Length and IDN:** standard label-length rules apply, and internationalized domain names (IDNs) are supported.
+- **Admin facts:** **DNSSEC** is supported for signed, tamper-evident DNS; WHOIS privacy is typically offered by registrars; and standard gTLD transfer, renewal, and redemption-grace-period behaviors apply.
+
+The governing rules live in the [.dev ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/dev), the authoritative source for this gTLD's policy obligations.
+
+## .dev pricing and value
+
+This page never lists live prices, but the pricing **dynamics** are worth understanding. .dev generally sits above commodity gTLDs in cost, reflecting its developer-premium positioning. Registries also designate **premium-tier names** — short, generic, or high-demand strings — which carry higher recurring fees than standard names. Expect **first-year and renewal pricing to differ**, and budget for the renewal rate rather than an introductory figure. The main cost drivers are the name's tier (standard vs premium), the registrar's margin, and any privacy or add-on services you select.
+
+## Reputation and email deliverability
+
+Because every .dev site is HTTPS-only and the TLD is operated by Google's registry, .dev carries a credible, technical reputation with little of the spam baggage attached to some cheap new gTLDs. It reads as **premium and developer-serious** rather than disposable.
+
+For email, .dev is not widely abused, but as with any non-.com extension, deliverability comes down to your own setup rather than the suffix. Configure **SPF, DKIM, and DMARC** correctly, warm up sending domains gradually, and maintain good list hygiene. Done properly, a .dev address sends and lands just like a mainstream domain.
+
+## Branding and naming tips
+
+- **Lean into the "is-a-dev" read.** Names like `build.dev` or `yourname.dev` work because the suffix completes a natural phrase about building or development.
+- **Keep it short and typeable.** Developers value concise, copy-pasteable names; avoid hyphens and ambiguous spellings.
+- **Mind the local-hostname association.** Some engineers still pattern-match `.dev` to local environments, so make the public, production intent obvious in your messaging.
+- **Pronounceability is easy here** — "dev" is one syllable and universally understood in tech — but spell-check any creative domain hack so it doesn't read as a typo.
+
+## How to register a .dev domain at Namefi
+
+1. **Search** your desired name on [Namefi](https://namefi.io) to confirm the .dev version is available.
+2. **Choose** the exact name and review the term and renewal details.
+3. **Register** and complete checkout, then point your DNS and provision a TLS certificate so the site loads over HTTPS.
+
+Namefi is an ICANN-accredited registrar with transparent pricing, fast DNS, and optional **Web3 tokenization** if you want to hold your domain as an on-chain asset. Get started at [Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .dev domain?
+
+Yes. The .dev TLD is open to everyone with no credential, profession, or local-presence requirement. You do not need to be a software developer or a registered company to buy one, though the suffix reads best for technical projects.
+
+### Does a .dev domain affect SEO?
+
+No. Google treats .dev as a generic gTLD with no ranking advantage or penalty versus .com. It is not tied to a country, so it stays geo-neutral. Rankings depend on content, links, and performance, not the suffix.
+
+### Why do .dev sites require HTTPS?
+
+The entire .dev TLD is on the browsers' HSTS preload list, so Chrome, Firefox, Safari, and Edge refuse to load any .dev site over plain HTTP. Every .dev domain must serve a valid TLS certificate, which is free through providers like Let's Encrypt.
+
+### Who should register a .dev domain?
+
+Software engineers, dev tooling and API products, open-source projects, technical blogs, and engineering teams who want a name that instantly signals a developer audience and enforces a secure, HTTPS-only setup by default.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [How to name your project](/en/blog/how-to-name-your-project)
+- [Glossary: DNSSEC](/en/glossary/dnssec)
+- [Glossary: ICANN](/en/glossary/icann)
+- [Glossary: SEO](/en/glossary/seo)
+- [.app domain](/en/tld/app)
+- [.io domain](/en/tld/io)
+- [.tech domain](/en/tld/tech)

--- a/content/tld/en/eth.md
+++ b/content/tld/en/eth.md
@@ -1,72 +1,142 @@
 ---
-title: What is .eth domain and why it's revolutionizing Web3 identity?
-date: '2025-06-21'
-language: en
+title: 'What Is the .eth Name? The ENS Web3 Name Explained'
+date: '2026-06-15'
+language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: .eth domains are blockchain-based names that replace complex wallet addresses with human-readable names. Learn how ENS is transforming Web3 identity and digital ownership.
+description: '.eth is not an ICANN domain but an Ethereum Name Service (ENS) name held as an NFT on-chain. Learn how it works, who can register one, and its real limits.'
+keywords: ['.eth domains', 'what is .eth', 'ENS domain', 'Ethereum Name Service', '.eth name NFT', 'register .eth', 'is .eth a real domain', '.eth vs DNS domain']
+faqs:
+  - question: 'Can anyone register a .eth name?'
+    answer: 'Yes. Registering a .eth name is permissionless and open to anyone with an Ethereum wallet and enough ETH to cover the annual rent plus gas. There is no credential check, no identity verification, and no ICANN-accredited registrar involved; the rules are enforced entirely by the ENS smart contracts on Ethereum.'
+  - question: 'Is a .eth name a real domain that works in browsers?'
+    answer: 'Not in the DNS sense. A .eth name does not resolve in ordinary browsers without a Web3 resolver, extension, or gateway. It is an Ethereum Name Service name used mainly to label wallet addresses and decentralized content, not a substitute for a conventional .com or .org website.'
+  - question: 'Is a .eth name owned forever like an NFT?'
+    answer: 'A .eth name is an ERC-721 NFT, but ownership is a paid annual registration, not a one-time purchase. You must renew it each year by paying rent in ETH. If it expires, a 90-day grace period applies, after which it can be re-registered by anyone via a declining-price premium auction.'
+  - question: 'Why are short .eth names so expensive to register?'
+    answer: 'The ENS .eth registrar charges annual rent by name length: roughly 5 USD per year for names of five or more characters, about 160 USD for four-character names, and about 640 USD for three-character names, paid in ETH. Shorter names are deliberately priced higher because they are scarce and in high demand.'
 ---
 
-## **What is .eth?**
+The **.eth name** is one of the best-known identifiers in Web3, but it is widely misunderstood. Despite the dot-suffix, **.eth is not an ICANN domain and not part of the DNS**. It is a name issued by the [Ethereum Name Service (ENS)](https://ens.domains), a set of smart contracts living on the Ethereum blockchain. There is no IANA root-zone entry for .eth and no ICANN registry agreement, because ENS exists entirely outside that system.
 
-The **.eth** domain is not a traditional top-level domain (TLD, a domain suffix that comes after the final dot in an internet address) but rather a **blockchain-based naming system** powered by the **Ethereum Name Service (ENS)**. Unlike conventional domains managed by ICANN, `.eth` domains are **decentralized, owned as NFTs, and stored on the Ethereum blockchain**.
+If you are deciding whether a .eth name fits your project, the key is to understand what it actually is: a blockchain-native name, held as an NFT, that mainly labels Ethereum addresses and decentralized content. It complements a conventional domain rather than replacing it.
 
-`.eth` domains serve as **human-readable names for Ethereum addresses**, replacing complex 42-character wallet addresses (like 0x742d35Cc6...) with simple, memorable names (like alice.eth). This revolutionary system is transforming how people interact with **Web3, DeFi, NFTs, and the decentralized internet**.
+## .eth at a glance
 
----
+| Fact | Detail |
+| --- | --- |
+| Type | ENS / Web3 name on Ethereum (not a DNS TLD) |
+| Registry / operator | ENS smart contracts on Ethereum, governed by the ENS DAO |
+| Year launched | ENS launched May 2017; redesigned permanent .eth registrar in 2019 |
+| Name format | ERC-721 NFT; second-level names like `alice.eth` |
+| DNSSEC | Not applicable (ENS is on-chain, not DNS) |
+| Registration restrictions | Permissionless and open to all — any wallet, paid in ETH |
+| Renewal | Annual rent in ETH; 90-day grace period after expiry |
+| Resolves in normal browsers | No — requires a Web3 resolver, extension, or gateway |
+| Best for | Wallet identity, Web3/DAO branding, on-chain usernames |
 
-## **How People Are Using .eth**
+## What is .eth?
 
-Since ENS launched, `.eth` domains have become essential infrastructure for Web3 users and organizations. They're widely used for:
+A .eth name is an [Ethereum Name Service](https://docs.ens.domains/) name. ENS is, in its own words, "a distributed, open, and extensible naming system based on the Ethereum blockchain." Its primary job is to map human-readable names to machine identifiers — most commonly an Ethereum wallet address, but also content hashes, other cryptocurrency addresses, and metadata like an avatar.
 
-* **Crypto wallet addresses** — replacing long hex addresses with memorable names like john.eth.
-* **Decentralized websites** — hosting censorship-resistant websites on IPFS and other decentralized networks.
-* **Web3 identity** — serving as universal usernames across DeFi protocols, NFT marketplaces, and dApps.
-* **DAO governance** — organizations using .eth domains for their decentralized autonomous organizations.
-* **NFT collections** — artists and creators using .eth domains for their digital art platforms.
-* **DeFi protocols** — major platforms using .eth domains for easy access and branding.
+This is the critical distinction from a normal top-level domain. A .com or .xyz name is a record in the global DNS, delegated through ICANN and IANA. A .eth name has none of that. The "registry" is not a company filing an ICANN agreement; it is the **ENS registry smart contract** on Ethereum, and issuance rules are enforced by a second contract, the **.eth registrar**. Because the logic is on-chain, no central operator can revoke a correctly held name — but equally, no ordinary DNS resolver knows the name exists. That is why .eth is best described as a **Web3 name**, not a gTLD or ccTLD.
 
-Because `.eth` domains are blockchain-native, they enable **true digital ownership** — you control your domain completely without relying on traditional registrars or governments.
+## History of .eth
 
----
+ENS launched on **May 4, 2017**, proposed by Nick Johnson and built with support from the Ethereum Foundation. The original system distributed names via Vickrey auctions and initially restricted registrations to names of seven characters or longer.
 
-## **Notable Entities Using .eth**
+In **May 2019** ENS migrated to the "permanent registrar" still in use today, replacing the auction model with length-based annual pricing and making .eth names tradable ERC-721 NFTs. In **November 2021** ENS decentralized governance by launching the **ENS DAO** and ENS token, so registration revenue now flows to the DAO treasury rather than a private registry. Short and dictionary .eth names have changed hands for large sums on NFT marketplaces, though specific sale figures vary and should be checked against on-chain records before being quoted.
 
-Many leading Web3 organizations and individuals have adopted `.eth` domains:
+## How people use .eth
 
-* **Vitalik.eth** — Ethereum's co-founder uses vitalik.eth as his primary Web3 identity.
-* **Uniswap.eth** — the leading decentralized exchange uses .eth for their protocol governance.
-* **OpenSea.eth** — the largest NFT marketplace embraces .eth for Web3 integration.
-* **Compound.eth** — the DeFi lending protocol uses .eth for decentralized governance.
-* **Major DAOs** like MakerDAO, Aave, and Compound all use .eth domains for their operations.
+A .eth name is used very differently from a website domain. Real, common uses include:
 
-These examples show that `.eth` is more than just a naming system — it's the **foundation of decentralized identity and Web3 infrastructure**.
+- **Human-readable wallet addresses** — replacing a 42-character `0x…` address with `alice.eth` when sending or receiving ETH and tokens.
+- **Web3 identity / usernames** — a single name reused as a login or profile across wallets, dApps, and crypto-social apps.
+- **DAO and protocol branding** — teams using a `name.eth` as their on-chain identity and treasury label.
+- **Decentralized content** — pointing a name at an IPFS content hash so it can serve a censorship-resistant site through a Web3 gateway.
+- **Subname issuance** — projects handing out `you.project.eth` subnames to members.
 
----
+**Who it's not ideal for:** anyone who needs a conventional, universally reachable website. If your goal is a marketing site, a business email address, or anything a non-crypto visitor must reach by typing it into Chrome or Safari, a .eth name is the wrong tool — you want a DNS domain such as [.com](/en/tld/com), [.io](/en/tld/io), [.ai](/en/tld/ai), or [.app](/en/tld/app).
 
-## **Why Choose .eth?**
+## Notable uses of .eth
 
-* **True Ownership**: Owned as NFTs on the blockchain — no one can take your domain away.
-* **Censorship Resistance**: Decentralized domains that can't be seized or blocked by governments.
-* **Web3 Integration**: Works seamlessly with all Ethereum-based applications and services.
-* **Multi-Purpose**: Functions as wallet address, website, and universal Web3 identity.
-* **Investment Potential**: Premium .eth domains have sold for hundreds of thousands of dollars.
+Rather than vanity sites, .eth names are best known as the on-chain identities of prominent Ethereum figures and projects. Ethereum co-founder Vitalik Buterin's `vitalik.eth` is the canonical example, widely used as his public wallet and identity, and many DAOs and Web3 builders maintain a `name.eth` as their primary on-chain handle. Because these are wallet and identity labels rather than hosted websites, .eth identifies an on-chain entity, not a web server.
 
----
+## .eth vs other domains
 
-## **Register Your .eth Domain at Namefi**
+| Extension | Type | Where it lives | Typical use |
+| --- | --- | --- | --- |
+| .eth | ENS / Web3 name | Ethereum blockchain | Wallet identity, on-chain branding |
+| [.com](/en/tld/com) | Legacy gTLD (DNS) | Global DNS via ICANN | Any website or business |
+| [.xyz](/en/tld/xyz) | New gTLD (DNS) | Global DNS via ICANN | Startups, Web3-adjacent brands |
+| [.io](/en/tld/io) | ccTLD used as tech gTLD (DNS) | Global DNS via ICANN | SaaS, developer, crypto projects |
 
-Ready to claim your Web3 identity and join the decentralized internet revolution?
+Pick **.eth** when you want a blockchain-native identity for a wallet, DAO, or on-chain app. Pick a **DNS domain** like **.com**, **.xyz**, or **.io** when you need a real, browser-reachable website and email. The two are not interchangeable, and many Web3 teams sensibly hold both — a DNS domain for the public site and a .eth name for on-chain identity.
 
-You can register your **.eth domain today at [Namefi](https://namefi.io)** — one of the few registrars that bridges traditional DNS and blockchain-based domains. Namefi offers comprehensive ENS services including:
+## Why choose .eth?
 
-* Easy .eth domain registration and management
-* Integration with traditional DNS for maximum compatibility
-* Portfolio management for blockchain domain investments
-* Advanced security features for protecting your digital assets
+- **True self-custody** — a correctly held .eth name lives in your wallet as an NFT; there is no registrar account that can be socially engineered into transferring it.
+- **Native Ethereum integration** — wallets and dApps resolve .eth names automatically, turning a cryptic address into something you can read and verify.
+- **Permissionless** — anyone can register one in minutes with a wallet and some ETH; no application, credential, or approval.
+- **Composability** — because it is a standard ERC-721 NFT, a .eth name can be traded, listed, lent, or used as collateral wherever NFTs are supported.
 
-Whether you're building a DeFi protocol, creating NFT art, or simply want to own your Web3 identity — **.eth gives you the decentralized ownership and censorship resistance that traditional domains cannot provide.**
+## Things to consider
 
-👉 **Visit [namefi.io](https://namefi.io) and secure your .eth today.**
-Own your name on the blockchain — join the decentralized web with **.eth**.
+The trade-offs are real and worth stating plainly. A .eth name **does not resolve in ordinary browsers** without a Web3 resolver, browser extension, or gateway service, so it cannot serve as a normal website address. Ownership is **rented, not permanent** — you pay annual rent in ETH, and a lapsed name can be lost after its grace period. You also bear **self-custody risk**: lose your wallet's keys and you lose control of the name, with no support desk to recover it. Finally, registration and renewal cost **gas** on top of rent, and short names are expensive by design.
+
+## Who can register a .eth name?
+
+**Registration restrictions: permissionless and open to all.** There is no eligibility gate of any kind — no ICANN-accredited registrar, no identity verification, no trademark sunrise process, and no credential requirement. Anyone with an Ethereum wallet and enough ETH can register an available .eth name directly through the ENS smart contracts.
+
+Because the .eth registrar enforces a **commit-reveal** scheme to prevent front-running, registration is a two-step on-chain process: you submit a commitment, wait at least 60 seconds, then call `register` and pay the rent. Names are issued as ERC-721 NFTs, registration is for a fixed term (commonly one year or more), and renewal is paid annually in ETH — notably, **any wallet can renew a name**, not just the owner. After expiry, a **90-day grace period** lets the current holder renew at the normal price; if they don't, the name enters a 21-day declining-price premium auction and can be claimed by anyone. The authoritative source for these mechanics is the [ENS .eth registrar documentation](https://docs.ens.domains/registry/eth) and the [ENS name-lifecycle support article](https://support.ens.domains/en/articles/8046877-name-lifecycle).
+
+## .eth pricing and value
+
+Pricing dynamics for .eth are unusual because rent is **length-based and denominated in USD but paid in ETH**. Per the ENS registrar, the approximate annual rent is **5 USD for names of five or more characters, 160 USD for four-character names, and 640 USD for three-character names**, with the ETH amount calculated at registration time. On top of rent you always pay Ethereum **gas**, which fluctuates with network conditions. Beyond the protocol price, scarce names (short strings, real words, well-known handles) trade on NFT secondary markets at whatever buyers will pay, entirely independent of the registrar's rent. We do not quote live or promotional figures; always confirm the current rent and gas at the moment of registration.
+
+## Reputation and resolution limitations
+
+This is where honesty matters most. Within crypto, a .eth name is a respected signal of an on-chain identity and is broadly trusted by wallets and dApps. **But it has a reach limitation that DNS domains do not:** it does **not** resolve in ordinary browsers, and it cannot be used as a normal email domain. Visiting a .eth "site" requires a Web3-aware resolver, a browser extension, or a gateway that bridges ENS to HTTP. Outside the Ethereum ecosystem, most people and most software simply cannot reach a bare .eth name. Treat it as an identity layer for Web3 — not a drop-in replacement for a website or business email, where a conventional DNS domain remains essential.
+
+## Branding and naming tips
+
+A .eth name reads as unmistakably crypto-native, which is an asset for a wallet, DAO, or Web3 product and a liability for a mainstream brand. Keep names short and easy to dictate, since they are often shared verbally in crypto communities. Remember the cost curve: three- and four-character names carry steep annual rent, so a memorable five-plus-character name is usually the pragmatic choice. If you are building a brand, the strongest pattern is to **secure the matching DNS domain and the .eth name together** so your public site and your on-chain identity stay consistent.
+
+## How to approach .eth with Namefi
+
+Namefi is an [ICANN-accredited registrar](https://namefi.io) that also supports Web3 and tokenized domains, which makes it a natural home base for builders who live in both worlds:
+
+1. **Secure your brand in DNS** — register the conventional domain your audience will actually type, such as a [.com](/en/tld/com), [.xyz](/en/tld/xyz), or [.dev](/en/tld/dev) name, with transparent pricing.
+2. **Tokenize for Web3 ownership** — turn that DNS domain into an on-chain NFT asset on Namefi, getting NFT-grade self-custody and transferability similar to what makes .eth appealing, while keeping a name that still resolves in every browser.
+3. **Pair it with your .eth identity** — use a .eth name as your Ethereum-native handle alongside the Namefi-managed domain that serves your real website and email.
+
+[Namefi](https://namefi.io) bridges Web2 and Web3 so you get the best of both: real DNS reachability plus blockchain-native ownership.
+
+## Frequently asked questions
+
+### Can anyone register a .eth name?
+
+Yes. Registering a .eth name is permissionless and open to anyone with an Ethereum wallet and enough ETH to cover the annual rent plus gas. There is no credential check, no identity verification, and no ICANN-accredited registrar involved; the rules are enforced entirely by the ENS smart contracts on Ethereum.
+
+### Is a .eth name a real domain that works in browsers?
+
+Not in the DNS sense. A .eth name does not resolve in ordinary browsers without a Web3 resolver, extension, or gateway. It is an Ethereum Name Service name used mainly to label wallet addresses and decentralized content, not a substitute for a conventional .com or .org website.
+
+### Is a .eth name owned forever like an NFT?
+
+A .eth name is an ERC-721 NFT, but ownership is a paid annual registration, not a one-time purchase. You must renew it each year by paying rent in ETH. If it expires, a 90-day grace period applies, after which it can be re-registered by anyone via a declining-price premium auction.
+
+### Why are short .eth names so expensive to register?
+
+The ENS .eth registrar charges annual rent by name length: roughly 5 USD per year for names of five or more characters, about 160 USD for four-character names, and about 640 USD for three-character names, paid in ETH. Shorter names are deliberately priced higher because they are scarce and in high demand.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains)
+- [Tokenized domain vs Web3 domain](/en/blog/tokenized-domain-vs-web3-domain)
+- [.com domain](/en/tld/com) · [.xyz domain](/en/tld/xyz) · [.io domain](/en/tld/io)
+- Glossary: [ENS](/en/glossary/ens) · [NFT](/en/glossary/nft) · [ERC-721](/en/glossary/erc-721) · [Web3](/en/glossary/web3)

--- a/content/tld/en/fun.md
+++ b/content/tld/en/fun.md
@@ -1,60 +1,152 @@
 ---
-title: 'Unleash Creativity: What is the .fun TLD and Why Choose It?'
-date: '2025-12-10'
+title: 'What Is the .fun Domain? Uses, Rules and Value'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: 'Discover the power of the .fun domain! Learn why this playful TLD is perfect for games, entertainment, and Web3 brands. Register yours today at Namefi.'
-keywords: ['.fun domains', '.fun TLD', '.fun top-level domain', 'what is .fun', 'why choose .fun', 'what is the .fun domain', 'why choose the .fun domain', 'domain investing', 'blockchain domains', 'tokenized domains', 'entertainment domains', 'gaming domains', 'creative domain names', 'new gTLD', 'Radix registry']
+description: 'The .fun domain is an open new gTLD run by Radix, popular with games, events, and Web3 projects like pump.fun. Here is who uses it, the rules, and its value.'
+keywords: ['.fun domain', '.fun TLD', 'what is .fun', '.fun domains', 'Radix registry', 'new gTLD', 'gaming domains', 'pump.fun']
+faqs:
+  - question: 'Can anyone register a .fun domain?'
+    answer: 'Yes. The .fun domain is an open new gTLD with no eligibility restrictions, so individuals, businesses, and projects worldwide can register one on a first-come, first-served basis. The only exceptions are ICANN-mandated and registry-reserved names, such as two-character labels and certain premium names.'
+  - question: 'Does a .fun domain affect SEO?'
+    answer: 'No. Google treats new gTLDs like .fun the same as legacy extensions such as .com for ranking purposes. There is no inherent SEO penalty or boost; content quality, links, and user experience determine rankings, not the suffix.'
+  - question: 'Who should register a .fun domain?'
+    answer: 'It suits gaming sites, event and entertainment brands, community and meme projects, and Web3 apps that want a short, upbeat name. It is less ideal for formal institutions like banks or law firms where a serious, conventional extension fits better.'
+  - question: 'Is .fun a good choice for Web3 and crypto projects?'
+    answer: 'It has real traction in Web3: pump.fun, a major Solana token-launch platform, is the most prominent example. The word reads as community-driven and approachable, which fits memecoin and dApp branding, though it carries no special technical features over other suffixes.'
+  - question: 'Does .fun support WHOIS privacy and DNSSEC?'
+    answer: 'Yes. The .fun registry supports DNSSEC, and most registrars offer WHOIS privacy so your personal contact details are not published publicly. Availability of privacy depends on your registrar and applicable law.'
 ---
 
-## **What is .fun?**
+The **.fun domain** is one of the more expressive choices in the modern domain landscape: a short, readable word that tells visitors a site is playful or entertaining before they even click. It is a generic top-level domain (gTLD) from ICANN's new gTLD program, open to anyone, and it has found a genuine home with game studios, event organizers, creative side-projects, and high-traffic Web3 platforms.
 
-The **.fun** domain extension is a generic Top-Level Domain (gTLD) specifically designed to represent entertainment, leisure, and enjoyment on the internet. Launched in 2017 and managed by the [Radix Registry](https://radix.website/dot-fun), one of the world's leading new domain registries, .fun was created to offer a lighter, more energetic alternative to traditional extensions like .com or .net.
+If you are weighing a memorable, on-theme extension against a crowded `.com` market, this page covers what .fun is, who runs it, who really uses it, and the trade-offs before you register.
 
-Unlike country-code TLDs (ccTLDs) which are tied to specific geographies, .fun is open for registration to anyone, anywhere in the world. It was introduced during [ICANN’s new gTLD program](https://newgtlds.icann.org/en/about/program), which aimed to expand the internet's namespace and allow for more descriptive web addresses.
+## .fun at a glance
 
-Today, usage trends for .fun are spiking, particularly within industries that thrive on engagement. It has found a strong foothold among gaming communities, event organizers, comedy hubs, and increasingly, within the **Web3 and blockchain ecosystem**, where developers look for catchy, memorable names for decentralized applications (dApps) and tokenized projects.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (new gTLD) |
+| Registry operator | Radix (Radix Technologies / Radix FZC DMCC) |
+| Registration date | 2016-11-30 (delegated; launched late 2016) |
+| IDN support | Yes (internationalized domain names supported) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility requirements |
+| Best for | Gaming, events, entertainment, community and Web3 projects |
 
-## **How People Are Using .fun**
+## What is .fun?
 
-Because the word "fun" is universally understood and carries a positive connotation, this TLD is versatile. Here is how different sectors are utilizing it:
+The **.fun** suffix is a generic top-level domain, not a country-code TLD, so it carries no geographic meaning and is available worldwide. It was delegated to the internet's root zone in late 2016 as part of [ICANN's new gTLD program](https://newgtlds.icann.org/en/), the expansion that added hundreds of descriptive word-based extensions alongside legacy names like `.com` and `.net`. You can confirm the delegation and operator details on its [IANA root-zone record](https://www.iana.org/domains/root/db/fun.html).
 
-*   **Gaming and Esports:** Game developers and streamers use .fun to host game lobbies, forums, and portfolio sites. It signals to the user immediately that the content is recreational.
-*   **Web3 and Memecoins:** In the fast-paced world of cryptocurrency, projects often use .fun to denote community-driven tokens or "meme" culture platforms that prioritize community engagement over corporate stiffness.
-*   **Event Planning:** Festivals, parties, and corporate team-building companies use the extension to market specific events (e.g., `summerfest.fun`).
-*   **Creative Portfolios:** Designers and content creators often use it to showcase side projects or "sandbox" experiments that are distinct from their main professional portfolio.
-*   **Marketing Campaigns:** Big brands utilize .fun for temporary viral marketing campaigns or contests to separate them from their main corporate identity.
+Because .fun is generic, search engines treat it that way: there is no geo-targeting tied to it as there is with a ccTLD, and Google does not favor or penalize it relative to `.com`. The literal meaning of the word does the work — a `.fun` address signals enjoyment and approachability, which is exactly why brands reach for it.
 
-## **Notable Entities Using .fun**
+## History of .fun
 
-While many Fortune 500 companies protect their brand on every extension, .fun has seen organic adoption by platforms that drive massive traffic.
+The .fun registry was delegated on 2016-11-30 and became broadly available shortly after, joining the wave of word-based gTLDs from the mid-2010s. It is operated by **Radix**, which also runs several other well-known new gTLDs, including `.online`, `.store`, `.tech`, `.site`, and `.space`. That portfolio matters: Radix is an established operator with broad registrar distribution, so .fun is widely sold rather than a niche extension.
 
-1.  **Pump.fun:** Perhaps the most notable recent example in the Web3 space is [pump.fun](https://pump.fun). This platform allows users to launch tokens instantly and has generated significant transaction volume on the Solana blockchain, proving that a .fun domain can host high-traffic, financial-adjacent applications.
-2.  **Mustard.fun:** Used by creative agencies or niche content creators, examples like these highlight the ability to create "domain hacks" or memorable phrases (i.e., making the URL a sentence).
-3.  **Kids and Educational Games:** Various educational startups use the domain to distinguish learning apps as "edutainment," signaling to parents and children that the learning process will be enjoyable.
+Adoption has been steady. Figures cited on the [.fun Wikipedia entry](https://en.wikipedia.org/wiki/.fun) put registrations in the hundreds of thousands, and the extension got a major boost from Web3 — pump.fun became one of the most-trafficked applications on Solana and made the suffix instantly recognizable to a crypto-native audience.
 
-*Note: As a "new gTLD," the most valuable use cases are often found in startups and agile digital-first companies rather than legacy corporations.*
+## How people use .fun
 
-## **Why Choose .fun?**
+Real, specific niches where .fun fits naturally:
 
-If you are considering a domain for your next project, here is why .fun is a strategic choice:
+- **Gaming and esports:** game lobbies, community forums, streamer hubs, and tournament pages where a recreational tone is the point.
+- **Web3, memecoins, and dApps:** community-driven token projects and launch platforms that want a casual, anti-corporate name.
+- **Events and festivals:** one-off party, festival, conference-afterparty, and team-building microsites (for example a `summerfest`-style name).
+- **Kids and edutainment:** learning apps that want to signal to parents that the experience is playful rather than academic.
+- **Campaigns and side projects:** viral marketing pages, contests, and personal experiments kept separate from a main brand domain.
 
-*   **High Availability:** Unlike .com, which is saturated, .fun offers a vast inventory of short, one-word, and premium names. You are more likely to get the exact name you want.
-*   **Instant Branding:** The extension does the marketing for you. It sets a tone of excitement, approachability, and positivity before the user even clicks the link.
-*   **SEO Relevance:** Search engines like Google treat new gTLDs neutrally compared to .com. However, having a descriptive TLD can improve your Click-Through Rate (CTR) because users immediately understand the intent of the website.
-*   **Memorable and Short:** "Fun" is a short, three-letter word. Combined with a short brand name, it creates a URL that is easy to type and hard to forget.
-*   **Investment Potential:** For domain investors, short and keyword-rich .fun domains are becoming increasingly valuable assets, especially as the digital entertainment sector grows.
+**Who it's not ideal for:** banks, law firms, healthcare providers, government bodies, and B2B enterprises selling on trust and authority. In those contexts a `.com` or a serious sector extension reads as more credible, and a playful suffix can undercut the message.
 
-## **Register Your .fun Domain at Namefi**
+## Notable sites using .fun
 
-Whether you are launching a new blockchain game, a viral marketing campaign, or a personal blog, a .fun domain tells the world you are ready to engage.
+- **pump.fun** — a Solana-based token-launch platform and one of the highest-activity applications in crypto; the single best-known example of the suffix at scale.
 
-At **Namefi**, we make owning domains easier and more functional than ever before. We are not just an ICANN-accredited registrar; we bridge the gap between Web2 and Web3. When you register with us, you enjoy seamless management and the unique ability to mint your domain as an NFT, making transfer and ownership as easy as sending a token.
+Beyond that headline case, .fun is used widely across smaller entertainment, gaming, and event sites rather than by legacy corporations, which is typical for a new gTLD. Where a large brand registers a `.fun` name it is usually defensive or for a single campaign rather than its primary identity.
 
-**Ready to start the fun?**
+## .fun vs other domains
 
-[**Register your .fun domain at Namefi today**](https://namefi.io)
+| Extension | Positioning | Availability of short names | Tone |
+| --- | --- | --- | --- |
+| [.fun](/en/tld/fun) | Playful, entertainment-focused | High | Upbeat, casual |
+| [.com](/en/tld/com) | Universal default | Very low | Neutral, authoritative |
+| [.xyz](/en/tld/xyz) | Generic, tech/Web3-friendly | High | Modern, flexible |
+| [.online](/en/tld/online) | Broad web presence | High | General-purpose |
 
-Don't let your perfect creative name get taken by someone else. Secure your digital identity now and build a brand that people love to visit.
+Pick `.com` when broad, conventional trust is the priority and you can find (or afford) the name. Pick `.fun` when the project's identity is genuinely about play, community, or entertainment. Choose a neutral alternative like [.xyz](/en/tld/xyz) or [.online](/en/tld/online) when you want availability and flexibility without a strong thematic lean.
+
+## Why choose .fun?
+
+- **The suffix carries meaning.** "fun" is a universally understood, positive word, so the extension itself communicates tone — useful for entertainment and community brands.
+- **Short, memorable names are still available.** Unlike the saturated `.com` zone, you can often register a clean one-word or two-word `.fun` name that is easy to say and type.
+- **Run by an established registry.** Radix operates a portfolio of major gTLDs, so .fun has wide registrar support and stable infrastructure.
+- **Proven at scale in Web3.** pump.fun shows the extension can sit under a high-traffic application without trouble.
+
+## Things to consider
+
+- **Niche connotation.** The playful meaning that helps an entertainment brand can hurt a serious one; the suffix narrows perceived use.
+- **Renewal pricing differs.** Like most new gTLDs, the renewal rate can exceed an introductory first-year rate — budget for the ongoing cost.
+- **Premium names cost more.** Short, high-demand `.fun` labels may be classified as premium and priced well above standard registrations.
+- **Recognition is still building.** Mainstream users default to `.com`; some audiences may need reassurance that a `.fun` address is legitimate.
+
+## Who can register a .fun domain?
+
+**Registration restrictions: open to all.** There are no eligibility requirements for .fun — you do not need a credential, a local presence, or community membership. Individuals, businesses, and projects anywhere in the world can register on a first-come, first-served basis.
+
+The only limits are standard registry and ICANN reservations: two-character labels are initially reserved under ICANN policy, certain names are held back as premium or for registry operations, and names protected for bodies such as the International Olympic Committee and the Red Cross/Red Crescent movement are unavailable. Trademark holders can use ICANN's Trademark Clearinghouse sunrise and claims mechanisms for protection.
+
+On the administrative side, the registry supports **DNSSEC**, most registrars offer **WHOIS privacy** to keep personal contact data off public records, and standard gTLD transfer, renewal, and redemption-grace processes apply. Because .fun is a gTLD rather than a ccTLD, its rules are governed by an ICANN contract — see the [.fun ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/fun) for the authoritative policy source.
+
+## .fun pricing and value
+
+Pricing for .fun follows the usual new gTLD pattern rather than a single flat rate. Standard names sit at the registry's general tier, while short, dictionary-word, or high-demand labels are often designated **premium** and cost more — sometimes substantially more — both to register and to renew. Expect first-year and renewal pricing to differ, since introductory rates do not always carry over.
+
+The value of a specific `.fun` name comes from its relevance and brevity: a short, on-theme name in an active niche (gaming, events, Web3) holds more practical and resale value than a long or obscure one. This page quotes no live prices; check current rates at registration time.
+
+## Reputation and email deliverability
+
+New gTLDs as a category once drew extra scrutiny from spam filters because low-cost extensions were sometimes abused, and .fun is occasionally caught in that broad-brush perception. In practice, deliverability and trust depend far more on sender behavior and authentication than on the suffix. If you send email from a `.fun` domain, set up **SPF, DKIM, and DMARC** correctly, warm up the domain, and keep clean sending practices — that does more for inbox placement than the extension. For a public-facing site, pump.fun shows the suffix is fully viable for serious, high-traffic use.
+
+## Branding and naming tips
+
+The strongest `.fun` names treat the suffix as part of the phrase rather than a bolt-on label. Domain hacks where the word completes a sentence read well — think `learning.fun`, `family.fun`, or a brand name that flows into "fun." Keep the second-level label short and phonetic so the whole address is easy to say aloud and type from memory. Avoid spellings that force the listener to guess. Because the suffix sets an unmistakably casual tone, make sure that tone matches the actual product before you commit.
+
+## How to register a .fun domain at Namefi
+
+1. Search your desired name to check availability and whether it is standard or premium.
+2. Choose the `.fun` name that fits your brand and budget.
+3. Complete registration and configure DNS.
+
+Namefi is an ICANN-accredited registrar with transparent pricing, fast DNS, and optional **Web3 tokenization** — mint your domain as an NFT so ownership and transfer are as simple as moving a token. Start at [Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .fun domain?
+
+Yes. The .fun domain is an open new gTLD with no eligibility restrictions, so individuals, businesses, and projects worldwide can register one on a first-come, first-served basis. The only exceptions are ICANN-mandated and registry-reserved names, such as two-character labels and certain premium names.
+
+### Does a .fun domain affect SEO?
+
+No. Google treats new gTLDs like .fun the same as legacy extensions such as .com for ranking purposes. There is no inherent SEO penalty or boost; content quality, links, and user experience determine rankings, not the suffix.
+
+### Who should register a .fun domain?
+
+It suits gaming sites, event and entertainment brands, community and meme projects, and Web3 apps that want a short, upbeat name. It is less ideal for formal institutions like banks or law firms where a serious, conventional extension fits better.
+
+### Is .fun a good choice for Web3 and crypto projects?
+
+It has real traction in Web3: pump.fun, a major Solana token-launch platform, is the most prominent example. The word reads as community-driven and approachable, which fits memecoin and dApp branding, though it carries no special technical features over other suffixes.
+
+### Does .fun support WHOIS privacy and DNSSEC?
+
+Yes. The .fun registry supports DNSSEC, and most registrars offer WHOIS privacy so your personal contact details are not published publicly. Availability of privacy depends on your registrar and applicable law.
+
+## Related resources
+
+- [.com domain](/en/tld/com) — the universal default and the main alternative to weigh against .fun.
+- [.xyz domain](/en/tld/xyz) — a flexible, tech- and Web3-friendly generic extension.
+- [.online domain](/en/tld/online) — another open Radix-operated gTLD for broad use.
+- [.io domain](/en/tld/io) — a popular choice for tech and startup projects.
+- [TLD directory](/en/tld) — browse and compare more extensions.

--- a/content/tld/en/info.md
+++ b/content/tld/en/info.md
@@ -1,56 +1,151 @@
 ---
-title: "What is the .info TLD? Meaning, History, and Why You Should Choose It"
-date: '2025-12-10'
+title: 'What Is the .info Domain? The Open Information gTLD Explained'
+date: '2026-06-15'
 language: 'en'
-tags: ['tld', 'domain-education', 'info-domain', 'domain-investing']
+tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: "Discover the power of the .info domain. Learn why this versatile gTLD is perfect for sharing information, its benefits for SEO, and how to register yours today."
-keywords: [".info", ".info domains", ".info TLD", "top-level domain", "what is .info", "why choose .info", "what is the .info domain", "why choose the .info domain", "domain investing", "tokenized domain", "blockchain domains", "buy .info domain", ".info meaning", "Web3 domains", "gTLD"]
+description: 'The .info domain is an open, unrestricted gTLD launched in 2001 for information-led sites. Learn who uses it, its SEO and reputation, and whether to register one.'
+keywords: ['.info', '.info domain', '.info TLD', 'what is .info', 'register .info domain', 'info domain meaning', 'Identity Digital', 'unrestricted gTLD']
+faqs:
+  - question: 'Can anyone register a .info domain?'
+    answer: 'Yes. The .info domain is an open, unrestricted gTLD with no eligibility requirements. Anyone, anywhere can register an available .info name without proving a credential, business type, or local presence.'
+  - question: 'Does a .info domain affect SEO?'
+    answer: 'No. Google treats .info as a standard generic top-level domain with no inherent ranking penalty or boost. Rankings depend on content quality, links, and user experience, not the suffix itself.'
+  - question: 'Who should register a .info domain?'
+    answer: 'It suits knowledge bases, documentation hubs, public-information portals, event pages, and reference sites where the goal is to inform rather than sell. It is also a practical way to secure a name that is taken on .com.'
+  - question: 'Why do some spam filters distrust .info domains?'
+    answer: 'Because .info has historically been low cost and unrestricted, it was used heavily for throwaway and spam sites, so some email filters score it cautiously. A warmed-up domain, proper SPF, DKIM, and DMARC, and a clean sending history overcome this.'
+  - question: 'Does .info support internationalized domain names and DNSSEC?'
+    answer: 'Yes. The .info registry supports internationalized domain names (IDNs) across multiple scripts and has supported DNSSEC since the zone was signed in 2010.'
 ---
 
-## **What is .info?**
+The **.info domain** is one of the original purpose-built generic top-level domains: a suffix that tells visitors, in almost any language, that a site exists to inform. If your project is a knowledge base, a public-data portal, a documentation hub, or a reference resource, .info communicates that intent in four letters before anyone reads a word of your content.
 
-The **.info** domain is a generic Top-Level Domain (gTLD) that stands for "information." It is one of the most recognizable and widely used domain extensions on the internet today. Unlike restricted TLDs (like .gov or .edu), .info is an open TLD, meaning anyone in the world can register a .info domain without specific restrictions.
+It is also one of the most genuinely open extensions on the internet: no credentials to prove and no geography to satisfy — anyone, anywhere can register an available .info name. That openness is its biggest strength and the source of its few real trade-offs.
 
-Launched in 2001, .info was part of the first round of new gTLDs released by [ICANN (Internet Corporation for Assigned Names and Numbers)](https://www.icann.org/) to relieve the overcrowding of the .com namespace. Because "information" is a universally understood concept across many languages and cultures, .info quickly became a global favorite for websites dedicated to sharing knowledge, specifications, and details.
+## .info at a glance
 
-Today, it is managed by [Identity Digital](https://identity.digital/) (formerly Afilias) and remains a top choice for entities that want to signal trustworthiness and resourcefulness to their visitors.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (gTLD) |
+| Registry operator | [Identity Digital](https://www.identity.digital/) (formerly Afilias) |
+| Year launched | 2001 |
+| IDN support | Yes (multiple scripts) |
+| DNSSEC | Supported (zone signed 2010) |
+| Registration restrictions | Open to all — no eligibility requirements |
+| Best for | Information hubs, documentation, public-data and reference sites |
 
-## **How People Are Using .info**
+## What is .info?
 
-Because the term "info" is short for "information" in over 30 languages, this TLD offers incredible versatility. Here is how different groups are leveraging it:
+.info is a generic top-level domain whose meaning needs no translation: "info" is an internationally understood abbreviation of "information." Per its [IANA root-zone record](https://www.iana.org/domains/root/db/info.html), .info is a generic TLD with no sponsoring community and no country tie. Because it is generic rather than a country-code TLD, [Google Search Central](https://developers.google.com/search/docs/specialty/international/locale-adaptive-pages) treats it as a global, non-geo-targeted suffix — a .info site is not assumed to target any single country, which is exactly what you want for a worldwide audience.
 
-*   **Information Hubs and Wikis:** Developers and communities often use .info for documentation sites, wikis, and "How-To" guides.
-*   **Product Support Pages:** Businesses use .info to separate their commercial sales pages (.com) from their customer support and specification sheets (e.g., `productname.info`).
-*   **Event Websites:** Conferences, weddings, and festivals often utilize this TLD to provide attendees with schedules, maps, and logistical details.
-*   **Public Services and Transit:** Transport agencies and public utilities frequently use .info to provide real-time updates to the public.
-*   **Domain Investing and Web3:** As the digital asset space grows, investors are acquiring short, memorable .info domains to tokenize them on the blockchain, preserving value in a universally recognized extension.
+That global readability is what made .info distinctive: it was designed from the start as a broad, semantically meaningful alternative to .com for content whose primary job is to explain something.
 
-## **Notable Entities Using .info**
+## History of .info
 
-While .com is often the default for commercial giants, many massive organizations rely on .info for their critical infrastructure and public-facing data portals.
+.info was delegated in 2001 as part of the first expansion round of new generic TLDs that ICANN authorized to relieve pressure on the crowded .com namespace. It holds a notable first: it was the first genuinely unrestricted, generic TLD introduced after .com, opening to all registrants worldwide rather than a specific industry or community.
 
-1.  **MTA.info (Metropolitan Transportation Authority):** The primary website for New York City's public transportation network uses a .info domain, serving millions of commuters daily.
-2.  **Scafellpike.info:** A dedicated resource for tourists and hikers visiting England’s highest mountain, demonstrating the TLD's strength in the travel and tourism niche.
-3.  **Afilias.info:** The site for the registry backend services often utilizes the extension to demonstrate its technical reliability.
+The registry was launched and operated for nearly two decades by Afilias. The ownership lineage then consolidated: Afilias was acquired by Donuts in 2020, and in 2022 the combined business was unified under the name [Identity Digital](https://www.identity.digital/), which operates .info today alongside a large portfolio of other gTLDs. The suffix grew into one of the larger legacy gTLDs by registration volume, with millions of names registered over its lifetime.
 
-## **Why Choose .info?**
+## How people use .info
 
-If you are debating between extensions, here is why .info might be the perfect choice for your next project:
+.info earns its keep wherever the goal is to inform rather than transact:
 
-*   **Global Clarity:** "Info" is recognized worldwide. It instantly tells the user, "You will find answers here." This reduces bounce rates because visitors know exactly what to expect.
-*   **Better Availability:** Finding a short, one-word, or two-word domain on .com is nearly impossible or incredibly expensive. The .info namespace offers a much higher chance of securing your ideal brand name.
-*   **SEO Relevance:** Search engines like Google treat .info as a standard gTLD. It ranks just as well as a .com or .net when high-quality content is published on it.
-*   **Credibility for Content:** If your primary goal is to educate rather than sell, .info can actually feel more trustworthy and less "salesy" than commercial extensions.
-*   **Cost-Effective:** Generally, .info domains are cost-effective to register and renew, making them excellent for startups and developers.
+- **Documentation and knowledge bases** — product docs, wikis, and "how-to" references.
+- **Public-information and transit portals** — agencies publishing schedules, maps, and service updates to the general public.
+- **Event and one-off pages** — conferences, festivals, and weddings hosting logistics, schedules, and directions.
+- **Reference and educational resources** — encyclopedic or niche-topic sites built to be looked up, not sold from.
+- **Companion sites** — a brand keeping commercial pages on .com and moving support, specs, or FAQs to a matching .info.
 
-## **Register Your .info Domain at Namefi**
+**Who it's not ideal for:** premium consumer brands and storefronts where buyers default to typing .com, and businesses that rely heavily on cold email outreach, where some filters still treat .info more cautiously than .com (see reputation below).
 
-Ready to share your knowledge with the world? Whether you are building a decentralized documentation hub, a tourism guide, or simply securing your brand across all major TLDs, Namefi makes the process seamless.
+## Notable sites using .info
 
-At Namefi, we combine the reliability of an ICANN-accredited registrar with the innovation of Web3. When you register a domain with us, you enjoy seamless management and the ability to tokenize your domain for easier transfer and liquidity.
+- **mta.info** — the public website of New York City's Metropolitan Transportation Authority, one of the busiest transit systems in the United States, serving schedules, maps, and service alerts to millions of riders. It is the best-known example of a major public institution running on .info.
 
-**Secure your digital presence today.**
+Beyond high-profile portals like this, the typical .info site is a documentation hub, a topical reference, or a public-information page — the suffix is far more common in the "look something up" corner of the web than in consumer retail.
 
-[**Register your .info domain at Namefi**](https://namefi.io)
+## .info vs other domains
+
+| Suffix | Type | Core signal | Openness |
+| --- | --- | --- | --- |
+| [.info](/en/tld/info) | Legacy gTLD | "Information / reference" | Open to all |
+| [.com](/en/tld/com) | Legacy gTLD | Default commercial | Open to all |
+| [.org](/en/tld/org) | Legacy gTLD | Organizations / non-profits | Open to all |
+| [.net](/en/tld/net) | Legacy gTLD | Networks / infrastructure | Open to all |
+
+Choose **.com** when you want the universally expected default and it is available. Choose **.org** when you are an organization, non-profit, or community and want that connotation. Choose **.net** for infrastructure or network-flavored projects. Choose **.info** when the content itself is the product — a resource people consult — or when the .com is gone and a meaningful, open alternative beats a contrived spelling.
+
+## Why choose .info?
+
+- **Self-describing meaning.** The suffix announces purpose; "info" reads the same across dozens of languages, so it travels well globally.
+- **Genuinely open.** No credential, business-type, or local-presence gate stands between you and an available name.
+- **Strong availability.** Because .com is so saturated, short and exact-match phrases are far more findable on .info, often letting you keep your real brand word instead of padding it.
+- **Standard SEO treatment.** As a generic TLD it competes on the same footing as .com in search — the suffix is not the variable that decides rankings.
+
+## Things to consider
+
+- **Default-to-.com instinct.** Some users will type .com out of habit; if a competitor holds the .com, you may leak traffic unless you also secure it.
+- **Historical spam association.** Cheap, unrestricted registration made .info attractive to spammers over the years, leaving a reputational tail that can affect email and, occasionally, user trust.
+- **Positioning, not selling.** The "information" connotation is an asset for reference content but a slightly weaker fit for a hard-charging consumer storefront.
+
+## Who can register a .info domain?
+
+**Registration restrictions: open to all.** .info is an unrestricted generic TLD — there are no eligibility requirements whatsoever. You do not need a license, a registered business, membership in any community, or a presence in any country. If a name is available, you can register it.
+
+The full registry rules are governed by .info's [ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/info) and the operator's published policies at [Identity Digital](https://www.identity.digital/). On the administrative side: the registry supports **internationalized domain names (IDNs)** across multiple scripts; **DNSSEC** has been available since the .info zone was signed in 2010; and standard gTLD lifecycle behavior applies, including WHOIS-privacy availability through registrars, an auto-renew grace period, and a redemption-grace window after expiry. Trademark holders can rely on the standard ICANN rights-protection mechanisms (such as the Trademark Clearinghouse) that apply across gTLDs.
+
+## .info pricing and value
+
+This page lists no prices, promotions, or registrar comparisons — only the dynamics that shape cost. Two things are worth understanding before you buy. First, **first-year and renewal pricing usually differ**: promotional first-year rates are common, and the renewal rate is the number that matters over a domain's life, so check it before committing. Second, **premium-tier names exist**: the registry can classify short, dictionary, or high-demand strings as premium, which carries its own (typically higher and recurring) pricing separate from standard registrations. Standard, non-premium .info names sit at the affordable end of the legacy-gTLD spectrum.
+
+## Reputation and email deliverability
+
+Honesty matters here because it is the question competitors skip. Because .info has long been **cheap and unrestricted**, it attracted a disproportionate share of throwaway and spam registrations over its history. As a result, some spam filters and reputation systems have historically scored .info more cautiously than .com, and a brand-new .info can occasionally see email land in spam more often at first.
+
+This is manageable, not disqualifying. Mitigation is the same disciplined sending hygiene any domain needs: warm up the domain gradually, publish correct **SPF, DKIM, and DMARC** records, keep your lists clean, and build a steady sending history. Reputation attaches to *your* domain and its behavior far more than to the suffix, and major public institutions running on .info — the NYC MTA among them — show that a .info can carry a fully trusted public presence.
+
+## Branding and naming tips
+
+.info works best when the suffix completes a phrase: `productname.info`, `event2026.info`, `transit.info`. Lean into its meaning rather than fighting it — a name that reads as "the place to find information about X" plays to the extension's strength. Keep names short and unambiguous, since memorability and clean word-of-mouth still win. Be aware of the **.com confusion tax**: spoken aloud, listeners may default to ".com," so if the matching .com is owned by someone else, weigh whether you should also secure it to protect direct traffic.
+
+## How to register a .info domain at Namefi
+
+1. **Search** your desired name and confirm the .info is available.
+2. **Choose** the exact name (and consider grabbing the matching .com to protect type-in traffic).
+3. **Register** and configure DNS.
+
+[Namefi](https://namefi.io) is an ICANN-accredited registrar with transparent pricing and fast DNS management, and it can additionally tokenize your domain for Web3 ownership and easier transfer. Note your renewal rate at checkout and enable DNSSEC if your setup supports it.
+
+## Frequently asked questions
+
+### Can anyone register a .info domain?
+
+Yes. .info is an open, unrestricted gTLD with no eligibility requirements. Anyone, anywhere can register an available .info name without proving a credential, business type, or local presence — it was, in fact, the first genuinely unrestricted generic TLD launched after .com.
+
+### Does a .info domain affect SEO?
+
+No. Google treats .info as a standard generic top-level domain with no inherent ranking penalty or boost. As a generic suffix it is not geo-targeted to any country. Your rankings come from content quality, links, and user experience — not from the extension you chose.
+
+### Who should register a .info domain?
+
+It suits knowledge bases, documentation hubs, public-information portals, reference sites, and event pages — anywhere the goal is to inform rather than sell. It is also a practical way to secure a meaningful name when the .com is already taken.
+
+### Why do some spam filters distrust .info domains?
+
+Because .info has historically been low cost and unrestricted, it saw heavy use by throwaway and spam sites, so some email filters score it cautiously. A warmed-up domain with correct SPF, DKIM, and DMARC and a clean sending history overcomes this.
+
+### Does .info support internationalized domain names and DNSSEC?
+
+Yes. The registry supports internationalized domain names across multiple scripts, and DNSSEC has been available since the .info zone was signed in 2010, letting you cryptographically protect your DNS responses.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [Domain terminology guide](/en/blog/domain-terminology-guide)
+- [ICANN](/en/glossary/icann) and [registrar](/en/glossary/registrar) glossary terms
+- [DNSSEC](/en/glossary/dnssec) and [WHOIS](/en/glossary/whois) explained
+- Compare with [.com](/en/tld/com), [.org](/en/tld/org), and [.net](/en/tld/net)
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains)

--- a/content/tld/en/io.md
+++ b/content/tld/en/io.md
@@ -1,111 +1,164 @@
 ---
-title: "What Is the .io Domain? Meaning, Uses, Pricing & Future (2026)"
-date: '2025-12-10'
-updated: '2026-06-10'
+title: 'What Is the .io Domain? The Tech and Web3 Extension Explained'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: "What is the .io domain? Learn its British Indian Ocean Territory origin, why .io is the tech-startup standard, why .io domains are expensive, .io vs .ai, and what the Chagos news means for its future."
-keywords: [".io domains", ".io TLD", "io tld", ".io tld", ".io top-level domain", "io top level domain", "what is .io", "what is .io domain", "what is .io domain used for", "io domain meaning", ".io domain extension", "why choose .io", "why are .io domains expensive", "io vs ai domain", ".io vs .ai", "British Indian Ocean Territory domain", "Chagos Islands io domain", "tech startup domains", "developer domains", "blockchain domains", "tokenized domains", "Web3 domains", "buy .io domain", "register io domain", "Namefi .io"]
+description: 'The .io domain is the de facto standard for startups, developers, and Web3 projects. Learn its origin, who can register one, pricing dynamics, and reputation.'
+keywords: ['.io domains', 'what is .io', '.io TLD', '.io domain extension', 'register .io domain', 'io domain meaning', '.io vs .ai', 'tech startup domains']
+faqs:
+  - question: 'Can anyone register a .io domain?'
+    answer: 'Yes. The .io namespace is open to everyone worldwide with no local-presence, business, or credential requirements. You do not need any connection to the British Indian Ocean Territory to register one.'
+  - question: 'Does a .io domain affect SEO?'
+    answer: 'No negatively. Google treats .io as a generic top-level domain rather than a country-targeted one, so a .io site can rank globally and is not geo-restricted to any single region.'
+  - question: 'Who should register a .io domain?'
+    answer: 'Software startups, SaaS products, developer tools, open-source projects, API services, browser game studios, and Web3 or blockchain teams that want a name reading as Input/Output and signaling a technology focus.'
+  - question: 'Is the .io domain going away because of the Chagos sovereignty deal?'
+    answer: 'Not as a settled fact. As of 2026 .io is fully operational. Any retirement would require the ISO country code to change first and would then follow a multi-year IANA transition, so it is an evolving situation to monitor rather than panic over.'
 ---
 
-## What Is the .io Domain? (British Indian Ocean Territory)
+The **.io domain** is technically a country-code extension for a remote Indian Ocean territory, but in practice it has become the unofficial home of software startups, developer tools, and Web3 projects. For most buyers, the **.io domain meaning** has nothing to do with geography and everything to do with how "io" reads to engineers: as **Input/Output**, one of the most fundamental concepts in computing.
 
-The **.io** domain is technically a **country code Top-Level Domain (ccTLD)** assigned to the **British Indian Ocean Territory (BIOT)**, a remote group of islands in the Indian Ocean known as the Chagos Archipelago. It was delegated in 1997 under the **ISO 3166-1** country-code standard, the same standard the [Internet Assigned Numbers Authority (IANA)](https://www.iana.org/domains/root/db/io.html) and [ICANN](/en/glossary/icann/) use to decide which two-letter codes are eligible to become a TLD.
+If you are launching a SaaS product, an API, an open-source project, or a blockchain venture, .io is one of the most recognized signals you can put after your brand name. This page covers where it came from, who can register one, how pricing works, and how it stacks up against the alternatives.
 
-But the **.io domain meaning** that matters today has almost nothing to do with geography. For developers, engineers, and tech entrepreneurs, **.io** reads as an abbreviation for **Input/Output (I/O)**, a foundational concept in computing. That happy coincidence transformed a tiny island ccTLD into one of the most recognized **top level domain** extensions in the technology world.
+## .io at a glance
 
-Importantly, major search engines treat the **.io domain extension** as a **generic** TLD rather than a geographic one. Google classifies it among the [generic ccTLDs it does not geotarget](https://developers.google.com/search/docs/crawling-indexing/manage-international-sites), so unlike .fr or .jp, a .io site is not tied to one region and is perfectly suitable for global businesses and international SEO. (Curious how a "country code" becomes "generic"? See our [glossary entry on registrars](/en/glossary/registrar/) and how the [ICANN](/en/glossary/icann/) accreditation system works.)
+| Fact | Detail |
+| --- | --- |
+| TLD type | Country-code TLD (ccTLD), treated as generic by Google |
+| Registry operator | Internet Computer Bureau Ltd (a subsidiary of Identity Digital) |
+| Year delegated | 1997 |
+| Assigned to | British Indian Ocean Territory (BIOT) |
+| IDN support | Yes |
+| DNSSEC | Yes |
+| Registration restrictions | Open to all — no local presence, credential, or business requirement |
+| Best for | Tech startups, SaaS, developer tools, APIs, browser games, Web3 |
 
-## What Is the .io Domain Used For?
+## What is .io?
 
-Because of its strong association with computer science, the **.io top level domain** has become the de facto standard for the modern tech ecosystem. Here is what .io is used for in practice:
+The **.io top-level domain** is a [country-code TLD (ccTLD)](/en/blog/cctld-market-share-by-registration-volume/) assigned to the **British Indian Ocean Territory** in the Chagos Archipelago. It was delegated in 1997 under the ISO 3166-1 standard, as documented in the [IANA root-zone entry for .io](https://www.iana.org/domains/root/db/io.html). The ccTLD manager of record is **Internet Computer Bureau Ltd**, now a subsidiary of registry-services provider [Identity Digital](https://www.identity.digital/).
 
-*   **SaaS and Tech Startups:** The primary choice for new software-as-a-service companies, AI platforms, and cloud-infrastructure businesses looking to establish instant credibility.
-*   **Web3 and Blockchain:** Given the technical nature of the crypto space, many blockchain projects, decentralized applications (dApps), and [tokenized assets](/en/blog/what-are-tokenized-domains/) use .io to signal their tech-savvy nature.
-*   **Open Source and Developers:** Programmers frequently use .io for personal portfolios, documentation sites, and project pages.
-*   **Gaming:** The extension surged in popularity thanks to "IO games" — browser-based multiplayer titles that require no downloads.
+Despite being a ccTLD on paper, .io behaves like a generic extension in every way that matters to a buyer. Google explicitly classifies .io as a **generic top-level domain** for search, noting that users and site owners see it as more generic than country-targeted. So, unlike `.fr` or `.jp`, a .io site is **not geo-targeted** to one region and is a sound choice for global audiences.
 
-### Notable Entities Using .io
+## History of .io
 
-The legitimacy of the **.io TLD** is reinforced by industry giants and essential tools across the web ecosystem:
+.io was delegated in 1997, making it one of the older ccTLDs in active commercial use. For its first decade it was an obscure island code. Two things changed that. First, developers noticed that "io" reads as **I/O (Input/Output)** — a coincidence that gave the suffix instant meaning to a technical audience. Second, in the 2010s a wave of well-funded startups and developer platforms adopted it, turning .io into a status marker for software companies.
 
-1.  **GitHub.io:** Perhaps the most famous usage. GitHub uses this domain for [GitHub Pages](https://pages.github.com/), letting millions of developers host websites directly from their repositories.
-2.  **Etherscan.io:** The leading block explorer for the Ethereum blockchain, essential to the Web3 and crypto community.
-3.  **Itch.io:** A popular open marketplace for independent digital creators with a focus on indie games.
-4.  **Greenhouse.io:** A major applicant-tracking system used by companies worldwide to manage hiring.
+The suffix also lent its name to an entire genre: **"io games"** — browser-based multiplayer titles like Agar.io and Slither.io that required no downloads and drew tens of millions of players. On the registry side, the original operator was eventually folded into the Identity Digital portfolio, which now provides registry services for the namespace.
 
-These examples show that .io is trusted by major platforms serving millions of daily users.
+## How people use .io
 
-## Why Are .io Domains Expensive?
+The suffix clusters tightly around technology niches:
 
-A common question from founders is **why are .io domains expensive** compared to a standard .com or .net. There are three main drivers:
+- **SaaS and tech startups** establishing instant credibility with a tech-native audience
+- **Developer tools, APIs, and infrastructure** where "I/O" is a literal fit
+- **Open-source projects, documentation sites, and developer portfolios**
+- **Web3, blockchain, and decentralized application** teams signaling technical depth
+- **Browser-based "io games"** and indie game marketplaces
 
-*   **Registry pricing.** The .io registry (operated under the Identity Digital portfolio after its acquisition of the original operator) sets a relatively high wholesale price. Registrars pass that floor on to you, so even a plain, unregistered .io name typically costs several times the price of a basic .com.
-*   **Startup demand and branding.** The tech and crypto communities treat .io as a status signal — a "secret handshake" that tells investors and users you are a serious technology company. That concentrated demand from well-funded startups keeps both registration prices and secondary-market resale values elevated.
-*   **Short, memorable names.** Because the namespace is younger and smaller than .com, short, brandable, and "domain hack" names (like `rad.io` or `stud.io`) are still attainable — and scarcity of premium short names pushes prices up further.
+**Who it's not ideal for:** local brick-and-mortar businesses that want to rank for a specific country, non-technical consumer brands, or budget buyers who need the cheapest registration — .io carries a premium price and a techy connotation that can feel off-brand outside software.
 
-We break the numbers down in our dedicated guide: **[Why are .io domains expensive?](/en/blog/why-are-io-domains-expensive/)**
+## Notable sites using .io
 
-## Why Choose .io?
+- **GitHub Pages** (`github.io`) — millions of developer sites hosted from repositories
+- **Etherscan** (`etherscan.io`) — the leading Ethereum blockchain explorer
+- **itch.io** — a popular open marketplace for indie game creators
+- **Agar.io** and **Slither.io** — the browser games that defined the "io games" genre
 
-If you are launching a new digital venture, here is why securing a **.io domain** still makes sense:
+These span developer infrastructure, Web3, indie publishing, and gaming, illustrating why .io reads as credible to a technical audience.
 
-*   **Industry recognition:** A .io domain instantly signals that you are a technology-focused entity.
-*   **Availability:** Finding a short, memorable .com is increasingly difficult and expensive; the .io namespace offers far better availability for concise, brandable names.
-*   **Creativity:** The two-letter extension enables clever domain hacks that fold the TLD into the word itself.
-*   **Global SEO:** Search engines treat it as generic, so your site can rank globally without being boxed into one region.
+## .io vs other domains
 
-## The Future of .io: What Domain Owners Should Know
+| Feature | .io | .com | .ai | .dev |
+| --- | --- | --- | --- | --- |
+| Type | ccTLD (generic) | gTLD | ccTLD (generic) | gTLD |
+| Primary signal | Tech / Input-Output | Universal / default | Artificial intelligence | Developers / code |
+| Short-name availability | Good | Very scarce | Good | Good |
+| Typical price tier | Premium | Standard | Premium+ | Standard+ |
 
-There has been real news around the **.io domain** that owners should understand — calmly and accurately, because the headlines have run ahead of the facts.
+Pick [.com](/en/tld/com/) for the universal default when you can find or afford the name. Choose [.ai](/en/tld/ai/) when your product is explicitly about artificial intelligence, or [.dev](/en/tld/dev/) for developer tools and documentation. Choose **.io** for general tech, SaaS, infrastructure, gaming, and Web3 where the Input/Output association fits and short names are still attainable.
 
-In 2024 the UK announced it would transfer sovereignty of the **Chagos Archipelago** (the territory behind BIOT) to **Mauritius**, and the two governments signed a treaty on **May 22, 2025**. Because the .io ccTLD exists on the basis of the **"IO" ISO 3166-1 country code** for that territory, the deal sparked widespread speculation that .io could eventually be retired.
+## Why choose .io?
 
-Here is what is actually true as of **June 2026**:
+- **Industry recognition.** Among founders, engineers, and investors, .io instantly reads as "technology company."
+- **Better short-name availability.** The namespace is younger and smaller than [.com](/en/tld/com/), so concise, brandable names are far easier to find.
+- **Domain-hack potential.** The two-letter suffix folds neatly into words (`rad.io`, `stud.io`), enabling clever, memorable names.
+- **Global SEO.** Search engines treat it as generic, so your site can rank worldwide without being boxed into one region.
 
-*   **.io is fully operational.** Registrations and renewals continue normally, and the ISO 3166-1 code "IO" remains active. The treaty has not yet completed ratification, and the Chagos arrangement has even been **paused at points amid US political review**, adding further uncertainty rather than triggering any shutdown.
-*   **Retirement is a slow, multi-year process — not an automatic switch.** A ccTLD is only put on a path to removal if the underlying ISO code actually changes. Even then, IANA/ICANN policy provides for a multi-year transition (often cited as a roughly **five-year** window) so registrants can migrate. ICANN's own [statement on the Chagos Archipelago and the .io domain](https://www.icann.org/en/blogs/details/the-chagos-archipelago-and-the-io-domain-14-11-2024-en) stresses that its overriding goal is the **security and stability of the DNS**, and that any change would be handled deliberately, not abruptly.
-*   **There is more than one possible outcome.** Codes can persist, be reassigned, or be grandfathered. With a large ecosystem of major platforms depending on it, there is strong practical pressure toward continuity.
+## Things to consider
 
-**Bottom line:** It is **not** a settled fact that .io is being deleted. This is an evolving situation. A prudent owner should treat .io as safe for the foreseeable future, keep an eye on official IANA/ICANN updates rather than headlines, and — as with any single TLD — avoid betting an entire brand on one extension without a backup. One advantage of registering through a modern registrar is portability: [tokenized domains](/en/blog/what-are-tokenized-domains/) make it far easier to move, manage, and prove ownership of your asset if you ever need to diversify.
+- **Premium pricing.** The registry sets a relatively high wholesale price, so .io typically costs several times a basic .com — at both registration and renewal.
+- **Niche connotation.** The techy meaning is an asset in software and a liability for mainstream consumer brands.
+- **Sovereignty uncertainty.** The Chagos Archipelago is the subject of an ongoing UK–Mauritius sovereignty arrangement, which has fueled speculation about the suffix's long-term future (covered below).
+- **Single-TLD risk.** As with any extension, betting an entire brand on one suffix without a backup is a risk worth weighing.
 
-## .io vs .ai: Which Should You Choose?
+## Who can register a .io domain?
 
-Both extensions started as ccTLDs (.io for BIOT, **.ai** for Anguilla) and both became tech-brand magnets. The short version:
+**Registration restrictions: open to all.** Anyone in the world can register a .io domain. There is **no local-presence requirement**, no business-eligibility check, and no credential gate — you need no connection to the British Indian Ocean Territory. Names run **3–63 characters**, allow letters, digits, and hyphens (not at the start or end), and **internationalized domain names (IDNs)** are supported.
 
-*   Choose **.io** for general tech, SaaS, developer tools, infrastructure, gaming, and Web3 projects where the "Input/Output" association fits.
-*   Choose **.ai** when your product is explicitly about artificial intelligence — the keyword is literally in your URL, and demand has pushed it to premium "digital gold" pricing.
+The registry supports **DNSSEC**, and standard transfer, renewal, and redemption-grace behavior applies. The only notable content restriction is a long-standing acceptable-use rule barring sexual or pornographic content and use that violates applicable law. Because .io is a ccTLD rather than an ICANN gTLD, the authoritative rules come from the operator, not an ICANN registry agreement — the binding policy is published by the [NIC.IO registry (rules for domain names)](https://nic.io/rules.htm).
 
-For a full side-by-side on pricing, branding, SEO, and longevity, read **[.ai vs .io domain: which is right for your startup?](/en/blog/ai-vs-io-domain/)** — and see our complete **[.ai TLD guide](/en/tld/ai/)**.
+### The Chagos sovereignty question
 
-## .io Domain FAQ
+In 2024 the UK announced plans to transfer sovereignty of the Chagos Archipelago to Mauritius, and an agreement was signed on May 22, 2025. Because .io rests on the "IO" ISO 3166-1 code, this sparked retirement speculation. As of 2026, **.io is fully operational** — registrations and renewals continue normally. Any retirement would require the ISO code to change first and would then trigger a multi-year IANA transition (often cited as roughly five years), so this is a situation to monitor, not a reason to avoid the suffix.
 
-**What is the .io domain?**
-It is the country code Top-Level Domain for the British Indian Ocean Territory, now used globally by tech companies because "io" also reads as "Input/Output."
+## .io pricing and value
 
-**What is the .io domain used for?**
-SaaS and tech startups, developer portfolios, open-source projects, Web3 and blockchain platforms, and browser-based "IO games."
+This page never quotes live prices, but the pricing **dynamics** are worth understanding:
 
-**Why are .io domains expensive?**
-A high registry wholesale price, strong demand from well-funded startups using it as a branding signal, and scarcity of short, memorable names. See our [pricing deep dive](/en/blog/why-are-io-domains-expensive/).
+- **A premium wholesale floor.** The .io registry sets a relatively high base price, which registrars pass on. Even a plain, unregistered .io typically costs several times a basic .com.
+- **First-year vs. renewal pricing differ.** An introductory first-year rate can sit below the recurring renewal rate, so budget for the renewal — not just the signup price.
+- **Premium-tier names exist.** Short, dictionary, or highly brandable .io names may be registry-reserved as premium, and the secondary market for them is active. We cover the drivers in [why are .io domains expensive](/en/blog/why-are-io-domains-expensive/).
 
-**Is the .io domain going away because of the Chagos Islands deal?**
-No — not as a settled fact. As of June 2026 .io is fully operational. Any retirement would only follow an ISO code change and a multi-year IANA/ICANN transition process. It is an evolving situation worth monitoring, not a reason to panic.
+## Reputation and email deliverability
 
-**Is .io good for SEO?**
-Yes. Google treats .io as a generic (non-geotargeted) TLD, so .io sites can rank globally.
+.io carries a **premium, technical reputation**. To founders, developers, and investors it reads as serious and modern — closer to a status signal than a discount extension, the opposite of the cheap, spam-prone new gTLDs that some aggressive mail filters treat with suspicion.
 
-**Should I choose .io or .ai?**
-Pick .io for general tech and Web3 projects; pick .ai for explicitly AI-focused products. See our [.ai vs .io comparison](/en/blog/ai-vs-io-domain/).
+Because .io is widely used by reputable startups and major developer platforms, it does not suffer the blanket spam-filtering problems that affect some bargain extensions. As always, deliverability depends far more on your own sending practices — properly configured SPF, DKIM, and DMARC records, a warmed-up sending domain, and clean list hygiene — than on the suffix itself.
 
-## Register Your .io Domain at Namefi
+## Branding and naming tips
 
-Ready to launch your next big idea? There is no better place to start than by securing the perfect **.io** domain.
+The two-letter suffix is built for **domain hacks** — names where the TLD becomes part of the word, folding ".io" onto a stem (`stud.io`, `rad.io`, `scenar.io`). Keep names short and pronounceable; the strength of .io is concision.
 
-At **Namefi**, we go beyond traditional registration. As an [ICANN-accredited](/en/glossary/icann/) [registrar](/en/glossary/registrar/), we bridge Web2 and Web3. When you register with us, you enjoy seamless management features and the ability to hold your name as a [tokenized domain](/en/blog/what-are-tokenized-domains/) — giving you true ownership, easy transferability, and a built-in path to diversify if any single TLD's future ever shifts.
+Watch two pitfalls. First, spoken aloud, "io" can be misheard, so test how your full name sounds on a phone call. Second, because .io is so strongly tied to software, a name in a non-technical category may feel mismatched.
 
-Don't let your perfect name get snatched up by someone else.
+## How to register a .io domain at Namefi
 
-**[Register your .io domain at Namefi today](https://namefi.io)** and join the community of innovators building the future of the web.
+1. **Search** for your desired name at [Namefi](https://namefi.io) to check availability.
+2. **Choose** the .io result (and any alternates worth securing).
+3. **Register** and configure DNS.
+
+As an [ICANN-accredited](/en/glossary/icann/) [registrar](/en/glossary/registrar/), Namefi bridges Web2 and Web3: transparent pricing, fast [DNS](/en/glossary/dns/) management, and the option to hold your name as a [tokenized domain](/en/blog/what-are-tokenized-domains/) for verifiable [domain ownership](/en/glossary/domain-ownership/) and easy transferability. Get started at [Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .io domain?
+
+Yes. The .io namespace is open to everyone worldwide with no local-presence, business, or credential requirements. You do not need any connection to the British Indian Ocean Territory to register one.
+
+### Does a .io domain affect SEO?
+
+Not negatively. Google treats .io as a generic top-level domain rather than a country-targeted one, so a .io site can rank globally and is not geo-restricted to any single region.
+
+### Who should register a .io domain?
+
+Software startups, SaaS products, developer tools, open-source projects, API services, browser game studios, and Web3 or blockchain teams. The "Input/Output" reading fits wherever a technology focus is part of the brand.
+
+### Is the .io domain going away because of the Chagos sovereignty deal?
+
+Not as a settled fact. As of 2026 .io is fully operational, with registrations and renewals continuing normally. Any retirement would require the ISO country code to change first and then follow a multi-year IANA transition, so monitor it rather than panic.
+
+### Does .io support WHOIS privacy and DNSSEC?
+
+DNSSEC is supported by the .io registry. WHOIS privacy availability depends on your registrar; most modern registrars, including Namefi, offer privacy protection on eligible registrations.
+
+## Related resources
+
+- [What is a domain?](/en/blog/what-is-domain/)
+- [Domain terminology guide](/en/blog/domain-terminology-guide/)
+- [Why are .io domains expensive?](/en/blog/why-are-io-domains-expensive/)
+- [.ai vs .io domain](/en/blog/ai-vs-io-domain/)
+- [Tokenized domain use cases (2026)](/en/blog/tokenized-domain-use-cases-2026/)
+- TLD guides: [.com](/en/tld/com/), [.ai](/en/tld/ai/), [.dev](/en/tld/dev/), [.app](/en/tld/app/), [.tech](/en/tld/tech/)
+- Glossary: [ICANN](/en/glossary/icann/), [registrar](/en/glossary/registrar/), [DNS](/en/glossary/dns/), [DNSSEC](/en/glossary/dnssec/)

--- a/content/tld/en/live.md
+++ b/content/tld/en/live.md
@@ -1,54 +1,153 @@
 ---
-title: "What is the .live TLD and Why Choose It?"
-date: '2025-12-10'
+title: 'What Is the .live Domain? The Streaming TLD Explained'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: "Unlock the potential of the .live domain extension. Ideal for streamers, broadcasters, and real-time events. Learn why you should register your .live domain today."
-keywords: ['.live domains', '.live TLD', 'top-level domain', 'what is .live', 'why choose .live', 'what is the .live domain', 'why choose the .live domain', 'streaming domains', 'real-time content domains', 'broadcast domain names', 'buy .live domain', 'domain investing', 'Web3 domain registration', 'tokenized domains', 'blockchain domains']
+description: 'The .live domain is an open new gTLD run by Identity Digital, built for streaming, events, and real-time content. Learn who uses it, the rules, and whether it fits you.'
+keywords: ['.live domains', '.live TLD', 'what is .live', 'why choose .live', 'streaming domain', 'live streaming domain name', 'Identity Digital', 'new gTLD']
+faqs:
+  - question: 'Can anyone register a .live domain?'
+    answer: 'Yes. The .live extension is an open generic top-level domain with no eligibility restrictions. Any individual, business, or organization worldwide can register an available .live name on a first-come, first-served basis, with no credential, license, or local-presence requirement.'
+  - question: 'Does a .live domain affect SEO?'
+    answer: 'No. Google treats .live like any other generic top-level domain, so the extension itself gives no ranking advantage or penalty. Rankings depend on content, links, and user experience, not on whether you use .live, .com, or another suffix.'
+  - question: 'Who should register a .live domain?'
+    answer: 'Streamers, broadcasters, event organizers, webinar hosts, and anyone publishing real-time or scheduled live content. The word reads as "happening now," so it suits projects where immediacy and a clear call to watch are central to the brand.'
+  - question: 'Is .live good for email and deliverability?'
+    answer: 'A .live domain can send and receive email reliably when you authenticate it properly with SPF, DKIM, and DMARC and warm it up gradually. As a newer suffix it carries less default trust than .com, so correct configuration matters more than the extension itself.'
+  - question: 'When was the .live domain launched?'
+    answer: 'The .live top-level domain was delegated to the DNS root in June 2015 as part of ICANN New gTLD Program and reached general availability later that year. It is now operated by Identity Digital, the registry formerly known as Donuts.'
 ---
 
-## **What is .live?**
+The **.live** domain is a generic top-level domain (gTLD) built around a single, instantly understood idea: something is happening right now. Where a country-code suffix signals geography, .live signals action and immediacy, which makes it a natural fit for streamers, broadcasters, event pages, and any project where the call to "watch now" is the point. This page explains what .live is, who runs it, who uses it, the rules, and how it compares with the alternatives.
 
-The **.live** domain extension is a New Generic Top-Level Domain (New gTLD) designed specifically for real-time engagement, streaming, and broadcasting. Unlike country-code TLDs (like .us or .uk) which are tied to geography, .live is a functional TLD that signals immediacy and action.
+Because "live" is a common English word with the same meaning across most of the world, the suffix doubles as part of the message rather than just a technical address: `concert.live` or `news.live` reads as a phrase, not a URL.
 
-Launched to the public around 2015 as part of [ICANN's New gTLD Program](https://newgtlds.icann.org/en/about/program), it is managed by the registry **Identity Digital** (formerly known as Donuts). The primary purpose of this TLD was to provide a dedicated digital space for individuals and businesses that share live content. In an era dominated by platforms like Twitch, YouTube Live, and Zoom, the .live extension has seen a massive surge in popularity, becoming the go-to choice for anyone demanding their audience's immediate attention.
+## .live at a glance
 
-## **How People Are Using .live**
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (new gTLD) |
+| Registry operator | Identity Digital (formerly Donuts), through Dog Beach, LLC |
+| Year launched | 2015 (delegated June 2015) |
+| IDN support | Yes (internationalized domain names supported) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility requirements |
+| Best for | Streamers, live events, webinars, broadcasters, real-time content |
 
-Because the word "live" is universally understood to mean "happening now," this TLD is incredibly versatile. It is used to create a sense of urgency and connection. Here is how various sectors are utilizing it:
+## What is .live?
 
-*   **Content Creators & Streamers:** Gamers, influencers, and vloggers often use a short .live domain (e.g., `YourName.live`) to forward traffic directly to their Twitch or YouTube channels. It is easier to remember than a long URL.
-*   **Media & News Outlets:** Traditional news organizations use these domains for breaking news pages or 24-hour broadcast streams.
-*   **Educational Webinars:** Coaches and educators use .live domains for landing pages where students can join scheduled classes or webinars.
-*   **Live Events & Concerts:** Music venues and festival organizers register these domains to host ticketing information, lineups, and live streams of performances.
-*   **Tech Product Launches:** Startups often use a .live subdomain or standalone domain to host the keynote presentation for a new product release.
+The .live domain is a generic top-level domain introduced under [ICANN's New gTLD Program](https://newgtlds.icann.org/en/), the expansion that took the domain name system far beyond the original handful of suffixes like .com and .org. Unlike a country-code TLD such as .uk or .de, .live carries no geographic meaning, so Google treats it as a generic, non-geotargeted extension. You can read the authoritative root-zone record on the [IANA .live database entry](https://www.iana.org/domains/root/db/live.html).
 
-## **Notable Entities Using .live**
+In practical terms, "generic and non-geotargeted" means a .live site is not automatically associated with any single country in search results. That helps if your audience is global — a livestream has no borders — and is neutral if your audience is local, since you would lean on content and local signals for regional relevance.
 
-While many .live domains are held by independent creators, major corporations and entities have recognized the branding power of this TLD to segment their real-time content from their static corporate pages.
+## History of .live
 
-1.  **Amazon:** The tech giant has utilized domains like `amazon.live` to highlight their livestream shopping experiences, separating active engagement from their standard e-commerce catalog.
-2.  **Microsoft/Xbox:** Various gaming communities and official channels utilize the "live" branding (synonymous with Xbox Live) to denote multiplayer or streaming connectivity.
-3.  **News Agencies:** Many local and international news stations acquire the .live version of their brand to host their "Watch Live" functionalities, ensuring users know exactly where to click for on-air content.
-4.  **Independent Journalists:** With the rise of independent media, many journalists on platforms like Substack or Patreon use .live domains to host town halls or Q&A sessions.
+The .live string was delegated to the DNS root in June 2015 and entered general availability later that year, putting it among the first wave of word-based new gTLDs aimed at content and lifestyle niches. It launched within the Rightside and Donuts portfolio — registry businesses later merged and rebranded as **Identity Digital** in 2022. Per the IANA record, the .live registry was transferred to the holding entity **Dog Beach, LLC** in 2021, which sits within the Identity Digital group.
 
-## **Why Choose .live?**
+Adoption tracked the broader rise of live video. As Twitch, YouTube Live, and livestream shopping moved from novelty to mainstream, .live found a steady niche among creators and event brands who wanted a name that described what they do. It is not one of the largest new gTLDs by volume, but it has a clear, durable use case rather than being a speculative landrush suffix.
 
-Choosing the right TLD is about more than just availability; it is about branding and psychology. Here is why .live is a smart investment for your portfolio or business:
+## How people use .live
 
-*   **Instant Context:** The moment a user sees a .live URL, they expect fresh, real-time content. It sets a clear expectation and encourages click-throughs from users seeking immediate information.
-*   **Higher Availability:** Compared to the saturated .com and .net markets, .live offers a much higher chance of securing a short, memorable, and keyword-rich domain name without paying a premium aftermarket price.
-*   **Memorable Branding:** `Concert.live` is infinitely more memorable and marketable than `ConcertLiveStream247.com`. It creates a punchy, modern brand identity.
-*   **Search Relevance:** For businesses focused on streaming or events, having "live" in the URL can act as a relevant signal to users searching for real-time coverage, potentially improving click-through rates (CTR) in search results.
+The word's "happening now" connotation makes it versatile across any real-time or scheduled-event context:
 
-## **Register Your .live Domain at Namefi**
+- **Streamers and creators** point a short `name.live` at their Twitch or YouTube channel instead of sharing a long platform URL.
+- **Event organizers** run ticketing, schedules, and stream embeds for concerts, festivals, and conferences on a dedicated .live page.
+- **Webinar and course hosts** use a .live landing page as the join point for scheduled sessions.
+- **Newsrooms and broadcasters** host "watch live" and breaking-coverage pages that signal active, on-air content.
+- **Product launches** put a keynote or launch-day stream on a standalone .live name.
 
-Whether you are launching a new streaming career, hosting a global webinar, or simply investing in high-potential digital real estate, the .live TLD is a powerful tool for the modern web.
+**Who it's not ideal for:** if your project is static — a portfolio, brochure site, dashboard, or blog — the "live" framing can mislead visitors who expect real-time video. A business that never broadcasts is usually better served by .com or a suffix matching its actual category.
 
-At **Namefi**, we make securing your digital identity seamless. As an ICANN-accredited registrar, we combine the reliability of traditional domains with the innovation of Web3. When you register with Namefi, you aren't just buying a URL; you are future-proofing your assets. Our platform allows for tokenized domain ownership, meaning you can manage, trade, and transfer your domains as easily as sending an NFT, all while enjoying enterprise-grade security.
+## Notable sites using .live
 
-**Don't let your perfect name disappear.**
+- **amazon.live** — Amazon uses the name in connection with its livestream shopping experience, separating shoppable live video from its standard catalog.
+- Many broadcasters, sports clubs, and festivals register the .live version of their brand to host "watch live" portals and event hubs.
 
-[**Register your .live domain at Namefi today**](https://namefi.io) and start broadcasting your brand to the world.
+Beyond a handful of large brands, the bulk of .live registrations are held by independent creators and event organizers, which reflects the suffix's grassroots, creator-driven character rather than blue-chip corporate adoption.
+
+## .live vs other domains
+
+| Extension | Core meaning | Typical use | Registration |
+| --- | --- | --- | --- |
+| [.live](/en/tld/live) | Happening now / real-time | Streaming, events, webinars | Open to all |
+| [.com](/en/tld/com) | Generic / commercial | Almost anything | Open to all |
+| .tv | Video / television (ccTLD of Tuvalu) | Video and streaming brands | Open to all |
+| [.club](/en/tld/club) | Community / membership | Communities, events, groups | Open to all |
+
+Choose **.com** when broad credibility and the exact-match name matter more than thematic fit. Choose **.live** when the immediacy of the word is part of your brand and the obvious .com is taken or expensive. For a video-first identity, many compare .live against .tv — both read as broadcast suffixes, but .tv is a country-code TLD for Tuvalu marketed for media, while .live is a generic suffix with no geographic tie. See the full directory at [the Namefi TLD index](/en/tld).
+
+## Why choose .live?
+
+- **Built-in meaning.** The suffix completes a phrase — `town-hall.live`, `q-and-a.live` — so the whole name communicates purpose at a glance.
+- **Availability.** Because the .com landscape is heavily registered, short, keyword-rich names are far easier to find on .live, often without aftermarket prices.
+- **Memorability for events.** A clean `event.live` is easier to print on a poster or say aloud than a long platform subdomain.
+- **Neutral, global footprint.** As a non-geotargeted gTLD, it works for an international audience without tying your brand to one country.
+
+## Things to consider
+
+- **Niche connotation.** "Live" sets a strong expectation of real-time content; using it for a static site can confuse visitors.
+- **Less default familiarity.** Some users still instinctively trust .com, so you may field occasional "is that a real website?" questions.
+- **Renewal pricing.** First-year and renewal pricing can differ, and standout one-word names may be classified as premium — check the terms first.
+- **Brand protection.** You may still want the matching .com to prevent confusion or typo-squatting on your primary name.
+
+## Who can register a .live domain?
+
+**Registration restrictions: none.** The .live domain is an open generic TLD. There is no credential, license, membership, or local-presence requirement — any person or organization anywhere can register an available .live name on a first-come, first-served basis. Unlike gated suffixes such as .law (bar membership) or .realtor (NAR membership), .live is fully open.
+
+Standard new-gTLD rules apply: a sunrise period gave trademark holders early access at launch, names follow normal length and label rules, and internationalized domain names (IDNs) are supported. The registry supports **DNSSEC**, and WHOIS privacy is generally available depending on your registrar. Transfer, renewal, and redemption-grace behavior follow ICANN's standard gTLD lifecycle. The authoritative rules come from the registry: see [Identity Digital's policies](https://www.identity.digital/policies), including the acceptable-use policy that applies across its TLDs.
+
+## .live pricing and value
+
+This page does not quote prices, but the dynamics are worth understanding. A .live registration typically prices above bargain-bin suffixes but in line with other word-based new gTLDs. Two factors commonly surprise first-time buyers. First, **first-year and renewal pricing often differ**, so a low introductory rate may renew higher — always check the renewal price. Second, **premium names exist**: short, generic, high-demand strings can be flagged by the registry as premium and carry elevated registration and renewal fees. The drivers of cost are name quality, premium classification, and registrar margin, not anything unique to .live's technology.
+
+## Reputation and email deliverability
+
+Newer gTLDs have at times drawn extra scrutiny from spam filters, because some cheap suffixes were heavily abused. The good news is that **.live has a clear, legitimate use case** and is not among the suffixes most associated with abuse, so its baseline reputation is reasonable — though it carries less inherited trust than a decades-old .com.
+
+For email, the extension matters far less than your configuration. Authenticate your domain with **SPF, DKIM, and DMARC**, warm up new sending domains gradually, and keep list hygiene tight, and a .live domain will deliver reliably. If deliverability is mission-critical and your audience skews conservative, many teams send transactional mail from a .com while using .live as their public-facing brand.
+
+## Branding and naming tips
+
+The strongest .live names are domain "hacks" where the suffix finishes the thought: `comedy.live`, `auction.live`, `worship.live`, `coding.live`. Aim for a name that reads naturally as "[something] live," and keep it short and easy to say aloud, since these names are frequently spoken on stream or announced at events. Avoid constructions where "live" could be misread as the verb (to live) rather than the adjective — context usually resolves it, but the clearest names lean on the broadcast meaning.
+
+## How to register a .live domain at Namefi
+
+1. **Search** for your desired name on [Namefi](https://namefi.io) to check availability.
+2. **Choose** the best available `name.live`, reviewing both the registration and renewal terms.
+3. **Register** and configure DNS to point at your stream, landing page, or platform.
+
+Namefi is an ICANN-accredited registrar with transparent pricing and fast DNS, and it also supports Web3 tokenized domains — so you can hold, manage, and transfer your .live name as an on-chain asset if you choose. [Register your .live domain at Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .live domain?
+
+Yes. The .live extension is an open generic top-level domain with no eligibility restrictions. Any individual, business, or organization worldwide can register an available .live name on a first-come, first-served basis, with no credential, license, or local-presence requirement.
+
+### Does a .live domain affect SEO?
+
+No. Google treats .live like any other generic top-level domain, so the extension itself gives no ranking advantage or penalty. Rankings depend on content, links, and user experience, not on whether you use .live, .com, or another suffix.
+
+### Who should register a .live domain?
+
+Streamers, broadcasters, event organizers, webinar hosts, and anyone publishing real-time or scheduled live content. The word reads as "happening now," so it suits projects where immediacy and a clear call to watch are central to the brand.
+
+### Is .live good for email and deliverability?
+
+A .live domain can send and receive email reliably when you authenticate it properly with SPF, DKIM, and DMARC and warm it up gradually. As a newer suffix it carries less default trust than .com, so correct configuration matters more than the extension itself.
+
+### When was the .live domain launched?
+
+The .live top-level domain was delegated to the DNS root in June 2015 as part of ICANN's New gTLD Program and reached general availability later that year. It is now operated by Identity Digital, the registry formerly known as Donuts.
+
+## Related resources
+
+- [What is a domain?](/en/blog/what-is-domain)
+- [Domain terminology guide](/en/blog/domain-terminology-guide)
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains)
+- [Glossary: ICANN](/en/glossary/icann)
+- [Glossary: registrar](/en/glossary/registrar)
+- [Glossary: DNSSEC](/en/glossary/dnssec)
+- [.com domain](/en/tld/com) · [.tech domain](/en/tld/tech) · [.club domain](/en/tld/club)

--- a/content/tld/en/loan.md
+++ b/content/tld/en/loan.md
@@ -1,71 +1,162 @@
 ---
-title: What is .loan TLD and how it serves financial services?
-date: '2025-06-22'
-language: en
+title: 'What Is a .loan Domain? Meaning, Uses, and Is It Safe?'
+date: '2026-06-15'
+language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: .loan is a specialized domain extension designed for financial services, lending institutions, and personal finance platforms. Discover its purpose, uses, and benefits.
+description: 'A .loan domain is an open new gTLD for lending and finance sites. Learn who can register it, how it is priced, its spam reputation, and whether it is worth buying.'
+keywords: ['.loan domain', 'what is .loan domain', '.loan tld', 'register .loan domain', 'is .loan domain safe', '.loan domain meaning', 'loan domain extension', 'new gTLD', 'cheap domain extensions', 'finance domain names']
+faqs:
+  - question: 'Can anyone register a .loan domain?'
+    answer: 'Yes. The .loan extension is an open generic top-level domain with no eligibility checks. You do not need a financial license, lending credential, or local presence to register one, so anyone worldwide can buy an available .loan name on a first-come, first-served basis.'
+  - question: 'Does a .loan domain affect SEO?'
+    answer: 'A .loan domain is treated as a generic gTLD by Google and carries no inherent ranking penalty or boost. However, because .loan is heavily abused by spammers, the extension can suffer reputation effects that affect email deliverability and user trust more than direct search rankings.'
+  - question: 'Is a .loan domain safe?'
+    answer: 'The .loan registry is legitimate and ICANN-accredited, but the extension has a high rate of spam and phishing because the names are very cheap and bought in bulk. A specific .loan site can be perfectly safe; treat unknown .loan links with the same caution you would any unfamiliar domain.'
+  - question: 'Who should register a .loan domain?'
+    answer: 'A .loan domain suits lenders, mortgage brokers, loan-comparison sites, and fintech projects that want an exact-match, descriptive name. It works best as a campaign or product domain paired with a .com, rather than as the sole brand for a regulated financial institution.'
 ---
 
-## **What is .loan?**
+A **.loan domain** is a web address that ends in **.loan** instead of a familiar extension like **.com** or **.net**. The part after the final dot is called a [top-level domain](/en/glossary/tld/) (TLD), and **.loan** is a **new generic top-level domain (gTLD)** built around a single, self-explanatory English word: *loan*. It tells visitors at a glance that a site is about lending, borrowing, or finance.
 
-The **.loan** domain extension is a specialized top-level domain (TLD) launched in **2014** specifically for the **financial services industry**. This domain is designed for businesses and organizations involved in **lending, borrowing, and financial services**. Whether you're a traditional bank, online lending platform, mortgage broker, or financial advisor specializing in loans, `.loan` provides a **clear, professional, and industry-specific** online identity.
+In short, **.loan is a real, open domain extension that anyone in the world can register** — there is no licensing requirement. That openness, combined with very low pricing, makes it attractive for descriptive, keyword-rich names, but it also gives the extension a reputation problem worth understanding before you buy. This page covers what .loan is, who runs it, how it is priced, and whether it is the right choice for your project.
 
-The `.loan` extension immediately communicates your business focus to potential customers, making it easier for them to find and trust your **financial services**.
+## .loan at a glance
 
----
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (new gTLD) |
+| Registry operator | dot Loan Limited (a Famous Four Media / Domain Venture Partners string) |
+| Year launched | Delegated 2015 |
+| IDN support | Generally supported |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no credential, license, or local presence required |
+| Best for | Lending, mortgage, and finance sites wanting an exact-match keyword name |
 
-## **How People Are Using .loan**
+## What is .loan?
 
-The `.loan` domain has been adopted by various financial service providers worldwide:
+The .loan string is a **dictionary-word new gTLD** introduced through ICANN's New gTLD Program, the expansion that added hundreds of word-based extensions to the root zone from 2013 onward. Unlike a [country-code TLD](/en/glossary/tld/) such as .uk or .de, .loan carries no geographic meaning and is not tied to any nation. You can confirm its delegation and sponsoring organization in the official [IANA root-zone entry for .loan](https://www.iana.org/domains/root/db/loan.html).
 
-* **Online lending platforms** offering personal, business, and peer-to-peer loans.
-* **Mortgage brokers and lenders** specializing in home financing solutions.
-* **Credit unions and community banks** providing local lending services.
-* **Financial comparison websites** helping consumers find the best loan options.
-* **Loan consultants and advisors** offering expert guidance on borrowing decisions.
+Because it is a generic gTLD, Google treats .loan as a **non-geo-targeted, generic extension** — the same way it treats .com or .net. Google's documentation on [how new gTLDs are handled in Search](https://developers.google.com/search/blog/2015/07/google-search-and-new-gtlds) confirms that new word-based extensions get no automatic ranking advantage or penalty simply for the string after the dot. What you do with the domain — content, links, security, and trust signals — is what matters.
 
-Because `.loan` is highly descriptive and industry-focused, it's particularly effective for businesses that want to immediately communicate their lending expertise.
+The appeal of .loan is its **literal clarity**: a name like `personal.loan` or `quick.loan` reads as a complete phrase, which is rare among extensions. That makes it a natural fit for exact-match marketing in the lending niche.
 
----
+## History of .loan
 
-## **Notable Entities Using .loan**
+The .loan TLD was **delegated to the root zone in 2015**, with **dot Loan Limited** as the sponsoring organization — one of roughly 60 generic strings applied for by the **Famous Four Media** group (backed by Domain Venture Partners) during the 2012 application round. Famous Four built its portfolio around short, broad keyword strings such as .loan, .bid, .win, .men, .review, and .date, and pursued a deliberately **high-volume, low-price** distribution strategy.
 
-While `.loan` is primarily used by specialized financial services, examples include:
+A notable part of the operational history is that registry-services responsibility for these strings later shifted away from Famous Four Media following commercial disputes within the Domain Venture Partners structure, with back-end and management duties moving to successor entities. The TLD itself remained live and continuously delegated throughout.
 
-* **Regional lending institutions** establishing their digital presence.
-* **Fintech startups** disrupting traditional lending with innovative solutions.
-* **Mortgage comparison platforms** helping consumers navigate home financing.
-* **Small business lending services** supporting entrepreneurship and growth.
-* **Educational loan specialists** focusing on student financing solutions.
+The adoption pattern that followed shaped .loan's identity more than any single milestone: aggressive sub-dollar promotions drove large bursts of registrations, but renewal rates stayed low — a hallmark of an extension picked up cheaply for short-lived campaigns rather than long-term brands. No headline-grabbing public .loan domain sale has defined the extension the way premium .com or [.io](/en/tld/io/) sales have defined theirs.
 
-These entities leverage `.loan` to build trust and clearly communicate their specialization in lending services.
+## How people use .loan
 
----
+Real, sensible uses of a .loan domain include:
 
-## **Why Choose .loan?**
+* **Lenders and loan products** — a direct-lending brand or a specific product line (for example, a "bridge loan" or "student loan" offering).
+* **Mortgage and broker sites** — home-financing and refinancing landing pages.
+* **Loan-comparison and lead-generation sites** — aggregators that rank or compare offers.
+* **Fintech campaigns and microsites** — a memorable, single-word domain for a marketing push or product launch.
+* **Calculators and educational resources** — repayment tools, glossaries, and borrower-education content.
 
-* **Industry Clarity**: Instantly communicates your focus on lending and financial services.
-* **Professional Credibility**: Establishes expertise in the competitive financial sector.
-* **SEO Benefits**: Highly relevant for financial service searches and loan-related keywords.
-* **Memorable Branding**: Easy for customers to remember and associate with loan services.
-* **Niche Authority**: Positions your business as a specialist in lending solutions.
+**Who it's not ideal for:** A .loan domain is a weak fit for a **regulated bank, credit union, or established financial institution** that needs maximum trust, because the extension's spam reputation can undercut perceived legitimacy. It is also a poor pick for any project outside finance — the word "loan" is too specific to repurpose.
 
----
+## Notable sites using .loan
 
-## **Register Your .loan Domain at Namefi**
+The .loan extension does not have a roster of household-name flagship sites the way [.com](/en/tld/com/) or [.io](/en/tld/io/) do. In practice it is used most by **small lenders, regional brokers, loan-comparison and lead-generation operators, and short-run marketing microsites** in the personal-finance space. Rather than name a site we cannot independently verify is reputable and active, the honest summary is this: .loan is a **descriptive utility extension** rather than a prestige one. Its value comes from the exact-match keyword, not from association with a famous brand.
 
-Ready to establish your professional presence in the financial services industry?
+## .loan vs other domains
 
-You can register your **.loan domain today at [Namefi](https://namefi.io)** — an **ICANN-accredited** registrar that combines traditional domain services with modern internet innovations. Namefi makes it simple to search, register, and manage your domains while offering advanced features like:
+| Extension | Type | Typical use | Trust / reputation |
+| --- | --- | --- | --- |
+| .loan | New gTLD | Exact-match lending and finance names | Cheap; high spam association |
+| [.com](/en/tld/com/) | Legacy gTLD | Any business, default brand domain | Highest trust and recognition |
+| [.finance](/en/tld/finance/) | New gTLD | Broader financial-services branding | More premium positioning than .loan |
+| [.net](/en/tld/net/) | Legacy gTLD | General-purpose fallback | Established and widely trusted |
 
-* Premium domain marketplace and auctions
-* Advanced DNS management and security
-* Integration with Web3 and decentralized services
-* Domain portfolio management tools
+Pick **.com** when trust and brand recall matter most. Pick **.finance** when you want a finance-themed extension with a more premium feel than .loan. Choose **.loan** when you specifically want the exact word "loan" in the address for a campaign, product, or comparison site — and pair it with a trusted primary domain.
 
-Whether you're launching a lending platform, establishing a mortgage brokerage, or building a financial consulting practice — **.loan gives you the industry-specific credibility you need to succeed.**
+## Why choose .loan?
 
-👉 **Visit [namefi.io](https://namefi.io) and secure your .loan today.**
-Build trust in financial services with **.loan** — the domain that speaks your industry language.
+* **Exact-match keyword:** Few extensions let you build a complete phrase like `home.loan`. The string itself communicates purpose instantly.
+* **Wide availability:** Because it is open and lightly registered for long-term use, many short, desirable .loan names are still obtainable.
+* **Low entry cost:** It is one of the cheaper extensions to register, which lowers the cost of experimenting with multiple campaign domains.
+* **No eligibility hurdles:** No license or credential is required, so you can register and launch immediately.
+
+## Things to consider
+
+Be honest with yourself about the trade-offs before committing:
+
+* **Spam reputation.** This is the big one. .loan has repeatedly appeared among the new gTLDs with elevated abuse, which can color how filters and users perceive it (see the reputation section below).
+* **Renewal pricing.** Cheap first-year promotions often renew at a substantially higher standard rate; budget for the long term, not just year one.
+* **Niche meaning.** "loan" is narrow. It is great if you are in lending and limiting if your scope ever broadens.
+* **Trust gap for regulated entities.** A bank or licensed lender may find a .loan address works against the credibility it needs.
+
+## Who can register a .loan domain?
+
+**Registration restrictions: open to all.** The .loan TLD is an **unrestricted, open generic extension**. There is no credential gate (unlike, say, [.cpa](/en/tld/cpa/) for accountants or [.law](/en/tld/law/) for licensed attorneys), no community-eligibility requirement, and no local-presence rule. Any individual or organization worldwide can register an available .loan name on a first-come, first-served basis.
+
+Standard ICANN-program protections still apply: registered trademark holders could use the **Trademark Clearinghouse** sunrise and claims mechanisms at launch, and ordinary length and [IDN](/en/glossary/tld/) rules apply to the label. On the administrative side, .loan supports **DNSSEC** for cryptographically signed DNS, WHOIS records are subject to the registry's privacy and redaction practices, and the usual gTLD lifecycle — transfer locks, renewal windows, and a redemption grace period after expiry — is in force. For the authoritative rules governing the extension, see the [ICANN Registry Agreement for .loan](https://www.icann.org/en/registry-agreements/details/loan).
+
+## .loan pricing and value
+
+This page does not quote prices, but the **pricing dynamics** are important because they explain .loan's character. .loan is positioned as a **budget extension**, and that shapes everything: it has historically been promoted at very low first-year rates, sometimes among the cheapest TLDs available. Expect a few realities:
+
+* **First-year vs renewal pricing differ.** Introductory pricing can be a fraction of the standard rate, and **renewals are typically much higher** than the promotional first year. Always check the renewal cost before you buy.
+* **Premium-tier names exist.** Short, high-demand strings (single dictionary words, common loan types) may be classified as **premium** by the registry and carry both a higher purchase price and a higher recurring renewal.
+* **What drives cost.** Registry wholesale pricing, premium classification, and any registrar margin determine the final figure. The low headline price is also exactly what attracts bulk abusive registration, which feeds the reputation issue below.
+
+## Reputation and email deliverability
+
+This deserves a frank discussion. **.loan has a notably poor security reputation.** Because the names are so cheap, the extension has been repeatedly cited among the new gTLDs most exploited by spammers and fraudsters, who register them in large batches for phishing, malware, and scam campaigns before abandoning them. ICANN's own [Statistical Analysis of DNS Abuse in gTLDs](https://www.icann.org/en/system/files/files/sadag-final-09aug17-en.pdf) documented dramatically higher spam rates in low-cost new gTLDs compared with legacy extensions, and ongoing industry [domain-reputation reporting from the Spamhaus Project](https://www.spamhaus.org/reputation-statistics/) continues to track abuse concentration in cheap TLDs.
+
+The practical consequences:
+
+* **Email deliverability risk.** Mail sent from a .loan domain may face stricter spam filtering or reduced inbox placement simply because of the extension's track record. If email is mission-critical, this is a real concern.
+* **User trust.** Some security-aware visitors are wary of unfamiliar .loan links.
+
+**Honest mitigation:** the reputation is a TLD-level statistic, not a verdict on your specific domain. You can substantially offset it by configuring proper email authentication (**SPF, DKIM, and DMARC**), warming up your sending domain, publishing clear contact and company information, securing the site with HTTPS, and — for anything trust-sensitive — using .loan as a campaign or redirect domain alongside a trusted primary brand.
+
+## Branding and naming tips
+
+* **Lean into the phrase.** The whole point of .loan is the readable construction: `instant.loan`, `business.loan`, `refinance.loan`. A name that completes a sentence is more memorable than one that ignores the suffix.
+* **Keep the label short.** Short, common words paired with .loan are the strongest — and may be premium-priced for that reason.
+* **Mind the spelling.** "loan" is occasionally misheard as "lone" or "loan" vs "lend"; in spoken contexts (radio, podcasts), spell it out.
+* **Protect your brand.** If you build anything serious on .loan, consider also holding the matching [.com](/en/tld/com/) to prevent confusion and capture direct-type traffic.
+
+## How to register a .loan domain at Namefi
+
+1. **Search** for your desired name on [Namefi](https://namefi.io) to check .loan availability.
+2. **Choose** the exact name (and consider grabbing a matching [.com](/en/tld/com/) for trust).
+3. **Register** and configure DNS, then enable DNSSEC and email authentication.
+
+[Namefi](https://namefi.io) is an **ICANN-accredited registrar** with transparent pricing, fast DNS management, and optional **Web3 tokenization** that lets eligible domains be represented as on-chain assets. Search, register, and manage your .loan domain in one place — no opaque add-ons.
+
+## Frequently asked questions
+
+### Can anyone register a .loan domain?
+
+Yes. The .loan extension is an open generic top-level domain with no eligibility checks. You do not need a financial license, lending credential, or local presence to register one, so anyone worldwide can buy an available .loan name on a first-come, first-served basis.
+
+### Does a .loan domain affect SEO?
+
+A .loan domain is treated as a generic gTLD by Google and carries no inherent ranking penalty or boost. However, because .loan is heavily abused by spammers, the extension can suffer reputation effects that affect email deliverability and user trust more than direct search rankings.
+
+### Is a .loan domain safe?
+
+The .loan registry is legitimate and ICANN-accredited, but the extension has a high rate of spam and phishing because the names are very cheap and bought in bulk. A specific .loan site can be perfectly safe; treat unknown .loan links with the same caution you would any unfamiliar domain.
+
+### Who should register a .loan domain?
+
+A .loan domain suits lenders, mortgage brokers, loan-comparison sites, and fintech projects that want an exact-match, descriptive name. It works best as a campaign or product domain paired with a .com, rather than as the sole brand for a regulated financial institution.
+
+## Related resources
+
+* [What is a TLD?](/en/blog/what-is-a-tld) — how top-level domains work.
+* [What is a domain?](/en/blog/what-is-domain) — domain-name fundamentals.
+* [Domain terminology guide](/en/blog/domain-terminology-guide) — key terms explained.
+* [Glossary: ICANN](/en/glossary/icann/) — the body that accredits registries and registrars.
+* [Glossary: registrar](/en/glossary/registrar/) — what a registrar does.
+* [Glossary: DNSSEC](/en/glossary/dnssec/) — securing DNS lookups.
+* [.com domain](/en/tld/com/) and [.finance domain](/en/tld/finance/) — common alternatives to compare.

--- a/content/tld/en/net.md
+++ b/content/tld/en/net.md
@@ -1,54 +1,163 @@
 ---
-title: 'What is the .net TLD and Why Choose It for Your Next Big Project?'
-date: '2025-12-10'
+title: 'What Is the .net Domain? The Original Network TLD Explained'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: 'Discover the power of the .net domain. Learn why tech leaders and businesses choose this trusted TLD and how to secure your .net address easily with Namefi.'
-keywords: ['what is .net', 'why choose .net', '.net TLD', '.net top-level domain', 'what is the .net domain', 'why choose the .net domain', '.net domains', 'domain investing', 'tokenized domain', 'blockchain domain registration', 'web3 domain management', 'buy .net domain', 'tech startup domains']
+description: 'The .net domain is one of the internet''s original gTLDs, run by Verisign and open to anyone. Learn who uses it, how it compares to .com, and when to register it.'
+keywords: ['.net domain', 'what is .net', '.net TLD', '.net vs .com', 'register .net domain', 'Verisign .net registry', 'is .net good for SEO', 'tech startup domains']
+faqs:
+  - question: 'Can anyone register a .net domain?'
+    answer: '.net is an open generic top-level domain with no registration restrictions. Anyone, anywhere can register an available .net name without proving membership, credentials, or a local presence. Standard ICANN rules on syntax, trademark sunrise history, and renewal apply.'
+  - question: 'Does a .net domain affect SEO?'
+    answer: 'No. Google treats .net as a standard generic gTLD with no inherent ranking advantage or penalty. Rankings depend on content, links, and user experience, not the suffix. As a non-geographic gTLD, .net is not tied to any single country for geo-targeting.'
+  - question: 'Who should register a .net domain?'
+    answer: '.net suits technology, infrastructure, networking, and community projects, and anyone whose preferred .com is taken. Because it is a trusted legacy extension, it is a strong fallback when the matching .com is unavailable or too expensive to acquire.'
+  - question: 'Is .net better than .com?'
+    answer: '.com remains the default users expect, so it generally wins for mainstream brands. .net is the closest trusted alternative and often has better availability for short names. Many companies register both to protect the brand and redirect one to the other.'
 ---
 
-## **What is .net?**
+The **.net domain** is one of the founding extensions of the internet, created in 1985 in the same wave as .com, .org, .edu, and .gov. The name is short for "network," and the suffix was originally meant for the organizations that ran internet infrastructure itself. Today it is fully open, broadly trusted, and one of the most widely registered top-level domains in the world.
 
-The **.net** domain extension is one of the original Top-Level Domains (TLDs) created in January 1985, alongside .com, .org, and .edu. The term stands for **"network,"** indicating its original intended purpose for organizations involved in networking technologies, such as Internet Service Providers (ISPs) and other infrastructure companies.
+If your ideal **.net** name is available, you get a legacy extension that signals technical credibility and reads as a natural sibling to .com — without the niche feel of a newer suffix.
 
-Operated by [Verisign](https://www.verisign.com/), the .net registry has grown to become one of the most popular and recognized domains on the internet. While it is classified as a generic Top-Level Domain (gTLD) open for anyone to register, it carries a legacy of technical reliability. According to [reports from Verisign](https://www.verisign.com/en_US/domain-names/dn-industry-brief/index.xhtml), .net consistently remains one of the most widely registered extensions globally, making it a staple of the internet ecosystem.
+## .net at a glance
 
-## **How People Are Using .net**
+| Fact | Detail |
+| --- | --- |
+| TLD type | Legacy generic top-level domain (gTLD) |
+| Registry operator | VeriSign Global Registry Services (Verisign) |
+| Year launched | 1985 |
+| IDN support | Yes (internationalized labels supported; a Korean IDN form, .닷넷, also exists) |
+| DNSSEC | Yes (supported at the registry) |
+| Registration restrictions | Open to all — no credential, membership, or local-presence requirement |
+| Best for | Tech, infrastructure, networking, communities, and .com fallbacks |
 
-While originally designed for network providers, the use cases for .net have expanded significantly over the last few decades. Today, it is a versatile extension used by a wide variety of registrants:
+## What is .net?
 
-*   **Technology Companies:** Due to the "network" etymology, SaaS platforms, app developers, and IT service companies often prefer .net to signal technical competence.
-*   **The "Second Choice" for Enterprises:** When a preferred .com domain is taken or unavailable for acquisition, businesses often secure the .net version as the most authoritative alternative.
-*   **Creative Portfolios and Communities:** Many online collectives and forums use .net to emphasize the "networking" aspect of bringing people together.
-*   **Infrastructure Services:** Cloud providers, hosting companies, and email service providers stick to the roots of the TLD to establish immediate trust.
+**.net** is a generic top-level domain, not a country-code one, which means it is not tied to any nation and search engines treat it as global rather than geo-targeted. The IANA root-zone entry lists its registration date as 1985-01-01 and its sponsoring organization as VeriSign Global Registry Services — you can confirm both on the official [IANA delegation record for .net](https://www.iana.org/domains/root/db/net.html).
 
-## **Notable Entities Using .net**
+The "net" label comes from "network." In the early internet it was intended for the entities that operated the network — internet service providers, network hardware vendors, and infrastructure providers. That original intent was never strictly enforced, and the registry has been effectively open to anyone for decades.
 
-The .net TLD is home to some of the internet's most recognizable brands and crucial infrastructure sites. These examples demonstrate that a .net domain can support massive scale and brand recognition:
+Because .net is a generic gTLD, Google does not associate it with any particular country for geo-targeting. [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites) classifies many generic extensions as non-geographic, so a .net site can target a global audience by default.
 
-*   **[Speedtest.net](https://www.speedtest.net/):** The global standard for internet speed testing perfectly utilizes the "network" connotation of the extension.
-*   **[Behance.net](https://www.behance.net/):** One of the world's largest creative networks for showcasing and discovering creative work uses .net to highlight its community aspect.
-*   **[Battle.net](https://battle.net):** Blizzard Entertainment’s online gaming platform has used this domain for decades, becoming synonymous with online multiplayer infrastructure.
-*   **[Slideshare.net](https://www.slideshare.net/):** A major platform for professional content hosting and sharing.
-*   **[Php.net](https://www.php.net/):** The home of the PHP programming language, proving .net's strong foothold in the developer community.
+## History of .net
 
-## **Why Choose .net?**
+.net was delegated on January 1, 1985, making it one of the original handful of top-level domains. For its first decades it was administered under the same operators that ran .com, and it has been operated by **Verisign** since the company took over the .com and .net registries in 2000.
 
-In a market flooded with hundreds of new domain extensions, .net remains a top contender for domain investors and business owners alike. Here is why you should consider it:
+Verisign continues to operate .net under an agreement with ICANN. You can review the governing terms in the [ICANN registry agreement for .net](https://www.icann.org/en/registry-agreements/details/net). The extension has remained one of the largest TLDs by registration volume throughout its history, and its long, stable track record is a large part of why it is still treated as a premium legacy suffix rather than a niche one.
 
-*   **Established Credibility:** As one of the original TLDs, .net enjoys a level of consumer trust that newer, niche extensions have yet to earn. It is universally recognized.
-*   **Tech-Forward Branding:** If your business is in the Web3, blockchain, or software development space, .net inherently suggests that you are a technology-focused entity.
-*   **Better Availability than .com:** While .com is often saturated with premium pricing or unavailability, .net offers a higher probability of finding a short, memorable name at a standard registration price.
-*   **SEO Performance:** Search engines like Google treat .net as a standard, high-quality gTLD. Because users trust the extension, click-through rates (CTR) are often higher compared to unfamiliar TLDs, which can indirectly benefit your SEO rankings.
+## How people use .net
 
-## **Register Your .net Domain at Namefi**
+.net is a generalist extension with a technical lean. Common uses include:
 
-Whether you are launching a new tech startup, building a portfolio site, or securing a valuable asset for domain investing, .net is a powerful choice.
+- **Technology and SaaS companies** that want the "network" connotation to signal engineering competence.
+- **Infrastructure and networking services** — ISPs, hosting providers, CDNs, and email services — staying close to the suffix's original meaning.
+- **Developer tools and open-source projects** that need a trusted, neutral home for documentation.
+- **Communities and forums** that lean on the "network of people" reading of the word.
+- **Brand protection and fallbacks**, where a company registers the .net to defend its name or because the matching .com was unavailable.
 
-At **Namefi**, we make domain ownership smarter. As an ICANN-accredited registrar, we bridge the gap between Web2 reliability and Web3 innovation. When you register with us, you not only secure your name but also gain the ability to manage your domains as tokenized assets on the blockchain, providing unparalleled security and transferability.
+**Who it is not ideal for:** if you are building a mainstream consumer brand and the matching .com is available and affordable, most users will still default to typing .com. In that case, lead with .com and treat .net as a defensive registration.
 
-**Ready to launch your network?**
+## Notable sites using .net
 
-[**Register your .net domain at Namefi today**](https://namefi.io) and secure your place in the digital future.
+Real, well-known sites have run on .net for years, which is strong evidence the suffix scales:
+
+- **[Speedtest.net](https://www.speedtest.net/)** — the global standard for internet speed testing, a fitting use of the "network" theme.
+- **[Behance.net](https://www.behance.net/)** — Adobe's large creative-portfolio network.
+- **[Battle.net](https://www.battle.net/)** — Blizzard Entertainment's long-running online gaming platform.
+- **[PHP.net](https://www.php.net/)** — the official home of the PHP programming language.
+
+These span infrastructure, creative communities, gaming, and developer tooling — the core niches where .net feels most natural.
+
+## .net vs other domains
+
+| Extension | Type | Reads as | Availability |
+| --- | --- | --- | --- |
+| [.com](/en/tld/com) | Legacy gTLD | The universal default | Scarce for short names |
+| .net | Legacy gTLD | Network / infrastructure | Better than .com |
+| [.org](/en/tld/org) | Legacy gTLD | Mission / community | Better than .com |
+| [.io](/en/tld/io) | Repurposed ccTLD | Tech / startup | Moderate, often premium-priced |
+
+Pick **.com** when you can get it and you want zero friction. Pick **.net** when the .com is gone and you want the closest trusted alternative, or when "network" genuinely fits your product. Choose [.org](/en/tld/org) for community and nonprofit framing, and [.io](/en/tld/io) if you specifically want a startup-coded signal and accept a niche, often pricier extension.
+
+## Why choose .net?
+
+- **Legacy trust.** As one of the original 1985 TLDs, .net carries recognition that newer extensions have to earn.
+- **Better availability than .com.** Short, clean names that are long gone in .com are more often still open in .net.
+- **Technical fit.** For infrastructure, networking, and developer products, the meaning of the word reinforces the brand.
+- **Neutral, global, and uncontroversial.** It is not geo-locked and not associated with any single industry beyond its general technical tone.
+
+## Things to consider
+
+- **.com is still the default.** Users may type .com out of habit, so you may want to own the .com too — or at least be ready to lose some direct type-in traffic.
+- **Word association is mild but real.** "Network" can feel slightly off for, say, a bakery or a clothing brand.
+- **Confusion risk with the bigger sibling.** Because .com is so dominant, some visitors mentally autocorrect a .net brand to .com; pick a name that is unambiguous when spoken.
+
+## Who can register a .net domain?
+
+**Registration restrictions: open to all.** .net is an unrestricted generic gTLD. There is no membership, credential, profession, or local-presence requirement — anyone in any country can register an available .net name. This is the same open model as .com, and it differs sharply from gated suffixes such as .law or .cpa.
+
+Standard rules still apply. Names must meet ICANN syntax requirements (length and allowed characters), and internationalized domain names are supported. Trademark holders had the usual sunrise opportunities historically, and ordinary registrar policies for renewal, transfer, and the redemption grace period apply after expiry. **DNSSEC** is supported at the registry, and WHOIS privacy is available through most registrars, including Namefi. For the authoritative rules, see the [ICANN registry agreement for .net](https://www.icann.org/en/registry-agreements/details/net).
+
+## .net pricing and value
+
+.net is priced as a mainstream legacy gTLD rather than a budget or ultra-premium suffix. A few pricing dynamics are worth understanding without quoting any number:
+
+- **First-year and renewal pricing can differ.** Introductory rates are common, and the renewal price is what matters long term — always check it before you commit.
+- **Premium names exist.** Short, dictionary, or high-demand .net names may be reserved as registry premiums and priced above the standard rate.
+- **The aftermarket sets value for the best names.** Because .net has been around since 1985, the most desirable short names were registered long ago and trade on the secondary market.
+
+We do not list live prices here; check current registration and renewal pricing at checkout.
+
+## Reputation and email deliverability
+
+.net has a solidly positive reputation. As a 1985-era legacy extension run by an established registry, it is perceived as professional and trustworthy — closer to .com than to the cheaper, abuse-prone new gTLDs that some spam filters scrutinize more aggressively.
+
+In practice, deliverability for a .net domain depends far more on your sending hygiene than on the suffix. Configure SPF, DKIM, and DMARC correctly, warm up new sending domains gradually, and keep your lists clean. Done properly, a .net sender is treated like any other reputable domain.
+
+## Branding and naming tips
+
+- **Lean into the "network" reading** when it fits — it can turn the suffix into part of the message rather than just an afterthought.
+- **Say it out loud.** Because .com is the spoken default, confirm that "yourname dot net" is unambiguous and easy to repeat.
+- **Mind the .com twin.** If a well-known brand already owns the .com of your chosen name, expect some misdirected traffic and possible trademark friction.
+- **Keep it short.** .net still has far more short, clean options than .com, so aim for a concise, memorable root.
+
+## How to register a .net domain at Namefi
+
+1. **Search** your desired name on Namefi to check .net availability.
+2. **Choose** the .net result (and any companion extensions you want to protect).
+3. **Register** and complete checkout.
+
+[Namefi](https://namefi.io) is an ICANN-accredited registrar with transparent pricing and fast DNS, and it also lets you tokenize eligible domains as on-chain assets for easier transfer and Web3 use. To learn more about that option, see [what are tokenized domains](/en/blog/what-are-tokenized-domains).
+
+## Frequently asked questions
+
+### Can anyone register a .net domain?
+
+Yes. .net is an open generic top-level domain with no registration restrictions. Anyone, anywhere can register an available .net name without proving membership, credentials, or a local presence. Standard ICANN rules on syntax, trademark sunrise history, and renewal apply.
+
+### Does a .net domain affect SEO?
+
+No. Google treats .net as a standard generic gTLD with no inherent ranking advantage or penalty. Rankings depend on content, links, and user experience, not the suffix. As a non-geographic gTLD, .net is not tied to any single country for geo-targeting.
+
+### Who should register a .net domain?
+
+.net suits technology, infrastructure, networking, and community projects, and anyone whose preferred .com is taken. Because it is a trusted legacy extension, it is a strong fallback when the matching .com is unavailable or too expensive to acquire.
+
+### Is .net better than .com?
+
+.com remains the default users expect, so it generally wins for mainstream brands. .net is the closest trusted alternative and often has better availability for short names. Many companies register both to protect the brand and redirect one to the other.
+
+## Related resources
+
+- [What is a domain?](/en/blog/what-is-domain)
+- [Domain terminology guide](/en/blog/domain-terminology-guide)
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains)
+- [Glossary: registrar](/en/glossary/registrar)
+- [Glossary: ICANN](/en/glossary/icann)
+- [Glossary: DNSSEC](/en/glossary/dnssec)
+- [.com domain](/en/tld/com)
+- [.org domain](/en/tld/org)
+- [.io domain](/en/tld/io)

--- a/content/tld/en/now.md
+++ b/content/tld/en/now.md
@@ -1,55 +1,147 @@
 ---
-title: "What is the .now Domain and Why Should You Choose It?"
-date: '2025-12-10'
+title: 'What Is the .now Domain? Amazon''s Brand TLD Explained'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: "Discover the power of the .now TLD. Learn why this urgent, real-time domain extension is perfect for modern brands and how to register yours at Namefi."
-keywords: [".now domains", ".now TLD", ".now top-level domain", "what is .now", "why choose .now", "what is the .now domain", "why choose the .now domain", "buy .now domain", "real-time domains", "domain investing", "tokenized domains", "Amazon Registry Services", "brandable domains", "new gTLD", "instant action domains"]
+description: 'The .now domain is a closed Amazon brand TLD (dotBrand), not open for public registration. Here is what .now really is and what to buy instead.'
+keywords: ['.now domain', 'what is .now', '.now TLD', '.now top-level domain', 'Amazon Registry Services', 'brand TLD', 'dotBrand', 'Specification 13']
+faqs:
+  - question: 'Can anyone register a .now domain?'
+    answer: 'No. .now is a closed Specification 13 brand TLD operated by Amazon Registry Services. Only Amazon, its affiliates, and authorized partners can register .now names, so the suffix is not available to the general public through any registrar.'
+  - question: 'Does a .now domain affect SEO?'
+    answer: 'The question is moot for most people because .now is not openly registrable. As a generic new gTLD it carries no built-in ranking penalty, but Google treats new gTLDs the same as legacy ones, so the extension itself neither helps nor hurts rankings.'
+  - question: 'Who should register a .now domain?'
+    answer: 'Effectively only Amazon and its authorized entities, since .now is a brand-restricted TLD. If you want a short, action-oriented name, consider an open generic extension such as .io, .app, or .xyz instead.'
+  - question: 'Is .now available for purchase anywhere?'
+    answer: 'Not for the public. Because .now is a dotBrand controlled by Amazon, no accredited registrar can sell .now names to outside buyers, regardless of any listings you might see elsewhere.'
 ---
 
-## **What is .now?**
+The **.now domain** is one of the most misunderstood entries in the domain world. It looks like a punchy, action-ready extension perfect for marketing — but in reality it is a **closed brand TLD** operated by Amazon, and you cannot register a `.now` name no matter how badly you want `buy.now` or `act.now`. Understanding **what .now is** matters precisely because it is so often described incorrectly.
 
-The **.now** extension is a generic Top-Level Domain (gTLD) designed for the immediate, the urgent, and the real-time. Unlike traditional domains that serve as static storefronts, **.now** captures the energy of the present moment. Managed by [Amazon Registry Services](https://www.amazonregistry.com/), this TLD was introduced to help businesses and creators communicate timeliness and relevance directly through their URL.
+This page explains what `.now` actually is, who controls it, why it is not for sale, and which open alternatives give you the same sense of immediacy if that is what you are after.
 
-In the crowded landscape of the internet, semantic domains—URLs that carry meaning beyond just a name—are becoming increasingly valuable. The word "now" is universally understood as a call to action. It implies live content, instant service, or up-to-the-minute news. While it is a newer entrant compared to the legacy `.com` or `.net`, it is rapidly gaining traction among forward-thinking developers and marketers who understand the psychology of urgency.
+## .now at a glance
 
-According to [IANA (Internet Assigned Numbers Authority)](https://www.iana.org/domains/root/db/now.html), `.now` is fully delegated and active, offering a fresh inventory of short, memorable names that are often unavailable in older extensions.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic new gTLD (dotBrand / Specification 13) |
+| Registry operator | Amazon Registry Services, Inc. |
+| Year delegated | 2016 |
+| IDN support | Not applicable for public use |
+| DNSSEC | Supported at the registry level |
+| Registration restrictions | **Closed brand TLD — only the registry operator (Amazon) and its affiliates may register** |
+| Best for | Amazon's own products and campaigns; not available to outside registrants |
 
-## **How People Are Using .now**
+## What is .now?
 
-Because of its inherent semantic meaning, **.now** is being utilized in creative and strategic ways across the web:
+`.now` is a **generic top-level domain** delegated to the internet's root zone in 2016. According to the [IANA root-zone database](https://www.iana.org/domains/root/db/now.html), the sponsoring organization is **Amazon Registry Services, Inc.**, the registry arm of Amazon.com headquartered in Seattle. Back-end registry services are provided by Nominet.
 
-*   **Live Streaming and Events:** Broadcasters and event organizers use domains like `conference.now` or `concert.now` to direct traffic to live feeds. It sets the expectation that something is happening *at this very moment*.
-*   **Call-to-Action (CTA) Links:** Marketing teams are clever with this TLD. Instead of a long, clunky URL for a checkout page, they use `buy.now`, `subscribe.now`, or `register.now`. These act as powerful psychological triggers for conversion.
-*   **Real-Time Data Services:** Tech platforms providing stock tickers, weather updates, or traffic news utilize the extension to emphasize the freshness of their data (e.g., `traffic.now`).
-*   **Instant Service Apps:** On-demand delivery services and ride-sharing platforms use the domain to highlight speed and availability.
+Although the string "now" reads like a generic English word, `.now` is not a generic open namespace. It was applied for and secured by Amazon during ICANN's [new gTLD program](https://newgtlds.icann.org/en/about/program) and is operated as a **dotBrand** — a top-level domain reserved for a single trademark owner. That single distinction changes everything about how the suffix can be used.
 
-## **Notable Entities Using .now**
+Because `.now` is a generic-style string rather than a country code, Google does not geo-target it. But for the overwhelming majority of readers the SEO question is academic: there is no public `.now` website to optimize, because the public cannot get a `.now` name in the first place.
 
-While `.now` is a unique niche TLD, several entities and sectors have adopted it to enhance their digital presence:
+## History of .now
 
-1.  **Amazon Services:** As the registry operator, Amazon utilizes the extension for various internal initiatives and promotional campaigns requiring time-sensitive engagement.
-2.  **Tech Startups and SaaS:** Many "Software as a Service" companies use `.now` for status pages (e.g., `status.now` subdomains or redirected standalone domains) to show real-time system uptime.
-3.  **News Outlets:** Digital media organizations use the TLD for breaking news segments or live blog coverage, differentiating "happening now" content from archival articles.
-4.  **Creative Campaigns:** Major retail brands often register `.now` domains specifically for flash sales (e.g., `sale.now`) to create a distinct landing page that separates the temporary event from their main corporate identity.
+Amazon applied for several short, evocative strings during the 2012 new gTLD application round, including `.now`. The string was delegated to the root zone in **2016** and assigned to Amazon Registry Services. Industry coverage at the time noted that Amazon positioned `.now` partly around immediacy and real-time services, with some speculation it could support Amazon Prime's streaming and instant-delivery messaging.
 
-## **Why Choose .now?**
+In practice, the milestone that defines `.now`'s history is what has *not* happened: years after delegation, the suffix remains effectively dormant, with names held by the registry rather than launched into general availability. There are no notable public domain sales or open-market transactions to report, because there is no open market for it.
 
-If you are considering a new digital asset for your portfolio or business, here is why `.now` stands out:
+## How people use .now
 
-*   **Unmatched Availability:** Because it is a newer gTLD, there is a significantly higher chance of securing your exact brand name or a premium one-word keyword compared to saturated namespaces like `.com`.
-*   **Psychological Urgency:** The word "now" creates a "Fear Of Missing Out" (FOMO) effect. It encourages users to click immediately rather than scroll past, which can improve Click-Through Rates (CTR).
-*   **Memorability:** It is short (three letters), punchy, and easy to spell. A domain like `learn.now` is far easier to remember than `learn-online-courses-today.com`.
-*   **Versatility:** It works exceptionally well for domain hacks (phrases created by the domain name), allowing for creative branding like `right.now` or `act.now`.
+The honest answer is that almost no one outside Amazon uses `.now`, because almost no one else can. Within the registry's control, the intended uses skew toward:
 
-## **Register Your .now Domain at Namefi**
+- Amazon's own promotional, product, or campaign pages where a short "now" call-to-action fits.
+- Time-sensitive or real-time service messaging controlled internally by Amazon.
+- Defensive registry holdings that keep the namespace under brand control.
 
-The internet moves fast, and securing a domain that reflects speed and relevance is a smart move for the future of your digital identity. Whether you are launching a real-time app, a limited-time marketing campaign, or simply investing in high-potential digital assets, `.now` is a compelling choice.
+**Who it's not ideal for:** everyone else. If you are an indie developer, founder, agency, or domain investor hoping to build on `clip.now`, `order.now`, or `learn.now`, this suffix is a dead end — those names are not yours to register, and never will be through a normal registrar.
 
-At **Namefi**, we make registering and managing your domains effortless. As an ICANN-accredited registrar, we bridge the gap between traditional Web2 ease and Web3 innovation. When you register with us, you aren't just renting a name; you are securing a tokenized asset that gives you true ownership and flexibility.
+## Notable sites using .now
 
-**Don't wait until the best names are taken.**
+There are no well-known, publicly accessible `.now` websites in active independent use. Because the suffix is a closed brand TLD, any `.now` resolution that exists is controlled by Amazon Registry Services rather than by third-party brands or creators. Rather than invent examples, the accurate statement is simple: `.now` has no public showcase sites, and you should be skeptical of any source that claims otherwise.
 
-[Register your .now domain at Namefi today](https://namefi.io) and capture the moment.
+## .now vs other domains
+
+If what attracted you to `.now` was the short, action-oriented feel, the right move is to choose an **open** extension. Here is how `.now` compares to alternatives you can actually register:
+
+| Extension | Open to public? | Typical use | Vibe |
+| --- | --- | --- | --- |
+| [.now](/en/tld/now) | No (Amazon brand TLD) | Amazon-internal only | Immediacy — but unavailable |
+| [.io](/en/tld/io) | Yes | Tech, startups, SaaS | Developer-favored, premium |
+| [.app](/en/tld/app) | Yes | Apps, web products | Modern, HTTPS-enforced |
+| [.xyz](/en/tld/xyz) | Yes | Generic, Web3, creative | Flexible, low-cost, broad |
+
+When to pick which: choose [.io](/en/tld/io) for a technical or startup brand, [.app](/en/tld/app) when you want a secure, product-focused name, and [.xyz](/en/tld/xyz) when you want maximum availability and creative freedom. None of these carries `.now`'s fatal restriction.
+
+## Why choose .now?
+
+For nearly all readers, you cannot choose `.now` — and that is the most important fact on this page. The only entity for whom `.now` is a genuine advantage is **Amazon**, which gains a fully controlled, brand-exclusive namespace with no third-party registrants, no abuse from unrelated parties, and complete authority over how the suffix appears. Those are real benefits of a dotBrand, but they accrue to the brand owner, not to the public.
+
+## Things to consider
+
+The decisive trade-off with `.now` is availability: it is **not for sale to you**. Other points worth knowing:
+
+- Listings or price quotes you see for `.now` on aggregator sites do not reflect actual public availability. A closed dotBrand cannot be sold through accredited registrars to outside buyers.
+- The word "now" is appealing precisely because it implies urgency — which is exactly why Amazon locked it down. Demand does not create access here.
+- Building a brand strategy around a domain you cannot own is a costly mistake; verify a suffix is open *before* you fall in love with a name.
+
+## Who can register a .now domain?
+
+**Registration restrictions: closed.** `.now` is governed under **Specification 13** of its [ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/now), the provision that defines a **dotBrand** TLD. Under Specification 13, the registry operator's trademark *is* the TLD string, and registrations are limited to the operator and a small set of affiliated or authorized parties. In concrete terms, only **Amazon Registry Services and Amazon-affiliated entities** can hold `.now` domains.
+
+That means there are no sunrise periods, no landrush, and no general availability for the public. Length rules, IDN options, WHOIS privacy, and renewal/redemption behavior are managed internally by the registry rather than exposed to outside registrants, because there are no outside registrants. If you need an authoritative confirmation, the Registry Agreement and its Specification 13 designation are the source of truth.
+
+## .now pricing and value
+
+There is no meaningful public **pricing** for `.now`, and any number you encounter should be treated with suspicion. In open gTLDs, pricing dynamics involve first-year versus renewal differences, premium-tier names, and registry wholesale fees passed through by registrars. None of that applies to a closed brand TLD: because the public cannot register `.now`, there is no retail price, no premium tier you can buy, and no resale value for outside parties. The "value" of `.now` is entirely captured by its single brand owner.
+
+## Reputation and email deliverability
+
+`.now` does not carry the spam-prone reputation that has dogged some cheap, freely registrable new gTLDs, simply because no one outside Amazon can register it to send mail or host content. As a tightly controlled brand namespace, it has no history of open abuse. The flip side is that mailbox providers and users rarely encounter `.now` at all, so it has minimal recognition — which, again, is irrelevant for a suffix you cannot use for your own email.
+
+## Branding and naming tips
+
+`.now` is a textbook **domain-hack** string — `act.now`, `buy.now`, `shop.now` all read cleanly — and that is exactly why it is so tempting and so frustrating. The branding lesson here is broader than `.now` itself: a perfect domain hack is worthless if the suffix is closed. Before designing a brand around any clever extension, confirm it is openly registrable. If immediacy is your theme, open suffixes like [.app](/en/tld/app), [.io](/en/tld/io), or even an action word on [.xyz](/en/tld/xyz) let you build the same energy on a name you can actually own.
+
+## How to register a .now domain at Namefi
+
+You cannot — and we would rather tell you the truth than sell you a name that does not exist. Because `.now` is a closed Amazon brand TLD, no ICANN-accredited registrar, including Namefi, can register it on your behalf.
+
+If you want a short, action-oriented domain you *can* own, here is the practical path:
+
+1. **Search** an open alternative — try [.io](/en/tld/io), [.app](/en/tld/app), or [.xyz](/en/tld/xyz) — on [Namefi](https://namefi.io).
+2. **Choose** the name that best fits your brand and confirm it is available.
+3. **Register** it with transparent pricing, fast DNS, and optional Web3 tokenization so you hold a verifiable, ownable asset.
+
+[Namefi](https://namefi.io) is an ICANN-accredited registrar that also supports tokenized domains — a real path to ownership, unlike a brand TLD that will never be yours.
+
+## Frequently asked questions
+
+### Can anyone register a .now domain?
+
+No. `.now` is a closed Specification 13 brand TLD operated by Amazon Registry Services. Only Amazon, its affiliates, and authorized partners can register `.now` names, so the suffix is not available to the general public through any registrar, regardless of price quotes you may see elsewhere.
+
+### Does a .now domain affect SEO?
+
+The question is moot for most people because `.now` is not openly registrable. As a generic new gTLD it carries no built-in ranking penalty, and Google treats new gTLDs the same as legacy extensions, so the suffix itself neither helps nor hurts rankings.
+
+### Who should register a .now domain?
+
+Effectively only Amazon and its authorized entities, since `.now` is a brand-restricted TLD. If you want a short, action-oriented name, consider an open generic extension such as [.io](/en/tld/io), [.app](/en/tld/app), or [.xyz](/en/tld/xyz) instead.
+
+### Is .now available for purchase anywhere?
+
+Not for the public. Because `.now` is a dotBrand controlled by Amazon, no accredited registrar can sell `.now` names to outside buyers. Any listing suggesting otherwise does not reflect real availability.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [Domain terminology guide](/en/blog/domain-terminology-guide)
+- [ICANN (glossary)](/en/glossary/icann)
+- [Registrar (glossary)](/en/glossary/registrar)
+- [.io domain](/en/tld/io)
+- [.app domain](/en/tld/app)
+- [.xyz domain](/en/tld/xyz)

--- a/content/tld/en/online.md
+++ b/content/tld/en/online.md
@@ -1,57 +1,155 @@
 ---
-title: 'Unlock Your Digital Presence: What is the .online TLD and Why Choose It?'
-date: '2025-12-10'
+title: 'What Is the .online Domain? A Complete Guide'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: 'Discover the versatility of the .online domain. Learn why businesses choose this TLD for branding, SEO, and availability, and register yours at Namefi today.'
-keywords: ['.online domains', '.online TLD', 'top-level domain', 'what is .online', 'why choose .online', 'what is the .online domain', 'why choose the .online domain', 'domain investing', 'blockchain domains', 'tokenized domain', 'buy .online domain', 'new gTLD investment', 'Web3 domains', 'digital identity', 'Radix registry']
+description: 'The .online domain is an open, unrestricted new gTLD by Radix that any person or business can register. Learn who it suits, how it ranks, and what to consider.'
+keywords: ['.online domain', 'what is .online', '.online TLD', 'register .online domain', 'Radix registry', 'new gTLD', 'online domain extension', 'is .online good for SEO']
+faqs:
+  - question: 'Can anyone register a .online domain?'
+    answer: 'Yes. .online is an open, unrestricted generic top-level domain. There is no credential, trademark, business, or local-presence requirement, so any individual or organization worldwide can register an available name on a first-come, first-served basis.'
+  - question: 'Does a .online domain affect SEO?'
+    answer: 'No. Google treats .online like any other generic top-level domain, with no inherent ranking advantage or penalty. Rankings depend on content, links, and user experience. As a non-geographic gTLD it is not tied to any single country in search results.'
+  - question: 'Who should register a .online domain?'
+    answer: 'It suits founders, freelancers, course creators, e-commerce sellers, and anyone whose preferred .com is taken. The literal word "online" reads clearly in many languages, making it a practical fit for web-first brands, landing pages, and personal sites.'
+  - question: 'Is .online a good alternative to .com?'
+    answer: 'It can be. Because the .com namespace is largely exhausted, .online often lets you register an exact-match keyword or brand name you could not get on .com. The trade-off is lower default recognition, so reinforce the full domain in your branding.'
+  - question: 'Does .online support WHOIS privacy and DNSSEC?'
+    answer: 'Yes. As a CentralNic-backed Radix TLD, .online supports DNSSEC for cryptographic DNS integrity, and most registrars including Namefi offer WHOIS privacy so your personal contact details are not published publicly.'
 ---
 
-## **What is .online?**
+The **.online domain** is one of the most literal extensions on the internet: the suffix itself is the word "online," instantly signaling that a site lives on the web. It is an open, unrestricted new generic top-level domain (gTLD) operated by Radix, and anyone in the world can register an available name. For founders, freelancers, and brands whose first choice is gone in legacy extensions, **.online** is a clear, broadly understood alternative.
 
-The **.online** domain extension is a generic Top-Level Domain (gTLD) designed to be a universal, intuitive, and modern namespace for the internet. Unlike country-code TLDs (like .uk or .de) which are geographically bound, or restricted TLDs (like .edu), **.online** is open to everyone.
+This guide covers what .online is, who runs it, how it performs for SEO and email, and the real trade-offs to weigh before you register.
 
-Launched in 2015, .online quickly became one of the most successful "new gTLDs" released under [ICANN’s New gTLD Program](https://newgtlds.icann.org/en/about/program). It is managed by the [Radix Registry](https://radix.website/), a leading player in the domain industry known for managing high-value extensions.
+## .online at a glance
 
-The primary purpose of .online is simplicity. In a digital world, the word "online" is universally understood across multiple languages to mean "connected to the internet." It serves as a perfect alternative to legacy domains like .com or .net, especially when your preferred short, snappy keyword is already taken in older extensions. Today, with millions of registrations globally, it is recognized as a staple TLD for businesses moving their operations to the web.
+| Fact | Detail |
+| --- | --- |
+| TLD type | New gTLD (generic, non-geographic) |
+| Registry operator | Radix (Radix Technologies Inc. SEZC); backend by CentralNic |
+| Year launched | 2015 |
+| IDN support | Yes (internationalized domain names supported) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no credential, trademark, or local-presence requirement |
+| Best for | Web-first brands, landing pages, personal sites, keyword domains |
 
-## **How People Are Using .online**
+## What is .online?
 
-Because the term "online" is so broad, this TLD does not pigeonhole a user into a specific niche. It is currently being used across a wide spectrum of industries:
+.online is a **generic top-level domain** — the part that comes after the final dot in a web address, like `.com` or `.org`. Unlike a country-code TLD such as `.uk` or `.de`, .online carries no national meaning, so search engines treat it as global rather than tied to one region.
 
-*   **Brick-and-Mortar Transitions:** Physical stores launching e-commerce platforms often use `BrandName.online` to differentiate their digital shop from their physical location.
-*   **Tech Startups & SaaS:** New software companies use it to signal that their service is cloud-based and always accessible.
-*   **Freelancers and Consultants:** Professionals building personal brands use it to host CVs, portfolios, and booking systems.
-*   **Educational Platforms:** Tutors and course creators use it to designate virtual learning environments.
-*   **Web3 and Blockchain Projects:** As the internet evolves, developers are using .online to represent decentralized applications (dApps) and tokenized projects that live natively on the web.
+The string is plain English and widely recognized: "online" appears in or is borrowed by many languages to mean "connected to the internet." That makes the suffix self-explanatory in a way most new extensions are not — a visitor seeing `yourbrand.online` immediately understands it is a web destination.
 
-## **Notable Entities Using .online**
+You can confirm the delegation details on the official [IANA root-zone entry for .online](https://www.iana.org/domains/root/db/online.html), the authoritative record of who operates the TLD and when it entered the root zone. On the search side, Google has stated that new gTLDs like .online are treated the same as any other generic domain for ranking purposes; see [Google Search Central on new TLDs](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level-domains).
 
-While many Fortune 500 companies secure their .online domains for brand protection, the TLD has seen massive adoption among energetic startups and modern enterprises.
+## History of .online
 
-*   **Casino.online:** A prime example of a "category killer" domain. This domain sold for a reported $201,250, proving the high investment value and SEO potential of premium .online names.
-*   **Startups and Innovators:** According to [Namestat](https://namestat.org/), .online consistently ranks in the top tier of new gTLDs by usage, hosting over 2 million active domains.
-*   **Personal Brands:** Many influencers and thought leaders have migrated to .online when their "FirstnameLastname.com" was unavailable, finding that it adds a professional touch to their digital identity.
+.online was delegated to the root zone in 2015 as part of [ICANN's New gTLD Program](https://newgtlds.icann.org/en/about/program), the expansion that introduced hundreds of new extensions beyond the original handful. After early rights consolidation in the industry, [Radix](https://radix.website/) emerged as the registry operator and has run it since launch, with technical registry services provided by CentralNic.
 
-## **Why Choose .online?**
+Among new gTLDs, .online has been one of the higher-volume extensions, consistently sitting in the upper tier by registration count. Its most cited milestone is a landmark secondary-market sale: in 2017 Radix announced that **casino.online** changed hands for **$201,250**, which it described as the largest single-domain sale recorded among new gTLDs at the time. The transaction, brokered via Sedo, is documented in [Radix's own announcement](https://radix.website/radix-announces-largest-new-gtld-sale-with-casino-online) and signaled that exact-match keyword names on .online could command premium prices.
 
-If you are debating between different extensions, here is why .online stands out as a smart choice for domain investors and business owners alike:
+## How people use .online
 
-*   **Global Recognition:** The word "online" is understood in over 24 languages. It requires no translation and immediately tells the user that you are active and accessible.
-*   **Superior Availability:** Finding a short, one-word, or two-word brandable name on .com is nearly impossible without spending a fortune. With .online, you have a much higher chance of registering the exact name you want.
-*   **SEO Friendly:** Google and other search engines treat .online exactly the same as .com or .org. There is no penalty for using a new gTLD, and a relevant name like `BestPizza.online` can perform exceptionally well in search results.
-*   **Versatility:** It works for a blog, a store, a corporate site, or a Web3 identity. It is future-proof.
+Because "online" is generic, the suffix does not box you into one industry. Common, real-world uses include:
 
-## **Register Your .online Domain at Namefi**
+- **Web-first businesses** moving operations to e-commerce or services delivered entirely over the internet.
+- **Freelancers and consultants** hosting portfolios, CVs, and booking pages when their `.com` is taken.
+- **Course creators and tutors** running virtual learning sites where "online" reinforces the format.
+- **Campaign and landing pages** where a short, descriptive `keyword.online` is easier to get than on legacy TLDs.
+- **Personal brands** using `firstnamelastname.online` as a clean identity domain.
 
-Ready to establish your presence on the web? There is no better place to secure your digital real estate than **Namefi**.
+**Who it's not ideal for:** organizations that need maximum default trust at first glance — banks, large enterprises, or anyone where a missing `.com` could cause hesitation — may prefer a legacy extension or pair .online with a defensive `.com` registration.
 
-At Namefi, we are revolutionizing the way you own domains. As an ICANN-accredited registrar, we offer the security you expect, combined with cutting-edge Web3 integration. When you register a domain with us, you enjoy seamless management and the unique ability to tokenize your domain—turning it into a liquid, transferable asset on the blockchain if you choose.
+## Notable sites using .online
 
-Whether you are launching a new business or building a portfolio of valuable domains, **.online** is the versatile foundation you need.
+Public, household-name brands using .online as a primary address are still relatively uncommon; much of the namespace is held by keyword owners and defensive registrants protecting their brand. The clearest notable data point is the secondary market: **casino.online** sold for $201,250, showing that strong exact-match keyword names on this suffix carry real commercial value. The honest picture is that .online is most actively used today for keyword sites, web-first startups, and personal projects rather than by legacy enterprises.
 
-[**Search for your perfect .online domain at Namefi**](https://namefi.io)
+## .online vs other domains
 
-Don't let your ideal name get snapped up by someone else. Get online with .online today!
+| Extension | Type | Meaning | Typical use |
+| --- | --- | --- | --- |
+| [.online](/en/tld/online) | New gTLD | "On the internet" | Web-first brands, landing pages, keyword sites |
+| [.com](/en/tld/com) | Legacy gTLD | Commercial / default | The universal default for almost any site |
+| [.site](/en/tld/site) | New gTLD | A website | Generic web presence, close substitute |
+| [.store](/en/tld/store) | New gTLD | A shop | E-commerce and retail |
+
+Pick **.com** when you can get the exact name and want maximum default recognition. Choose **.online** when the .com is taken and you want a plain, globally readable word; it competes most directly with [.site](/en/tld/site), and with [.store](/en/tld/store) when your focus is retail.
+
+## Why choose .online?
+
+- **Self-explanatory meaning.** The suffix is a real English word understood across many languages — no abbreviation to teach your audience.
+- **Availability.** The .com namespace is largely exhausted; on .online you can often register an exact-match keyword or your full brand name.
+- **Truly open.** No eligibility hoops, credentials, or local-presence rules — register and go.
+- **Standard technical support.** DNSSEC and IDNs are supported, matching mainstream TLDs.
+
+## Things to consider
+
+.online is not a drop-in equal of .com in every respect:
+
+- **Lower default recognition.** Some users still assume "the .com" by habit and may mistype the address.
+- **Pricing structure differs.** Like many new gTLDs, first-year and renewal pricing can differ, and standout keyword names may be classified as premium (see below).
+- **Confusion with neighbors.** It sits close in meaning to .site, .net, and .com, so reinforce the full domain in marketing to avoid drift.
+- **Defensive costs.** Brands often still register the matching .com to protect against confusion, which adds to total cost.
+
+## Who can register a .online domain?
+
+**Registration restrictions: open to all.** .online is an unrestricted generic TLD. There is no credential gate (unlike `.law` or `.cpa`), no community eligibility requirement, and no local-presence rule. Any individual or organization worldwide can register an available .online name on a first-come, first-served basis.
+
+Standard gTLD policies apply: there was a sunrise period at launch for trademark holders, and the [Trademark Clearinghouse](https://newgtlds.icann.org/en/about/trademark-clearinghouse) continues to support rights-protection notices. Names support internationalized characters (IDNs), DNSSEC can be enabled for cryptographic DNS integrity, and most registrars including Namefi offer WHOIS privacy. Transfer, renewal, and redemption-grace handling follow standard ICANN gTLD lifecycle rules. The binding terms are set out in the [ICANN Registry Agreement for .online](https://www.icann.org/en/registry-agreements/details/online) and Radix's published [registry policies](https://radix.website/policies).
+
+## .online pricing and value
+
+This page never quotes live prices, but the **pricing dynamics** matter. As with most new gTLDs, the registry designates a tier of **premium names** — short, generic, or high-demand keywords — that carry higher registration and sometimes higher renewal fees than a standard name. For non-premium domains, the first-year price and the recurring renewal price often differ, so always check the renewal rate before you commit, not just the introductory cost. Cost is driven mainly by the registry's tier classification for that string plus your registrar's margin and any included services such as WHOIS privacy.
+
+## Reputation and email deliverability
+
+New gTLDs as a class have at times attracted extra scrutiny from spam filters, because low-cost extensions can see disproportionate abuse. .online is an established, high-volume Radix TLD rather than an obscure one, which helps, but a brand-new domain on any extension starts with no sending reputation. If you send email from a .online address, the mitigations are the same as for any TLD: authenticate with **SPF, DKIM, and DMARC**, warm up volume gradually, keep lists clean, and avoid shared IPs with poor history. Reputation is earned by domain behavior far more than by the suffix, so a well-run .online domain can achieve strong deliverability.
+
+## Branding and naming tips
+
+- **Use the suffix as a word.** .online shines when the name reads as a phrase — `learn.online`, `shop.online`, `book.online` — turning the TLD into part of the message.
+- **Keep it short and unambiguous.** Because some users still default to .com, avoid names that are easy to mistype or that sound like a different extension when spoken aloud.
+- **Say it out loud.** "Yourbrand dot online" should be easy to dictate over the phone; if it isn't, reconsider.
+- **Protect the brand.** If budget allows, also secure the matching .com to reduce confusion and type-in leakage.
+
+## How to register a .online domain at Namefi
+
+1. **Search** your desired name on [Namefi](https://namefi.io) to check .online availability.
+2. **Choose** the exact name, reviewing both the first-year and renewal terms.
+3. **Register** and complete checkout, then point your DNS records to start using the domain.
+
+As an ICANN-accredited registrar, Namefi offers transparent pricing, fast DNS management, and the option to **tokenize** your domain into a transferable on-chain asset — useful if you later want to trade or hold it as Web3 property. Start at [Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .online domain?
+
+Yes. .online is an open, unrestricted generic top-level domain. There is no credential, trademark, business, or local-presence requirement, so any individual or organization worldwide can register an available name on a first-come, first-served basis.
+
+### Does a .online domain affect SEO?
+
+No. Google treats .online like any other generic top-level domain, with no inherent ranking advantage or penalty. Rankings depend on content, links, and user experience. As a non-geographic gTLD it is not tied to any single country in search results.
+
+### Who should register a .online domain?
+
+It suits founders, freelancers, course creators, e-commerce sellers, and anyone whose preferred .com is taken. The literal word "online" reads clearly in many languages, making it a practical fit for web-first brands, landing pages, and personal sites.
+
+### Is .online a good alternative to .com?
+
+It can be. Because the .com namespace is largely exhausted, .online often lets you register an exact-match keyword or brand name you could not get on .com. The trade-off is lower default recognition, so reinforce the full domain in your branding.
+
+### Does .online support WHOIS privacy and DNSSEC?
+
+Yes. As a CentralNic-backed Radix TLD, .online supports DNSSEC for cryptographic DNS integrity, and most registrars including Namefi offer WHOIS privacy so your personal contact details are not published publicly.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [Domain terminology guide](/en/blog/domain-terminology-guide)
+- [How to sell a domain name you own](/en/blog/how-to-sell-a-domain-name-you-own)
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains)
+- [.com domain](/en/tld/com) · [.site domain](/en/tld/site) · [.store domain](/en/tld/store) · [.tech domain](/en/tld/tech)
+- Glossary: [registrar](/en/glossary/registrar) · [DNSSEC](/en/glossary/dnssec) · [DNS](/en/glossary/dns) · [SEO](/en/glossary/seo)

--- a/content/tld/en/org.md
+++ b/content/tld/en/org.md
@@ -1,58 +1,169 @@
 ---
-title: "What is the .org TLD? A Guide to the Internet's Most Trusted Domain"
-date: '2025-12-10'
+title: 'What Is the .org Domain? The Trusted Nonprofit Extension'
+date: '2026-06-15'
 language: 'en'
-tags: ['tld', 'domain-education', 'web3', 'investing']
+tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: "Discover the power of the .org TLD. Learn why organizations, DAOs, and open-source projects choose .org to build trust, and how to register yours today."
-keywords: [".org domains", "TLD", "top-level domain", "what is .org", "why choose .org", "what is the .org domain", "why choose the .org domain", "buy .org domain", "domain investing strategies", "blockchain domain names", "tokenized domains", "DAO domains", "Public Interest Registry", "nonprofit domain registration", "legacy gTLD"]
+description: 'The .org domain is an open legacy gTLD run by the nonprofit Public Interest Registry, trusted by charities, open-source projects, and communities worldwide.'
+keywords: ['.org domains', 'what is .org', '.org domain meaning', 'org TLD', 'Public Interest Registry', 'nonprofit domain', 'register .org domain', 'is .org good for SEO']
+faqs:
+  - question: 'Can anyone register a .org domain?'
+    answer: 'Yes. The .org extension is open and unrestricted, so any individual, business, nonprofit, or project can register an available name. There is no proof-of-nonprofit-status requirement and no local-presence rule.'
+  - question: 'Does a .org domain affect SEO?'
+    answer: 'No. Google treats .org as a generic top-level domain with no inherent ranking advantage or penalty. Rankings depend on content, links, and user experience, not the suffix. The .org label can improve click-through rates because users associate it with trustworthy institutions.'
+  - question: 'Who should register a .org domain?'
+    answer: 'Nonprofits, charities, open-source projects, foundations, community groups, advocacy organizations, and Web3 DAOs benefit most from .org because the suffix signals a mission-driven, noncommercial purpose. It also works as a defensive registration for any brand.'
+  - question: 'Who operates the .org registry?'
+    answer: 'The Public Interest Registry (PIR), a nonprofit corporation created by the Internet Society in 2002, has operated .org since 2003. Back-end technical services are provided by Identity Digital.'
+  - question: 'Does .org support WHOIS privacy and DNSSEC?'
+    answer: 'Yes. DNSSEC is supported across .org, and most registrars offer WHOIS privacy on .org registrations to mask personal contact details in public records.'
 ---
 
-## **What is .org?**
+The **.org domain** is one of the internet's original top-level domains and the default home for organizations that put a mission ahead of a margin. Short for "organization," it carries decades of accumulated trust from charities, open-source software, encyclopedias, and standards bodies — making it the natural choice when you want a name that reads as credible and community-minded rather than commercial.
 
-The **.org** extension is one of the original generic Top-Level Domains (gTLDs) established in 1985, alongside .com and .net. While "org" stands for "organization," this TLD has evolved into a powerful symbol of trust, integrity, and community service on the internet.
+If you are weighing **what .org means** and whether it fits your project, the short answer is this: it is an open, unrestricted extension run by a nonprofit registry, anyone can register one, and it remains one of the most recognizable suffixes on the web.
 
-Originally intended for non-profit organizations that didn't fit into the commercial (.com) or networking (.net) categories, the registry was opened to the general public in August 2019. Today, anyone can register a .org domain, but it maintains a distinct reputation for serving the public interest.
+## .org at a glance
 
-The domain is managed by the **[Public Interest Registry (PIR)](https://thenew.org/)**, a non-profit corporation. Because of its long history and strict management, .org is widely considered one of the most secure and stable domains available. According to recent reports by **[ICANN](https://www.icann.org/)**, .org remains one of the largest TLDs in the world, hosting millions of websites dedicated to social causes, open-source technology, and community governance.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Legacy generic top-level domain (gTLD) |
+| Registry operator | [Public Interest Registry (PIR)](https://pir.org/) |
+| Year launched | 1985 (delegated as an original gTLD) |
+| IDN support | Yes (internationalized domain names supported) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility or local-presence requirement |
+| Best for | Nonprofits, open-source, communities, foundations, DAOs |
 
-## **How People Are Using .org**
+## What is .org?
 
-While .com is often associated with commercial gain, .org signals a mission-driven purpose. Here is how modern entities utilize this TLD:
+The **.org** suffix is a generic top-level domain (gTLD), not a country-code domain, so it has no geographic meaning and is not tied to any nation. It was one of the handful of original TLDs described in [RFC 920](https://www.rfc-editor.org/rfc/rfc920) and was delegated in 1985 alongside .com, .net, .edu, and .gov.
 
-*   **Non-Profits and NGOs:** Charities, foundations, and humanitarian groups use .org to legitimize their cause and encourage donations.
-*   **Open Source Projects:** Software developers and tech communities (such as Linux distributions or coding frameworks) prefer .org to host documentation and code repositories.
-*   **DAOs and Web3 Projects:** In the blockchain space, Decentralized Autonomous Organizations (DAOs) and protocol foundations frequently choose .org to emphasize community ownership and decentralization over corporate structure.
-*   **Educational Platforms:** While .edu is restricted, many private learning initiatives, museums, and research institutes utilize .org.
-*   **Corporate CSR:** For-profit companies often register the .org version of their brand to host their Corporate Social Responsibility (CSR) initiatives or philanthropic foundations.
+According to the [IANA root-zone database](https://www.iana.org/domains/root/db/org.html), .org is operated by the **Public Interest Registry (PIR)**, a nonprofit corporation, with back-end technical operations handled by Identity Digital. "Org" was originally meant as a catch-all category for organizations that did not fit the commercial (.com) or networking (.net) buckets — and that "everything else, for the public good" character is exactly what gave it its lasting nonprofit reputation.
 
-## **Notable Entities Using .org**
+Because .org is a generic gTLD, Google treats it as a neutral, non-geo-targeted extension. Per [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites), generic TLDs like .org are not used to infer a target country, so a .org site can rank globally just like a .com.
 
-The .org extension hosts some of the most influential and high-traffic websites on the internet. These entities reinforce the TLD's reputation for knowledge and service:
+## History of .org
 
-1.  **[Wikipedia](https://www.wikipedia.org/):** The world's largest free encyclopedia uses .org, underscoring its non-profit, community-contributed model.
-2.  **[Ethereum](https://ethereum.org/):** A prime example for the Web3 community, the Ethereum Foundation uses .org to host resources for the world's leading smart contract blockchain.
-3.  **[WordPress](https://wordpress.org/):** This distinguishes the open-source software project from its commercial hosting counterpart (.com), a common strategy in the tech world.
-4.  **[The Red Cross](https://www.icrc.org/):** Major international humanitarian networks rely on .org to maintain global trust during crises.
-5.  **[Mozilla](https://www.mozilla.org/):** The creators of the Firefox browser use .org to highlight their dedication to internet health and open standards.
+The .org TLD was registered on January 1, 1985, and the very first .org domain — **mitre.org** — was registered on July 10, 1985 by the MITRE Corporation. The defining moment came in 2002–2003, when the **Internet Society** created the Public Interest Registry to steward the domain; PIR formally assumed responsibility on January 1, 2003, and that nonprofit governance has shaped the suffix's identity ever since.
 
-## **Why Choose .org?**
+The other landmark event was the **2019 attempted sale**: the Internet Society announced plans to sell PIR to the private-equity firm Ethos Capital. The proposal triggered intense opposition from nonprofits, technologists, and lawmakers, and in [April 2020 ICANN rejected the sale](https://www.icann.org/en/board-activities-and-meetings/materials/approved-resolutions-special-meeting-of-the-icann-board-30-04-2020-en), keeping .org under nonprofit control — reinforcing publicly that .org is viewed as a community asset rather than a commodity.
 
-If you are debating between .org and other extensions, consider these distinct advantages:
+## How people use .org
 
-*   **Unrivaled Trust and Credibility:** Studies consistently show that internet users perceive .org websites as more trustworthy and credible than many other TLDs. It acts as a badge of honor for ethical operations.
-*   **Strong SEO Performance:** While Google treats all gTLDs equally technically, the high click-through rate (CTR) associated with the trusted .org label can indirectly boost your search engine rankings.
-*   **Domain Availability:** While it is a "legacy" domain, you are more likely to find a concise, memorable name on .org than on .com, which is heavily saturated.
-*   **Asset Value:** For domain investors, short and one-word .org domains hold significant value, particularly as more Web3 organizations and DAOs enter the market looking for "clean" identities.
-*   **Safety:** The PIR actively works to keep the .org namespace free of malicious activity, making it a safer neighborhood for your digital identity.
+Real, specific niches where .org is the convention rather than the exception:
 
-## **Register Your .org Domain at Namefi**
+- **Nonprofits, charities, and NGOs** — the canonical use; donors expect a .org.
+- **Open-source software projects** — used to separate the project from any commercial offering (the classic wordpress.org vs wordpress.com split).
+- **Foundations and standards bodies** — protocol foundations, working groups, and consortia.
+- **Encyclopedias, archives, and public-knowledge resources.**
+- **Advocacy, civic-tech, and community groups.**
+- **Web3 DAOs and protocol foundations** that want to emphasize community ownership over corporate identity.
 
-Ready to establish trust and signal your commitment to your community? There is no better place to secure your .org domain than Namefi.
+**Who it's not ideal for:** a purely commercial product, an e-commerce store, or a consumer SaaS brand is usually better served by .com or a niche gTLD — visitors instinctively type `.com`, and a storefront on .org can feel slightly off-genre.
 
-At Namefi, we combine the reliability of an ICANN-accredited registrar with the innovation of Web3. When you register a domain with us, you enjoy seamless management and the unique ability to tokenize your domain—minting it as an NFT for easy transfer, enhanced security, and integration with DeFi applications.
+## Notable sites using .org
 
-Whether you are launching a non-profit, an open-source project, or the next big DAO, start with a domain that means business.
+- **wikipedia.org** — the free encyclopedia, the most prominent nonprofit on the web.
+- **mozilla.org** — the maker of Firefox and a champion of an open internet.
+- **wordpress.org** — the open-source CMS, distinct from the commercial wordpress.com.
+- **ethereum.org** — the Ethereum Foundation's official resource hub, a leading Web3 example.
+- **archive.org** — the Internet Archive and its Wayback Machine.
 
-**[Register your .org domain at Namefi today.](https://namefi.io)**
+These are not vague categories — they are some of the highest-traffic sites online, and each chose .org deliberately to signal a noncommercial mission.
+
+## .org vs other domains
+
+| Feature | .org | [.com](/en/tld/com) | [.net](/en/tld/net) | [.info](/en/tld/info) |
+| --- | --- | --- | --- | --- |
+| Primary association | Nonprofit / mission | Commercial / default | Networking / tech | Information / reference |
+| Type | Legacy gTLD | Legacy gTLD | Legacy gTLD | Legacy gTLD |
+| Open registration | Yes | Yes | Yes | Yes |
+| Trust perception | Very high | Very high | Moderate | Moderate |
+| Availability of short names | Better than .com | Heavily saturated | Moderate | Good |
+
+Pick **.org** when your identity is a cause, community, or open project; pick **.com** when you are a commercial brand and want the suffix users type by default; consider **.net** or **.info** as fallbacks when the .com is taken. Many organizations register both the .org and the matching .com defensively.
+
+## Why choose .org?
+
+- **Instant credibility.** Decades of association with trusted institutions mean visitors extend goodwill to a .org before they read a word.
+- **Nonprofit stewardship.** The namespace is run by a nonprofit (PIR), and ICANN's 2020 decision affirmed that governance — a stability story few suffixes can tell.
+- **Better short-name availability.** Because .com is saturated, you are far more likely to land a clean, one-word name on .org.
+- **Global and generic.** No geo-targeting, no eligibility hoops — it works for an audience anywhere.
+- **Clear positioning.** It immediately tells visitors you are mission-driven, not a storefront.
+
+## Things to consider
+
+- **Genre expectations.** A .org on a commercial product can confuse buyers who expect a .com; the suffix carries a "noncommercial" connotation you can't fully shake.
+- **Type-in habit.** Users default to typing `.com`; you may lose direct traffic (and want the .com defensively).
+- **Open, not exclusive.** Because anyone can register .org, the suffix alone does not certify nonprofit status — credibility still rests on your actual content and transparency.
+
+## Who can register a .org domain?
+
+**Registration restrictions: open to all.** The .org extension is unrestricted. You do not need to be a registered nonprofit, hold any credential, or prove a local presence — any individual, company, project, or DAO can register any available .org name. PIR explicitly states that anyone may register and use .org domains.
+
+Standard gTLD rules apply: names follow ASCII or internationalized-domain-name (IDN) conventions, the registry honored its **sunrise and trademark-claims** processes during launches, and registrants are covered by ICANN's Uniform Domain-Name Dispute-Resolution Policy (UDRP). On the administrative side, **DNSSEC is supported**, most registrars offer **WHOIS privacy**, and .org follows the standard transfer, renewal, and redemption-grace-period lifecycle. The authoritative source for the rules is the [.org ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/org) and the registry operator's site at [pir.org](https://pir.org/).
+
+## .org pricing and value
+
+The .org extension sits in the standard "legacy gTLD" pricing band — typically more than the cheapest new gTLDs but in line with mainstream suffixes. A few dynamics matter when you budget:
+
+- **Premium names exist.** Short, dictionary, or high-demand .org strings can carry elevated registry-set premium pricing.
+- **First-year vs renewal differ.** Promotional first-year rates do not always match the renewal rate, so look at the long-term cost, not just year one.
+- **Aftermarket value.** Clean one-word and brandable .org names hold real resale value, increasingly so as DAOs and foundations seek "clean" community identities. (For the mechanics, see [how to sell a domain name you own](/en/blog/how-to-sell-a-domain-name-you-own).)
+
+We don't quote live numbers here — registrar pricing changes — but expect .org to be predictable and mainstream.
+
+## Reputation and email deliverability
+
+Among all suffixes, **.org enjoys one of the strongest reputations** on the web. It reads as institutional, trustworthy, and noncommercial, and spam filters do not single it out — there is no broad "cheap TLD" stigma the way newer, heavily-discounted extensions sometimes attract. Email sent from a well-configured .org domain is treated on its own merits.
+
+That said, deliverability is earned at the domain level, not the suffix level. To land in inboxes, set up **SPF, DKIM, and DMARC** correctly, warm up new sending domains, and keep your list clean. The .org label gives you a credibility head-start; proper authentication is what actually protects your deliverability.
+
+## Branding and naming tips
+
+- **Lean into the mission.** A .org reads best when the name evokes a cause, community, or project (`save-, open-, -foundation, -project`).
+- **The split-brand pattern.** A common, legible move is project.org for the open/community side and project.com for the commercial side (as Mozilla and WordPress do).
+- **Avoid implying false status.** Don't pick a name that pretends to be an official charity or government body if it isn't.
+- **Keep it pronounceable.** Because .org domains are often shared by word of mouth at events and in print, prioritize names that are easy to say and spell.
+
+## How to register a .org domain at Namefi
+
+1. Search your desired name on [Namefi](https://namefi.io) to check .org availability.
+2. Choose your exact `.org` string (and consider grabbing the matching .com defensively).
+3. Complete registration with an ICANN-accredited registrar and configure DNS.
+
+Namefi combines a traditional ICANN-accredited registrar experience with Web3 tokenization, so you can register a .org with transparent pricing and fast DNS — and optionally tokenize it for on-chain ownership and transfer. **[Register your .org domain at Namefi](https://namefi.io).**
+
+## Frequently asked questions
+
+### Can anyone register a .org domain?
+
+Yes. The .org extension is open and unrestricted, so any individual, business, nonprofit, or project can register an available name. There is no proof-of-nonprofit-status requirement and no local-presence rule.
+
+### Does a .org domain affect SEO?
+
+No. Google treats .org as a generic top-level domain with no inherent ranking advantage or penalty. Rankings depend on content, links, and user experience, not the suffix. The .org label can improve click-through rates because users associate it with trustworthy institutions.
+
+### Who should register a .org domain?
+
+Nonprofits, charities, open-source projects, foundations, community groups, advocacy organizations, and Web3 DAOs benefit most from .org because the suffix signals a mission-driven, noncommercial purpose. It also works as a defensive registration for any brand.
+
+### Who operates the .org registry?
+
+The Public Interest Registry (PIR), a nonprofit corporation created by the Internet Society in 2002, has operated .org since 2003. Back-end technical services are provided by Identity Digital.
+
+### Does .org support WHOIS privacy and DNSSEC?
+
+Yes. DNSSEC is supported across .org, and most registrars offer WHOIS privacy on .org registrations to mask personal contact details in public records.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [Domain terminology guide](/en/blog/domain-terminology-guide)
+- [How to sell a domain name you own](/en/blog/how-to-sell-a-domain-name-you-own)
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains)
+- Glossary: [ICANN](/en/glossary/icann), [Registrar](/en/glossary/registrar), [DNS](/en/glossary/dns), [DNSSEC](/en/glossary/dnssec), [DAO](/en/glossary/dao)
+- Compare TLDs: [.com](/en/tld/com), [.net](/en/tld/net), [.info](/en/tld/info), [.io](/en/tld/io), [.xyz](/en/tld/xyz)

--- a/content/tld/en/sbs.md
+++ b/content/tld/en/sbs.md
@@ -1,109 +1,148 @@
 ---
-title: "What Is a .sbs Domain? Meaning, Origin, and Is It Safe?"
-date: '2025-06-21'
-updated: '2026-06-10'
+title: 'What Is the .sbs Domain? Meaning, Safety & Who Uses It'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: "What is a .sbs domain? It's a cheap new gTLD meaning 'side by side.' Learn where .sbs comes from, whether it's safe, and why some .sbs sites are spam."
-keywords: [".sbs domain", "sbs domain", "what is .sbs domain", ".sbs domain meaning", "sbs tld", "what is .sbs", "is .sbs domain safe", "sbs stands for", "where is .sbs domain from", "what domain is .sbs", ".sbs meaning", ".sbs domain spam", "is .sbs safe", ".sbs phishing", "what does .sbs stand for", "sbs side by side", "sbs side business", "new gTLD", "ShortDot .sbs", "cheap domain extensions", "suspicious .sbs link", ".sbs domain scam", "register .sbs domain", "tokenized domains", "Namefi .sbs"]
+description: 'The .sbs domain is a low-cost open generic gTLD run by ShortDot, often read as "side by side." Learn its origin, real uses, reputation, and whether to buy.'
+keywords: ['.sbs domain', 'what is .sbs', '.sbs domain meaning', 'sbs tld', 'is .sbs safe', 'ShortDot .sbs', 'side by side domain', 'new gTLD']
+faqs:
+  - question: 'Can anyone register a .sbs domain?'
+    answer: 'Yes. .sbs is an open, unrestricted generic top-level domain operated by ShortDot SA. There are no credential, membership, or local-presence requirements, so individuals and businesses anywhere in the world can register a .sbs name through any accredited registrar.'
+  - question: 'Does a .sbs domain affect SEO?'
+    answer: 'Google treats .sbs as a generic top-level domain with no built-in ranking penalty or geographic bias. However, because .sbs has a documented history of spam abuse, some email and security filters apply stricter scrutiny, which can indirectly affect deliverability and click-through.'
+  - question: 'Is a .sbs domain safe?'
+    answer: 'The .sbs extension itself is legitimate and ICANN-accredited, but it has been listed among the more abused new gTLDs by Spamhaus. The extension does not make a site dangerous; judge each individual site on its own merits and verify before clicking unexpected links.'
+  - question: 'Who should register a .sbs domain?'
+    answer: 'It suits side businesses, community and social-cause projects, collaborations, and low-cost experiments where the "side by side" or "side business" reading fits. It is a weaker choice for a flagship brand, payment site, or anything that depends heavily on email deliverability.'
 ---
 
-## What is a .sbs domain?
+The **.sbs domain** is a short, open generic top-level domain that anyone in the world can register. Operated by the registry [ShortDot SA](https://shortdot.bond/) and most often read as **"side by side,"** it positions itself for community projects, social causes, and side ventures. This page explains what .sbs really is, where it came from, who uses it, and the honest trade-offs — including its reputation among spam filters — so you can decide whether it fits your project.
 
-A **.sbs domain** is a web address that ends in **.sbs** instead of the more familiar **.com** or **.net**. The part after the final dot is called a [top-level domain](/en/glossary/tld/) (TLD), and **.sbs** is a **generic top-level domain (gTLD)** operated by the registry **ShortDot SA**.
+## .sbs at a glance
 
-In short: **.sbs is a real, legitimate domain extension** that anyone in the world can register. It is most commonly marketed as **"side by side"** — a nod to collaboration, community, and causes — though many people also adopt it as a memorable abbreviation for **"side business."** Because it is short, inexpensive, and widely available, it has become a popular pick for small ventures, hobby projects, and community initiatives.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (new gTLD) |
+| Registry operator | ShortDot SA (Luxembourg); technical back-end by CentralNic |
+| Year launched | Delegated 2015; relaunched as open gTLD by ShortDot in 2021 |
+| IDN support | Yes |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no credential, community, or local-presence requirement |
+| Best for | Side businesses, community/social-cause sites, low-cost experiments |
 
-If you landed here because you received a link or email from a strange-looking .sbs address (something like `fff1.sbs` or `0o0o.sbs`) and you want to know whether it's safe, jump to **[Is a .sbs domain safe?](#is-a-sbs-domain-safe-why-am-i-getting-spam-from-sbs-domains)** below.
+## What is .sbs?
 
-## What does .sbs stand for and where is it from?
+.sbs is a [generic top-level domain](/en/glossary/tld) (gTLD), not a country-code TLD, and it carries no geographic tie. The three letters have no fixed dictionary meaning; ShortDot markets the string primarily as **"side by side"** to evoke collaboration and community, while many registrants adopt it as a natural shorthand for **"side business."**
 
-The .sbs string has an interesting history that explains why its meaning has shifted over time:
+Because it is a generic extension, Google treats .sbs like any other gTLD: there is no automatic ranking penalty and no built-in geo-targeting. You can confirm its delegation and operator details in the [IANA root-zone entry for .sbs](https://www.iana.org/domains/root/db/sbs.html), the authoritative record for any delegated TLD.
 
-* **Original owner (Australian broadcaster):** The .sbs TLD was first delegated through ICANN's New gTLD Program and originally belonged to **SBS — the Special Broadcasting Service**, an Australian public-service broadcaster. The broadcaster registered it as a "brand TLD" for its own use but never launched it publicly.
-* **Acquisition by ShortDot:** SBS terminated the contract, and in **2021** the domain registry **ShortDot SA** acquired .sbs and relaunched it as an **open generic TLD** available to the general public. ShortDot also runs other budget-friendly extensions like .bond, .cfd, and .icu.
-* **Today's meaning:** ShortDot markets .sbs primarily as **"side by side,"** positioning it for social causes, community projects, non-profits, and collaborative ventures. In everyday use, plenty of registrants simply read it as **"side business."**
+## History of .sbs
 
-So when people ask **"where is .sbs from?"** — the answer is that it is no longer tied to Australia or any country. It is a **global generic TLD**, not a [country-code TLD](/en/glossary/tld/), and it is not geographically restricted.
+The .sbs string has an unusually winding history:
 
-## Is a .sbs domain safe? Why am I getting spam from .sbs domains?
+- **Original brand TLD (2014–2020):** The Australian public broadcaster **SBS — the Special Broadcasting Service** applied for .sbs during ICANN's New gTLD Program, signing its registry agreement in November 2014. The string was delegated to the root zone in 2015 but was operated as a closed "brand" TLD and never opened to the public. SBS later filed to terminate, and ICANN finalized the termination in 2020.
+- **Acquisition and relaunch (2021):** ShortDot SA acquired the string and relaunched it as an **open generic TLD**, holding a sunrise period for trademark holders in May 2021 before general availability that June. ShortDot also operates other budget-friendly extensions such as .bond, .cfd, and .icu.
 
-This is the most common reason people search for ".sbs," so let's be direct.
+So when people ask "where is .sbs from?", the honest answer is: it began as an Australian broadcaster's unused brand domain and is now a globally available generic extension operated from Luxembourg.
 
-**The .sbs TLD itself is legitimate** — it is a properly accredited extension managed by a real registry under ICANN rules. But because .sbs domains are **extremely cheap to register** (often well under a dollar in promotions), they are sometimes **abused by spammers and scammers** who buy them in bulk for short-lived phishing and spam campaigns. Security firms have repeatedly flagged .sbs as one of the new gTLDs with a high rate of malicious or spammy email traffic.
+## How people use .sbs
 
-That is why you may have received a suspicious text, email, or link from a random-looking .sbs address. **The extension being .sbs does not automatically mean a site is dangerous — but it does mean you should be cautious and verify before you click, log in, or pay.**
+Real, specific niches where .sbs shows up:
 
-### How to tell if a specific .sbs site is trustworthy
+- **Side businesses and solo ventures** — freelancers and weekend founders leaning on the "side business" reading (`yourname.sbs`).
+- **Community and social-cause projects** — aligning with the official "side by side" branding for non-profits, mutual-aid groups, and grassroots campaigns.
+- **Collaborations and partnerships** — joint ventures using the suffix to signal working together.
+- **Low-cost experiments and landing pages** — a cheap way to park an idea or test a concept before committing to a premium [.com](/en/tld/com).
+- **Short, brandable names** — the .sbs namespace still has wide availability for concise names long gone in legacy zones.
 
-If you've received a link or landed on a .sbs page you don't recognize, check these signals:
+**Who it's not ideal for:** flagship brands, financial or payment sites, and any project where customer email reliably reaching the inbox is mission-critical. For those, a more established extension is the safer pick.
 
-* **Did you expect it?** Unsolicited messages with urgent demands ("your package is held," "verify your account now," "claim your refund") are classic phishing — regardless of the TLD.
-* **Does the name impersonate a brand?** Scam .sbs domains often mimic real companies (e.g., a "tracking" or "login" page that looks like a bank, courier, or email provider). Legitimate companies almost never run their login pages on a random .sbs domain.
-* **Look up its reputation.** Free tools like Google Safe Browsing, VirusTotal, or domain-reputation checkers can flag known-bad sites. A brand-new domain with no history is a yellow flag.
-* **Check the [WHOIS](/en/glossary/whois/) record.** Recently registered, anonymized domains used for "official" communications are a red flag.
-* **Never enter credentials or card details** on a site you reached from an unexpected link. Navigate to the real company's known website directly instead.
-* **Watch for look-alike characters.** Strings like `0o0o.sbs` mix zeros and the letter "o" precisely to confuse you — a common scammer tactic called typosquatting.
+## Notable sites using .sbs
 
-In other words: judge the **specific website**, not the extension. A .sbs domain run by a real small business is perfectly safe; a hastily registered .sbs domain blasting you with "verify your password" links is not.
+.sbs is a young, low-cost extension and does not yet have widely recognized flagship public sites in the way [.io](/en/tld/io) or [.app](/en/tld/app) do. In practice, its visible footprint skews toward small side-business pages, community and cause sites, and short-lived promotional or disposable domains. Rather than name a specific site that may not last, the honest characterization is that .sbs is used mostly by independent operators and small projects rather than major brands.
 
-To understand the registration system that makes both legitimate and abusive domains possible, see our glossary entries on [registrars](/en/glossary/registrar/) and [ICANN](/en/glossary/icann/).
+## .sbs vs other domains
 
-## The legit side: why .sbs is great for side businesses and causes
+| Factor | .sbs | [.com](/en/tld/com) | [.xyz](/en/tld/xyz) |
+| --- | --- | --- | --- |
+| Recognition & trust | Newer, low familiarity | Highest, universal | Moderate, widely known |
+| Availability of short names | Wide | Very scarce | Wide |
+| Typical price tier | Budget | Standard | Budget |
+| Reputation/abuse exposure | Elevated (spam history) | Low | Mixed |
+| Geo bias in SEO | None (generic) | None (generic) | None (generic) |
 
-Spam aside, .sbs has plenty of honest, practical uses — and for the right project it can be a smart choice:
+Pick .com when trust and instinctive credibility matter most; pick [.xyz](/en/tld/xyz) for a slightly more recognized budget alternative; pick .sbs when the "side by side" or "side business" meaning genuinely fits and you want a short, inexpensive name for a project rather than a flagship brand.
 
-* **Side businesses and solo ventures:** The "side business" reading makes .sbs a natural, on-the-nose fit for freelancers, creators, and weekend entrepreneurs (`yourname.sbs`).
-* **Community and social-cause projects:** Aligning with the official "side by side" branding, it suits non-profits, mutual-aid groups, and grassroots campaigns.
-* **Collaborations and partnerships:** Joint ventures and co-branded projects use it to signal working together.
-* **Affordable experiments and landing pages:** Because registration is cheap, it's a low-risk way to test an idea before committing to a premium .com.
-* **Short, brandable names:** The .com namespace is crowded; .sbs still has excellent availability for concise, memorable names.
+## Why choose .sbs?
 
-## .sbs vs. .com: what to consider
+- **Open and unrestricted** — no paperwork, credentials, or eligibility checks; register and go.
+- **Meaningful for the right project** — the "side by side" / "side business" reading is genuinely on-the-nose for collaborations, causes, and side hustles.
+- **Strong availability** — short, memorable names are still attainable where legacy zones are exhausted.
+- **Budget-friendly** — among the more affordable extensions, lowering the cost of experimentation.
 
-| Consideration | .com | .sbs |
-| --- | --- | --- |
-| **Recognition & trust** | Highest, universally familiar | Newer, less familiar to mainstream users |
-| **Availability** | Scarce for short names | Wide availability |
-| **Price** | Standard | Very low / budget |
-| **Best for** | Primary business brand | Side projects, causes, experiments |
-| **SEO** | Treated as generic | Treated as generic (no geo penalty) |
+## Things to consider
 
-For SEO, search engines treat .sbs as a standard generic TLD, so it can rank globally just like a .com. The bigger factor is **user trust**: for a flagship brand handling payments, .com still carries more instinctive credibility. For a side project, community page, or experiment, .sbs is an affordable, expressive option. If you're weighing your options across extensions, our guide on [what makes a great domain name](/en/blog/what-is-domain/) is a helpful starting point.
+- **Spam reputation.** This is the biggest trade-off. .sbs has appeared among the more abused new gTLDs in industry reporting (see the reputation section below). That perception can rub off on a legitimate .sbs site.
+- **Lower mainstream familiarity.** Many users still equate "a real website" with .com, which can cost a sliver of trust at first glance.
+- **Ambiguous meaning.** "SBS" isn't a dictionary word; you may need to spell out what it stands for in your branding.
+- **Email scrutiny.** Some mail providers weight newer, low-cost TLDs more cautiously, which can affect deliverability.
 
-## Frequently asked questions about .sbs
+## Who can register a .sbs domain?
 
-### What does .sbs stand for?
-Officially, the registry ShortDot markets **.sbs as "side by side"** to evoke collaboration and community. Many registrants also use it to mean **"side business."** It once belonged to the Australian broadcaster **SBS (Special Broadcasting Service)**, which is where the three letters originally came from.
+**Registration restrictions: open to all.** .sbs is an unrestricted generic TLD — there is no credential, professional-membership, community, or local-presence requirement. Any individual or organization worldwide can register a .sbs name through an accredited [registrar](/en/glossary/registrar).
 
-### Is .sbs a real / legitimate domain?
-Yes. **.sbs is a legitimate generic top-level domain** accredited under ICANN and operated by a real registry. Anyone can register one through an accredited [registrar](/en/glossary/registrar/).
+A trademark **sunrise period** ran ahead of general availability in 2021, so the land-rush phase is long over; today registrations are handled on a first-come, first-served basis. The extension supports internationalized domain names (IDNs) and [DNSSEC](/en/glossary/dnssec), and WHOIS privacy is available through most registrars. Standard ICANN lifecycle rules apply — including the auto-renew grace, redemption-grace, and pending-delete periods — so a lapsed name is not immediately re-available. The binding rules are set out in the [ICANN Registry Agreement for .sbs](https://www.icann.org/en/registry-agreements/details/sbs) and ShortDot's [domain registration terms](https://shortdot.bond/terms-and-conditions-for-domain-registration).
 
-### Is a .sbs domain safe to click?
-The extension itself is safe, but **individual .sbs sites should be evaluated case by case.** Because .sbs is cheap, it sees more than its share of spam and phishing. Don't enter passwords or payment details on a .sbs site you reached from an unexpected message — verify it first.
+## .sbs pricing and value
 
-### Where is the .sbs domain from?
-It is a **global generic TLD** with no country tie. It was originally an Australian broadcaster's brand domain and is now operated worldwide by ShortDot SA.
+.sbs sits in the budget tier of the gTLD market, and that shapes its pricing dynamics rather than any single number. Expect **first-year and renewal pricing to differ** — introductory first-year rates are commonly promotional, while the standing renewal rate is what you'll pay long term, so budget for the renewal, not the teaser. The registry may also reserve a set of **premium names** (short, dictionary, or high-demand strings) that carry higher registration and sometimes higher renewal pricing. The main drivers of cost are the length and desirability of the string, premium classification, and registrar margin. We list no figures here; check current rates at the point of purchase.
 
-### Why am I getting spam or texts from .sbs domains?
-Spammers register cheap .sbs domains in bulk for disposable phishing campaigns. Treat any unsolicited .sbs link with caution, report it as spam, and don't interact with it.
+## Reputation and email deliverability
 
-### How much does a .sbs domain cost?
-.sbs is one of the more affordable extensions, frequently offered at promotional first-year prices below a dollar, with standard renewal rates afterward. Pricing varies by registrar.
+This is where buyers most need candor. Because .sbs is cheap and easy to acquire in bulk, it has been repeatedly flagged for abuse. Spamhaus has published reporting calling out .sbs and asking ShortDot to keep the zone clean, noting it entered the ranks of the more abused TLDs with a sharp rise in botnet command-and-control and disposable-domain activity (see [Spamhaus on .sbs](https://www.spamhaus.org/resource-hub/service-providers/we-hope-you-keep-sbs-clean-shortdot/)).
 
-### Can I build a normal website and email on .sbs?
-Absolutely. A .sbs domain works exactly like any other for hosting a website, setting up [DNS](/en/glossary/dns/), and running email — the technology is identical to .com.
+Practically, that means some spam filters, security tools, and cautious users apply extra scrutiny to .sbs traffic. The extension itself is legitimate and ICANN-accredited — being on .sbs does not make a site malicious — but a legitimate .sbs site may have to work harder to earn trust. **Mitigation:** properly configure SPF, DKIM, and DMARC for email; warm up sending domains gradually; keep content clean; and, for anything trust-sensitive, weigh whether a more established extension serves you better.
 
-## Register or tokenize your .sbs domain at Namefi
+## Branding and naming tips
 
-Whether you're launching a side business, rallying a community "side by side," or grabbing a short brandable name before someone else does, **.sbs is an affordable and expressive choice**.
+- **Lean into the meaning.** "Side by side" and "side business" are the readings users will reach for — choose a name where one of those fits naturally.
+- **Spell out the acronym.** Since SBS isn't a common word, reinforce what it stands for in your tagline or logo lockup.
+- **Avoid look-alike strings.** Confusable characters (zeros vs. the letter "o", repeated letters) are exactly what scammers exploit; a clean, pronounceable name distances you from that pattern.
+- **Keep it short and say-able.** The main upside of .sbs is availability of concise names — use it for something easy to type and speak aloud.
 
-At **[Namefi](https://namefi.io)**, we go beyond traditional registration. As an ICANN-accredited registrar bridging Web2 and Web3, we let you register your domain and optionally **[tokenize it](/en/blog/what-are-tokenized-domains/)** — turning it into a blockchain asset you truly own, with easier transfers and enhanced security. When the time comes to move on, tokenized ownership also makes it far simpler to [sell a domain you own](/en/blog/how-to-sell-a-domain-name-you-own/).
+## How to register a .sbs domain at Namefi
 
-* **Simple registration:** Search and secure your .sbs name in seconds.
-* **Web3 ready:** Manage DNS or mint your domain as an NFT.
-* **Transparent pricing:** No hidden fees.
+1. **Search** for your desired `.sbs` name to check availability.
+2. **Choose** the exact name and review the term.
+3. **Register** and configure [DNS](/en/glossary/dns) to point your site or email.
 
-**[Register your .sbs domain at Namefi today](https://namefi.io)** and put your idea online — side by side.
+[Namefi](https://namefi.io) is an [ICANN](/en/glossary/icann)-accredited registrar that bridges Web2 and Web3. Beyond standard registration, you can optionally [tokenize your domain](/en/blog/what-are-tokenized-domains) — turning it into a blockchain asset you truly own, with easier transfers and added security — all with transparent pricing and fast DNS.
+
+## Frequently asked questions
+
+### Can anyone register a .sbs domain?
+
+Yes. .sbs is an open, unrestricted generic top-level domain operated by ShortDot SA. There are no credential, membership, or local-presence requirements, so individuals and businesses anywhere in the world can register a .sbs name through any accredited registrar.
+
+### Does a .sbs domain affect SEO?
+
+Google treats .sbs as a generic top-level domain with no built-in ranking penalty or geographic bias. However, because .sbs has a documented history of spam abuse, some email and security filters apply stricter scrutiny, which can indirectly affect deliverability and click-through.
+
+### Is a .sbs domain safe?
+
+The .sbs extension itself is legitimate and ICANN-accredited, but it has been listed among the more abused new gTLDs by Spamhaus. The extension does not make a site dangerous; judge each individual site on its own merits and verify before clicking unexpected links.
+
+### Who should register a .sbs domain?
+
+It suits side businesses, community and social-cause projects, collaborations, and low-cost experiments where the "side by side" or "side business" reading fits. It is a weaker choice for a flagship brand, payment site, or anything that depends heavily on email deliverability.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains)
+- [How to sell a domain name you own](/en/blog/how-to-sell-a-domain-name-you-own)
+- Glossary: [registrar](/en/glossary/registrar), [ICANN](/en/glossary/icann), [DNSSEC](/en/glossary/dnssec), [WHOIS](/en/glossary/whois)
+- Compare TLDs: [.com](/en/tld/com), [.xyz](/en/tld/xyz), [.io](/en/tld/io), [.app](/en/tld/app)

--- a/content/tld/en/shop.md
+++ b/content/tld/en/shop.md
@@ -1,59 +1,160 @@
 ---
-title: 'Unlock Your E-Commerce Potential: What is the .shop TLD?'
-date: '2025-12-10'
+title: 'What Is the .shop Domain? The E-Commerce Extension Explained'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: 'Looking to launch an online store? Discover the benefits of the .shop TLD, its impact on branding, and how to register your perfect domain with Namefi.'
-keywords: ['.shop domains', '.shop TLD', '.shop top-level domain', 'what is .shop', 'why choose .shop', 'what is the .shop domain', 'why choose the .shop domain', 'e-commerce branding', 'buy online store domain', 'domain investing', 'tokenized domains', 'blockchain domains', 'digital retail', 'GMO registry', 'web3 ecommerce']
+description: 'The .shop domain is an open new gTLD run by GMO Registry that signals "this is a place to buy." Learn who uses it, the rules, pricing dynamics, and SEO.'
+keywords: ['.shop domains', 'what is .shop', '.shop TLD', '.shop domain registration', 'e-commerce domain', 'GMO Registry', 'new gTLD for retail', 'buy .shop domain']
+faqs:
+  - question: 'Can anyone register a .shop domain?'
+    answer: 'Yes. .shop is an open generic top-level domain with no eligibility restrictions, so any individual or business worldwide can register an available name on a first-come, first-served basis. There is no credential, local-presence, or community requirement.'
+  - question: 'Does a .shop domain affect SEO?'
+    answer: 'No. Google treats .shop the same as .com and other gTLDs, with no ranking penalty or bonus from the extension itself. A descriptive .shop name can lift click-through rates on commercial searches because the suffix signals a place to buy.'
+  - question: 'Who should register a .shop domain?'
+    answer: 'It suits online stores, direct-to-consumer brands, creators selling merchandise, and physical retailers building a transactional site. It is a strong fit when the matching .com is taken or expensive and you want a name that says "shop here" at a glance.'
+  - question: 'Is .shop good for an online store?'
+    answer: 'Yes. The word "shop" is understood globally and instantly communicates commercial intent, which is why brands like Netflix and MrBeast run merchandise stores on it. The large, newer namespace also makes short, exact-match retail names easier to secure.'
+  - question: 'Does .shop support WHOIS privacy and DNSSEC?'
+    answer: 'Yes. .shop supports DNSSEC at the registry level, and most registrars offer free WHOIS privacy that masks personal contact details in public records. Availability of privacy depends on your registrar rather than the registry.'
 ---
 
-## **What is .shop?**
+The **.shop** domain is one of the most literal extensions on the internet: the suffix is the call to action. Where a generic name leaves visitors guessing, a name ending in `.shop` tells them before they click that this is a place to browse and buy. That clarity is why retailers, direct-to-consumer brands, and creators have adopted it as a purpose-built address for selling online.
 
-The **.shop** domain constitutes a generic Top-Level Domain (gTLD) specifically designed for the e-commerce sector. In the crowded landscape of the internet, a TLD serves as the suffix of a web address (like .com or .org). The **.shop** extension was introduced to provide a dedicated digital identity for retailers, online merchants, and service providers.
+As a modern, open new gTLD with a deep pool of unregistered names, **.shop** is a practical answer to a familiar problem: the short, exact-match `.com` you want is taken or priced like real estate. This page covers who runs the registry, who uses it, the rules, pricing dynamics, and how the suffix is perceived for trust and email.
 
-Managed by the [GMO Registry](https://www.gmo-registry.com/), the .shop TLD was one of the most highly anticipated launches in the history of the new gTLD program overseen by [ICANN](https://www.icann.org/). Since its public launch in 2016, it has grown to become one of the most popular choices for businesses looking to clearly signal their intent to sell products or services.
+## .shop at a glance
 
-Unlike generic extensions, **.shop** is semantically meaningful. It tells a user exactly what to expect before they even click the link: a place to browse and buy. This clarity is invaluable in the modern digital economy where attention spans are short and trust is paramount.
+| Fact | Detail |
+| --- | --- |
+| TLD type | New gTLD (generic, not geo-targeted) |
+| Registry operator | GMO Registry, Inc. (Tokyo, Japan) |
+| Year launched | Delegated 2016; general availability September 2016 |
+| IDN support | Yes (internationalized domain names supported) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility requirements |
+| Best for | Online stores, D2C brands, creator merch, retail microsites |
 
-## **How People Are Using .shop**
+## What is .shop?
 
-The versatility of the **.shop** extension has led to its adoption across a wide variety of industries. It is not limited to massive retail conglomerates; it is a tool for anyone transacting online.
+**.shop** is a [generic top-level domain (gTLD)](/en/glossary/tld) introduced under [ICANN](/en/glossary/icann)'s New gTLD Program — the 2012 expansion that added hundreds of word-based suffixes to the root zone. Its meaning is self-explanatory: "shop" is a near-universal English word for a retail destination, and it functions as a clear semantic label for commerce.
 
-*   **E-commerce Pure Plays:** New brands launching solely online use .shop to secure short, memorable names that are often unavailable in the .com namespace.
-*   **Brick-and-Mortar Retailers:** Physical stores expanding their presence online use this TLD to differentiate their shopping portal from their corporate or informational sites (e.g., `brandname.shop` vs. `brandname.com`).
-*   **Content Creators and Influencers:** YouTubers, streamers, and bloggers often use a .shop domain to direct fans specifically to their merchandise pages, separating their content hub from their commercial hub.
-*   **Service Providers:** It isn't just for physical goods. Repair shops, digital agencies selling packages, and consultants selling courses utilize the extension to highlight their service offerings.
-*   **Domain Investors:** Given the universal understanding of the word "shop," investors frequently acquire high-value generic terms coupled with .shop (e.g., `coffee.shop` or `shoes.shop`) as valuable digital assets.
+Because it is generic rather than a country-code TLD, search engines do not tie **.shop** to any geography. Google's guidance is that it treats new gTLDs the same as legacy extensions and does not apply geo-targeting based on a name like `.shop` — so a `.shop` site can rank globally just like a `.com`. You can confirm the registry details on the official [IANA root-zone entry for .shop](https://www.iana.org/domains/root/db/shop.html).
 
-## **Notable Entities Using .shop**
+## History of .shop
 
-The legitimacy of the .shop TLD has been solidified by its adoption by major global brands. These entities use the domain to create dedicated spaces for merchandise and direct-to-consumer sales.
+The `.shop` string was one of the most contested in the entire New gTLD Program. Multiple applicants — including Google and Amazon — filed for it, and the contention set was ultimately resolved at an ICANN auction in January 2016, where GMO Registry won the rights with a reported winning bid of US$41.5 million, among the highest auction prices of the program.
 
-1.  **Netflix (Netflix.shop):** The streaming giant uses this domain for their official merchandise store, selling apparel and collectibles related to their hit shows.
-2.  **Universal Music Group (Bravado.shop):** As a leader in music merchandise, they utilize the extension to manage consumer products for various artists.
-3.  **MrBeast (MrBeast.shop):** One of the world's most popular content creators uses this TLD for his massive merchandise operations, proving its effectiveness for the creator economy.
-4.  **Design and Tech Startups:** Many modern tech companies create a `.shop` subdomain or standalone site to sell company swag or add-on hardware accessories, keeping the transactional experience distinct from their main software-as-a-service (SaaS) platform.
+GMO Registry, a Tokyo-based operator that also runs strings such as `.tokyo`, added **.shop** to the root zone on 5 May 2016 and opened general availability in September 2016. Adoption has been steady: by the early 2020s the namespace had grown past 1.5 million registered domains, placing it among the more widely used new gTLDs. Background on the operator and the string is documented on [ICANNWiki's .shop page](https://icannwiki.org/.shop).
 
-## **Why Choose .shop?**
+## How people use .shop
 
-Choosing the right domain name is a critical business decision. Here is why **.shop** stands out as a superior choice for online sellers:
+Real-world **.shop** usage clusters around transactional intent:
 
-*   **Instant Recognition:** The word "shop" is understood globally. It creates an immediate call to action and sets clear user expectations.
-*   **Better Availability:** Finding a short, catchy single-word domain on legacy TLDs like .com is nearly impossible or prohibitively expensive. The .shop namespace offers a vast inventory of high-quality, concise names.
-*   **SEO and Click-Through Rates:** Search engines like Google treat new gTLDs just like legacy TLDs. However, a relevant extension like .shop can improve Click-Through Rates (CTR) in search results because users immediately recognize the relevance of the link to their transactional search query (e.g., searching for "buy running shoes").
-*   **Brand Protection:** For established brands, registering the .shop version of their trademark is a crucial defensive strategy to prevent cybersquatting and to control their brand narrative in the e-commerce space.
-*   **Modern Branding:** It signals that a business is current and focused on the customer experience.
+- **Online-only retailers** that want a short, exact name unavailable on `.com`.
+- **Direct-to-consumer brands** running a storefront separate from a corporate or content site (for example `brand.shop` alongside `brand.com`).
+- **Creators and influencers** sending fans to a dedicated merchandise page rather than mixing commerce into their main channel.
+- **Physical retailers** standing up an e-commerce front that is clearly distinct from informational pages.
+- **Domain investors** holding generic retail terms such as category words paired with `.shop`.
 
-## **Register Your .shop Domain at Namefi**
+**Who it's not ideal for:** brands whose value rests on an established `.com`, non-commercial projects (a blog, portfolio, or docs site reads oddly on `.shop`), and anyone who needs the absolute maximum default trust of a legacy extension for a regulated or financial service.
 
-Ready to open your doors to the world? Securing a **.shop** domain is the first step toward building a successful online storefront.
+## Notable sites using .shop
 
-At **Namefi**, we make domain registration simple, secure, and future-proof. As an ICANN-accredited registrar, we offer standard Web2 domain services with a powerful twist: we bridge the gap to Web3. When you register with us, you enjoy seamless management and the unique ability to tokenize your domain, turning your digital identity into a liquid asset on the blockchain.
+- **Netflix.shop** — the streaming company's official merchandise store for apparel and collectibles.
+- **MrBeast.shop** — the creator's large direct-to-consumer merchandise operation, a clear proof point for the creator economy.
 
-Whether you are launching a global brand, a local boutique, or building a portfolio of valuable digital real estate, Namefi provides the tools you need to succeed.
+These are real, active commercial sites. When a major brand runs its merch on `.shop`, it lends the extension visible legitimacy for the smaller storefronts that use it the same way.
 
-**Don't let your perfect store name get snatched up.**
+## .shop vs other domains
 
-[**Register your .shop domain at Namefi today**](https://namefi.io) and start selling tomorrow.
+| Extension | Meaning signal | Namespace availability | Best when |
+| --- | --- | --- | --- |
+| [.com](/en/tld/com) | Generic, default trust | Very scarce / expensive | Maximum familiarity matters most |
+| **.shop** | "A place to buy" | Large, open | You want explicit retail intent |
+| [.store](/en/tld/store) | "A store" | Large | Similar retail framing, alternative word |
+| [.online](/en/tld/online) | Broad web presence | Large | Generic site, not strictly retail |
+
+Pick `.com` when default recognition outweighs everything and you can get the exact name. Pick **.shop** when you want the address itself to announce that you sell. [.store](/en/tld/store) is its closest semantic rival — choose based on which word reads better with your brand — while [.online](/en/tld/online) is broader and less commerce-specific.
+
+## Why choose .shop?
+
+- **Instant commercial meaning.** The suffix is an implicit call to action that sets buyer expectations before the page loads.
+- **Real availability.** A newer, large namespace means short, exact-match retail names are far more attainable than on `.com`.
+- **Global legibility.** "Shop" is understood across most markets without translation.
+- **Brand protection.** Established companies register the `.shop` version of a trademark defensively, to control how their name appears in the commerce space.
+- **Proven by major brands.** Adoption by names like Netflix and MrBeast demonstrates it works for serious storefronts.
+
+## Things to consider
+
+- **String similarity.** `.shop`, `.store`, and `.shopping` are easy to confuse; you may want to defensively register a near-match so traffic isn't lost.
+- **Niche by design.** The suffix only fits commercial uses — it reads awkwardly for non-retail projects.
+- **Renewal pricing.** Like most new gTLDs, the renewal price can differ from a low first-year promo; budget for the ongoing cost, not just year one.
+- **Type-in habit.** Some users still default to typing `.com`, so consider whether you also want the matching `.com` redirect.
+
+## Who can register a .shop domain?
+
+**Registration restrictions: open to all.** There are no eligibility requirements for **.shop** — no credential, local presence, or community membership is needed. Any individual or organization worldwide can register an available name on a first-come, first-served basis, which the registry confirms by listing no registration restrictions for the string.
+
+Standard new gTLD practices apply. Trademark holders could use the ICANN sunrise period at launch, and the Trademark Clearinghouse still supports rights protection. The registry supports internationalized domain names (IDNs) and [DNSSEC](/en/glossary/dnssec) for signed, tamper-resistant DNS. WHOIS privacy is offered by most registrars to mask personal details in [WHOIS](/en/glossary/whois) records, and transfer, renewal, and redemption-grace behavior follow standard ICANN policy. The authoritative rules live in the [ICANN Registry Agreement for .shop](https://www.icann.org/en/registry-agreements/details/shop).
+
+## .shop pricing and value
+
+This page never quotes live prices, but the **dynamics** are worth understanding. Standard `.shop` names sit in the typical new gTLD range, and as with most such extensions the **first-year price and the renewal price can differ** — promotional first years are common, so always check what the name costs to keep year after year.
+
+The registry also designates some high-demand names as **premium**, with elevated registration and sometimes elevated renewal fees; generic one-word retail terms are the most likely to be premium-tier. What drives cost overall is the registry's wholesale fee, whether a name is flagged premium, and your [registrar](/en/glossary/registrar)'s margin and any introductory offer. For aftermarket sales, a desirable exact-match `.shop` can also command a resale premium between owners.
+
+## Reputation and email deliverability
+
+New gTLDs once carried a faint "cheap and spammy" reputation because low prices attracted bulk and throwaway registrations. **.shop** has largely outrun that perception: its visible use by major brands, its clear commercial purpose, and a registry-backed, e-commerce-focused positioning have normalized it for legitimate storefronts.
+
+For email, the extension itself is not what spam filters judge — sender authentication is. Whatever suffix you use, configure SPF, DKIM, and DMARC correctly, warm up a new sending domain gradually, and maintain good list hygiene. A `.shop` domain with proper authentication and a clean reputation lands in inboxes just like any other; deliverability problems almost always trace to misconfiguration or sending behavior, not the TLD string.
+
+## Branding and naming tips
+
+- **Let the suffix do the work.** `coffee.shop` or `sneaker.shop` reads as a full phrase — lean into domain-hack patterns where the word before the dot completes the idea.
+- **Keep it short and spellable.** The advantage of `.shop` is clarity; don't undercut it with a long or hard-to-spell second-level name.
+- **Mind the lookalikes.** Decide early whether to also hold the `.store` or `.com` to protect against typos and confusion.
+- **Match brand voice.** `.shop` signals retail and approachability; if your brand wants to feel like a luxury house or a software company, weigh whether the connotation fits.
+
+## How to register a .shop domain at Namefi
+
+1. Search your desired name on [Namefi](https://namefi.io) to check availability across `.shop` and alternatives.
+2. Choose the exact name (and any defensive variants like `.store` or `.com`).
+3. Complete registration and configure DNS.
+
+[Namefi](https://namefi.io) is an [ICANN](/en/glossary/icann)-accredited registrar with transparent pricing and fast [DNS](/en/glossary/dns) management. It also lets you tokenize your domain for Web3 ownership — turning your `.shop` address into a transferable on-chain asset — while keeping standard registrar features intact.
+
+## Frequently asked questions
+
+### Can anyone register a .shop domain?
+
+Yes. **.shop** is an open generic top-level domain with no eligibility restrictions. Any individual or business worldwide can register an available name on a first-come, first-served basis. There is no credential, local-presence, or community requirement to qualify.
+
+### Does a .shop domain affect SEO?
+
+No. Google treats **.shop** the same as `.com` and other gTLDs, with no ranking penalty or bonus from the extension. A descriptive `.shop` name can lift click-through rates on commercial searches, because the suffix signals a place to buy.
+
+### Who should register a .shop domain?
+
+Online stores, direct-to-consumer brands, creators selling merchandise, and physical retailers building a transactional site. It is an especially strong fit when the matching `.com` is taken or expensive and you want a name that says "shop here" at a glance.
+
+### Is .shop good for an online store?
+
+Yes. "Shop" is understood globally and instantly communicates commercial intent — which is why brands like Netflix and MrBeast run merchandise stores on it. The large, newer namespace also makes short, exact-match retail names easier to secure than on legacy extensions.
+
+### Does .shop support WHOIS privacy and DNSSEC?
+
+Yes. **.shop** supports DNSSEC at the registry level, and most registrars offer free WHOIS privacy that masks personal contact details in public records. Whether privacy is included depends on your registrar rather than the registry.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [Top TLDs to secure for your e-commerce store](/en/blog/top-tlds-to-secure-for-your-ecommerce-store)
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains)
+- [.store domain](/en/tld/store)
+- [.online domain](/en/tld/online)
+- [.com domain](/en/tld/com)
+- Glossary: [registrar](/en/glossary/registrar), [DNSSEC](/en/glossary/dnssec), [WHOIS](/en/glossary/whois)

--- a/content/tld/en/site.md
+++ b/content/tld/en/site.md
@@ -1,62 +1,146 @@
 ---
-title: "What is the .site Domain? A Versatile Choice for Your Online Presence"
-date: '2025-12-10'
+title: 'What Is the .site Domain? The Universal Website Extension'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: "Explore the .site TLD: a flexible, universally understood domain extension. Learn why businesses and developers choose .site and register yours with Namefi."
-keywords: [".site domains", ".site TLD", ".site top-level domain", "what is .site", "why choose .site", "what is the .site domain", "why choose the .site domain", "buy .site domain", "domain investing", "tokenized domain", "blockchain domains", "Web3 domains", "Radix registry", "business website domain", "new gTLD availability"]
+description: 'The .site domain is an open, globally understood new gTLD by Radix. Learn who uses it, its SEO and deliverability profile, and how to register one at Namefi.'
+keywords: ['.site domains', 'what is .site', '.site TLD', '.site domain registration', 'Radix registry', 'new gTLD', 'buy .site domain', 'is .site good for SEO']
+faqs:
+  - question: 'Can anyone register a .site domain?'
+    answer: 'Yes. The .site extension is an open generic top-level domain with no eligibility restrictions. There is no credential, trademark, business, or local-presence requirement, so individuals and organizations anywhere in the world can register an available .site name on a first-come, first-served basis.'
+  - question: 'Does a .site domain affect SEO?'
+    answer: 'No. Google treats .site like any other generic top-level domain, including .com. The extension itself carries no ranking advantage or penalty; content quality, links, and user experience determine rankings. New gTLDs are not given less weight in Google Search.'
+  - question: 'Who should register a .site domain?'
+    answer: 'It suits anyone who wants a short, literal web address when the matching .com is taken or expensive: small businesses, portfolios, landing pages, side projects, and campaign microsites. Because the word "site" simply means website, it is broadly understood and easy to remember.'
+  - question: 'Is .site associated with spam?'
+    answer: 'Low-cost open new gTLDs, including .site, have seen some abuse, so a few aggressive spam filters score unknown new-gTLD senders more cautiously. A properly configured domain with SPF, DKIM, and DMARC and a warmed-up sending reputation delivers reliably.'
 ---
 
-## **What is .site?**
+The **.site** domain is one of the most literal extensions on the internet: the word "site" is shorthand for "website" in English and is recognized in many other languages, so a .site address tells visitors exactly what they are looking at. It is a generic top-level domain (gTLD) launched under ICANN's New gTLD Program, open to anyone, anywhere, with no eligibility hoops.
 
-The **.site** extension is a generic top-level domain (gTLD) that has rapidly become one of the most popular alternatives to traditional extensions like .com or .net. Managed by the [Radix Registry](https://radix.website/), .site was launched in 2015 as part of ICANN’s New gTLD Program, designed to expand the internet's namespace and provide more availability for website owners.
+For founders, indie developers, and brand owners who find their ideal name already taken on .com, .site is a practical, descriptive alternative that keeps the address short and self-explanatory. This page covers who runs it, how it is used, its SEO and email-deliverability profile, and what to weigh before you register.
 
-The term "site" is short for "website," making this TLD intuitively understood across the globe. It is not restricted to a specific geography or industry, making it a truly universal choice. Whether you are launching a personal blog, a corporate landing page, or a Web3 project, .site tells users exactly what to expect: a destination on the web.
+## .site at a glance
 
-Currently, .site consistently ranks among the top registered new gTLDs worldwide, boasting millions of registrations. Its popularity stems from its simplicity and the fact that "site" is a recognizable word in many languages, not just English.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (new gTLD) |
+| Registry operator | Radix (Radix Technologies Inc. SEZC) |
+| Year launched | 2015 |
+| IDN support | Yes |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no credential, business, or local-presence requirement |
+| Best for | Websites, portfolios, landing pages, small businesses, microsites |
 
-## **How People Are Using .site**
+## What is .site?
 
-Because .site is open to everyone without restriction, its usage is incredibly diverse. Here is how different sectors are leveraging this TLD:
+.site is a generic top-level domain delegated to the DNS root in 2015 as part of [ICANN's New gTLD Program](https://newgtlds.icann.org/), the 2012-round expansion that added hundreds of new endings to the namespace. Unlike a country-code TLD such as .io or .de, .site has no geographic meaning — it is fully generic and globally targeted.
 
-*   **Tech Startups and SaaS:** Many technology companies use .site for product landing pages or documentation portals when their primary .com is unavailable or too expensive.
-*   **Creative Portfolios:** Designers, architects, and artists use the extension to create a professional showcase (e.g., `firstnamelastname.site`).
-*   **Web3 and Blockchain Projects:** In the decentralized space, where innovation is key, developers often choose .site for dApps and tokenized platforms, creating a distinct identity separate from legacy web institutions.
-*   **Local Businesses:** Small business owners find .site to be an affordable and memorable alternative that pairs well with service keywords (e.g., `plumbingservices.site`).
-*   **Temporary Projects:** Event organizers and marketers often register .site domains for specific campaigns or microsites due to their cost-effectiveness and availability.
+That distinction matters for international projects. According to [Google Search Central](https://developers.google.com/search/docs/crawling-indexing/managing-multi-regional-sites), generic new TLDs like .site are treated as global by default, so a .site site is not geo-locked to any single country the way a ccTLD often is. The [IANA root-zone record for .site](https://www.iana.org/domains/root/db/site.html) lists Radix as the current operator and shows its delegation history.
 
-## **Notable Entities Using .site**
+## History of .site
 
-While many Fortune 500 companies stick to legacy domains for their headquarters, the .site TLD has been embraced by millions of innovators and modern enterprises.
+.site was delegated in 2015 and opened to general registration the same year through the registry now operated by Radix, a company that runs a portfolio of word-based new gTLDs including .online, .store, .tech, and .fun. Because "site" is such a universal web term, the extension drew steady demand from its launch rather than relying on a single niche.
 
-1.  **Direct-to-Consumer Brands:** Various e-commerce innovators have utilized .site to launch online storefronts, capitalizing on short, brandable names that were unavailable on older TLDs.
-2.  **Educational Platforms:** Coding bootcamps and educational repositories often utilize .site to host course materials and student projects.
-3.  **The "Side Project" Community:** The TLD has become a favorite among the [Product Hunt](https://www.producthunt.com/) community and indie hackers who need a clean, descriptive URL for their latest app or tool.
+Adoption grew quickly enough that the registry reported the namespace passing one million registrations in February 2019. It has remained one of the more widely registered new gTLDs since. Radix has reported that the large majority of .site registrations come from small and medium businesses, concentrated in ecommerce and information-technology use — a profile consistent with the extension's plain "this is a website" framing.
 
-*Note: While usage is widespread, the primary "celebrity" of the .site domain is the vast community of over 3 million small-to-medium businesses and developers who have adopted it worldwide.*
+## How people use .site
 
-## **Why Choose .site?**
+.site is deliberately generic, so its real-world use is broad rather than tied to one industry:
 
-If you are debating between .site and other extensions, consider these distinct advantages:
+- **Small-business and local sites** — a clear, descriptive address when the .com is gone, e.g. pairing a service word with the extension.
+- **Portfolios and personal pages** — designers, writers, and freelancers using a `firstnamelastname.site` pattern.
+- **Landing pages and microsites** — single-purpose campaign, product, or event pages where the URL just needs to read as "a website."
+- **Documentation and project sites** — developers spinning up a public page for an open-source tool or side project.
+- **Brand-defensive registrations** — companies securing the .site version of a trademark alongside their primary domain.
 
-*   **Universal Understanding:** The word "site" is arguably one of the most recognized internet terms globally. It transcends language barriers, making it excellent for international audiences.
-*   **Superior Availability:** Finding a short, one-word, or two-word domain on .com is nearly impossible without spending thousands of dollars. With .site, you have a high probability of securing your exact brand name.
-*   **SEO Friendliness:** [Google Search Central](https://developers.google.com/search/docs/crawling-indexing/new-top-level-domains) has confirmed that new gTLDs like .site are treated the same as .com for ranking purposes. Your content quality determines your rank, not the extension.
-*   **Brand Protection:** For larger companies, registering the .site version of their trademark prevents cybersquatting and secures a defensive perimeter around their brand.
-*   **Investment Potential:** As the internet expands, short and generic .site domains hold intrinsic value, making them attractive assets for domain investors and tokenized asset portfolios.
+**Who it's not ideal for:** large enterprises whose audience expects a .com flagship, or projects that want a country-specific signal (a ccTLD fits better there). If you are building an explicitly tech- or app-branded product, a more specialized ending like [.app](/en/tld/app), [.dev](/en/tld/dev), or [.tech](/en/tld/tech) may communicate the category more sharply.
 
-## **Register Your .site Domain at Namefi**
+## Notable sites using .site
 
-Ready to secure a domain that is short, memorable, and globally recognized? Namefi is the premier destination for registering your **.site** domain.
+.site is used overwhelmingly by independent businesses, creators, and side projects rather than household-name flagships, so its strength is breadth of adoption rather than a few marquee brands. Radix has reported that around 70% of .site registrations come from small and medium businesses in ecommerce and IT — the everyday websites, storefronts, and portfolios the extension was named for. Rather than cite a single famous example that could change hands, the honest picture is a long tail of working sites where the address simply reads as "this is a website."
 
-At Namefi, we bridge the gap between traditional Web2 domain registration and the Web3 ecosystem. When you register with us, you aren't just getting a URL; you are getting a future-proof digital asset.
+## .site vs other domains
 
-*   **ICANN Accredited:** Safe, secure, and compliant registration.
-*   **Tokenized Utility:** Your domain can be easily managed as an NFT, allowing for seamless transfers and integration into DeFi and blockchain applications.
-*   **Transparent Pricing:** No hidden fees, just great domains.
+| Extension | Type | Meaning | Typical use |
+| --- | --- | --- | --- |
+| [.site](/en/tld/site) | New gTLD | Literally "website" | General-purpose websites, SMBs, portfolios |
+| [.com](/en/tld/com) | Legacy gTLD | Commercial / default | The mainstream default; widest recognition |
+| [.online](/en/tld/online) | New gTLD | Being online | Broad, brandable alternative to .com |
+| [.store](/en/tld/store) | New gTLD | A shop | Ecommerce and retail specifically |
 
-Don't let your perfect name get taken by someone else.
+Choose [.com](/en/tld/com) when maximum familiarity matters and the name is affordable. Choose .site when you want a short, plain-language address and the .com is unavailable. Pick [.store](/en/tld/store) instead if the project is unmistakably a shop, or [.online](/en/tld/online) if you simply want another broad, generic option to compare.
 
-**[Search for your .site domain at Namefi today](https://namefi.io)** and build your place on the web.
+## Why choose .site?
+
+- **Instantly understood** — "site" means website to a global audience, with no explanation needed.
+- **Strong availability** — short, one- and two-word names that are long gone on .com are often still open on .site.
+- **No restrictions** — anyone can register; no paperwork, credentials, or local presence.
+- **Globally neutral** — as a generic gTLD it carries no country bias, which suits international audiences.
+- **Standards support** — DNSSEC and internationalized domain names (IDNs) are supported by the registry.
+
+## Things to consider
+
+.site is not the right fit for every project. Because it is an inexpensive, open new gTLD, some users still default to assuming "real" sites live on .com, so a .site address can feel less established to conservative audiences. Like other low-cost open extensions, it has seen a share of spam and abuse, which can occasionally affect how unfamiliar recipients or filters treat a brand-new domain. And while first-year promotions are common across new gTLDs, you should budget for renewals that may differ from the introductory rate. None of these is disqualifying, but they are worth weighing against the extension's clarity and availability.
+
+## Who can register a .site domain?
+
+**Registration restrictions: open to all.** .site has no eligibility requirements — there is no credential gate (unlike .law or .cpa), no membership requirement, and no local-presence rule. Any individual or organization worldwide can register an available .site name on a first-come, first-served basis.
+
+Standard new-gTLD safeguards still apply. During launch, a Sunrise period gave trademark holders (via the Trademark Clearinghouse) first opportunity to claim matching names, and the usual reserved- and premium-name lists apply. Names follow standard length rules, and the registry supports IDNs for non-Latin scripts. On the administrative side, DNSSEC is supported, WHOIS privacy is generally available through registrars, and transfers, renewals, and redemption-grace handling follow ICANN's standard gTLD lifecycle. The authoritative rules live in the [.site ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/site) and the [Radix registry policies](https://radix.website/policies).
+
+## .site pricing and value
+
+This page does not quote prices, but it helps to understand what drives them. Like most new gTLDs, .site has a standard tier and a **premium tier**: short, common, or high-demand keyword names are classified as premium and priced higher, often with premium renewal pricing that persists year over year. Standard names are far more affordable.
+
+Be aware that **first-year and renewal pricing usually differ** — introductory promotions are common across registrars, while renewals settle at the standard rate. The main cost drivers are whether the name is premium, the registration term, and any add-ons such as privacy. Always check the renewal price, not just the first-year teaser, before committing to a name you plan to keep.
+
+## Reputation and email deliverability
+
+.site is generally perceived as a clear, functional, budget-friendly extension rather than a premium or "techy" one. Because it is cheap and open, it has — like many low-cost new gTLDs — attracted some spammers, and a minority of aggressive mail filters historically score unfamiliar new-gTLD senders more cautiously than long-established .com senders.
+
+In practice this is very manageable. Deliverability is driven far more by your domain's configuration and sending history than by the suffix itself. Set up **SPF, DKIM, and DMARC** correctly, warm up a new sending domain gradually, keep lists clean, and monitor your sender reputation. A well-run .site domain reaches inboxes reliably; the extension is not a deliverability blocker on its own.
+
+## Branding and naming tips
+
+The appeal of .site is its literalness, so lean into it: pair a descriptive word with the suffix so the whole address reads as a phrase (for example a craft or service plus `.site`). This makes the most of the rare cases where the .com equivalent is unavailable. Keep names short and easy to spell aloud — the word "site" is unambiguous, but the part you choose in front of it should be too. Avoid hyphens and numbers where possible, since they hurt memorability and are easy to mishear. Because "site" sounds identical to "cite" and "sight," say the full domain clearly in any spoken or radio context to avoid confusion.
+
+## How to register a .site domain at Namefi
+
+1. **Search** for your desired name on [Namefi](https://namefi.io) to check availability across .site and alternatives.
+2. **Choose** the exact .site name you want, noting whether it is a standard or premium registration.
+3. **Register** and complete checkout, then manage DNS from your dashboard.
+
+Namefi is an ICANN-accredited registrar that also supports Web3 tokenization, so a .site domain can optionally be managed as an on-chain asset alongside conventional DNS. You get transparent pricing and fast DNS management. [Search for your .site domain at Namefi](https://namefi.io) to get started.
+
+## Frequently asked questions
+
+### Can anyone register a .site domain?
+
+Yes. The .site extension is an open generic top-level domain with no eligibility restrictions. There is no credential, trademark, business, or local-presence requirement, so individuals and organizations anywhere in the world can register an available .site name on a first-come, first-served basis.
+
+### Does a .site domain affect SEO?
+
+No. Google treats .site like any other generic top-level domain, including .com. The extension itself carries no ranking advantage or penalty; content quality, links, and user experience determine rankings. New gTLDs are not given less weight in Google Search.
+
+### Who should register a .site domain?
+
+It suits anyone who wants a short, literal web address when the matching .com is taken or expensive: small businesses, portfolios, landing pages, side projects, and campaign microsites. Because the word "site" simply means website, it is broadly understood and easy to remember.
+
+### Is .site associated with spam?
+
+Low-cost open new gTLDs, including .site, have seen some abuse, so a few aggressive spam filters score unknown new-gTLD senders more cautiously. A properly configured domain with SPF, DKIM, and DMARC and a warmed-up sending reputation delivers reliably.
+
+## Related resources
+
+- [What is a domain?](/en/blog/what-is-domain)
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains)
+- [ICANN (glossary)](/en/glossary/icann)
+- [Registrar (glossary)](/en/glossary/registrar)
+- [DNSSEC (glossary)](/en/glossary/dnssec)
+- [.com domain](/en/tld/com)
+- [.online domain](/en/tld/online)
+- [.store domain](/en/tld/store)
+- [.tech domain](/en/tld/tech)

--- a/content/tld/en/space.md
+++ b/content/tld/en/space.md
@@ -1,50 +1,165 @@
 ---
-title: What is .space TLD and Why Choose It?
-date: '2025-12-10'
+title: 'What Is the .space Domain? The Creative & Tech Extension Explained'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: Discover the versatility of the .space domain! Perfect for startups, creatives, and anyone building their digital presence. Register your .space domain today!
-keywords: [.space, domain name, TLD, generic TLD, web design, startup, creative portfolio, online presence, domain registration, Namefi, web3 domains, blockchain domains, alternative domain endings, ICANN]
+description: 'The .space domain is an open new gTLD from Radix, popular with startups, creatives, and space-tech projects. Learn who it suits, how it ranks, and what it costs.'
+keywords: ['.space domain', 'what is .space', 'space TLD', 'register .space domain', 'Radix registry', 'new gTLD', 'creative domain extension', 'startup domain']
+faqs:
+  - question: 'Can anyone register a .space domain?'
+    answer: 'Yes. .space is an open generic TLD with no eligibility restrictions, so individuals, companies, and organizations anywhere in the world can register an available name on a first-come, first-served basis. There is no credential, trademark, or local-presence requirement.'
+  - question: 'Does a .space domain affect SEO?'
+    answer: 'No. Google treats .space as a generic, non-geographic TLD and ranks it on the same merits as .com. Your content, links, and user experience drive rankings, not the suffix itself. A .space site can rank just as well as any other.'
+  - question: 'Who should register a .space domain?'
+    answer: 'Startups, creatives, portfolio owners, coworking brands, and aerospace or astronomy projects suit .space best, especially when the literal word "space" reinforces the brand or when the matching .com is taken or expensive.'
+  - question: 'Is .space good for email and deliverability?'
+    answer: 'Yes, when configured correctly. .space is a legitimate Radix-operated gTLD, but as a lower-cost new gTLD it sees abuse, so set up SPF, DKIM, and DMARC and warm up your sending domain to keep messages out of spam folders.'
+  - question: 'Does .space support DNSSEC and WHOIS privacy?'
+    answer: 'Yes. The .space registry supports DNSSEC for signed, tamper-resistant DNS, and most registrars including Namefi offer WHOIS privacy to keep your personal contact details out of the public directory.'
 ---
 
-## **What is .space?**
+The **.space domain** is one of the most literal, brandable new generic top-level domains (gTLDs) on the market: a short, evocative word that works equally well for a SaaS startup, a designer's portfolio, a coworking brand, or an actual aerospace project. Operated by the registry Radix, it launched in the first wave of ICANN's gTLD expansion and has become a familiar alternative for anyone whose ideal `.com` is taken or priced out of reach.
 
-The .space Top-Level Domain (TLD) is a generic TLD (gTLD) that provides a broad and versatile online identity. Launched as part of the new gTLD program overseen by [ICANN](https://www.icann.org/), .space offers a clear and intuitive namespace for individuals, businesses, and organizations looking to establish a digital "space" for their ideas, projects, or brand. It is not a country-code TLD (ccTLD). The purpose of the .space TLD is to provide a simple and memorable domain extension that reflects concepts of creativity, freedom, and location for online presence. Current usage trends indicate popularity among startups, creative professionals, and those seeking a modern and adaptable domain name.
+This page covers what `.space` is, who really uses it, how search engines treat it, the registration rules, and the honest trade-offs — so you can decide whether it fits your project before you buy.
 
-## **How People Are Using .space**
+## .space at a glance
 
-The .space TLD is being used by a diverse range of individuals and organizations:
+| Fact | Detail |
+| --- | --- |
+| TLD type | New gTLD (generic, non-geographic) |
+| Registry operator | Radix (Radix Technologies / DotSpace) |
+| Year launched | Delegated 2014; general availability 2015 |
+| IDN support | Yes (internationalized domain names supported) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility requirements |
+| Best for | Startups, creatives, portfolios, coworking, space-tech |
 
-*   **Tech Startups:** Creating online "space" for their innovative products and services.
-*   **Creative Professionals:** Showcasing portfolios of their work (design, photography, writing, etc.).
-*   **Architects and Interior Designers:** Highlighting design projects and professional expertise.
-*   **Co-working Spaces:** Promoting shared workspaces and community environments.
-*   **Anyone Building an Online Community:** Forums, online gatherings, and shared interest groups.
-*   **Personal Blogs and Websites:** Establishing an online presence with a memorable domain name.
+## What is .space?
 
-## **Notable Entities Using .space**
+`.space` is a **generic top-level domain**, not a country-code TLD. The word carries two strong, useful meanings at once: physical or creative *space* (a studio, a coworking floor, a canvas, a "space to build") and outer *space* (astronomy, rockets, satellites, the final frontier). That dual sense is what makes it brandable across very different niches.
 
-While .space isn't typically used by mega-corporations, many forward-thinking organizations leverage its versatility:
+Because `.space` is generic and not tied to any country, Google treats it as a standard global gTLD with no geographic targeting baked in — exactly the way it treats `.com`, [`.org`](/en/tld/org), or [`.net`](/en/tld/net). You can read this directly in the [IANA root-zone entry for .space](https://www.iana.org/domains/root/db/space.html), and Google's own guidance in [Search Central](https://developers.google.com/search/docs/crawling-indexing/managing-multi-regional-sites) confirms that newer gTLDs are ranked on the same footing as legacy ones. The suffix is not a ranking factor; your content is.
 
-*   **Co-working spaces:** Several co-working and shared office environments use .space to highlight their commitment to open collaboration and community.
-*   **Independent Developers:** Many independent software developers and designers use .space to showcase their projects and availability for hire.
-*   **Creative Agencies:** Smaller creative agencies use .space to create a modern, flexible brand image.
-*   **Hypothetical Best Use Cases:** Imagine NASA creating a [futureof.space](http://example.space) to host educational resources, or a school with a dedicated learning portal at [learn.space](http://example.space).
+## History of .space
 
-## **Why Choose .space?**
+`.space` was part of ICANN's New gTLD Program, the 2012-era expansion that opened the root zone to hundreds of new word-based extensions. It was delegated to the DNS root in 2014 and reached general availability in 2015, after the standard sunrise and landrush phases.
 
-Choosing a .space domain name offers several distinct advantages:
+The registry is **Radix**, one of the larger new-gTLD portfolio operators, which also runs extensions such as [`.store`](/en/tld/store), [`.online`](/en/tld/online), [`.site`](/en/tld/site), [`.tech`](/en/tld/tech), and `.website`. Radix runs `.space` on professional registry infrastructure and distributes it through ICANN-accredited registrars worldwide. Over the years `.space` has settled into a steady mid-tier adoption pattern: it is widely available and inexpensive, with a meaningful share of registrations from startups, creators, and the space-and-science community.
 
-*   **Memorable and Intuitive:** .space is easy to remember and understand, making it a great choice for branding.
-*   **Availability:** Because .space is a newer TLD, there is a higher chance of securing a short, desirable domain name compared to more established TLDs like .com.
-*   **Branding Flexibility:** The term "space" is versatile, suitable for a wide range of industries and purposes, offering freedom in branding.
-*   **Modern Image:** Using .space communicates innovation and a forward-thinking approach, aligning well with tech startups and creative ventures.
-*   **Potential SEO Benefit:** While not a direct ranking factor, a relevant domain name can contribute to overall SEO efforts by improving brand recall and click-through rates.
+## How people use .space
 
-## **Register Your .space Domain at Namefi**
+Real, recurring uses of `.space` include:
 
-Ready to claim your digital .space? At [Namefi](https://namefi.io), we make domain registration simple, secure, and seamless. As an ICANN-accredited registrar, you can trust us to handle your domain needs with professionalism and expertise. Plus, with Namefi, you gain access to seamless Web3 integration, allowing you to easily connect your .space domain to blockchain-based applications and services.
+- **Tech startups and SaaS** that want a clean one-word brand when the `.com` is gone — "build your space" framing is a natural fit.
+- **Designers, photographers, and artists** hosting portfolios — the word reads as a personal *studio* or *gallery*.
+- **Coworking and event venues** whose product literally *is* a physical space or community hub.
+- **Aerospace, astronomy, and "space-tech" projects** — companies and enthusiasts working on rockets, satellites, telescopes, and space education love the literal meaning.
+- **Personal sites and microsites** — short, memorable hacks like `my.space`-style constructions.
 
-Don't wait! Secure your .space domain today and start building your online presence with Namefi.
+**Who it's not ideal for:** established offline-first businesses (a local plumber, a law firm) where customers default to typing `.com`, and anyone who needs the maximum default trust of a legacy suffix for cold outreach. If brand recall outside a tech/creative audience is critical, weigh `.space` carefully.
+
+## Notable sites using .space
+
+`.space` skews toward startups, indie projects, and the space community rather than household-name megabrands, so its strength is breadth rather than a few famous flagships. In practice you will most often see it on:
+
+- Startup and product landing pages where the founders chose `.space` over a costly `.com`.
+- Astronomy, rocketry, and space-education projects that use the word literally.
+- Creative portfolios and coworking brands.
+
+Several hundred `.space` sites appear within the top one million websites by traffic, which signals real, sustained usage. We do not name specific sites we cannot independently verify are live, but the typical use above reflects the genuine profile of the namespace.
+
+## .space vs other domains
+
+| | .space | .com | [.site](/en/tld/site) | [.tech](/en/tld/tech) |
+| --- | --- | --- | --- | --- |
+| Type | New gTLD | Legacy gTLD | New gTLD | New gTLD |
+| Default trust | Moderate | Highest | Moderate | Moderate |
+| Availability of short names | High | Very low | High | Moderate |
+| Literal brand meaning | Strong (dual) | Neutral | Generic | Tech-specific |
+| Typical price tier | Low/mid | Mid | Low | Mid |
+
+Pick [`.com`](/en/tld/com) when maximum mainstream trust and muscle-memory typing matter most. Pick `.space` when the word reinforces your brand (creative, coworking, or space-tech) or when the `.com` is taken. Choose [`.tech`](/en/tld/tech) for a deep-tech signal, or [`.site`](/en/tld/site) for a fully generic, lowest-cost web presence.
+
+## Why choose .space?
+
+- **Meaningful, dual-sense word.** Few extensions are this brandable across both "creative space" and "outer space."
+- **Strong availability.** Short, exact-match names that are long gone in `.com` are often still free in `.space`.
+- **Global and generic.** No country targeting, no eligibility hoops — register from anywhere.
+- **Modern signal.** It reads as forward-looking, which suits startups and design-led brands.
+- **Full technical parity.** DNSSEC, IDNs, and standard DNS features are all supported.
+
+## Things to consider
+
+- **Lower default trust than `.com`.** Some mainstream users still assume `.com`; you may need to reinforce your URL in marketing.
+- **Type-in risk.** People may forget the suffix and land on the `.com` equivalent owned by someone else.
+- **Renewal pricing.** Like many new gTLDs, the first-year promo price can be much lower than the standard renewal — always check the renewal rate before committing.
+- **Abuse-driven filtering.** Cheap new gTLDs attract spammers, which can occasionally affect reputation if you don't authenticate your email properly (see below).
+
+## Who can register a .space domain?
+
+**Registration restrictions: none.** `.space` is **open to everyone** — there is no credential, profession, community, or local-presence requirement. Any individual, business, or organization worldwide can register an available `.space` name on a first-come, first-served basis.
+
+Standard new-gTLD rules apply: names run from 1 to 63 characters, IDNs are supported, and trademark holders had a sunrise window at launch (the [Trademark Clearinghouse](https://www.trademark-clearinghouse.com/) still provides ongoing claims protection). The registry supports DNSSEC, most registrars including Namefi offer WHOIS privacy, and transfers, renewals, and the redemption-grace period follow ICANN's standard policies. The authoritative rulebook is the [ICANN Registry Agreement for .space](https://www.icann.org/en/registry-agreements/details/space), and the operator's portfolio details are published by [Radix](https://radix.website/).
+
+## .space pricing and value
+
+This page never quotes live prices, but the **dynamics** are worth understanding. `.space` is a value-priced new gTLD, so standard names typically sit at the lower-to-mid end of the market. Two things drive what you actually pay:
+
+- **Premium tiers.** The registry classifies short, common, or high-demand strings as premium names, which carry higher registration *and* renewal fees set by Radix, not the registrar.
+- **First-year vs. renewal.** Promotional first-year pricing is common across new gTLDs and can differ sharply from the ongoing renewal rate. Always confirm the renewal price before you buy a name you intend to keep long-term.
+
+Aftermarket value follows the same logic as any gTLD: short, dictionary, and brandable `.space` names resell for more, while the long tail stays inexpensive.
+
+## Reputation and email deliverability
+
+`.space` is a legitimate, professionally operated Radix gTLD, and a well-run `.space` site carries no inherent penalty. That said, like most low-cost new gTLDs, it has seen its share of abuse, and some aggressive spam filters weight newer, cheaper suffixes more cautiously than legacy ones.
+
+The mitigation is standard email hygiene and applies to any domain: publish **SPF, DKIM, and DMARC** records, warm up a new sending domain gradually, keep your lists clean, and monitor your domain's reputation. Done properly, `.space` email lands reliably. Skipping authentication is what gets messages filtered — not the suffix itself.
+
+## Branding and naming tips
+
+- **Lean into the word.** The best `.space` names use "space" as part of the phrase — a coworking brand, a studio, a build-your-space product, or a literal space-tech project.
+- **Watch for ambiguity.** "Space" can read as either physical room or outer space; make sure your context makes the intended meaning obvious.
+- **Say it out loud.** "[brand] dot space" is easy to pronounce and spell, which helps word-of-mouth — a real advantage over more obscure extensions.
+- **Defensive `.com`.** If budget allows, consider also holding the matching `.com` to reduce type-in leakage.
+
+## How to register a .space domain at Namefi
+
+1. **Search** your desired name on [Namefi](https://namefi.io) to check `.space` availability.
+2. **Choose** the exact name (and note whether it is a standard or premium tier).
+3. **Register** and complete checkout, then point your DNS or enable WHOIS privacy.
+
+As an ICANN-accredited registrar, Namefi offers transparent pricing, fast DNS, and optional Web3 [tokenization](/en/glossary/tokenize) so you can hold your domain as an on-chain asset. Start at [Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .space domain?
+
+Yes. `.space` is an open generic TLD with no eligibility restrictions, so individuals, companies, and organizations anywhere in the world can register an available name on a first-come, first-served basis. There is no credential, trademark, or local-presence requirement.
+
+### Does a .space domain affect SEO?
+
+No. Google treats `.space` as a generic, non-geographic TLD and ranks it on the same merits as `.com`. Your content, links, and user experience drive rankings, not the suffix itself. A `.space` site can rank just as well as any other.
+
+### Who should register a .space domain?
+
+Startups, creatives, portfolio owners, coworking brands, and aerospace or astronomy projects suit `.space` best, especially when the literal word "space" reinforces the brand or when the matching `.com` is taken or expensive.
+
+### Is .space good for email and deliverability?
+
+Yes, when configured correctly. `.space` is a legitimate Radix-operated gTLD, but as a lower-cost new gTLD it sees abuse, so set up SPF, DKIM, and DMARC and warm up your sending domain to keep messages out of spam folders.
+
+### Does .space support DNSSEC and WHOIS privacy?
+
+Yes. The `.space` registry supports DNSSEC for signed, tamper-resistant DNS, and most registrars including Namefi offer WHOIS privacy to keep your personal contact details out of the public directory.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [Domain terminology guide](/en/blog/domain-terminology-guide)
+- [Top TLDs to secure for your startup](/en/blog/top-tlds-to-secure-for-your-startup)
+- Glossary: [ICANN](/en/glossary/icann), [registrar](/en/glossary/registrar), [DNSSEC](/en/glossary/dnssec), [SEO](/en/glossary/seo)
+- Compare TLDs: [.com](/en/tld/com), [.tech](/en/tld/tech), [.site](/en/tld/site), [.online](/en/tld/online), [.store](/en/tld/store)

--- a/content/tld/en/store.md
+++ b/content/tld/en/store.md
@@ -1,62 +1,147 @@
 ---
-title: "The Ultimate Guide to the .store TLD: What Is It and Why Choose It?"
-date: '2025-12-10'
+title: 'What Is the .store Domain? The E-Commerce TLD Explained'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: "Discover why .store is the premier domain choice for e-commerce. Learn about its benefits, SEO impact, and notable users. Register your .store at Namefi today."
-keywords: [".store domains", ".store TLD", "top-level domain", "what is .store", "why choose .store", "what is the .store domain", "why choose the .store domain", "e-commerce domain names", "online shop website", "retail branding", "domain investing", "blockchain domains", "tokenized domains", "Web3 e-commerce", "buy .store domain"]
+description: 'The .store domain is an open new gTLD built for retail and online shopping. Learn who runs it, who should use it, how it affects SEO, and where to register.'
+keywords: ['.store domains', 'what is .store', '.store TLD', 'e-commerce domain', 'online store domain name', 'retail domain extension', 'buy a .store domain', 'register .store']
+faqs:
+  - question: 'Can anyone register a .store domain?'
+    answer: 'Yes. The .store domain is an open generic top-level domain with no eligibility restrictions, so individuals, brands, and businesses anywhere in the world can register one on a first-come, first-served basis. There is no proof of a retail license, local presence, or membership required.'
+  - question: 'Does a .store domain affect SEO?'
+    answer: 'No, the suffix itself carries no inherent ranking penalty or boost. Google treats .store like any other generic top-level domain and ranks pages on content, links, and user experience, not on the extension. A descriptive name can lift click-through rates because shoppers see the purpose at a glance.'
+  - question: 'Who should register a .store domain?'
+    answer: 'It suits online retailers, direct-to-consumer brands, creators selling merchandise, and businesses whose exact-match .com is taken or unaffordable. It is a weaker fit for non-commercial blogs, internal tools, or services that do not sell products, where a neutral extension reads better.'
+  - question: 'Is .store good for an online shop?'
+    answer: 'Yes. Because the word store appears in the address, the extension signals a transactional, shop-first destination before a visitor clicks. Many brands also use it as a dedicated merchandise hub alongside a primary corporate site.'
+  - question: 'Does .store support WHOIS privacy and DNSSEC?'
+    answer: 'Yes. As a modern new gTLD, .store supports DNSSEC for cryptographic DNS integrity, and most registrars including Namefi offer WHOIS privacy to keep your personal contact details out of public records.'
 ---
 
-## **What is .store?**
+The **.store** domain is a generic top-level domain (gTLD) built for one job: signaling that a website sells things. Where a neutral suffix tells visitors nothing about a site's purpose, a .store address puts the word *store* directly in the URL, so shoppers and search engines know they are looking at a place to buy before they even click.
 
-The **.store** extension is a generic Top-Level Domain (gTLD) specifically designed for the e-commerce, retail, and online shopping sectors. Unlike the traditional .com, which serves as a catch-all for commercial entities, .store was introduced to provide a dedicated digital identity for businesses that sell products or services online.
+For online retailers, direct-to-consumer brands, and creators launching a merchandise hub, this clarity is the whole pitch. It is also one of the more widely adopted retail-focused extensions, with well over a million registrations worldwide, which makes it a serious mainstream option rather than a novelty.
 
-Launched in 2016 as part of [ICANN’s new gTLD program](https://newgtlds.icann.org/en/about/program), .store is managed by the registry **Radix**. The primary goal of this TLD was to alleviate the overcrowding of the .com namespace, offering merchants a chance to secure short, relevant, and keyword-rich domain names that were previously unavailable.
+## .store at a glance
 
-Today, .store is recognized globally as a signpost for commerce. Whether you are a small local artisan or a multinational corporation, this TLD immediately communicates the purpose of your website to visitors and search engines alike.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (new gTLD) |
+| Registry operator | Radix (Radix Technologies Inc.) |
+| Back-end registry | Tucows Registry |
+| Year launched | 2016 (delegated February 2016; general availability June 2016) |
+| IDN support | Yes |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility requirements |
+| Best for | E-commerce sites, retail brands, merch stores, marketplaces |
 
-## **How People Are Using .store**
+## What is .store?
 
-The versatility of the .store domain has led to its adoption across a wide variety of sectors. Here is how it is currently being utilized:
+The **.store** suffix is a descriptive new gTLD introduced through [ICANN's New gTLD Program](https://newgtlds.icann.org/en/about/program), the initiative that expanded the domain name system far beyond legacy extensions like .com and .net. Its meaning is self-evident in English and widely understood internationally: a store is a place where you buy goods, so the suffix instantly frames a website as a commercial, transactional destination.
 
-*   **E-commerce Startups:** New businesses are choosing .store as their primary web address to secure their exact brand name without hyphens or misspelled words often required when settling for a .com.
-*   **Merchandise Outlets:** Influencers, YouTubers, and bands often use a .store subdomain or separate domain (e.g., `brandname.store`) to link specifically to their merchandise shop from their main social media profiles.
-*   **Brick-and-Mortar Retailers:** Physical shops moving online use .store to differentiate their digital storefront from their corporate informational sites.
-*   **Dropshipping Ventures:** Entrepreneurs use the extension to build niche-specific stores that garner immediate trust regarding the site's transactional nature.
+Because .store is a *generic* TLD and not a country-code TLD, it carries no geographic targeting. According to [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites), generic top-level domains are treated as global by default, so a .store site is not tied to any single country and can rank for audiences anywhere. You can confirm the technical record on the [IANA root-zone entry for .store](https://www.iana.org/domains/root/db/store.html).
 
-## **Notable Entities Using .store**
+## History of .store
 
-The credibility of the .store TLD has been bolstered by its adoption by major global brands and celebrities. These entities often use .store to separate their shopping experience from their main corporate portals.
+The .store TLD was delegated to the root zone in February 2016 and reached general availability in June 2016. It was among the first new gTLDs created explicitly for e-commerce, arriving as the namespace race for retail-friendly suffixes heated up. Multiple major applicants — including Amazon and several large registry portfolios — originally competed for the string, and Radix ultimately secured the rights to operate it.
 
-1.  **Emirates:** The world-renowned airline utilizes `www.emirates.store` for its official merchandise, separating its flight booking engine from its retail operations.
-2.  **Dude Perfect:** The massive sports-entertainment group uses `dudeperfect.store` to direct millions of subscribers to their product lines.
-3.  **Khalid:** The Grammy-nominated singer-songwriter uses `khalid.store` as the hub for his fan merchandise.
-4.  **Husk:** High-profile luxury wellness brands and smaller boutiques alike have adopted the extension to create a clean, "shop-first" aesthetic.
+The registry has changed hands over the suffix's life: the delegation moved through different Radix entities and the back-end registry services are now provided by Tucows. Adoption has grown steadily; the namespace has accumulated well over a million active registrations, and notable early sales such as Hanes acquiring **t-shirts.store** demonstrated brand-level interest in short, exact-match retail names.
 
-## **Why Choose .store?**
+## How people use .store
 
-If you are debating between a traditional extension and .store, consider the following distinct advantages:
+- **Direct-to-consumer brands** that want an exact-match name when the .com is taken or priced out of reach.
+- **Creator and artist merch shops** — musicians, YouTubers, and streamers point fans to a dedicated storefront separate from their main site or social profiles.
+- **Established companies** running a branded merchandise hub alongside their corporate site (for example, an airline selling travel accessories).
+- **Niche and keyword stores** built around a category term, such as a single-product or single-category shop.
+- **Marketplaces and resellers** that want the address itself to communicate a transactional, shop-first experience.
 
-*   **Instant Brand Clarity:** The word "store" in your URL tells a user exactly what to expect before they even click the link. It reduces bounce rates because visitors know they are entering a transactional space.
-*   **High Availability:** Because .store is newer than .com or .net, there is a much higher probability of finding your exact brand name or a premium short keyword (e.g., `vegan.store` or `nyc.store`).
-*   **SEO Relevance:** Search engines like Google treat .store just like any other gTLD. However, having a relevant keyword in the URL (like "store") can improve click-through rates (CTR) in search results when users are specifically looking to buy products.
-*   **Short and Memorable:** Using .store allows you to drop unnecessary words from your domain. Instead of `TheCoffeeShopOnline.com`, you can simply register `Coffee.store`.
-*   **Future-Proofing:** As the web moves toward more semantic naming conventions, having a descriptive extension aligns your brand with modern internet standards.
+**Who it's not ideal for:** non-commercial blogs, portfolios, internal tools, SaaS dashboards, or any project that does not sell products. For those, a neutral or tech-leaning extension reads more naturally than one that promises a shopping experience.
 
-## **Register Your .store Domain at Namefi**
+## Notable sites using .store
 
-Ready to launch your online shop or secure a valuable asset for your domain investment portfolio? 
+- **emirates.store** — the airline's official merchandise shop, kept separate from its flight-booking site.
+- **lorde.store** — the musician's storefront for music merchandise.
+- **backtothefuture.store** — the film franchise's official merchandising destination.
 
-At **Namefi**, we make registering your .store domain simple, secure, and innovative. As an ICANN-accredited registrar, we bridge the gap between traditional Web2 ease and Web3 ownership. When you register a domain with us, you enjoy seamless management and the unique ability to tokenize your domain, giving you true ownership and flexibility in the evolving digital landscape.
+Beyond these, a range of well-known brands and entertainment properties have adopted the suffix for dedicated retail and merch experiences, reinforcing .store as an established choice rather than an experimental one.
 
-**Why register with Namefi?**
-*   Transparent pricing with no hidden fees.
-*   Easy DNS management.
-*   Advanced security features.
-*   The option to mint your domain as an NFT for instant liquidity and transferability.
+## .store vs other domains
 
-Don't let your perfect brand name get taken. 
+| Extension | Type | Best fit | Trade-off |
+| --- | --- | --- | --- |
+| [.store](/en/tld/store) | Retail new gTLD | Shops, merch hubs, retail brands | Less universal recognition than .com |
+| [.com](/en/tld/com) | Legacy gTLD | Any business, default trust | Exact-match names often taken or costly |
+| [.shop](/en/tld/shop) | Retail new gTLD | E-commerce, online shopping | Same niche; comes down to name availability and preference |
+| [.online](/en/tld/online) | Generic new gTLD | Broad web presence | Less specific to commerce than .store |
 
-**[Secure your .store domain at Namefi today](https://namefi.io)** and start selling to the world.
+Pick **.com** when the ideal name is available and budget allows, since it remains the default users type. Choose **.store** (or its closest rival **.shop**) when you want a short, exact-match name that broadcasts a shopping intent. Between .store and .shop, the decision usually comes down to which exact name is free and which word reads better for your brand.
+
+## Why choose .store?
+
+- **Purpose-built clarity** — the word *store* in the address tells visitors and search engines that this is a place to buy, which can reduce hesitation and improve click-through from search and social.
+- **Availability** — because it is far newer than .com, you can often register an exact brand or keyword match that would be long gone in the legacy namespace.
+- **Global and unrestricted** — as a generic TLD with no eligibility rules, anyone anywhere can register, and it carries no geo-targeting that would limit your audience.
+- **Short, semantic names** — instead of padding a .com with extra words, you can drop "shop" or "online" from the second level and let the suffix carry the meaning.
+
+## Things to consider
+
+A descriptive extension cuts both ways. The suffix pins your domain to a retail context, so if your business later pivots away from selling products, the name can feel mismatched. New gTLDs also still trail .com in raw familiarity, since a minority of users instinctively append ".com." Finally, pricing structures for new gTLDs differ from legacy domains, with premium names and differing renewal rates worth checking before you commit.
+
+## Who can register a .store domain?
+
+**Registration restrictions: open to all.** The .store domain has no eligibility gate. Unlike credential-restricted suffixes such as .cpa or membership-gated ones like .realtor, .store requires no proof of a retail license, no local presence, and no community membership. Any individual, brand, or business worldwide can register an available name on a first-come, first-served basis.
+
+Standard new gTLD rules apply: names follow the usual length limits, internationalized domain names (IDNs) are supported, and the registry operates DNSSEC for DNS integrity. Trademark holders could use ICANN's Trademark Clearinghouse protections during the launch sunrise period, and ordinary registrant safeguards — WHOIS privacy, transfer locks, and a redemption grace period after expiry — are available through registrars. You can review the governing rules in the [ICANN Registry Agreement for .store](https://www.icann.org/en/registry-agreements/details/store) and the operator's policies at the [Radix registry site](https://radix.website/).
+
+## .store pricing and value
+
+The .store registry uses standard new gTLD pricing dynamics rather than a single flat rate. Most names register at a baseline price, but a subset of short, high-demand, or category-defining terms are designated **premium** and carry higher registration and sometimes higher renewal fees. As with many new gTLDs, a promotional first-year price can differ from the standard renewal price, so it is worth confirming the renewal rate — not just the initial cost — before you build a brand on a name. Value is driven by length, keyword strength, and commercial relevance; a short, exact-match retail term will command more than a long or obscure one.
+
+## Reputation and email deliverability
+
+Because .store is unmistakably commercial, it reads as a legitimate retail address to most shoppers, and major brands using it lend the namespace credibility. That said, any inexpensive, open new gTLD can attract some throwaway registrations, so a few aggressive spam filters weigh newer suffixes more cautiously than decades-old .com. The practical impact is small and manageable: authenticate your sending domain with SPF, DKIM, and DMARC, warm up new sending addresses gradually, and keep your lists clean. With proper email authentication in place, a .store domain delivers reliably, and the suffix's clear retail meaning is generally an asset to brand trust.
+
+## Branding and naming tips
+
+The strongest .store names treat the suffix as part of the phrase rather than an afterthought. Single-word brand or category names — think `yourbrand.store` or `coffee.store` — are crisp and memorable. Avoid stacking redundant words; `shop.store` or `mystoreonline.store` waste the clarity the suffix already provides. Spelling is rarely an issue since *store* is a common English word, but if your audience is heavily non-English-speaking, test that the meaning translates. Where practical, secure the matching .com to protect against type-in traffic loss.
+
+## How to register a .store domain at Namefi
+
+1. **Search** for your desired name on [Namefi](https://namefi.io) to check availability.
+2. **Choose** the .store option from the results and review whether it is a standard or premium name.
+3. **Register** it through Namefi's ICANN-accredited checkout, then manage DNS and renewals from your dashboard.
+
+As an ICANN-accredited registrar, [Namefi](https://namefi.io) offers transparent pricing with no hidden fees, fast DNS management, and the option to tokenize your domain as an on-chain asset — bridging Web2 convenience with Web3 ownership and liquidity.
+
+## Frequently asked questions
+
+### Can anyone register a .store domain?
+
+Yes. The .store domain is an open generic top-level domain with no eligibility restrictions, so individuals, brands, and businesses anywhere in the world can register one on a first-come, first-served basis. There is no proof of a retail license, local presence, or membership required.
+
+### Does a .store domain affect SEO?
+
+No, the suffix itself carries no inherent ranking penalty or boost. Google treats .store like any other generic top-level domain and ranks pages on content, links, and user experience, not on the extension. A descriptive name can lift click-through rates because shoppers see the purpose at a glance.
+
+### Who should register a .store domain?
+
+It suits online retailers, direct-to-consumer brands, creators selling merchandise, and businesses whose exact-match .com is taken or unaffordable. It is a weaker fit for non-commercial blogs, internal tools, or services that do not sell products, where a neutral extension reads better.
+
+### Is .store good for an online shop?
+
+Yes. Because the word *store* appears in the address, the extension signals a transactional, shop-first destination before a visitor clicks. Many brands also use it as a dedicated merchandise hub alongside a primary corporate site.
+
+### Does .store support WHOIS privacy and DNSSEC?
+
+Yes. As a modern new gTLD, .store supports DNSSEC for cryptographic DNS integrity, and most registrars including Namefi offer WHOIS privacy to keep your personal contact details out of public records.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [Top TLDs to secure for your e-commerce store](/en/blog/top-tlds-to-secure-for-your-ecommerce-store)
+- [Domain terminology guide](/en/blog/domain-terminology-guide)
+- [.shop domain](/en/tld/shop) · [.com domain](/en/tld/com) · [.online domain](/en/tld/online)
+- Glossary: [registrar](/en/glossary/registrar), [DNS](/en/glossary/dns), [DNSSEC](/en/glossary/dnssec), [tokenize](/en/glossary/tokenize)

--- a/content/tld/en/tech.md
+++ b/content/tld/en/tech.md
@@ -1,59 +1,147 @@
 ---
-title: "Unlocking Innovation: What is the .tech Domain and Why Choose It?"
-date: '2025-12-10'
+title: 'What Is the .tech Domain? The Extension for Tech Brands'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: "Discover the power of the .tech domain for your brand. Learn why tech startups and developers choose this TLD and how to register yours at Namefi today."
-keywords: [".tech domains", ".tech TLD", ".tech top-level domain", "what is .tech", "why choose .tech", "what is the .tech domain", "why choose the .tech domain", "technology branding", "developer portfolio domains", "blockchain domains", "tokenized domain investing", "Web3 domains", "tech startup naming", "best domain for software", "Radix registry"]
+description: 'The .tech domain is an open new gTLD run by Radix for technology brands, startups, and developers. Learn who it suits, its trade-offs, and how to register.'
+keywords: ['.tech domain', 'what is .tech', '.tech TLD', 'tech domain extension', 'Radix registry', 'new gTLD for startups', 'developer portfolio domain', 'register .tech domain']
+faqs:
+  - question: 'Can anyone register a .tech domain?'
+    answer: 'Yes. The .tech domain is an open generic top-level domain with no eligibility restrictions. There is no credential, industry membership, or local-presence requirement, so individuals, startups, and established companies anywhere can register one on a first-come, first-served basis.'
+  - question: 'Does a .tech domain affect SEO?'
+    answer: 'No. Google treats .tech the same as .com and other generic top-level domains; the extension itself carries no ranking advantage or penalty. Rankings depend on content, links, and user experience, not on the suffix you choose.'
+  - question: 'Who should register a .tech domain?'
+    answer: 'It suits technology companies, startups, SaaS products, developers building portfolio sites, hackathons, and tech events that want a short, descriptive name when the .com equivalent is taken or expensive. It is less ideal for non-technical local businesses.'
+  - question: 'Does .tech support WHOIS privacy and DNSSEC?'
+    answer: 'Yes. The .tech registry supports DNSSEC for cryptographic DNS integrity, and most registrars offer WHOIS privacy that masks personal contact details in the public directory. Both are widely available, though privacy is provided by the registrar rather than the registry.'
 ---
 
-## **What is .tech?**
+The **.tech domain** is a generic top-level domain built explicitly for the technology world. Where a name like `acme.com` says nothing about what you do, `acme.tech` signals "we build technology" before a visitor reads a single line of copy. That descriptive clarity is the core reason startups, developers, and tech events reach for it.
 
-The **.tech** domain extension is a generic Top-Level Domain (gTLD) specifically designed for the technology industry. Unlike traditional extensions like .com or .net, which are industry-agnostic, .tech serves as a definitive digital identity for brands, individuals, and organizations involved in the technology sector.
+It is one of the most widely adopted new gTLDs launched in the 2012 ICANN expansion, and because it reads the same in every language, it travels well for founders going global. This page covers what `.tech` is, who runs it, who actually uses it, its honest trade-offs, and how to register one.
 
-Launched in 2015 and operated by the [Radix Registry](https://radix.website/), this TLD was introduced to address the saturation of the .com namespace and to provide a dedicated home for the booming tech ecosystem. It allows innovators to establish a clear, relevant, and modern web presence from the very first glance.
+## .tech at a glance
 
-Today, .tech is one of the most successful "new" gTLDs, widely adopted by startups, developers, and industry giants alike who want to signal their commitment to innovation and the future.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (new gTLD) |
+| Registry operator | Radix (Radix Technologies / Radix FZC) |
+| Back-end provider | Tucows Registry |
+| Year launched | 2015 (delegated 2015; general availability 21 March 2015) |
+| IDN support | Yes |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility requirement |
+| Best for | Tech startups, SaaS, developer portfolios, hackathons, tech events |
 
-## **How People Are Using .tech**
+## What is .tech?
 
-Because "tech" is a universally understood term, this TLD offers immense versatility. Here is how different groups are utilizing it:
+`.tech` is a **new gTLD** — a generic extension introduced through ICANN's New gTLD Program, which opened in 2012 and dramatically widened the namespace beyond legacy options like `.com`, `.net`, and `.org`. It is a dictionary word for "technology," so its meaning is instantly legible to a global audience.
 
-*   **Tech Startups and Scale-ups:** New companies are using .tech to immediately categorize their business. It saves marketing effort by telling visitors exactly what the company does before the page even loads.
-*   **Developers and Engineers:** Software engineers, full-stack developers, and coding enthusiasts use .tech for personal portfolios, GitHub redirects, and resume sites to showcase their coding prowess.
-*   **Hackathons and Events:** Organizers of coding competitions and technology conferences frequently use this TLD (e.g., `cityname.tech`) to create a dedicated hub for their community events.
-*   **Industry News and Blogs:** Media outlets focusing on gadget reviews, software updates, or blockchain news utilize the extension to establish authority in the niche.
-*   **Web3 and Blockchain Projects:** Given the forward-looking nature of the blockchain space, many decentralized apps (dApps) and tokenized projects prefer .tech to emphasize their cutting-edge infrastructure.
+Unlike a country-code TLD such as `.io` or `.co`, `.tech` is generic and carries no geographic association. That matters for international projects: [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites) treats most new gTLDs as generic by default, so a `.tech` site is not geo-targeted to any country and competes globally on equal footing. You can confirm the delegation in the [IANA root-zone database entry for .tech](https://www.iana.org/domains/root/db/tech.html).
 
-## **Notable Entities Using .tech**
+## History of .tech
 
-The validity and prestige of the .tech domain have been cemented by its adoption by some of the world's most influential companies and organizations.
+`.tech` was delegated to the root zone in 2015 and reached general availability on 21 March 2015. It launched into a crowded field of new gTLDs but stood out because its meaning is unambiguous and universally understood, which helped it accumulate hundreds of thousands of registrations and become one of Radix's flagship extensions alongside [.store](/en/tld/store), [.online](/en/tld/online), and [.site](/en/tld/site).
 
-1.  **Consumer Electronics Show (CES):** The most influential tech event in the world uses [CES.tech](https://www.ces.tech/) as its primary digital home, moving away from a generic .org or .com.
-2.  **Intel:** The semiconductor giant utilizes **insight.tech** as a content hub for the Internet of Things (IoT) and edge computing solutions.
-3.  **Viacom:** The massive media conglomerate uses **viacom.tech** to showcase their engineering team and technology initiatives.
-4.  **Aurora:** A leader in self-driving vehicle technology, Aurora Innovation uses **aurora.tech**, perfectly aligning their brand name with their industry vertical.
+The most visible adoption milestone came when the Consumer Technology Association moved the Consumer Electronics Show to **CES.tech**, [retiring its older `.org` web address](https://www.prnewswire.com/news-releases/the-worlds-largest-technology-conference-is-now-on-a-tech-domain-extension-582361021.html) — a high-profile endorsement that signaled the extension was ready for major brands, not just experiments.
 
-## **Why Choose .tech?**
+## How people use .tech
 
-Choosing the right domain name is critical for your brand's long-term success. Here is why .tech is often a superior choice for modern businesses:
+- **Tech startups and SaaS products** that want a name describing what they do, especially when the `.com` is taken or priced as a premium.
+- **Developers and engineers** building personal portfolio sites, resume pages, and project hubs that signal "I work in tech."
+- **Hackathons and coding events** using patterns like `cityname.tech` for a dedicated, on-theme event hub.
+- **Tech conferences and trade shows**, following the CES.tech precedent.
+- **Internal engineering and IoT content hubs** spun off from a larger brand to house developer-facing material.
 
-*   **Availability of Short Names:** Because the .com namespace is overcrowded, finding a short, memorable, and keyword-rich domain is difficult. The .tech namespace offers a much higher probability of securing your first-choice name without hyphens or misspelled words.
-*   **Instant Branding and Trust:** A .tech domain acts as a label. It instantly positions you as a forward-thinking, modern, and relevant entity. It filters your audience immediately, attracting those interested in technology.
-*   **Semantic Relevance for SEO:** Search engines like Google treat new gTLDs the same as .com. However, having "tech" in your URL provides semantic relevance. When users search for "[Brand Name] tech," your domain is a perfect match.
-*   **Community Recognition:** In the developer and startup ecosystem, a .tech domain signals that you are "part of the club." It resonates well with investors, early adopters, and tech talent.
+**Who it's not ideal for:** non-technical local businesses (a bakery or law firm), where the suffix sends a confusing signal, and brands whose audience strongly expects a `.com` and may mistype the address.
 
-## **Register Your .tech Domain at Namefi**
+## Notable sites using .tech
 
-If you are ready to build the future, your digital identity should reflect that ambition. Whether you are launching a new AI startup, building a developer portfolio, or investing in valuable digital assets, **Namefi** is your ideal partner.
+- **CES.tech** — official home of the Consumer Electronics Show, run by the Consumer Technology Association.
+- **CTA.tech** — the Consumer Technology Association's own corporate site.
+- **live.ces.tech** — CES's content and on-demand discovery platform, showing the extension used at subdomain scale.
 
-At Namefi, we bridge the gap between Web2 and Web3. We are an ICANN-accredited registrar that allows you to buy domains using crypto or credit cards, and we offer seamless **tokenization** of your domains. This means you can hold your .tech domain as an NFT, making transfers and management as easy as sending a token, while still enjoying full DNS functionality in the traditional web.
+These are large, public, actively maintained sites, which is why `.tech` reads as a credible business choice rather than a novelty.
 
-**Why register with Namefi?**
-*   **ICANN Accredited:** Safe, secure, and compliant.
-*   **Web3 Integrated:** Manage your domains via your Ethereum wallet.
-*   **Transparent Pricing:** No hidden fees.
+## .tech vs other domains
 
-**[Register your .tech domain at Namefi today](https://namefi.io)** and claim your place in the future of technology.
+| Extension | Type | Signal | Typical use |
+| --- | --- | --- | --- |
+| [.tech](/en/tld/tech) | New gTLD | "We build technology" | Startups, dev portfolios, tech events |
+| [.com](/en/tld/com) | Legacy gTLD | Default, universal | Any business |
+| [.io](/en/tld/io) | ccTLD (tech-coded) | Developer / SaaS | Tech tools, APIs, startups |
+| [.dev](/en/tld/dev) | New gTLD | Developers, code | Dev tools, docs, portfolios |
+| [.app](/en/tld/app) | New gTLD | Applications | Mobile and web apps |
+
+Pick [.com](/en/tld/com) when broad familiarity outweighs everything else. Pick [.io](/en/tld/io) or [.dev](/en/tld/dev) when you want developer credibility specifically. Choose `.tech` when you want a plain, descriptive "technology" label that a general audience — not only engineers — immediately understands.
+
+## Why choose .tech?
+
+- **Descriptive by default.** The word does branding work for you; visitors know your sector at a glance.
+- **Strong inventory of short names.** Because the namespace is younger than `.com`, exact-match and short names are far more attainable without hyphens or misspellings.
+- **Globally legible.** As a generic, non-geographic extension, it suits founders going global without locking the brand to a country.
+- **Proven at scale.** Adoption by CES and the CTA shows the extension holds up for serious, high-traffic brands.
+
+## Things to consider
+
+- **`.com` default bias.** Some users still type `.com` reflexively, so you may lose direct-navigation traffic or want to defensively hold the matching `.com`.
+- **Premium pricing tiers.** Short, high-demand `.tech` names are often classified as premium, with higher recurring fees than a standard registration.
+- **Niche framing.** The "technology" meaning is an asset for tech brands but a liability if your business is not obviously technical.
+- **Renewal differs from first year.** As with most new gTLDs, renewal pricing can sit above the introductory first-year rate.
+
+## Who can register a .tech domain?
+
+**Registration restrictions: open to all.** `.tech` has no eligibility gate — there is no credential, professional membership, or local-presence requirement (unlike restricted extensions such as `.cpa` or `.realtor`). Any individual or organization worldwide can register one on a first-come, first-served basis.
+
+Standard new-gTLD operational rules apply: names follow normal length and character conventions, [internationalized domain names](/en/tld/io) (IDNs) are supported, and **DNSSEC** can be enabled for cryptographic integrity of DNS responses. WHOIS privacy is typically available through your registrar to mask personal contact details, and transfer, renewal, and redemption-grace behavior follows ICANN's standard gTLD lifecycle. The authoritative source for the rules is the registry's own [Radix policies page](https://radix.website/policies) and the ICANN Registry Agreement for `.tech`. Sunrise and trademark-claims periods closed years ago, so brand owners now rely on the [Trademark Clearinghouse](https://www.icann.org/resources/pages/tmch-2014-01-09-en) and ordinary dispute mechanisms.
+
+## .tech pricing and value
+
+Pricing for `.tech` is **dynamic and tiered rather than flat.** A large pool of standard names registers at a common rate, while short, common-word, or otherwise high-demand names are designated **premium** and carry higher fees — sometimes substantially so — that also apply at renewal. As is typical for new gTLDs, the **first-year price and the renewal price are set separately**, so it is worth checking the renewal figure before you commit to a name. Aftermarket value is driven by length, dictionary relevance, and brandability. (This page lists no specific prices; check current pricing at registration time.)
+
+## Reputation and email deliverability
+
+`.tech` is generally perceived as **modern and credible** rather than cheap or spammy, and its adoption by mainstream brands like CES reinforces that. Because it is a younger namespace, a handful of new gTLDs have historically attracted heavier spam-filter scrutiny than legacy domains, so deliverability comes down to your own sending hygiene more than the suffix itself. To keep `.tech` email landing in inboxes, configure **SPF, DKIM, and DMARC** correctly, warm up new sending domains gradually, and maintain a clean sender reputation. With proper authentication, `.tech` performs on par with established extensions.
+
+## Branding and naming tips
+
+`.tech` works best when the second-level name pairs naturally with "technology" — `quantum.tech` or `payments.tech` read cleanly, while a name that fights the suffix feels awkward. It supports light **domain-hack** patterns where the whole phrase reads as one idea (for example, a brand name plus `.tech`). Keep it short and easy to dictate aloud; avoid spellings that listeners might render as `.com`. Where the matching `.com` exists and is affordable, holding it defensively protects against typo traffic and brand confusion.
+
+## How to register a .tech domain at Namefi
+
+1. **Search** your desired name on [Namefi](https://namefi.io) to check availability and whether it is a standard or premium `.tech` name.
+2. **Choose** the exact name and confirm the registration term.
+3. **Register** and complete checkout — Namefi supports both card and crypto payments.
+
+As an [ICANN-accredited registrar](/en/glossary/registrar), Namefi offers transparent pricing, fast DNS management, and optional **Web3 tokenization**, letting you hold your `.tech` domain as an NFT while retaining full traditional DNS functionality. [Register your .tech domain at Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .tech domain?
+
+Yes. `.tech` is an open generic top-level domain with no eligibility restrictions. There is no credential, industry membership, or local-presence requirement, so individuals, startups, and established companies anywhere can register one on a first-come, first-served basis.
+
+### Does a .tech domain affect SEO?
+
+No. Google treats `.tech` the same as `.com` and other generic top-level domains; the extension itself carries no ranking advantage or penalty. Rankings depend on content, links, and user experience, not on the suffix you choose.
+
+### Who should register a .tech domain?
+
+It suits technology companies, startups, SaaS products, developers building portfolio sites, hackathons, and tech events that want a short, descriptive name when the `.com` equivalent is taken or expensive. It is less ideal for non-technical local businesses.
+
+### Does .tech support WHOIS privacy and DNSSEC?
+
+Yes. The `.tech` registry supports DNSSEC for cryptographic DNS integrity, and most registrars offer WHOIS privacy that masks personal contact details in the public directory. Both are widely available, though privacy is provided by the registrar rather than the registry.
+
+## Related resources
+
+- [.com domain](/en/tld/com)
+- [.io domain](/en/tld/io)
+- [.dev domain](/en/tld/dev)
+- [.app domain](/en/tld/app)
+- [.online domain](/en/tld/online)
+- [What is a registrar?](/en/glossary/registrar)
+- [What is DNS?](/en/glossary/dns)
+- [What is DNSSEC?](/en/glossary/dnssec)

--- a/content/tld/en/today.md
+++ b/content/tld/en/today.md
@@ -1,45 +1,150 @@
 ---
-title: What is .today TLD and Why Choose It?
-date: '2025-12-10'
+title: 'What Is the .today Domain? The Timely gTLD Explained'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: Discover the power of .today domains. Learn how individuals, businesses, and developers leverage this relevant TLD. Secure your .today domain with Namefi today!
-keywords: ['.today', 'domain name', 'tld', 'top-level domain', 'domain registration', 'Namefi', 'web3 domain', 'gTLD', 'domain investing', 'domain availability', 'branding', 'online presence', 'marketing', 'ICANN']
+description: '.today is an open new gTLD run by Identity Digital, built for news, daily deals, events, and updates. Learn who uses it, the rules, and whether to buy.'
+keywords: ['.today domain', 'what is .today', '.today TLD', 'today domain extension', 'new gTLD', 'Identity Digital', 'domain registration', 'news domain']
+faqs:
+  - question: 'Can anyone register a .today domain?'
+    answer: 'Yes. .today is an open generic top-level domain with no eligibility restrictions. Anyone worldwide can register an available name on a first-come, first-served basis, with no credential, trademark, or local-presence requirement.'
+  - question: 'Does a .today domain affect SEO?'
+    answer: 'No. Google treats .today as a generic gTLD with no inherent ranking advantage or penalty. Rankings depend on content, links, and user experience, not the suffix. A descriptive .today name can lift click-through rates, which helps indirectly.'
+  - question: 'Who should register a .today domain?'
+    answer: 'It suits projects centered on timeliness: news and media sites, daily-deal and offers pages, event and conference microsites, daily newsletters, and content with a recurring or live cadence. The word completes naturally in phrases like deals.today or events.today.'
+  - question: 'Is .today a good domain for a news or events site?'
+    answer: 'Yes. The suffix reads as a full English word that signals freshness and immediacy, which fits news, events, and daily-update brands well. It also leaves more short, exact-match names available than legacy extensions like .com.'
+  - question: 'Does .today support WHOIS privacy and DNSSEC?'
+    answer: 'Yes. As an Identity Digital gTLD, .today supports DNSSEC at the registry level, and most registrars including Namefi offer free WHOIS privacy to mask personal contact details in public records.'
 ---
 
-## **What is .today?**
+The **.today domain** is a new generic top-level domain (gTLD) built around one of the most action-oriented words in English. Where a legacy suffix simply ends an address, ".today" finishes a thought — `deals.today`, `events.today`, `launch.today` — turning the domain itself into a promise of fresh, time-sensitive content.
 
-The ".today" Top-Level Domain (TLD) is a generic Top-Level Domain (gTLD) that offers a clear and concise way to communicate timeliness and relevance. It falls under the category of new gTLDs introduced to expand the domain name space and provide more specific and meaningful options. Approved by [ICANN](https://www.icann.org/), the Internet Corporation for Assigned Names and Numbers, it was created to offer businesses and individuals a domain extension that emphasizes up-to-the-minute information, daily deals, events happening now, or simply a sense of immediacy.
+For news outlets, event organizers, daily-deal sites, and anyone publishing on a recurring cadence, .today is an open, unrestricted extension that signals immediacy in a way `.com` cannot. This page covers who runs it, who uses it, the registration rules, and whether it is the right fit for your project.
 
-The .today domain extension is currently used by various entities, ranging from news outlets and event organizers to businesses promoting daily deals and individuals sharing their daily thoughts or activities. Its usage reflects a growing trend towards emphasizing real-time content and immediate engagement.
+## .today at a glance
 
-## **How People Are Using .today**
+| Fact | Detail |
+| --- | --- |
+| TLD type | New gTLD (generic) |
+| Registry operator | Identity Digital (via Binky Moon, LLC) |
+| Year delegated | 2013 |
+| IDN support | Yes (varies by registrar) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility requirements |
+| Best for | News, daily deals, events, newsletters, time-sensitive content |
 
-*   **News and Media Outlets:** For websites dedicated to delivering the latest news, headlines, and current events.
-*   **Event Organizers:** To promote events happening on a specific day, like concerts, conferences, or festivals.
-*   **Businesses Offering Daily Deals:** Highlighting special offers, discounts, and promotions that are valid only for that particular day.
-*   **Personal Blogs and Journals:** Individuals can use .today for daily entries, sharing their thoughts, experiences, and activities.
-*   **Community Forums:** To create a sense of urgency and encourage active participation in discussions and events happening "today" within the community.
+## What is .today?
 
-## **Notable Entities Using .today**
+.today is a [new gTLD](/en/blog/what-is-a-tld) introduced during ICANN's 2012 New gTLD Program, the largest expansion of the domain name space in the Internet's history. Unlike a [country-code TLD](/en/blog/cctld-market-share-by-registration-volume) such as `.uk` or `.de`, .today carries no geographic meaning. It is a dictionary-word gTLD: the suffix simply *is* the word "today," which is why so many registrations read as complete phrases rather than awkward abbreviations.
 
-While specific high-profile examples are constantly evolving, here are hypothetical best use cases illustrating the types of entities leveraging the .today domain:
+Because it is a generic extension, [Google](https://developers.google.com/search/docs/crawling-indexing/managing-multi-regional-sites) treats .today like any other gTLD — it is not tied to a region for geo-targeting, and it confers no ranking advantage or penalty on its own. You can read the official root-zone record at the [IANA database entry for .today](https://www.iana.org/domains/root/db/today.html).
 
-*   **Local News Aggregators:** A website aggregating local news stories and events under a domain like `YourCity.today`.
-*   **Daily Deal Websites:** Businesses focused on time-sensitive promotions using domains like `DealsOfTheDay.today`.
-*   **Online Learning Platforms:** Highlighting daily lessons or courses at a domain such as `LearnSomethingNew.today`.
-*   **Community Event Calendars:** Local community organizations might use `CommunityEvents.today` to showcase today's events.
-*   **Personal Finance Blogs**: Promoting daily financial tips with a domain such as `MoneyTips.today`.
+## History of .today
 
-## **Why Choose .today?**
+.today was delegated to the DNS root zone in November 2013, among the first wave of dictionary-word gTLDs to launch under the 2012 program. It originally came to market through Donuts Inc., the registry that pioneered hundreds of generic new gTLDs. Following the consolidation of Donuts, Afilias, and other operators, the extension is now part of the portfolio of [Identity Digital](https://www.identity.digital/), one of the largest new-gTLD registry operators in the world, with the contractual registry entity being Binky Moon, LLC.
 
-*   **Relevance:** Clearly communicates the timeliness and immediacy of your content. If your website is focused on what's happening right now, .today is a perfect fit.
-*   **Availability:** Compared to more common TLDs like .com or .net, you're more likely to find the exact domain name you want with the .today extension. Short and memorable names are still readily available.
-*   **Branding:** A .today domain helps to create a distinct and memorable brand identity, particularly for businesses or individuals focused on real-time information and daily updates.
-*   **SEO Potential:** While not a direct ranking factor, a relevant domain name like .today can improve click-through rates and user engagement, indirectly benefiting your website's search engine optimization.
+Adoption grew steadily from 2014 onward as blogs, news aggregators, and event sites adopted the suffix to convey a sense of "happening now." Like most new gTLDs, .today did not displace `.com`, but it carved out a durable niche among publishers and marketers who value a descriptive, on-message address.
 
-## **Register Your .today Domain at Namefi**
+## How people use .today
 
-Ready to embrace the power of .today? Secure your .today domain name with [Namefi](https://namefi.io) today and establish a strong online presence. As an ICANN-accredited registrar, Namefi offers seamless domain registration, management tools, and Web3 integration capabilities to help you navigate the evolving digital landscape. Don't wait – claim your .today domain and start connecting with your audience!
+- **News and media** — sites delivering headlines, briefings, and breaking coverage where freshness is the whole point.
+- **Daily deals and offers** — promotion pages where a name like `deals.today` reinforces a time-limited call to action.
+- **Events and conferences** — single-day or recurring event microsites, schedules, and "what's on" calendars.
+- **Newsletters and daily digests** — landing pages for a daily email or briefing product.
+- **Live or recurring content** — sports scores, market updates, weather, horoscopes, and other refresh-often verticals.
+
+**Who it's not ideal for:** evergreen brands, reference resources, or businesses whose value is permanence rather than recency. A law firm, an archive, or a long-lived SaaS may find "today" implies content that expires. For those, a [.com](/en/tld/com), [.org](/en/tld/org), or a sector suffix is a cleaner fit.
+
+## Notable sites using .today
+
+- **nintendo.today** — Nintendo's official "Nintendo Today!" service, used to surface daily news, events, and announcements to fans. It is one of the most visible mainstream uses of the suffix and shows how a major brand can deploy a dictionary-word gTLD for a recurring-content product.
+
+Beyond brand deployments, the typical .today registration is a descriptive two-word combination — a city plus "today," an industry plus "today," or a deal/offer phrase — used by independent publishers, local news projects, and marketing campaigns where the word does real work in the name.
+
+## .today vs other domains
+
+| Extension | Core signal | Typical use | Availability |
+| --- | --- | --- | --- |
+| [.today](/en/tld/today) | Timeliness, daily updates | News, deals, events | High |
+| [.com](/en/tld/com) | Default, universal trust | Anything | Very low |
+| [.deals](/en/tld/deals) | Discounts, offers | Promotions, e-commerce | High |
+| [.now](/en/tld/now) | Immediacy, real-time | Live, on-demand services | High |
+
+Choose [.com](/en/tld/com) when you want maximum familiarity and your name is available. Choose .today when timeliness is central to the brand and you want a phrase that reads as a sentence. Pick [.deals](/en/tld/deals) if the focus is specifically discounts, or [.now](/en/tld/now) if "real-time" beats "daily" as your hook.
+
+## Why choose .today?
+
+- **The name says it all.** "Today" is a high-intent, universally understood word that frames your content as current and worth checking back on.
+- **Strong exact-match availability.** Short, clean names that are long gone in `.com` are frequently still open in .today.
+- **No restrictions.** Anyone, anywhere can register, with no paperwork or credentials.
+- **Backed by a major registry.** Identity Digital operates the extension on stable, well-supported infrastructure used across hundreds of gTLDs.
+
+## Things to consider
+
+- **Niche connotation.** "Today" frames content as time-bound. That is an asset for news and an awkward fit for evergreen brands.
+- **Lower default recognition than .com.** Some non-technical visitors still assume every site ends in `.com`; you may need to spell the suffix out in offline marketing.
+- **Renewal pricing.** As with many new gTLDs, standard renewals can sit above the cheapest legacy options, so factor in the long-term cost.
+- **Type-in risk.** Visitors who hear your address may default to typing `.com`, so secure the matching `.com` defensively if it matters to you.
+
+## Who can register a .today domain?
+
+**Registration restrictions: open to all.** .today is an unrestricted generic top-level domain. There is no credential gate, no community-membership requirement, and no local-presence rule — unlike restricted suffixes such as `.law` (bar membership) or some ccTLDs (in-country presence). Any individual or organization worldwide can register an available .today name on a first-come, first-served basis.
+
+Standard new-gTLD policies apply: trademark holders can use ICANN's Trademark Clearinghouse for sunrise and claims protections, names follow normal length and IDN rules, and the registry supports DNSSEC. Most registrars, including Namefi, offer free WHOIS privacy, and the suffix follows ICANN's standard transfer, renewal, and redemption-grace lifecycle. The governing rules live in the [ICANN Registry Agreement for .today](https://www.icann.org/en/registry-agreements/details/today) and in the registry policies published by [Identity Digital](https://www.identity.digital/).
+
+## .today pricing and value
+
+.today is generally priced as a mid-tier new gTLD. A few things drive what you pay. First, registries reserve **premium names** — short, common, or high-demand words — and price them well above the standard rate, often with premium renewals that recur every year. Second, **first-year and renewal prices differ**: promotional first-year rates are common, while the renewal is what you pay long-term, so always check it before committing. Third, the **registrar** you choose and any bundled services (privacy, DNS, email forwarding) shape the total. We quote no specific numbers here because pricing changes and varies by provider; check live pricing at checkout.
+
+## Reputation and email deliverability
+
+New gTLDs as a category once carried a faint spam-association because abuse operators bulk-registered cheap, novel suffixes. .today has not been a notable offender, and being run by a large, established registry like Identity Digital helps its standing. Still, a brand-new domain on *any* suffix starts with no sending reputation. If you plan to send email from a .today domain, the suffix is not the bottleneck — your setup is. Authenticate properly with [SPF, DKIM, and DMARC](/en/glossary/dns), warm up sending volume gradually, and keep list hygiene clean. Done right, .today delivers as reliably as any mainstream extension.
+
+## Branding and naming tips
+
+The strongest .today names treat the suffix as the final word of a phrase, not a tacked-on label: `[city].today` for local news, `[topic].today` for a daily briefing, `[product].today` for a launch or deal page. Because the word is a real English term, it reads aloud cleanly and is easy to remember. Watch two pitfalls: visitors conditioned on `.com` may mistype your address, and a "today" brand implies you will actually keep content current — an abandoned .today site looks stale faster than a neutral suffix would. Keep the second-level name short and literal so the whole address parses at a glance.
+
+## How to register a .today domain at Namefi
+
+1. **Search** your desired name on [Namefi](https://namefi.io) to check availability across .today and alternatives.
+2. **Choose** the exact name and confirm whether it is a standard or premium registration.
+3. **Register** and configure DNS in minutes.
+
+As an ICANN-accredited registrar, Namefi offers transparent pricing, fast DNS, free WHOIS privacy, and optional [Web3 tokenization](/en/blog/what-are-tokenized-domains) so you can hold your domain as an on-chain asset. Start your search at [Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .today domain?
+
+Yes. .today is an open generic top-level domain with no eligibility restrictions. Anyone worldwide can register an available name on a first-come, first-served basis, with no credential, trademark, or local-presence requirement.
+
+### Does a .today domain affect SEO?
+
+No. Google treats .today as a generic gTLD with no inherent ranking advantage or penalty. Rankings depend on content, links, and user experience, not the suffix. A descriptive .today name can lift click-through rates, which helps indirectly.
+
+### Who should register a .today domain?
+
+It suits projects centered on timeliness: news and media sites, daily-deal and offers pages, event and conference microsites, daily newsletters, and content with a recurring or live cadence. The word completes naturally in phrases like deals.today or events.today.
+
+### Is .today a good domain for a news or events site?
+
+Yes. The suffix reads as a full English word that signals freshness and immediacy, which fits news, events, and daily-update brands well. It also leaves more short, exact-match names available than legacy extensions like .com.
+
+### Does .today support WHOIS privacy and DNSSEC?
+
+Yes. As an Identity Digital gTLD, .today supports DNSSEC at the registry level, and most registrars including Namefi offer free WHOIS privacy to mask personal contact details in public records.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [Domain terminology guide](/en/blog/domain-terminology-guide)
+- [ICANN (glossary)](/en/glossary/icann)
+- [DNS (glossary)](/en/glossary/dns)
+- [DNSSEC (glossary)](/en/glossary/dnssec)
+- [Compare the .com domain](/en/tld/com)
+- [Compare the .deals domain](/en/tld/deals)
+- [Compare the .now domain](/en/tld/now)

--- a/content/tld/en/top.md
+++ b/content/tld/en/top.md
@@ -1,61 +1,163 @@
 ---
-title: "Rise to the Peak: What is the .top Domain and Why Choose It?"
-date: '2025-12-10'
+title: 'What Is the .top Domain? Meaning, Uses & SEO Explained'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: "Discover why the .top domain is a global favorite for startups and creators. Learn about its meaning, benefits, and how to register yours with Namefi today."
-keywords: [".top domains", ".top TLD", ".top top-level domain", "what is .top", "why choose .top", "what is the .top domain", "why choose the .top domain", "domain investing", "blockchain domains", "tokenized domains", "buy .top domain", "cheap domain registration", ".top domain meaning", "web3 domains", "new gTLD registration"]
+description: 'The .top domain is an open, low-cost new gTLD popular for short, keyword-rich names. Learn who runs it, who can register, its SEO and reputation trade-offs.'
+keywords: ['.top domains', 'what is .top', '.top TLD', '.top domain meaning', 'is .top good for SEO', '.top vs .com', 'buy .top domain', 'new gTLD']
+faqs:
+  - question: 'Can anyone register a .top domain?'
+    answer: 'Yes. The .top domain is an open generic top-level domain with no eligibility requirements. There is no local presence, credential, trademark, or community membership needed, so individuals and businesses anywhere can register an available name on a first-come, first-served basis.'
+  - question: 'Does a .top domain affect SEO?'
+    answer: 'Google treats .top as a generic gTLD with no inherent ranking penalty, so content and links determine rankings. However, .top has a documented history of spam and phishing abuse, which can hurt how some spam filters and security tools score a new .top site.'
+  - question: 'Who should register a .top domain?'
+    answer: 'It suits budget-conscious founders, domain investors, ranking and review projects, and anyone wanting a short, keyword-rich name when the .com is taken. Brands needing maximum trust or clean email deliverability should weigh its abuse reputation first.'
+  - question: 'Why is .top so cheap?'
+    answer: 'The registry has long priced .top aggressively to drive registration volume, and many registrars run low first-year promotions. Renewal prices are usually higher than the first year, and short or dictionary names may carry premium pricing.'
+  - question: 'Does .top have a spam reputation?'
+    answer: 'Yes. Studies have ranked .top among the most common suffixes in phishing, and ICANN issued a DNS-abuse breach notice to the registry in 2024. A legitimate .top site can still perform well, but expect closer scrutiny from spam and security filters.'
 ---
 
-## **What is .top?**
+The **.top** domain is one of the largest and lowest-cost new generic top-level domains (gTLDs) on the internet, built around a single, globally understood English word that signals "best," "peak," or "number one." Because short, keyword-rich names are still readily available and cheap, .top has attracted millions of registrations — especially from founders, domain investors, and projects priced out of the crowded .com namespace.
 
-The **.top** extension is a generic top-level domain (gTLD) that has rapidly become one of the most registered domain extensions in the world. Unlike country-specific domains (like .us or .uk), .top is borderless and universally understood.
+That popularity comes with a complicated reputation. This page covers what .top is, who operates it, who can register, how Google treats it for SEO, and the spam and deliverability trade-offs you should understand before you buy.
 
-Managed by the [.top Registry](http://www.nic.top/en/index.asp), this TLD was officially launched in 2014 as part of [ICANN’s New gTLD Program](https://newgtlds.icann.org/en/about/program). The program was designed to expand the internet's addressing system, allowing for more competition and choice beyond the crowded .com namespace.
+## .top at a glance
 
-The word "top" carries a distinct, positive meaning in English and is recognized globally as a synonym for "best," "peak," or "highest quality." Because of this inherent association with excellence and rankings, the .top domain has maintained a position as one of the most popular new gTLDs by registration volume for several years.
+| Fact | Detail |
+| --- | --- |
+| TLD type | New gTLD (generic, not geo-targeted) |
+| Registry operator | Jiangsu Bangning Science & Technology Co., Ltd. |
+| Year launched | Delegated 2014; general availability November 2014 |
+| IDN support | Yes (internationalized domain names supported) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility requirements |
+| Best for | Short keyword names, ranking/review sites, budget projects, domain investing |
 
-## **How People Are Using .top**
+## What is .top?
 
-Due to its versatile meaning, the .top domain is utilized across a wide variety of industries. It is not limited to a specific niche, making it a flexible choice for:
+The .top domain is a [new gTLD](/en/glossary/tld) introduced under [ICANN](/en/glossary/icann)'s New gTLD Program, the initiative that expanded the domain name system far beyond legacy extensions like .com, .net, and .org. Unlike a country-code TLD such as .uk or .de, .top is a **generic** extension with no geographic meaning, so it is available to registrants worldwide.
 
-*   **Ranking and Review Sites:** Websites that curate "Top 10" lists, product reviews, or service comparisons naturally fit the semantics of the extension (e.g., `besttech.top`).
-*   **Startups and Agencies:** emerging tech companies and creative agencies use it to signal that they are at the top of their game or providing premium services.
-*   **Personal Portfolios:** Freelancers, developers, and artists use it to showcase their "top" work or best projects.
-*   **E-commerce Stores:** Online retailers use it to denote top-selling products or high-quality merchandise lines.
-*   **Web3 and Blockchain Projects:** With the scarcity of short .com names, many Web3 developers are turning to affordable, memorable TLDs like .top for decentralized apps (dApps) and tokenized projects.
+The string itself is the everyday English word "top." That semantic association with rankings, quality, and being "at the top" is the suffix's main branding hook, and it reads cleanly in many markets — including across Asia, where .top saw especially strong early adoption.
 
-## **Notable Entities Using .top**
+For search, this matters: Google treats new gTLDs like .top as ordinary generic domains. Per [Google Search Central](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level-domains), a TLD such as .top carries no built-in ranking advantage or penalty and is not geo-targeted by default. You can confirm the delegation and operator details on the [IANA root zone database entry for .top](https://www.iana.org/domains/root/db/top.html).
 
-While many major corporations still protect their brand primarily on legacy domains, .top has seen massive adoption among small-to-medium enterprises (SMEs) and agile digital brands.
+## History of .top
 
-*   **Echoing the "Best":** You will often find niche content creators and affiliate marketers utilizing .top to build authority sites (e.g., sites dedicated to "Top Gadgets" or "Top Travel Destinations").
-*   **Global Adopters:** The extension is particularly popular in Asian markets and among international exporters who want an English term that is easily understood by non-native speakers.
-*   **Tech Innovators:** Various agile software projects and open-source repositories utilize .top for documentation or landing pages when their preferred .io or .com is taken.
+ICANN delegated .top to the root zone in 2014, with general availability opening in November of that year. The registry priced the extension aggressively from the start, and growth was rapid: .top quickly became one of the highest-volume new gTLDs by total registrations, frequently appearing near the top of new-gTLD zone-size rankings throughout the late 2010s and into the 2020s.
 
-*Note: As with any open TLD, usage is vast. The true strength of .top lies in the millions of small businesses and creators defining their corner of the internet.*
+That scale has been a double-edged sword. The same low prices and easy, unrestricted registration that fueled adoption also attracted abuse. In 2024, security researchers and ICANN flagged .top as a heavily abused namespace (covered in the reputation section below), making its history as much about volume management as about brand-building. Beyond aggregate registration counts, the registry does not publish independently verified milestone figures, so we avoid quoting specific sales or counts here.
 
-## **Why Choose .top?**
+## How people use .top
 
-If you are debating between a long, hyphenated .com or a short, snappy .top, here is why you should consider the latter:
+Real, common use cases for .top include:
 
-*   **Positive Branding:** The word itself implies superiority. It psychologically primes visitors to expect high quality or the "best" of something.
-*   **Incredible Availability:** Finding a short, one-word, or two-word domain on .com is nearly impossible or prohibitively expensive. With .top, you can still register concise, keyword-rich names.
-*   **Cost-Effective:** .top domains are generally very affordable to register and renew, making them excellent for startups with lean budgets or domain investors building a portfolio.
-*   **Global Recognition:** "Top" is one of the most commonly understood English words worldwide. It transcends language barriers, making it suitable for international business.
-*   **SEO Friendly:** Google and other search engines treat .top just like any other standard gTLD. With good content and backlinks, a .top site can rank just as high as a .com.
+- **Ranking and review sites** — "top 10," comparison, and curation projects where the word matches the content (e.g. a gadgets or travel ranking site).
+- **Budget-first startups and side projects** — founders who want a short, brandable name without paying premium .com or .io prices.
+- **Domain investing** — investors building portfolios of short, dictionary, or keyword .top names because acquisition and renewal costs are low.
+- **Asia-facing and international brands** — a simple English word that is easy to recognize for non-native speakers.
+- **Redirects and campaign domains** — short marketing or vanity URLs that forward to a primary site.
 
-## **Register Your .top Domain at Namefi**
+**Who it's not ideal for:** established brands that need maximum institutional trust, financial or healthcare services that depend on clean email deliverability, or anyone who cannot tolerate extra scrutiny from spam and security filters. For those cases a [.com](/en/tld/com) or a more reputation-stable niche TLD is usually safer.
 
-Ready to take your digital presence to the peak? A .top domain offers the perfect blend of affordability, availability, and positive branding.
+## Notable sites using .top
 
-At **Namefi**, we make registering your domain easier and more powerful than ever before. As an ICANN-accredited registrar, we offer:
-*   **Seamless Web3 Integration:** We are the first registrar to bridge the gap between Web2 and Web3.
-*   **Tokenized Domains:** When you register with us, your domain can be represented as an NFT, allowing for instant transfers and easy management within your crypto wallet.
-*   **Competitive Pricing:** Get the "top" domain you want without breaking the bank.
+.top is dominated by long-tail small businesses, marketers, and personal projects rather than household-name flagship sites, so its most honest description is a high-volume, broadly distributed namespace rather than one anchored by famous brands. Major companies typically register .top defensively (to protect a trademark) and keep their primary presence on legacy extensions. Rather than name a specific marquee site — which would risk fabricating an example — the realistic picture is millions of independent ranking sites, regional businesses, redirects, and investor-held names. Treat any "famous .top site" claim with skepticism unless you can verify it directly.
 
-Don't let your perfect name get taken by someone else. Secure your brand's excellence today.
+## .top vs other domains
 
-[**Register your .top domain at Namefi**](https://namefi.io)
+| Feature | .top | [.com](/en/tld/com) | [.xyz](/en/tld/xyz) | [.online](/en/tld/online) |
+| --- | --- | --- | --- | --- |
+| Type | New gTLD | Legacy gTLD | New gTLD | New gTLD |
+| Typical price tier | Very low | Standard | Low | Low–mid |
+| Short-name availability | High | Very low | High | High |
+| Trust / familiarity | Mixed | Highest | Growing | Moderate |
+| Abuse reputation | Elevated | Baseline | Mixed | Moderate |
+
+Choose **.com** when trust and recognition matter most and you can find or afford the name. Choose **.top** when you want a short, keyword-rich, low-cost name and accept the reputation trade-off — its closest peers are other open, low-priced new gTLDs like [.xyz](/en/tld/xyz) and [.online](/en/tld/online).
+
+## Why choose .top?
+
+- **Genuine availability** — short, one- and two-word names that are long gone in .com are still registrable in .top.
+- **Low cost** — among the most affordable extensions to register and renew, which is why it is popular with investors and bootstrappers.
+- **Clear, positive meaning** — "top" universally implies best/highest, a ready-made branding angle for ranking, premium, or comparison sites.
+- **Global readability** — a simple English word recognized far beyond native-English markets.
+- **Standard technical support** — IDNs and [DNSSEC](/en/glossary/dnssec) are supported, so you are not giving up modern DNS security.
+
+## Things to consider
+
+- **Spam and phishing reputation** — .top has been one of the most abused TLDs (see below), which can color first impressions and filter behavior.
+- **Renewal vs first-year pricing** — promotional first-year prices often jump at renewal; budget for the recurring cost, not the headline.
+- **Brand perception** — some audiences read low-cost new gTLDs as less established than .com.
+- **Email deliverability risk** — mail from a brand-new .top can face stricter scoring until the domain builds a clean sending history.
+
+## Who can register a .top domain?
+
+**Registration restrictions: open to all.** There are no eligibility requirements for .top — no local-presence rule, no credential, no community membership, and no trademark prerequisite for general registration. Anyone, anywhere can register an available .top name on a first-come, first-served basis.
+
+Standard new-gTLD mechanics apply: trademark holders could use the Trademark Clearinghouse during the original Sunrise period, IDNs are supported, and ordinary length rules apply. Administratively, .top supports [DNSSEC](/en/glossary/dnssec), most registrars offer WHOIS privacy, and the namespace follows the usual ICANN registrar transfer, renewal, and redemption-grace lifecycle. For the binding rules and operator obligations — including the DNS-abuse requirements that have been enforced against this registry — see the official [ICANN Registry Agreement for .top](https://www.icann.org/en/registry-agreements/details/top).
+
+## .top pricing and value
+
+Pricing for .top is driven by registry strategy and registrar promotions rather than by scarcity. A few dynamics to understand without quoting numbers:
+
+- **First-year vs renewal pricing differ.** Introductory first-year prices are often heavily discounted, while renewals revert to the standard rate — always check the renewal cost before committing.
+- **Premium names exist.** Short, dictionary, or high-demand .top strings can be reserved as premium inventory with higher registration and sometimes higher renewal prices.
+- **Volume positioning.** The registry has historically used low pricing to drive registration volume, which is part of why .top is both large and cheap.
+
+Because prices, promotions, and premium tiers change constantly, we list no figures here — check current pricing at the point of registration.
+
+## Reputation and email deliverability
+
+This is the single most important section for a .top buyer. The suffix has a **documented abuse problem**. An Interisle Consulting study found .top to be one of the most common TLDs in phishing during 2023–2024, and in July 2024 ICANN issued a public breach notice to the registry for failing to act adequately on DNS-abuse reports — reporting summarized in [KrebsOnSecurity's coverage of the .top breach notice](https://krebsonsecurity.com/2024/07/phish-friendly-domain-registry-top-put-on-notice/).
+
+Practically, this means some spam filters, reputation services, and security tools may score a brand-new .top domain more cautiously than a .com. It does **not** mean a .top site cannot succeed or rank — Google evaluates the page, not the TLD — but you should plan mitigation: warm up email sending gradually, configure SPF, DKIM, and DMARC correctly, keep your content clean, and monitor blocklists. If pristine deliverability is mission-critical (e.g. transactional email for a financial product), a less abuse-associated extension may be the safer default.
+
+## Branding and naming tips
+
+- **Lean into the meaning.** .top works best when the name reinforces "best/peak/ranking" — `gadgets.top`, `crypto.top`-style patterns read naturally.
+- **Domain hacks are limited.** "top" rarely completes a real word the way ".io" or ".ly" can, so treat it as a standalone keyword rather than a word-ending hack.
+- **Keep it short and unambiguous.** The value of .top is concise, memorable strings; avoid hyphens and numbers that invite confusion.
+- **Pronunciation is easy** in English, but confirm it reads well in your primary market.
+
+## How to register a .top domain at Namefi
+
+1. Search your desired name on [Namefi](https://namefi.io) to check .top availability.
+2. Choose the .top name (and any defensive variants) you want.
+3. Complete registration and configure DNS.
+
+[Namefi](https://namefi.io) is an ICANN-accredited registrar with transparent pricing, fast DNS, and optional Web3 [tokenization](/en/glossary/tokenize) — so a .top domain can be represented as an on-chain asset and managed from your wallet. No specific prices are quoted here; see current rates at checkout.
+
+## Frequently asked questions
+
+### Can anyone register a .top domain?
+
+Yes. The .top domain is an open generic top-level domain with no eligibility requirements. There is no local presence, credential, trademark, or community membership needed, so individuals and businesses anywhere can register an available name on a first-come, first-served basis.
+
+### Does a .top domain affect SEO?
+
+Google treats .top as a generic gTLD with no inherent ranking penalty, so content and links determine rankings. However, .top has a documented history of spam and phishing abuse, which can hurt how some spam filters and security tools score a new .top site.
+
+### Who should register a .top domain?
+
+It suits budget-conscious founders, domain investors, ranking and review projects, and anyone wanting a short, keyword-rich name when the .com is taken. Brands needing maximum trust or clean email deliverability should weigh its abuse reputation first.
+
+### Why is .top so cheap?
+
+The registry has long priced .top aggressively to drive registration volume, and many registrars run low first-year promotions. Renewal prices are usually higher than the first year, and short or dictionary names may carry premium pricing.
+
+### Does .top have a spam reputation?
+
+Yes. Studies have ranked .top among the most common suffixes in phishing, and ICANN issued a DNS-abuse breach notice to the registry in 2024. A legitimate .top site can still perform well, but expect closer scrutiny from spam and security filters.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [Domain terminology guide](/en/blog/domain-terminology-guide)
+- [ccTLD market share by registration volume](/en/blog/cctld-market-share-by-registration-volume)
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains)
+- Glossary: [ICANN](/en/glossary/icann), [DNSSEC](/en/glossary/dnssec), [SEO](/en/glossary/seo), [WHOIS](/en/glossary/whois)
+- Compare TLDs: [.com](/en/tld/com), [.xyz](/en/tld/xyz), [.online](/en/tld/online), [.io](/en/tld/io)

--- a/content/tld/en/vip.md
+++ b/content/tld/en/vip.md
@@ -1,115 +1,147 @@
 ---
-title: 'What Is a .vip Domain? Meaning, Uses & Is It Safe? (2026 Guide)'
-date: '2025-12-10'
-updated: '2026-06-10'
+title: 'What Is a .vip Domain? Meaning, Uses & Who Can Register'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: 'What is a .vip domain? It is a gTLD meaning "Very Important Person," used for membership, exclusive, and premium brands. Learn its meaning, uses, safety, and how to register .vip at Namefi.'
-keywords: ['.vip domain', 'vip domain', '.vip domain meaning', 'what is .vip domain', 'what is a .vip website', 'vip tld', '.vip tld', 'is .vip domain safe', 'vip domain names', '.vip domain names', 'what is .vip domain used for', '.vip domains', '.vip TLD', 'top-level domain', 'what is .vip', 'why choose .vip', 'buy .vip domain name', 'premium domain names', 'membership domains', 'domain investing', 'tokenized domains', 'blockchain domains', 'Web3 identity', 'register .vip', 'Namefi .vip']
+description: 'The .vip domain is an open new gTLD meaning Very Important Person, built for membership, loyalty, and premium brands. Learn its rules, value, and how to register at Namefi.'
+keywords: ['.vip domain', 'vip domain', '.vip domain meaning', 'what is .vip', '.vip TLD', 'is .vip domain safe', 'register .vip domain', 'membership domains', 'premium domain names', 'new gTLD']
+faqs:
+  - question: 'Can anyone register a .vip domain?'
+    answer: 'Yes. .vip is an open, unrestricted new gTLD with no eligibility requirements. Individuals, brands, creators, and communities can all register one, subject only to standard availability and the registry policies that apply to every domain.'
+  - question: 'Does a .vip domain affect SEO?'
+    answer: 'No. Google treats .vip as a standard generic top-level domain with no inherent ranking advantage or penalty. Your content quality, links, and site performance determine rankings, not the suffix itself.'
+  - question: 'Who should register a .vip domain?'
+    answer: 'It suits membership portals, loyalty and rewards clubs, premium or luxury brands, fan communities, personal brands, and event-access pages, where the word VIP signals exclusivity. It is also popular in Asian markets, especially China.'
+  - question: 'Is a .vip domain safe to visit and use?'
+    answer: 'The .vip namespace is a legitimate ICANN-delegated gTLD operated by Registry Services, LLC (GoDaddy Registry). Because it is open and inexpensive, some throwaway domains exist, so judge individual sites by HTTPS, verifiable brand identity, and reputation, as you would for any TLD.'
+  - question: 'Does .vip support WHOIS privacy and DNSSEC?'
+    answer: 'Yes. .vip supports DNSSEC for cryptographic DNS integrity, and WHOIS privacy is available through most registrars, including Namefi, to keep personal registrant details out of public lookups.'
 ---
 
-## **What is a .vip website / .vip domain?**
+The **.vip domain** is one of the most successful new generic top-level domains (gTLDs) of the post-2014 expansion. Its three-letter ending stands for **"Very Important Person,"** a phrase recognized across nearly every language and culture. That instant readability is the whole pitch: a `.vip` address signals prestige, membership, and exclusive access before a visitor reads a single word of your content.
 
-A **.vip domain** is a generic Top-Level Domain (gTLD) whose three-letter ending stands for **"Very Important Person."** A **.vip website** is simply any website that uses an address ending in `.vip` — for example, `members.brand.vip` or `john.vip`. There is no technical difference between a .vip site and a .com site in how it loads in your browser; the difference is purely in what the ending *signals*: prestige, membership, exclusivity, and premium access.
+If you are building a members area, a loyalty program, a premium brand, or a fan community — and the perfect `.com` is long gone or absurdly expensive — `.vip` gives you short, meaningful names that still communicate exactly what they are for.
 
-In plain terms, **.vip domain meaning** comes down to status and inclusion. The acronym "VIP" is recognized worldwide, so the extension instantly communicates that whatever sits behind it is intended for important people, valued customers, fans, or members.
+## .vip at a glance
 
-So **what is a .vip domain used for?** The most common use cases are:
+| Fact | Detail |
+| --- | --- |
+| TLD type | New gTLD (generic, not geo-targeted) |
+| Registry operator | Registry Services, LLC (GoDaddy Registry) |
+| Year launched | General availability 17 May 2016 |
+| IDN support | Yes |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility requirement |
+| Best for | Membership, loyalty, premium brands, fan clubs, events |
 
-*   **Membership and loyalty:** exclusive member portals, rewards clubs, and subscriber-only areas.
-*   **Premium and luxury brands:** high-end services, boutique labels, and concierge businesses that want a name that reads as upscale.
-*   **Fan clubs and personal brands:** creators, athletes, musicians, and influencers hosting fan communities or premium content.
-*   **Events and access:** ticketing pages for galas, backstage passes, and private launches.
-*   **Web3 communities:** whitelist gateways, exclusive DAOs, and token-gated groups.
+## What is .vip?
 
-Launched to the public in **May 2016**, .vip was originally operated by Minds + Machines and is now part of the **GoDaddy Registry** portfolio. It became one of the most successful new gTLD launches in history, gaining especially strong adoption across Asian markets before spreading globally. Like other modern gTLDs (see our guides to [.club](/en/tld/club/), [.online](/en/tld/online/), and [.store](/en/tld/store/)), it gives you access to short, memorable names that are long gone in the crowded [.com namespace](/en/tld/com/).
+`.vip` is a generic top-level domain whose label is the universally understood acronym for "Very Important Person." Unlike traditional extensions such as `.com` or [`.net`](/en/tld/net), which carry no specific meaning, `.vip` arrives pre-loaded with connotations of status, inclusion, and premium treatment.
 
-*For the technical classification of gTLDs, see the [ICANN website](https://www.icann.org/) or the [IANA root database entry for .vip](https://www.iana.org/domains/root/db/vip.html).*
+Critically, it is a **generic** gTLD, not a country-code domain. That means Google does not geo-target it to any single country. As the [IANA root database entry for .vip](https://www.iana.org/domains/root/db/vip.html) confirms, the suffix is delegated globally, so a `.vip` site competes worldwide rather than being algorithmically tied to one region. For search engines it behaves like any other generic suffix: the extension itself is neutral, and ranking comes from content, links, and site quality.
 
-## **What is .vip? (Quick Definition)**
+## History of .vip
 
-The **.vip** TLD is an unrestricted generic Top-Level Domain meaning **"Very Important Person."** Unlike traditional extensions like .com or .net — which are broad and undefined — .vip immediately conveys prestige, exclusivity, and high status. Anyone can register a .vip domain; there is no eligibility requirement, which is part of why it is so flexible (and, as we cover below, part of why you should evaluate individual .vip sites on their merits).
+`.vip` was applied for during ICANN's new gTLD program and originally delegated to **Minds + Machines Group Limited**, with the root-zone record first registered on 30 July 2015. It entered general availability on **17 May 2016** and immediately became a phenomenon: registrations passed roughly [200,000 within the first five days of launch](https://domainnamewire.com/2016/05/23/dot-vip-domain/), placing it among the top new gTLDs almost overnight.
 
-## **How People Are Using .vip**
+A defining feature of `.vip`'s story is its strength in Asia, and China in particular, where the great majority of early registrations originated. The suffix later received Chinese regulatory approval, an unusual distinction that helped cement its standing in that market. Operational control of the registry transferred to its current operator, **Registry Services, LLC**, part of the **GoDaddy Registry** portfolio, in September 2021.
 
-The versatility of the .vip extension lets it work across many industries while keeping an air of sophistication. Here is how different sectors use this TLD:
+## How people use .vip
 
-*   **Luxury brands and services:** High-end real estate agents, limousine services, and boutique fashion labels use .vip to instantly tell customers they offer a premium experience.
-*   **Customer loyalty portals:** Major corporations use a dedicated .vip address (e.g., `rewards.brand.vip`) to host exclusive member areas or loyalty programs.
-*   **Influencers and personal branding:** Celebrities, bloggers, and thought leaders use .vip to brand their personal portfolios and signal top-tier content.
-*   **Web3 and blockchain projects:** In DeFi and NFTs, a .vip domain is increasingly used to denote "whitelist" access, exclusive DAOs, or premium tokenized communities.
-*   **Event hosting:** Organizers of galas, backstage passes, and private webinars use the extension to manage ticketing for special guests.
+- **Membership and loyalty portals** — exclusive member areas, rewards clubs, and subscriber-only hubs (for example `rewards.brand.vip`).
+- **Premium and luxury brands** — boutique labels, concierge services, and high-end agencies that want a name reading as upscale.
+- **Fan clubs and personal brands** — creators, athletes, and musicians hosting communities or premium content.
+- **Events and access** — ticketing and backstage pages for galas, launches, and private webinars.
+- **Web3 and token-gated communities** — whitelist gateways and exclusive groups, where "VIP" already signals tiered access.
 
-## **Notable Entities Using .vip**
+**Who it's not ideal for:** organizations whose audience expects a conventional corporate `.com`, public-sector or non-commercial bodies, or anyone whose brand is undercut rather than helped by a status-laden word. If "VIP" doesn't describe your offer, a neutral suffix is the safer pick.
 
-While many .vip domains power specific campaigns or sub-sections of a business, several major entities have secured these names to protect their brand and offer exclusive services.
+## Notable sites using .vip
 
-1.  **Tencent (QQ):** One of the largest technology companies in Asia uses `qq.vip` for premium membership services, demonstrating the scale at which this TLD operates.
-2.  **Google:** The tech giant has secured `google.vip`, typically used for internal purposes or partner gateways, showcasing the corporate utility of the extension.
-3.  **Real estate leaders:** Numerous luxury property groups use .vip variations to separate high-value listings from standard market fare.
-4.  **Blockchain identities:** With the rise of on-chain identity, many crypto-natives secure their "OG" handles on .vip to signal early adoption or "whale" status within the Web3 ecosystem.
+Because much `.vip` usage sits on subdomains and internal campaign pages, public flagship sites are less visible than with older suffixes. Its real, verifiable footprint is concentrated in the Asian market — particularly China — where it is widely used for membership, gaming, and entertainment portals, and where it achieved hundreds of thousands of registrations within its first months. Rather than name a site we cannot independently verify is in active production use, the honest summary is this: `.vip` is a high-volume, real-world namespace whose strongest adoption is regional, used heavily for member-facing and premium-access properties.
 
-## **Is a .vip domain safe?**
+## .vip vs other domains
 
-**Short answer:** The **.vip TLD itself is completely legitimate** — it is an ICANN-delegated gTLD operated by a major, established registry (GoDaddy Registry). Visiting a .vip website is no more inherently dangerous than visiting a .com, .net, or [.io](/en/tld/io/) site. The extension does not carry malware or compromise your security on its own.
+| Feature | .vip | [.club](/en/tld/club) | [.com](/en/tld/com) |
+| --- | --- | --- | --- |
+| Core meaning | Very Important Person / exclusivity | Communities and groups | Generic / commercial |
+| Registration | Open to all | Open to all | Open to all |
+| Best signal | Membership, premium access | Membership, fandom, community | Trust, default credibility |
+| Availability of short names | Good | Good | Very limited |
 
-**The nuance:** Because .vip is inexpensive and open to anyone, it — like many cheap, unrestricted new gTLDs (.top, .xyz, .online, and similar) — is sometimes abused by spammers and scammers who register large numbers of throwaway domains. As a result, some spam filters and security tools may apply extra scrutiny to unfamiliar .vip addresses. This is a reflection of *who registers some of these domains*, **not** a flaw in the TLD itself, and the overwhelming majority of .vip domains are used by legitimate brands, creators, and businesses.
+Choose `.com` when you simply need the most trusted, default address and the name is available. Choose [`.club`](/en/tld/club) when "community" is the message more than "exclusivity." Choose `.vip` when the value proposition is specifically status, tiered access, or premium membership — that is the one word `.vip` says that the others do not.
 
-**How to judge whether a specific .vip site is trustworthy** (the same checklist applies to any TLD):
+## Why choose .vip?
 
-*   **Check for HTTPS:** Look for a valid SSL certificate (the padlock). A secure connection is a baseline requirement, though by itself it does not prove legitimacy.
-*   **Verify the brand and contact details:** Confirm the site belongs to the real organization. Cross-check the company name, support email, and links against the brand's known official .com or social channels.
-*   **Be wary of urgency and "too good to be true" offers:** Unsolicited "you've been selected as a VIP" messages, prize claims, or pressure to pay quickly are classic scam signals — regardless of the domain ending.
-*   **Look up the domain's history:** A [WHOIS](/en/glossary/whois/) lookup can reveal how recently the domain was registered. Brand-new domains used for high-stakes transactions deserve extra caution.
-*   **Use the brand's official link:** When in doubt, navigate to the company through a search engine or a link you already trust rather than clicking one sent to you.
+- **Instant, language-independent meaning.** "VIP" needs no explanation in virtually any market, which is rare for a domain suffix.
+- **Availability of strong names.** While the `.com` namespace is saturated, `.vip` still offers short, keyword-rich, brandable options.
+- **Purpose-built signal.** For loyalty, membership, and premium tiers, the suffix reinforces the offer rather than sitting neutrally beside it.
+- **Proven scale.** It is not an obscure novelty; it is one of the highest-volume new gTLDs, with a mature, established registry behind it.
 
-**Bottom line:** `.vip` is a safe, legitimate namespace. Evaluate *individual websites* on their content, security signals, and reputation — exactly as you would for any other extension.
+## Things to consider
 
-## **Why Choose .vip?**
+- **Open and inexpensive cuts both ways.** Low cost and no eligibility gate mean some throwaway and spam registrations exist, which can affect how unfamiliar `.vip` addresses are perceived (see reputation below).
+- **The word carries baggage.** "VIP" implies exclusivity; on the wrong project it can read as boastful or off-brand.
+- **Regional skew.** Its heaviest adoption is in Asia, so Western audiences may find it less familiar than `.com` or [`.io`](/en/tld/io).
+- **Confusion risk is low but real.** It is short and clear, but always confirm users hear "dot V-I-P" rather than mishearing it.
 
-Choosing the right domain extension is critical for your digital identity. Here is why .vip might be the perfect choice for your next project or investment:
+## Who can register a .vip domain?
 
-*   **Instant prestige and branding:** "VIP" is universally recognized. It associates your brand with quality, importance, and exclusivity without extra explanation.
-*   **High availability:** While .com is overcrowded, the .vip namespace still offers excellent availability for short, keyword-rich, brandable names.
-*   **SEO relevance:** Search engines like Google treat .vip as a standard gTLD with no ranking penalty. Its distinctiveness can even lift Click-Through Rates (CTR) for users seeking premium or exclusive services.
-*   **Domain investing potential:** Short, memorable .vip domains are valued assets in the domain investing community. As digital real estate grows scarcer, premium names become a store of value.
-*   **Perfect for tokenization:** For the Web3 space, a .vip domain pairs naturally with [tokenized assets](/en/blog/what-are-tokenized-domains/), serving as a unique, high-value identifier for your wallet or decentralized website.
+**Registration restrictions: open to all.** `.vip` is an unrestricted new gTLD. There is no credential, membership, profession, or local-presence requirement — individuals, companies, creators, and communities can all register, subject only to availability and the registry's standard rules (which apply equally to every registrant).
 
-## **Frequently Asked Questions about .vip**
+Standard new-gTLD safeguards apply: trademark holders could protect their marks during the launch sunrise period, and the Trademark Clearinghouse continues to support rights protection. The namespace supports internationalized domain names (IDNs), DNSSEC for DNS integrity, and WHOIS privacy through most registrars including Namefi. Transfer, renewal, and redemption-grace handling follow ICANN's standard generic-TLD lifecycle. Because `.vip` is a gTLD governed by an ICANN Registry Agreement, its authoritative rules live in the registry operator's published policies at [nic.vip](https://nic.vip/) and the [IANA root database entry for .vip](https://www.iana.org/domains/root/db/vip.html), rather than in any country-specific policy.
 
-**What does .vip mean?**
-.vip stands for **"Very Important Person."** It is a generic Top-Level Domain used to signal status, exclusivity, membership, and premium access.
+## .vip pricing and value
 
-**What is a .vip website?**
-A .vip website is any site whose address ends in `.vip`. Technically it works just like any other website; the ending simply communicates that the content is premium, exclusive, or membership-oriented.
+`.vip` pricing follows the normal new-gTLD pattern rather than a single flat rate. A subset of short, dictionary, or otherwise desirable labels are designated **premium names** and carry higher standing prices set by the registry. Standard names are typically affordable, but **first-year and renewal prices commonly differ**, so the long-term cost matters more than the initial figure — always check the renewal rate before committing a brand to a name. Cost drivers include the registry's base wholesale price, premium tiering, and your registrar's margin. We do not quote live numbers here because they change; check current pricing at registration time.
 
-**Is a .vip domain safe?**
-Yes. The .vip TLD is a legitimate, ICANN-delegated extension operated by GoDaddy Registry. As with any TLD, judge an individual site by its HTTPS security, verifiable brand identity, and reputation rather than by the ending alone.
+## Reputation and email deliverability
 
-**Who can register a .vip domain?**
-Anyone. .vip is an unrestricted gTLD with no eligibility requirements, so individuals, brands, creators, and communities can all register one.
+Honesty matters here. Like several open, low-cost new gTLDs, `.vip` has seen its share of bulk and throwaway registrations, and some spam filters and security tools apply extra scrutiny to unfamiliar addresses on suffixes with that profile. This reflects *who registers some of these domains*, not a defect in the TLD, and the legitimate share is large — but it has practical consequences.
 
-**What is a .vip domain used for?**
-Common uses include membership and loyalty portals, luxury and premium brands, fan clubs and personal branding, event ticketing, and exclusive Web3 communities.
+To keep deliverability and trust high on a `.vip` domain: configure SPF, DKIM, and DMARC correctly from day one; warm up any new sending domain gradually; maintain consistent, recognizable branding; and pair the domain with HTTPS and a real, verifiable business presence. A well-run `.vip` site earns trust the same way any domain does — through reputation and signals, not the suffix alone.
 
-**Is .vip good for SEO?**
-Yes. Google treats .vip as a normal gTLD with no inherent ranking disadvantage. Your content, links, and site quality determine rankings — not the extension.
+## Branding and naming tips
 
-**Who operates the .vip registry?**
-The .vip TLD launched in May 2016 and is operated by the GoDaddy Registry. You can verify its delegation in the [IANA root database](https://www.iana.org/domains/root/db/vip.html).
+`.vip` is at its best when the word completes a phrase: `members.vip`, `rewards.vip`, or `<brand>.vip` all read naturally. Domain-hack style works when the second-level name plus "vip" forms a coherent idea (a club, a tier, an access level). Avoid forcing it onto projects where "VIP" adds nothing — the suffix should reinforce your meaning, not decorate it. It is short, phonetic, and easy to say aloud, so it performs well in spoken and audio contexts; just confirm listeners parse it as the familiar acronym.
 
-## **Register Your .vip Domain at Namefi**
+## How to register a .vip domain at Namefi
 
-Whether you are launching a luxury brand, creating an exclusive membership community, or simply want a domain name that stands out, .vip is an exceptional choice.
+1. **Search** your desired name at [Namefi](https://namefi.io) to check `.vip` availability.
+2. **Choose** the exact label, reviewing both first-year and renewal terms.
+3. **Register** and configure DNS — and optionally tokenize the domain on-chain.
 
-At **Namefi**, we make registering and managing your .vip domain seamless. As an [ICANN-accredited registrar](/en/glossary/registrar/), we bridge the gap between Web2 and Web3. When you register with us, you don't just get a domain — you get the option to tokenize it, enabling easy transfer, enhanced security, and integration with the blockchain ecosystem.
+As an [ICANN-accredited registrar](/en/glossary/registrar), Namefi offers transparent pricing, fast DNS, [DNSSEC](/en/glossary/dnssec), and the option to mint your domain as an [NFT](/en/glossary/nft) so it can be transferred or traded as a [tokenized domain](/en/blog/what-are-tokenized-domains). Get started at [Namefi](https://namefi.io).
 
-*   **Simple registration:** Search and secure your name in seconds.
-*   **Web3 ready:** Manage your DNS settings or mint your domain as an NFT.
-*   **Transparent pricing:** No hidden fees, just premium service.
+## Frequently asked questions
 
-**Don't let your perfect name get taken.** Establish your status today.
+### Can anyone register a .vip domain?
 
-[**Register your .vip domain at Namefi**](https://namefi.io)
+Yes. `.vip` is an open, unrestricted new gTLD with no eligibility requirements. Individuals, brands, creators, and communities can all register one, subject only to standard availability and the registry policies that apply to every domain.
+
+### Does a .vip domain affect SEO?
+
+No. Google treats `.vip` as a standard generic top-level domain with no inherent ranking advantage or penalty. Your content quality, backlinks, and site performance determine rankings, not the suffix itself.
+
+### Who should register a .vip domain?
+
+It suits membership portals, loyalty and rewards clubs, premium or luxury brands, fan communities, personal brands, and event-access pages, where the word VIP signals exclusivity. It is also notably popular in Asian markets, especially China.
+
+### Is a .vip domain safe to visit and use?
+
+The `.vip` namespace is a legitimate ICANN-delegated gTLD operated by Registry Services, LLC (GoDaddy Registry). Because it is open and inexpensive, some throwaway domains exist, so judge individual sites by HTTPS, verifiable brand identity, and reputation, exactly as you would for any TLD.
+
+### Does .vip support WHOIS privacy and DNSSEC?
+
+Yes. `.vip` supports DNSSEC for cryptographic DNS integrity, and WHOIS privacy is available through most registrars, including Namefi, to keep personal registrant details out of public lookups.
+
+## Related resources
+
+- [What is a domain?](/en/blog/what-is-domain)
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains)
+- [Registrar (glossary)](/en/glossary/registrar)
+- [ICANN (glossary)](/en/glossary/icann)
+- [DNSSEC (glossary)](/en/glossary/dnssec)
+- Compare with [.club](/en/tld/club), [.com](/en/tld/com), and [.io](/en/tld/io)

--- a/content/tld/en/website.md
+++ b/content/tld/en/website.md
@@ -1,47 +1,148 @@
 ---
-title: What is .website TLD and why choose it?
-date: '2025-12-10'
+title: 'What Is the .website Domain? The Plain-English gTLD Explained'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: Discover the benefits of .website domain! Learn why it's a great choice for businesses, creatives, and anyone establishing an online presence.
-keywords: [.website, domain, domain name, TLD, website domain, online presence, brand, marketing, web3, namefi, register domain, domain extension, generic TLD, website address]
+description: '.website is an open generic top-level domain run by Radix that literally spells out what a site is. Here is who it suits, how it is perceived, and what to weigh.'
+keywords: ['.website domain', 'what is .website', '.website TLD', 'Radix registry', 'generic TLD', 'register .website domain', '.website vs .site', 'new gTLD']
+faqs:
+  - question: 'Can anyone register a .website domain?'
+    answer: 'Yes. .website is an unrestricted generic top-level domain operated by Radix. There are no eligibility requirements, credentials, or local-presence rules, and any individual or organization can register an available name on a first-come, first-served basis.'
+  - question: 'Does a .website domain affect SEO?'
+    answer: 'No. Google treats .website as a generic gTLD with no built-in ranking advantage or penalty, the same as .com. Search Central has stated that new gTLDs are not given preference. Rankings depend on content, links, and user experience, not the suffix.'
+  - question: 'Who should register a .website domain?'
+    answer: 'It suits startups, freelancers, creatives, bloggers, and small businesses that want a clear, self-describing address when the .com is taken. It is especially handy for a brand whose name plus "website" reads naturally, such as yourbrand.website.'
+  - question: 'Is .website good for email deliverability?'
+    answer: 'It can work, but newer and lower-cost gTLDs sometimes draw extra scrutiny from spam filters. With proper SPF, DKIM, and DMARC records and a warmed-up sending reputation, .website email is deliverable; many senders still prefer an established suffix for high-volume mail.'
 ---
 
-## **What is .website?**
+If you have ever struggled to explain a domain over the phone, **.website** has an obvious appeal: it spells out exactly what sits at the other end of the link. As a generic, unrestricted suffix, the .website domain is open to anyone and reads as plainly as a street sign — your-name dot website.
 
-The ".website" Top-Level Domain (TLD) is a generic Top-Level Domain (gTLD). Introduced to the internet landscape, it serves as a clear and concise identifier for websites of all kinds. Unlike some TLDs with specific connotations, ".website" is broadly applicable, indicating simply that a domain hosts a website. It gained popularity as a versatile option, particularly useful for businesses and individuals establishing their online presence. The .website TLD is managed and regulated by [ICANN](https://www.icann.org/) through various accredited registrars.
+That literalness is both its strength and its limit. This page covers what .website actually is, who runs it, where it shines, how it is perceived for trust and email, and when a different extension is the smarter pick.
 
-## **How People Are Using .website**
+## .website at a glance
 
-The .website domain is used by a wide range of individuals and organizations:
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (new gTLD) |
+| Registry operator | Radix (Radix Technologies Inc.) |
+| Year launched | Delegated 2014 |
+| IDN support | Yes |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility requirements |
+| Best for | Startups, freelancers, creatives, and small businesses wanting a clear, self-describing address |
 
-*   **Startups and Small Businesses:** Establishing a straightforward and easily understood online identity.
-*   **Creative Professionals (Designers, Photographers, Writers):** Showcasing portfolios and personal websites.
-*   **Bloggers and Content Creators:** Building a personal brand and sharing their content online.
-*   **E-commerce Businesses:** Selling products and services online.
-*   **Individuals:** Creating personal websites for hobbies, interests, or personal branding.
+## What is .website?
 
-## **Notable Entities Using .website**
+.website is a **generic top-level domain (gTLD)** introduced during ICANN's New gTLD Program, which expanded the domain name system far beyond the legacy set of .com, .net, and .org. Unlike a country-code TLD such as .io or .ai, .website carries no national association and is not geo-targeted by search engines. It is a plain dictionary word, so it works in any market and any language.
 
-While the .website TLD isn't dominated by huge corporations, many successful and innovative businesses and individuals have embraced it. Examples include:
+The word "website" itself is the whole pitch. Where suffixes like .io or .xyz require explanation, .website is self-evident — a non-technical visitor instantly understands that the address points to a web presence. That makes it one of the most descriptive options in the entire namespace.
 
-*   Companies showcasing new software or SaaS platforms.
-*   Marketing agencies promoting their services.
-*   Online educators offering courses and resources.
-*   Community groups establishing an online forum.
+For the authoritative record, see the [IANA root-zone entry for .website](https://www.iana.org/domains/root/db/website.html). On the SEO question, Google's [Search Central guidance](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level-domains) confirms that new gTLDs like .website receive no inherent ranking boost or penalty.
 
-The inherent flexibility of the .website TLD makes it suitable for a myriad of applications.
+## History of .website
 
-## **Why Choose .website?**
+.website was delegated to the root zone in 2014, in the first wave of new gTLDs. It was originally operated by DotWebsite Inc., then moved to Radix FZC in 2021, and is today run by **Radix Technologies Inc.** Radix is one of the most prominent new-gTLD operators, founded in 2012 by entrepreneurs Bhavin and Divyank Turakhia, and runs a well-known portfolio that also includes [.site](/en/tld/site), [.online](/en/tld/online), [.store](/en/tld/store), and [.tech](/en/tld/tech).
 
-*   **Clarity and Memorability:** The word "website" is universally understood, making your domain instantly recognizable.
-*   **Availability:** Shorter, more desirable domain names are often available with the .website extension compared to more saturated TLDs like .com.
-*   **Versatility:** Suitable for any type of website, from personal blogs to e-commerce stores.
-*   **Branding:** Establishes a clear and direct connection to your online presence.
-*   **SEO Potential:** While not a direct ranking factor, a relevant and memorable domain can contribute to overall SEO success by improving click-through rates and brand recognition.
+Because it is a common English word rather than a niche term, .website has seen steady, broad adoption among small businesses, freelancers, and individuals — the audience that benefits most from an instantly legible address — rather than a single headline industry. Radix has historically released a meaningful share of short, dictionary-word names in premium pricing tiers, which is typical of the descriptive new gTLDs.
 
-## **Register Your .website Domain at Namefi**
+## How people use .website
 
-Ready to establish your online presence with a .website domain? [Namefi](https://namefi.io) is an ICANN-accredited registrar that makes it easy to register your perfect .website domain. We offer seamless Web3 integration, secure domain management, and competitive pricing. Find your perfect .website domain today and start building your online presence! Secure your .website domain today!
+.website tends to fit projects that want their address to be self-explanatory:
+
+- **Freelancers and personal brands** — a portfolio at `yourname.website` needs no explanation.
+- **Startups and small businesses** whose preferred `.com` is taken, want a clear fallback.
+- **Creatives** — photographers, designers, writers, and musicians showcasing work.
+- **Local services and community groups** that value plain language over technical flair.
+- **Campaign, event, and landing pages** where "website" itself reinforces the call to action.
+
+**Who it is not ideal for:** large enterprises and high-trust sectors (finance, healthcare) where buyers still expect a `.com`; pure-tech or developer brands that may prefer [.io](/en/tld/io), [.dev](/en/tld/dev), or [.ai](/en/tld/ai); and high-volume email senders who want the most established suffix possible.
+
+## Notable sites using .website
+
+.website is used mostly by independent creators, small businesses, and project sites rather than household-name corporations, so it has no single flagship brand. Its real, typical use is exactly that long tail: portfolio pages, small-business homepages, event sites, and personal landing pages where the literal word "website" makes the address easy to share out loud. Treat it as a practical, descriptive home for a project rather than a status-signal suffix — and verify any specific name yourself, since active sites change constantly.
+
+## .website vs other domains
+
+| Suffix | Type | Connotation | Typical use |
+| --- | --- | --- | --- |
+| [.website](/en/tld/website) | Generic gTLD | Literal, self-describing | Any site, especially personal and small business |
+| [.site](/en/tld/site) | Generic gTLD | Short, near-synonym | The same audience, fewer characters |
+| [.online](/en/tld/online) | Generic gTLD | Broad, web-presence | Shops, services, "we're online" framing |
+| [.com](/en/tld/com) | Legacy gTLD | Default, premium trust | The universal first choice |
+
+Pick **.website** when you want the most literal, plain-language address and your name plus "website" reads well. Choose [.site](/en/tld/site) if you want something shorter with the same vibe, [.online](/en/tld/online) if you want a slightly broader feel, or [.com](/en/tld/com) when maximum recognition and trust outweigh everything else. Other versatile alternatives worth a look include [.xyz](/en/tld/xyz), [.app](/en/tld/app), [.store](/en/tld/store), and [.club](/en/tld/club).
+
+## Why choose .website?
+
+- **Instant clarity.** No suffix explains itself better; anyone who hears "dot website" understands it.
+- **Strong availability.** Because the namespace is younger and larger than .com, short, brandable, exact-match names are far easier to find.
+- **No restrictions.** Open to anyone worldwide with no paperwork, credentials, or local presence.
+- **Language-neutral.** As a plain word with no country tie, it works globally and supports internationalized (IDN) names.
+- **SEO-neutral.** It carries no ranking penalty; a relevant, memorable address can lift click-through and recall.
+
+## Things to consider
+
+.website is a longer string than [.com](/en/tld/com), [.io](/en/tld/io), or [.xyz](/en/tld/xyz) — eight characters — so it adds visual weight to a full address and to printed materials. Some audiences still default to typing `.com`, so a memorable .website name benefits from clear reinforcement in marketing. The most desirable one-word names are often sold at premium pricing tiers. And as with many newer gTLDs, a small share of recipients and filters perceive lower-cost extensions as less established, which matters most for cold email at scale.
+
+## Who can register a .website domain?
+
+**Registration restrictions: open to all.** .website is an unrestricted generic TLD. There are no eligibility requirements — no credential, no membership, no local-presence rule — and any interested party may register any available name on a first-come, first-served basis, per the [Radix registry policies](https://radix.website/policies).
+
+A few administrative notes:
+
+- **Sunrise and trademark protection.** Like other new gTLDs, .website ran an ICANN-mandated sunrise period for validated trademark holders before general availability; brand owners can also use the Trademark Clearinghouse for ongoing protection.
+- **Length and IDN.** Standard label length rules apply, and the registry supports internationalized domain names for non-Latin scripts.
+- **Admin facts.** DNSSEC is supported, and WHOIS privacy is generally available through registrars subject to applicable policy. Transfer, renewal, and redemption-grace handling follow standard ICANN gTLD lifecycle rules. The governing terms ultimately sit in the [ICANN Registry Agreement for .website](https://www.icann.org/en/registry-agreements/details/website).
+
+## .website pricing and value
+
+.website pricing follows the usual new-gTLD pattern, so think in terms of dynamics rather than figures. Standard names are priced as ordinary registrations, while short, common, one-word labels are frequently placed in **premium tiers** that carry higher registration and sometimes higher renewal costs. First-year and renewal prices can differ, so it is worth confirming the renewal rate before you commit to a name long-term. What drives cost is mainly name desirability — length, dictionary value, and brandability — rather than the suffix alone. We do not list live prices here; check current rates at registration time.
+
+## Reputation and email deliverability
+
+.website reads as approachable and clear rather than premium. For a personal site, portfolio, or small-business page that is an asset. For high-stakes B2B or financial contexts, some audiences still associate maximum trust with a [.com](/en/tld/com).
+
+On email, newer and lower-cost gTLDs occasionally attract extra scrutiny from spam filters, particularly for cold or high-volume sending, simply because such suffixes have been abused elsewhere. The suffix itself does not doom your mail — deliverability is driven mainly by sender reputation and authentication. Configure **SPF, DKIM, and DMARC** correctly, warm up your sending domain gradually, and keep list hygiene tight, and a .website address can deliver reliably. If email is mission-critical at large scale, many teams still pair a .website site with an established suffix for outbound mail.
+
+## Branding and naming tips
+
+The winning pattern is **brand + website**: a name where the suffix completes the phrase, like `acme.website` or `studio.website`. Because the word is universally understood, you can lean into the literalness instead of fighting it. Keep the second-level label short so the overall address does not run long, and favor names that are easy to spell aloud — the whole point of .website is that people can hear it and type it without help. Avoid hyphens and numbers, which undercut that clarity, and say the full domain out loud before you buy to confirm it reads cleanly.
+
+## How to register a .website domain at Namefi
+
+1. **Search** your desired name on [Namefi](https://namefi.io) to check .website availability.
+2. **Choose** the exact label and confirm whether it is a standard or premium-tier name.
+3. **Register** and complete checkout, then manage DNS from your dashboard.
+
+[Namefi](https://namefi.io) is an ICANN-accredited registrar with transparent pricing, fast DNS, and optional Web3 tokenization so you can hold your domain as an on-chain asset. Search your .website name today and claim a clear, self-describing address.
+
+## Frequently asked questions
+
+### Can anyone register a .website domain?
+
+Yes. .website is an unrestricted generic top-level domain operated by Radix. There are no eligibility requirements, credentials, or local-presence rules, and any individual or organization can register an available name on a first-come, first-served basis.
+
+### Does a .website domain affect SEO?
+
+No. Google treats .website as a generic gTLD with no built-in ranking advantage or penalty, the same as .com. Search Central has stated that new gTLDs are not given preference. Rankings depend on content, links, and user experience, not the suffix.
+
+### Who should register a .website domain?
+
+It suits startups, freelancers, creatives, bloggers, and small businesses that want a clear, self-describing address when the .com is taken. It is especially handy for a brand whose name plus "website" reads naturally, such as yourbrand.website.
+
+### Is .website good for email deliverability?
+
+It can work, but newer and lower-cost gTLDs sometimes draw extra scrutiny from spam filters. With proper SPF, DKIM, and DMARC records and a warmed-up sending reputation, .website email is deliverable; many senders still prefer an established suffix for high-volume mail.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [Domain terminology guide](/en/blog/domain-terminology-guide)
+- [Glossary: TLD](/en/glossary/tld)
+- [Glossary: registrar](/en/glossary/registrar)
+- [Glossary: DNS](/en/glossary/dns)
+- Compare similar suffixes: [.site](/en/tld/site), [.online](/en/tld/online), [.store](/en/tld/store), and [.com](/en/tld/com)

--- a/content/tld/en/world.md
+++ b/content/tld/en/world.md
@@ -1,44 +1,151 @@
 ---
-title: What is .world TLD and Why Choose It?
-date: '2025-12-10'
+title: 'What Is the .world Domain? A Global gTLD Explained'
+date: '2026-06-15'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 draft: false
-description: Discover the .world domain extension, its uses, advantages, and how to register yours with Namefi for a global online presence.
-keywords: ['.world', 'domain name', 'TLD', 'domain registration', 'global domain', 'branding', 'web presence', 'Namefi', 'ICANN', 'domain investing', 'web3', 'globalization', 'international domain']
+description: 'The .world domain is an open generic gTLD run by Identity Digital, ideal for global brands, international projects, and community sites. Here is how it works.'
+keywords: ['.world domain', 'what is .world', 'world TLD', 'world domain registration', 'global domain extension', 'Identity Digital', 'generic top-level domain', 'register .world']
+faqs:
+  - question: 'Can anyone register a .world domain?'
+    answer: 'Yes. The .world domain is an open generic gTLD with no eligibility restrictions. Any individual, business, or organization anywhere can register an available .world name on a first-come, first-served basis without proving location, profession, or community membership.'
+  - question: 'Does a .world domain affect SEO?'
+    answer: 'No. Google treats .world as a generic, non-geographic gTLD, so it carries no built-in ranking advantage or penalty and is not geo-targeted to any country. Rankings depend on content, links, and site quality, not the suffix you choose.'
+  - question: 'Who should register a .world domain?'
+    answer: 'It suits global brands, international communities, travel and culture projects, NGOs, events, and anyone whose name pairs naturally with the word "world." It is also a strong domain-hack option when the exact .com is taken or expensive.'
+  - question: 'Is .world good for email deliverability?'
+    answer: 'A .world address can send and receive email like any domain. Deliverability depends on proper SPF, DKIM, and DMARC setup and your sending reputation, not the TLD itself. New gTLDs occasionally face stricter filtering, so authenticate your domain and warm it up gradually.'
+  - question: 'Does .world support WHOIS privacy and DNSSEC?'
+    answer: 'Yes. As an Identity Digital gTLD, .world supports DNSSEC for registries that enable it, and most registrars offer WHOIS privacy to mask personal contact details in public records, subject to ICANN and registrar policy.'
 ---
 
-## **What is .world?**
+The **.world domain** is one of the most literal extensions on the internet: it says exactly what many brands want to project — global reach. As an open generic top-level domain, it lets any person, company, or organization stake out a name that reads as borderless, making it a natural fit for international ventures, communities, and ideas that aim to travel.
 
-The .world Top-Level Domain (TLD) is a generic TLD (gTLD) designed to represent global reach, international communities, and worldwide connections. Introduced to the internet landscape, it offers a versatile option for individuals, businesses, and organizations seeking to establish a global online identity. The .world TLD has quickly gained traction as a domain of choice for companies looking to showcase their international presence and appeal to a worldwide audience. You can read more about gTLDs on [ICANN's website](https://www.icann.org/resources/pages/gtld-2012-02-25-en).
+Unlike country-code suffixes tied to a specific nation, **.world** is geographically neutral and available to everyone. That combination of meaning and openness is why it has grown into one of the more widely adopted new gTLDs from the 2012 expansion round.
 
-## **How People Are Using .world**
+## .world at a glance
 
-*   **Global Businesses:** Companies with international operations use .world to highlight their worldwide reach and presence.
-*   **Travel and Tourism:** Businesses in the travel industry adopt .world to attract a global customer base and showcase destinations around the globe.
-*   **International Communities:** Organizations and groups that focus on international collaboration or cultural exchange use .world to create a sense of global community.
-*   **Personal Blogs and Portfolios:** Individuals with a global perspective or international experiences utilize .world to share their stories and connect with a worldwide audience.
-*   **Startups with Global Ambitions:** New businesses aiming for international expansion use .world to signal their global aspirations from the outset.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (new gTLD) |
+| Registry operator | Binky Moon, LLC (operated by Identity Digital) |
+| Year delegated | 2014 |
+| IDN support | Yes (varies by registrar) |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility requirements |
+| Best for | Global brands, international communities, travel, culture, events, NGOs |
 
-## **Notable Entities Using .world**
+## What is .world?
 
-While specific, widely-known brands using .world may not be as prevalent as with older TLDs like .com, many innovative organizations are leveraging it. Examples include:
+The **.world** suffix is a generic top-level domain (gTLD) introduced through ICANN's New gTLD Program, the initiative that expanded the domain name system far beyond the original handful of extensions like .com and .org. Its meaning is self-evident in English and widely understood in many other languages, which gives it instant semantic value: a .world address signals scope, openness, and a global audience.
 
-*   **Global NGOs:** Organizations working on international development or humanitarian aid are using .world to connect with supporters and beneficiaries worldwide.
-*   **International News Outlets:** Smaller, independent news organizations focusing on global events are adopting .world for their online presence.
-*   **Travel Influencers and Bloggers:** Many travel content creators are using .world for websites showcasing their adventures and inspiring others to explore the world.
-*   **Multilingual Educational Platforms:** Online education platforms offering courses in multiple languages are utilizing .world to emphasize their global reach.
-*   **Global E-commerce Startups:** E-commerce businesses focused on selling products internationally are using .world to signal their global market presence.
+Crucially for site owners, Google treats **.world** as a generic, non-geographic extension. It is not tied to any country and is not used for geo-targeting in [Google Search Central's documentation on generic top-level domains](https://developers.google.com/search/docs/specialty/international/locale-specific-urls). In practice, that means choosing .world neither helps nor hurts your search rankings on its own — your content, links, and overall site quality do the real work. You can verify the suffix's official root-zone record on the [IANA delegation page for .world](https://www.iana.org/domains/root/db/world.html).
 
-## **Why Choose .world?**
+## History of .world
 
-*   **Global Appeal:** Instantly conveys a sense of international reach and global perspective.
-*   **Branding:** Reinforces your brand's commitment to a global audience and international collaboration.
-*   **Availability:** Often offers a greater chance of securing your desired domain name compared to more saturated TLDs like .com. You are more likely to find a short, memorable domain.
-*   **Memorability:** .world is easy to remember and pronounce, making it a valuable asset for marketing and branding efforts.
-*   **SEO Relevance:** While not a direct ranking factor, a relevant domain name can contribute to overall SEO efforts by signaling your target audience to search engines.
+The **.world** domain was delegated to the internet root zone in 2014, during the first wave of new gTLDs. It was originally launched by Donuts Inc., a company that secured hundreds of generic extensions in that round. Through a series of industry consolidations, Donuts merged with Afilias and rebranded as **Identity Digital**, which now operates the technical registry through its subsidiary **Binky Moon, LLC** — the entity named on the official IANA and ICANN records.
 
-## **Register Your .world Domain at Namefi**
+Since launch, .world has been adopted by a broad mix of global businesses, media outlets, and community projects. As a non-restricted, semantically rich extension, it has accumulated hundreds of thousands of registrations, placing it among the more successful generic gTLDs in Identity Digital's large portfolio of word-based suffixes (which also includes names like .life, .live, and .news).
 
-Ready to establish your global online presence? Register your .world domain with [Namefi](https://namefi.io) today! As an ICANN-accredited registrar, Namefi offers secure and reliable domain registration services. We provide a seamless experience, including easy-to-use domain management tools and even Web3 integration capabilities for the next evolution of the internet. Secure your .world domain today and unlock your brand's global potential!
+## How people use .world
+
+Real, specific niches where **.world** fits naturally:
+
+- **Global brands and campaigns** — companies wanting a borderless identity that does not anchor to one country.
+- **International communities and fan groups** — forums, fandoms, and movements with members across many countries.
+- **Travel, culture, and lifestyle** — publications and projects covering destinations, food, and global culture.
+- **NGOs and cause-driven sites** — humanitarian, environmental, and development organizations emphasizing worldwide impact.
+- **Events and conferences** — summits and expos that gather an international audience.
+- **Domain hacks** — pairing a brand name with "world" when the matching .com is unavailable or costly.
+
+**Who it's not ideal for:** strictly local businesses (a neighborhood cafe or regional service often reads better on a ccTLD or .com), and anyone who needs the absolute default-trust that a plain .com still carries with the most conservative, non-technical audiences.
+
+## Notable sites using .world
+
+- **data.world** — an enterprise data catalog and collaboration platform (now part of ServiceNow). It is the best-known example of a serious company using the suffix as its primary brand domain.
+
+Beyond this flagship example, .world is commonly used by independent media, global community projects, and brand campaigns to reinforce an international, open-to-everyone positioning.
+
+## .world vs other domains
+
+| Extension | Meaning / positioning | Restrictions | Typical use |
+| --- | --- | --- | --- |
+| [.com](/en/tld/com) | Universal default, maximum trust | Open | Almost anything |
+| [.world](/en/tld/world) | Global reach, borderless | Open | International brands, communities |
+| [.org](/en/tld/org) | Organizations, nonprofits | Open | NGOs, communities |
+| [.xyz](/en/tld/xyz) | Generic, modern, neutral | Open | Startups, projects |
+
+Pick **.com** when default familiarity matters most and the name is available. Choose **.world** when you specifically want to signal global scope or your name pairs naturally with "world." Consider [.org](/en/tld/org) if your project is community- or mission-driven, and [.xyz](/en/tld/xyz) if you want a short, neutral, widely available alternative.
+
+## Why choose .world?
+
+- **Instant meaning** — the word "world" communicates international scope with zero explanation.
+- **Open to everyone** — no credentials, location, or community membership required.
+- **Strong availability** — many short, exact-match names that are long gone in [.com](/en/tld/com) are still open in .world.
+- **Reputable operator** — backed by Identity Digital, one of the largest and most established gTLD registries.
+- **Domain-hack potential** — brand names ending naturally in "world" can form a clean, readable address.
+
+## Things to consider
+
+- **Less default trust than .com** — some non-technical visitors still equate "real website" with .com, so .world may need a moment of recognition.
+- **Premium pricing on some names** — short, dictionary, or high-demand .world domains can carry elevated registry pricing.
+- **Renewal differs from first year** — like most new gTLDs, the first-year price and the renewal price are not the same.
+- **Type-in confusion** — because the suffix is a full word, make sure your second-level name does not create an awkward or unintended phrase.
+
+## Who can register a .world domain?
+
+**Registration restrictions: open to all.** The **.world** domain has no eligibility requirements. You do not need to prove a location, profession, trademark, or community affiliation — any individual or organization worldwide can register an available name on a first-come, first-served basis.
+
+During the original 2014 launch, .world went through standard sunrise and landrush phases that let trademark holders and early adopters claim names first; the suffix has long since been in general availability. Trademark owners can still protect their marks across new gTLDs through ICANN's Trademark Clearinghouse. Standard administrative rules apply: names follow the usual length and character conventions, IDNs are supported by many registrars, **DNSSEC** is available, and most registrars offer **WHOIS privacy** along with normal transfer, renewal, and redemption-grace handling. The authoritative rules for the suffix live in the [ICANN Registry Agreement for .world](https://www.icann.org/en/registry-agreements/details/world).
+
+## .world pricing and value
+
+Pricing for **.world** follows the typical new-gTLD pattern rather than a single flat rate. Most standard names register at the registry's regular tier, but a subset of short, dictionary, or otherwise high-demand names are designated **premium** and priced higher — sometimes with premium renewals as well. As with nearly all gTLDs, the **first-year price and the renewal price differ**, so it is worth checking the ongoing cost before you commit to a name for the long term. What drives cost is mainly name length, dictionary value, and overall demand for the specific string — not the suffix alone. Namefi keeps this transparent so you see what you are paying before checkout.
+
+## Reputation and email deliverability
+
+As a meaningful, full-word extension from a major registry, **.world** is generally perceived as legitimate and brand-friendly rather than cheap or spammy. That said, new gTLDs as a category have occasionally faced stricter scrutiny from spam filters compared to long-established suffixes, simply because abuse patterns are easier to track on newer namespaces.
+
+For email, the suffix you use matters far less than your configuration. Set up **SPF, DKIM, and DMARC** correctly, send from a domain with a clean history, and warm up new sending domains gradually. Do those things and a .world address delivers reliably; skip them and even a .com will land in spam. Pairing your domain with a reputable email provider and monitoring your sender reputation is the real safeguard.
+
+## Branding and naming tips
+
+The best **.world** names treat the suffix as the final word of a phrase: pick a second-level name that reads cleanly when "world" is appended. Short, single-word brands and names that already imply scale or community tend to work best. Because the suffix is a recognizable English word, it is easy to say aloud and easy to spell — an advantage for word-of-mouth and radio or podcast mentions. Watch for accidental phrasing (make sure the combined string says what you intend), and keep the second-level portion short to preserve memorability.
+
+## How to register a .world domain at Namefi
+
+1. **Search** for your desired name on [Namefi](https://namefi.io) to check .world availability.
+2. **Choose** the exact name you want and review its details, including any premium designation.
+3. **Register** and complete checkout with transparent pricing and no surprises.
+
+Namefi is an ICANN-accredited registrar that also supports Web3 tokenized domains, giving you fast DNS management and the option to tokenize your domain for on-chain ownership. Start your search at [Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .world domain?
+
+Yes. The .world domain is an open generic gTLD with no eligibility restrictions. Any individual, business, or organization anywhere can register an available .world name on a first-come, first-served basis without proving location, profession, or community membership.
+
+### Does a .world domain affect SEO?
+
+No. Google treats .world as a generic, non-geographic gTLD, so it carries no built-in ranking advantage or penalty and is not geo-targeted to any country. Rankings depend on content, links, and site quality, not the suffix you choose.
+
+### Who should register a .world domain?
+
+It suits global brands, international communities, travel and culture projects, NGOs, events, and anyone whose name pairs naturally with the word "world." It is also a strong domain-hack option when the exact .com is taken or expensive.
+
+### Is .world good for email deliverability?
+
+A .world address can send and receive email like any domain. Deliverability depends on proper SPF, DKIM, and DMARC setup and your sending reputation, not the TLD itself. New gTLDs occasionally face stricter filtering, so authenticate your domain and warm it up gradually.
+
+### Does .world support WHOIS privacy and DNSSEC?
+
+Yes. As an Identity Digital gTLD, .world supports DNSSEC for registries that enable it, and most registrars offer WHOIS privacy to mask personal contact details in public records, subject to ICANN and registrar policy.
+
+## Related resources
+
+- [.com domain](/en/tld/com) — the universal default extension
+- [.org domain](/en/tld/org) — for organizations and communities
+- [.xyz domain](/en/tld/xyz) — a short, neutral alternative
+- [.io domain](/en/tld/io) — popular with tech and startups

--- a/content/tld/en/xyz.md
+++ b/content/tld/en/xyz.md
@@ -1,72 +1,144 @@
 ---
-title: 'What is the .xyz TLD and Why Should You Choose It?'
-date: '2025-12-10'
+title: 'What Is the .xyz Domain? The Generic TLD Explained'
+date: '2026-06-15'
 language: 'en'
-tags:
-  - tld
-authors:
-  - namefiteam
+tags: ['tld']
+authors: ['namefiteam']
 draft: false
-description: 'Discover why .xyz is the choice for Web3 and startups. Learn about .xyz domain meaning, benefits, and how to register yours with Namefi today.'
-keywords:
-  - .xyz domains
-  - .xyz TLD
-  - .xyz top-level domain
-  - what is .xyz
-  - why choose .xyz
-  - what is the .xyz domain
-  - why choose the .xyz domain
-  - tokenized domains
-  - blockchain domains
-  - domain investing
-  - Web3 domains
-  - best TLD for startups
-  - .xyz vs .com
-  - buy .xyz domain
-  - Namefi .xyz registration
+description: 'The .xyz domain is an open generic TLD launched in 2014 and famously used by Alphabet at abc.xyz. Learn who it suits, how it is priced, and how to register.'
+keywords: ['.xyz domains', 'what is .xyz', '.xyz TLD', '.xyz domain meaning', 'abc.xyz Alphabet', '.xyz vs .com', 'register .xyz domain', 'is .xyz good for SEO']
+faqs:
+  - question: 'Can anyone register a .xyz domain?'
+    answer: 'Yes. The .xyz domain is an unrestricted generic top-level domain, so anyone worldwide can register one on a first-come, first-served basis with no credential, business, or local-presence requirement. Registrations are handled through ICANN-accredited registrars rather than directly with the registry.'
+  - question: 'Does a .xyz domain affect SEO?'
+    answer: 'No. Google has stated that new generic TLDs like .xyz are treated the same as legacy extensions such as .com, with no inherent ranking advantage or penalty. Rankings depend on content, links, and user experience, not the suffix itself.'
+  - question: 'Who should register a .xyz domain?'
+    answer: 'The .xyz domain suits startups, Web3 and crypto projects, developers, and anyone whose preferred .com is taken. Because it carries no industry meaning, it works as a blank-slate brand for almost any venture seeking a short, available name.'
+  - question: 'Why does .xyz have a reputation for spam?'
+    answer: 'Its low pricing and open registration have attracted bulk and abusive registrations, and security trackers have flagged .xyz among extensions with high malicious volume. The TLD itself is legitimate; reputation depends on the individual domain and how it is used.'
 ---
 
-## **What is .xyz?**
+The **.xyz domain** is one of the most widely adopted new generic top-level domains (gTLDs) of the post-2014 era, and arguably the best-known alternative to .com. Its three-letter, end-of-the-alphabet name carries no built-in industry meaning, which makes it a true blank canvas for any brand, project, or personal site.
 
-The **.xyz** extension is a generic top-level domain (gTLD) that has rapidly become one of the most popular and recognizable alternatives to the traditional .com. Unlike legacy domains that were often industry-specific (like .net for networks or .org for organizations), .xyz was created to be truly generic.
+If you are weighing a modern extension against a legacy one, .xyz is the reference case: it is open to everyone, deliberately generic, and validated at the highest level by Alphabet Inc., Google's parent company, which runs its investor site at abc.xyz.
 
-Launched to the general public in 2014, the logic behind the name is simple and inclusive: it represents the end of the alphabet, catering to Generations X, Y, and Z. It was designed to provide short, memorable naming options for the next generation of internet users. According to the [official .xyz registry](https://xyz.xyz/), the goal was to create a domain space with "no specific meaning," allowing users to project their own branding onto the URL without pre-conceived notions.
+## .xyz at a glance
 
-Today, .xyz is frequently cited as a top choice for innovators, Web3 developers, and domain investors looking for high-value digital assets.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Generic top-level domain (new gTLD) |
+| Registry operator | XYZ.COM LLC (Generation XYZ), backend by CentralNic |
+| Year launched | Delegated February 2014; public availability June 2014 |
+| IDN support | Yes |
+| DNSSEC | Supported |
+| Registration restrictions | Open to all — no eligibility requirement |
+| Best for | Startups, Web3/crypto projects, developers, blank-slate brands |
 
-## **How People Are Using .xyz**
+## What is .xyz?
 
-Because it lacks a specific category association, .xyz is incredibly versatile. It has found a particularly strong product-market fit in the following areas:
+The .xyz domain is a generic top-level domain (gTLD) introduced through [ICANN's New gTLD Program](https://newgtlds.icann.org/). The string "xyz" was chosen precisely because it has no semantic baggage: the last three letters of the Latin alphabet, often framed as a nod to Generations X, Y, and Z. Where .org implies an organization and .io has come to read as "tech," .xyz signals nothing in particular, which is the entire point — it lets the second-level name carry all the meaning.
 
-*   **Web3 and Blockchain Projects:** The .xyz extension has arguably become the default TLD for the Web3 ecosystem. From DAOs to NFT platforms, using an .xyz domain signals that a project is modern, tech-forward, and part of the decentralized future.
-*   **Tech Startups:** Many startups finding their preferred .com unavailable or too expensive have flocked to .xyz for its brevity and availability.
-*   **Creative Portfolios:** Designers and artists use it to showcase work, appreciating the "end of the alphabet" completeness.
-*   **Domain Investing:** As premium .com names become scarce, domain investors are increasingly acquiring short, one-word, or numeric .xyz domains, viewing them as valuable assets in the tokenized domain economy.
+Because it is a generic rather than a country-code TLD, Google does not geo-target .xyz to any region. According to [Google Search Central](https://developers.google.com/search/docs/specialty/international/locale-adaptive-pages), generic new TLDs are treated like any other gTLD for search, so a .xyz site can rank globally without being tied to a country. You can confirm the registry details in the official [IANA root-zone record for .xyz](https://www.iana.org/domains/root/db/xyz.html).
 
-## **Notable Entities Using .xyz**
+## History of .xyz
 
-The credibility of the .xyz TLD skyrocketed due to adoption by some of the world's most influential technology companies.
+The .xyz string was delegated to the DNS root in February 2014 and opened to the public on June 2, 2014, championed by founder and CEO Daniel Negari under the company XYZ.COM LLC. Its technical backend is operated by CentralNic, a long-established registry-services provider.
 
-1.  **Alphabet Inc. (abc.xyz):** In perhaps the most famous case study for new gTLDs, Google restructured under a parent company named Alphabet in 2015 and chose [abc.xyz](https://abc.xyz) as its primary home. This move instantly validated the TLD for the global business community.
-2.  **Block (block.xyz):** Square, the financial services platform led by Jack Dorsey, rebranded to Block and migrated to block.xyz, further cementing the TLD's connection to blockchain and fintech.
-3.  **Starship Technologies (starship.xyz):** A leading company in autonomous delivery robots, utilizing the domain to highlight their futuristic approach to logistics.
+Adoption was unusually fast. Within roughly eighteen months the TLD had passed 1.5 million registrations, a trajectory helped enormously when Google restructured under a new parent company, Alphabet Inc., in August 2015 and placed its corporate home at abc.xyz. In June 2017 the registry launched its "1.111B" class, a pool of six- to nine-digit numeric domains (from 000000.xyz upward) priced at rock-bottom rates to encourage mass adoption and experimentation. That low-cost strategy is central to both the TLD's scale and its reputation, discussed further below.
 
-## **Why Choose .xyz?**
+## How people use .xyz
 
-If you are debating between a legacy domain and a new gTLD, here is why .xyz stands out:
+The .xyz domain is genuinely industry-agnostic, but a few niches have gravitated to it:
 
-*   **Availability:** Finding short, memorable, and pronounceable names is significantly easier on .xyz than on .com.
-*   **Web3 Signaling:** If you are building in the blockchain or crypto space, an .xyz domain acts as a subtle shibboleth, indicating to your users that you are "crypto-native."
-*   **SEO Neutrality:** Google has confirmed that their algorithms treat new gTLDs like .xyz exactly the same as legacy TLDs like .com. You will not be penalized for choosing a modern extension.
-*   **Flexibility:** It fits any industry. Whether you are opening a coffee shop or launching a DeFi protocol, "xyz" makes sense.
-*   **Global Recognition:** With millions of registrations worldwide, it is no longer an obscure extension; users recognize and trust it.
+- **Web3, crypto, and DAO projects** — .xyz has become something of a default among decentralized and on-chain teams; it reads as crypto-native without being limited to it.
+- **Startups priced out of .com** — founders whose exact-match .com is taken or expensive often pick the matching .xyz to keep a short, clean brand.
+- **Developers and side projects** — cheap registration makes it a low-stakes home for experiments, portfolios, and demos.
+- **Personal brands and creators** — the neutral suffix works for a name-based site without committing to a category.
 
-## **Register Your .xyz Domain at Namefi**
+**Who it's not ideal for:** organizations that need maximum out-of-the-box trust with non-technical or older audiences (a law firm, a bank, a hospital) may still be better served by a .com or a credentialed/regulated extension, simply because .xyz is less universally familiar and has a mixed abuse reputation.
 
-Ready to claim your piece of the internet? Whether you are launching a Web3 venture, a personal portfolio, or a new startup, .xyz offers the perfect blend of affordability and modern branding.
+## Notable sites using .xyz
 
-At **Namefi**, we make domain ownership easier and more functional than ever before. We are an ICANN-accredited registrar that bridges the gap between Web2 and Web3. When you register with us, you enjoy seamless management and the unique ability to tokenize your domain for easier transfer and investment management.
+- **abc.xyz** — Alphabet Inc., the parent company of Google, hosts its investor and corporate site here. This is the single most influential endorsement any new gTLD has received.
+- **block.xyz** — Block, Inc. (formerly Square), the fintech company led by Jack Dorsey, uses block.xyz as its corporate home, reinforcing the TLD's association with payments and blockchain.
 
-**Don't let your perfect name get taken.**
+These are real, high-profile deployments rather than vanity redirects, which is why .xyz is treated as a credible production extension rather than a novelty.
 
-[**Register your .xyz domain at Namefi today**](https://namefi.io) and start building the future.
+## .xyz vs other domains
+
+| Extension | Type | Meaning | Typical use |
+| --- | --- | --- | --- |
+| [.com](/en/tld/com) | Legacy gTLD | None (universal default) | Any commercial or general site |
+| .xyz | New gTLD | None (deliberately generic) | Startups, Web3, blank-slate brands |
+| [.io](/en/tld/io) | ccTLD (used as tech gTLD) | "Tech/startup" by convention | SaaS, developer tools, crypto |
+| [.app](/en/tld/app) | New gTLD | Apps/software | Product and app sites |
+
+Pick **.com** when universal familiarity matters most and the name is available. Choose **.xyz** when you want a short, neutral, affordable name and the .com is gone. Reach for **.io** or **.app** when you specifically want the audience to read "software" from the suffix alone.
+
+## Why choose .xyz?
+
+- **Availability** — short, pronounceable, and one-word names are far easier to find on .xyz than on .com.
+- **No category lock-in** — the generic meaning lets you rebrand or pivot without the domain fighting you.
+- **SEO neutral** — Google treats it the same as any gTLD, so there is no ranking penalty for choosing it.
+- **Proven at scale** — with millions of registrations and marquee users like Alphabet and Block, it is an established extension, not an obscure one.
+- **Web3-friendly perception** — within crypto and developer circles, .xyz reads as modern and on-trend.
+
+## Things to consider
+
+The same low pricing that fuels .xyz adoption also attracts spam and bulk abusive registrations, which has affected how some filters and users perceive the TLD (see Reputation below). It is also less instantly trusted by mainstream, non-technical audiences than .com. Finally, because it is so widely available, defensively securing your exact name across a few extensions can be worthwhile to avoid impersonation.
+
+## Who can register a .xyz domain?
+
+**Registration restrictions: open to all.** The .xyz domain is an unrestricted generic TLD. There is no credential, membership, business-registration, or local-presence requirement — anyone, anywhere can register one on a first-come, first-served basis. The registry does not sell directly to end users; you register through an ICANN-accredited registrar.
+
+Standard new-gTLD rules apply: trademark holders could claim names during the original sunrise period, and the Trademark Clearinghouse continues to provide notice protections. The TLD supports internationalized domain names (IDNs), DNSSEC for cryptographic integrity, and registrar-level WHOIS privacy. Transfers, renewals, and the redemption grace period for expired names follow standard ICANN gTLD policy. The authoritative source for the operator's obligations is the [ICANN Registry Agreement for .xyz](https://www.icann.org/en/registry-agreements/details/xyz), and the official registry is [Generation XYZ](https://gen.xyz/).
+
+## .xyz pricing and value
+
+The .xyz domain is positioned as an affordable extension, but a few pricing dynamics matter. First, **premium-tier names exist**: short, dictionary, or otherwise desirable strings are flagged by the registry as premium and carry higher recurring fees than a standard registration. Second, **first-year and renewal pricing often differ** — an introductory rate is not the long-term cost, so always check the renewal price before committing a brand to it. The registry's numeric 1.111B domains are a separate, ultra-low-cost class. As with any TLD, cost is driven by the name's perceived value (length, memorability, keyword) and by registry-set premium tiers. Namefi shows transparent pricing at registration so there are no surprises at renewal.
+
+## Reputation and email deliverability
+
+This is where honesty matters most. Because .xyz is cheap and open, it has attracted a high volume of spam, phishing, and malware registrations, and security trackers and anti-abuse groups have repeatedly listed it among extensions with elevated malicious activity. Some aggressive spam filters and corporate allowlists treat unfamiliar new-gTLD senders more skeptically than .com, which can affect cold-email deliverability for a brand-new .xyz domain.
+
+None of this makes the TLD illegitimate — Alphabet and Block run real businesses on it. Reputation attaches to the individual domain, not the suffix. To mitigate: warm up any sending domain gradually, configure SPF, DKIM, and DMARC correctly, keep the name off shared/abused IP ranges, and build a clean sending history. A well-maintained .xyz domain delivers fine; a brand-new one used for bulk outreach may face extra scrutiny.
+
+## Branding and naming tips
+
+The .xyz suffix invites playful constructions and is easy to say aloud, but spell-out clarity is key when sharing verbally — "x-y-z" reads cleanly, so prefer names that don't blur into the suffix. It works especially well for short, brandable, made-up words where the lack of meaning is an asset. Avoid pairing it with a name that itself looks spammy or keyword-stuffed, since that compounds the TLD's abuse perception. Numeric and ultra-short combinations are popular thanks to the registry's numeric program.
+
+## How to register a .xyz domain at Namefi
+
+1. **Search** for your desired name on [Namefi](https://namefi.io) to check availability and see transparent pricing.
+2. **Choose** the .xyz extension (and any alternates you want to secure defensively).
+3. **Register** and manage DNS instantly, with the option to tokenize your domain for Web3-native ownership and transfer.
+
+[Namefi](https://namefi.io) is an ICANN-accredited registrar bridging Web2 and Web3, so you can run a conventional .xyz site or hold it as a tokenized on-chain asset — with clear pricing and no hidden renewal surprises.
+
+## Frequently asked questions
+
+### Can anyone register a .xyz domain?
+
+Yes. The .xyz domain is an unrestricted generic top-level domain, so anyone worldwide can register one on a first-come, first-served basis with no credential, business, or local-presence requirement. Registrations are handled through ICANN-accredited registrars rather than directly with the registry.
+
+### Does a .xyz domain affect SEO?
+
+No. Google has stated that new generic TLDs like .xyz are treated the same as legacy extensions such as .com, with no inherent ranking advantage or penalty. Rankings depend on content, links, and user experience, not the suffix itself.
+
+### Who should register a .xyz domain?
+
+The .xyz domain suits startups, Web3 and crypto projects, developers, and anyone whose preferred .com is taken. Because it carries no industry meaning, it works as a blank-slate brand for almost any venture seeking a short, available name.
+
+### Why does .xyz have a reputation for spam?
+
+Its low pricing and open registration have attracted bulk and abusive registrations, and security trackers have flagged .xyz among extensions with high malicious volume. The TLD itself is legitimate; reputation depends on the individual domain and how it is used.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld)
+- [What is a domain?](/en/blog/what-is-domain)
+- [Domain terminology guide](/en/blog/domain-terminology-guide)
+- [Top TLDs to secure for your startup](/en/blog/top-tlds-to-secure-for-your-startup)
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains)
+- [.com domain](/en/tld/com) · [.io domain](/en/tld/io) · [.app domain](/en/tld/app)
+- Glossary: [ICANN](/en/glossary/icann) · [registrar](/en/glossary/registrar) · [SEO](/en/glossary/seo)


### PR DESCRIPTION
## Why
The popular TLD docs (`.com`, `.io`, `.ai`, `.net`, `.org`, `.xyz`, `.app` …) predated our `tld-page.md` spec — they were the old ~800-word, 5-section format with **no at-a-glance table, no FAQ schema, no eligibility/reputation sections**. The 23 newly-created docs already follow the spec; this brings the important *existing* ones up to parity.

## What
Regenerated **35 docs** (Opus-authored, registry facts verified against IANA/ICANN/operators) to the full structure: at-a-glance table, history, eligibility/registration-restrictions, pricing dynamics (no numbers), reputation/deliverability, FAQ (+ `faqs:` frontmatter → FAQPage schema), related resources.

- **Tier 1 (20, linked from listicles):** com io ai app dev net org xyz shop store online site tech cloud club vip info agency accountants abogado
- **Tier 2 (15, popular generics):** academy blog city click fun live loan now space today top website world sbs eth

### Notable accuracy handling
- **`.eth`** authored as an **ENS / Web3 name on Ethereum — not a DNS TLD** (no IANA/ICANN; cites ENS docs; ties into Namefi's tokenized-domains angle).
- **`.sbs`** honestly notes its spam-filter reputation (Spamhaus).
- Brand TLDs (aaa/abb/abbott…) intentionally **not** upgraded (low value).

## Verified
- 35/35 conform (faqs + at-a-glance + eligibility) ✅
- internal links use `/en/tld/<x>` (no `/r/`) ✅ · all targets exist ✅
- `data:validate` ✅ · `lint:mdx` ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only SEO/content changes with no runtime code, APIs, or security-sensitive logic.
> 
> **Overview**
> **35 English TLD articles** under `content/tld/en/` are rewritten from the old short (~5-section) format to the full **`tld-page.md` structure**, matching newer TLD docs and what listicles link to.
> 
> Each page now adds **`faqs:` frontmatter** (FAQPage schema), an **at-a-glance table**, and expanded sections: registry/history, **registration restrictions**, pricing **dynamics** (no live prices), **reputation and email deliverability**, TLD **comparison tables**, branding tips, duplicated FAQ body, and **related resources** with `/en/tld/`, blog, and glossary links. Titles, descriptions, and dates are refreshed (e.g. `2026-06-15`).
> 
> Notable content choices called out in the PR: **`.eth`** documented as ENS/Web3 (not ICANN DNS), **`.sbs`** includes honest spam-filter reputation notes, and low-value brand TLDs are left unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdf2b52936da29301cc7c4fde89fd41c1b9b363c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Comprehensively updated 26 TLD information pages with improved structure and organization, including new "at a glance" reference tables, expanded FAQ sections, and detailed guidance on registration, pricing, email deliverability, and branding best practices across all domain extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->