### PR TITLE
content(blog): backfill topic-cluster + series frontmatter on 83 EN posts

### DIFF
--- a/content/blog/en/ai-vs-io-domain.md
+++ b/content/blog/en/ai-vs-io-domain.md
@@ -5,6 +5,8 @@ language: 'en'
 tags: ['guide']
 authors: ['namefiteam']
 draft: false
+cluster: choosing-a-tld
+format: comparison
 description: ".ai vs .io for your startup? Compare origins, Google SEO treatment, pricing, branding signals, and the .io Chagos question, plus a clear decision guide and FAQ."
 keywords: ["ai vs io tld", "io vs ai domain", "ai or io domain", "io vs ai domain extension", "ai vs io domain extension", ".ai vs .io", "ai or io tld", "ai vs io domain", "io or ai domain", ".ai vs .io domain", "ai domain vs io domain", "best domain for ai startup", "best domain for tech startup", "ai tld", "io tld", "domain extension for startup", "ccTLD for tech", "gccTLD seo", "io domain chagos", "io domain future", "ai domain pricing", "io domain pricing", "domain branding", "choosing a domain extension", "tokenized domain"]
 ---

--- a/content/blog/en/building-for-people-not-wallets.md
+++ b/content/blog/en/building-for-people-not-wallets.md
@@ -5,6 +5,7 @@ language: en
 tags: ['partners', 'namefi space']
 authors: ['namefiteam']
 draft: false
+format: opinion
 description: A conversation-driven exploration of Henri Stern’s journey building Privy, focusing on usability, customer-led product development, and the shift from crypto complexity to human-centered design.
 ---
 

--- a/content/blog/en/cctld-market-share-by-registration-volume.md
+++ b/content/blog/en/cctld-market-share-by-registration-volume.md
@@ -5,6 +5,8 @@ language: en
 tags: ['cctld', 'domains', 'market-analysis', 'registry']
 authors: ['namefiteam']
 draft: false
+cluster: choosing-a-tld
+format: analysis
 description: A look at which country-code top-level domains command the largest share of registrations worldwide, why the leaders differ from what most people expect, and what the volume numbers tell us about how the internet is actually used.
 ogImage: ../../assets/cctld-market-share-by-registration-volume-og.jpg
 keywords: ['cctld market share', 'country code domains', '.cn', '.de', '.uk', '.tk', '.io', 'domain statistics', 'registry data', 'namefi']

--- a/content/blog/en/choosing-a-domain-tokenization-platform.md
+++ b/content/blog/en/choosing-a-domain-tokenization-platform.md
@@ -5,6 +5,8 @@ language: en
 tags: ['comparison']
 authors: ['namefiteam']
 draft: false
+cluster: domain-tokenization
+format: comparison
 description: An honest, side-by-side look at the major domain tokenization platforms — what each one is actually good at, where they overlap, where they don't, and how to pick the one that fits how you intend to use your domains.
 keywords: ['domain tokenization platforms', 'Doma alternative', 'D3 Global Inc alternative', '3DNS alternative', 'compare domain tokenization', 'Namefi vs Doma', 'Namefi vs D3 Global Inc', 'Namefi vs 3DNS', 'best domain tokenization', 'Namefi review', 'Doma Protocol review', 'D3 Global Inc review', '3DNS review', 'choose domain tokenization', 'domain tokenization comparison']
 ---

--- a/content/blog/en/dns-is-the-control-plane.md
+++ b/content/blog/en/dns-is-the-control-plane.md
@@ -5,6 +5,10 @@ language: en
 tags: ['dns', 'aws', 'resilience', 'incident-explainer']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+series: domain-apocalypse
+seriesOrder: 2
+format: case-study
 description: A registrar/DNS‑operations perspective on the October 20, 2025 AWS incident, how DNS actually works, why this failure propagated so widely, and what resilient internet teams can do about it.
 keywords: ['dns', 'aws outage', 'control plane', 'dynamodb', 'us-east-1', 'dns caching', 'cloud resilience', 'multi-signer dns', 'incident response']
 ---

--- a/content/blog/en/dns-on-tokenized-domains.md
+++ b/content/blog/en/dns-on-tokenized-domains.md
@@ -5,6 +5,10 @@ language: en
 tags: ['guide']
 authors: ['namefiteam']
 draft: false
+cluster: domain-tokenization
+series: tokenize-your-com
+seriesOrder: 2
+format: guide
 description: A practical look at how regular DNS — nameservers, A/AAAA, MX, TXT, DNSSEC, CAA — keeps working after you tokenize an ICANN domain. What changes, what doesn't, and where to point your existing DNS provider.
 keywords: ['DNS tokenized domain', 'DNSSEC NFT domain', 'tokenized domain nameservers', 'tokenized domain email', 'MX records NFT domain', 'CAA records tokenized domain', 'tokenized domain DNS management', 'on-chain domain DNS', 'NFT domain MX', 'NFT domain DNSSEC', 'tokenized domain Cloudflare', 'tokenized domain Route53', 'how DNS works tokenized', 'tokenized domain resolution']
 ---

--- a/content/blog/en/dns-over-https-vs-enterprise-split-horizon-dns.md
+++ b/content/blog/en/dns-over-https-vs-enterprise-split-horizon-dns.md
@@ -5,6 +5,8 @@ language: en
 tags: ['dns', 'doh', 'enterprise', 'security', 'networking']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+format: comparison
 description: DNS over HTTPS (DoH) protects user privacy by encrypting DNS queries inside HTTPS. Enterprise split-horizon DNS relies on the network being able to see those queries. The collision between the two is reshaping how corporate networks, browsers, and operating systems handle name resolution.
 ogImage: ../../assets/dns-over-https-vs-enterprise-split-horizon-dns-og.jpg
 keywords: ['dns over https', 'doh', 'split horizon dns', 'enterprise dns', 'dot', 'encrypted dns', 'internal dns', 'name resolution', 'namefi']

--- a/content/blog/en/do-multisig-wallets-actually-improve-security.md
+++ b/content/blog/en/do-multisig-wallets-actually-improve-security.md
@@ -5,6 +5,8 @@ language: en
 tags: ['security', 'wallets', 'multisig', 'web3', 'key-management']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+format: explainer
 description: Multisignature wallets are widely treated as the default secure custody pattern in crypto, but the answer to "do they actually improve security?" depends entirely on the threat model. This post walks through what multisig defeats, what it does not, and where it can make things worse.
 ogImage: ../../assets/do-multisig-wallets-actually-improve-security-og.jpg
 keywords: ['multisig wallet', 'multisignature', 'safe wallet', 'gnosis safe', 'key management', 'self custody', 'threshold signature', 'social recovery', 'namefi']

--- a/content/blog/en/domain-escrow-explained.md
+++ b/content/blog/en/domain-escrow-explained.md
@@ -5,6 +5,8 @@ language: en
 tags: ['guide']
 authors: ['namefiteam']
 draft: false
+cluster: domain-basics
+format: explainer
 description: A plain-English guide to escrow and domain escrow — what an escrow account is, how escrow works step by step in a domain sale, why it matters for avoiding fraud, traditional escrow services vs. the modern tokenized approach, and how smart contracts can replace escrow with atomic on-chain settlement.
 keywords: ['domain escrow', 'what is escrow', 'escrow account', 'escrow meaning', 'how does escrow work', 'domain escrow service', 'escrow.com alternative', 'buy a domain safely', 'sell a domain safely', 'auth code', 'EPP code', 'registrar transfer', 'escrow fees', 'safe domain transaction', 'domain sale fraud', 'tokenized domain escrow', 'smart contract escrow', 'atomic settlement', 'on-chain domain sale', 'how to avoid domain fraud']
 ---

--- a/content/blog/en/domain-industry-media.md
+++ b/content/blog/en/domain-industry-media.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'media', 'news', 'community', 'domain-investing']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: domain-investor-field-guide
+seriesOrder: 2
+format: roundup
 description: A guide to the news outlets, sales-data sites, and podcasts that cover the domain name industry as journalism — DomainNameWire, DNJournal, TheDomains, NameBio, DomainSherpa, CircleID, and more.
 ogImage: ../../assets/domain-industry-media-og.jpg
 keywords: ['domain industry news', 'domain name media', 'domainnamewire', 'dnjournal', 'namebio', 'domain sherpa', 'thedomains', 'domain gang', 'circleid', 'icann news']

--- a/content/blog/en/domain-terminology-guide.md
+++ b/content/blog/en/domain-terminology-guide.md
@@ -5,6 +5,8 @@ language: en
 tags: ['faq', 'domains']
 authors: ['namefiteam']
 draft: false
+cluster: domain-basics
+format: faq
 description: Master domain investing with our comprehensive guide to essential domain terminology. From basic concepts to advanced trading strategies, learn the language of domain professionals.
 keywords: ['domain terminology', 'domain investing', 'domain names', 'domain trading', 'domain glossary', 'TLD', 'registrar', 'domain auction', 'domain portfolio', 'domain valuation', 'premium domains', 'domain flipping']
 ---

--- a/content/blog/en/famous-domainer-blogs-and-newsletters.md
+++ b/content/blog/en/famous-domainer-blogs-and-newsletters.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'domain-investing', 'blogs', 'newsletters', 'community']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: domain-investor-field-guide
+seriesOrder: 3
+format: roundup
 description: A curated list of the individual domainers, brokers, and traders whose blogs, newsletters, and Substacks are worth reading in 2026 — what each one is known for, and how they fit together.
 ogImage: ../../assets/famous-domainer-blogs-and-newsletters-og.jpg
 keywords: ['domainer blogs', 'domain investing blogs', 'elliot silver', 'rick schwartz', 'morgan linton', 'konstantinos zournas', 'mike mann', 'jamie zoch', 'domainshane', 'domain newsletter', 'domain substack']

--- a/content/blog/en/from-airbedandbreakfast-com-to-airbnb-com.md
+++ b/content/blog/en/from-airbedandbreakfast-com-to-airbnb-com.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'branding', 'startups', 'domain-upgrades']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: name-change-game-change
+seriesOrder: 3
+format: case-study
 description: 'How Airbnb launched in 2008 as AirBed & Breakfast on AirBedAndBreakfast.com, then shortened to Airbnb.com in 2009 to escape the literal air-mattress name and become a scalable global brand.'
 keywords: ['airbedandbreakfast.com', 'airbnb.com', 'airbnb domain name', 'airbnb rebrand', 'airbed and breakfast', 'domain upgrade', 'startup naming', 'brand naming', 'premium domain', 'domain strategy', 'airbnb history', 'y combinator airbnb', 'company rebrand']
 ---

--- a/content/blog/en/from-box-net-to-box-com.md
+++ b/content/blog/en/from-box-net-to-box-com.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'branding', 'startups', 'domain-upgrades']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: name-change-game-change
+seriesOrder: 8
+format: case-study
 description: 'How Box launched in 2005 on Box.net because Box.com was taken, pivoted from consumer storage to the enterprise, and in 2011 paid Digimedia close to $1 million for the exact-match Box.com — a .net-to-.com upgrade that landed right as the company became simply "Box."'
 keywords: ['box.net', 'box.com', 'box domain name', 'aaron levie', 'dylan smith', 'digimedia', 'scott day', 'domain upgrade', 'startup naming', 'brand naming', 'premium domain', 'exact match domain', 'net to com']
 ---

--- a/content/blog/en/from-bufferapp-com-to-buffer-com.md
+++ b/content/blog/en/from-bufferapp-com-to-buffer-com.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'branding', 'startups', 'domain-upgrades']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: name-change-game-change
+seriesOrder: 9
+format: case-study
 description: 'How Buffer launched in 2010 on BufferApp.com because Buffer.com was taken, then spent 624 days acquiring the exact-match domain — even showing the seller its bank balance — and why a company famous for radical transparency stayed quiet on the one number everyone wanted: the price.'
 keywords: ['bufferapp.com', 'buffer.com', 'buffer domain name', 'domain upgrade', 'joel gascoigne', 'buffer transparency', 'exact match domain', 'startup naming', 'brand naming', 'premium domain', 'domain strategy', 'buffer history', 'domain acquisition', 'category-defining domain']
 ---

--- a/content/blog/en/from-ctrip-com-to-trip-com.md
+++ b/content/blog/en/from-ctrip-com-to-trip-com.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'branding', 'startups', 'domain-upgrades']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: name-change-game-change
+seriesOrder: 10
+format: case-study
 description: 'How Ctrip, China''s largest online travel agency, acquired the premium Trip.com domain in 2017 from a startup called Gogobot, relaunched its global brand around it, and in 2019 renamed the entire parent company Trip.com Group to expand internationally.'
 keywords: ['ctrip.com', 'trip.com', 'ctrip rebrand', 'trip.com group', 'trip.com domain', 'domain upgrade', 'chinese brand global expansion', 'gogobot trip.com', 'james liang ctrip', 'premium travel domain', 'startup naming', 'brand naming', 'domain acquisition']
 ---

--- a/content/blog/en/from-del-icio-us-to-delicious-com.md
+++ b/content/blog/en/from-del-icio-us-to-delicious-com.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'branding', 'startups', 'domain-upgrades']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: name-change-game-change
+seriesOrder: 11
+format: case-study
 description: 'How the pioneering social-bookmarking site launched in 2003 as the famous domain hack "del.icio.us," why those dots became a permanent tax on every mention, and how Yahoo moved it to the cleaner Delicious.com in 2008.'
 keywords: ['del.icio.us', 'delicious.com', 'delicious domain name', 'domain hack', 'joshua schachter', 'social bookmarking', 'yahoo delicious', 'domain upgrade', 'startup naming', 'brand naming', 'premium domain', 'domain strategy', 'ccTLD domain hack', 'category-defining domain']
 ---

--- a/content/blog/en/from-discordapp-com-to-discord-com.md
+++ b/content/blog/en/from-discordapp-com-to-discord-com.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'branding', 'startups', 'domain-upgrades']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: name-change-game-change
+seriesOrder: 12
+format: case-study
 description: 'How Discord launched in 2015 on DiscordApp.com because Discord.com was taken, quietly bought the bare word, and in 2020 made discord.com its primary home — partly for brand cleanliness, partly because the "discordapp.com" vs "discord.com" split was a gift to phishers and malware crews.'
 keywords: ['discordapp.com', 'discord.com', 'discord domain name', 'domain upgrade', 'jason citron', 'discord history', 'cdn.discordapp.com', 'discord phishing', 'startup naming', 'brand naming', 'premium domain', 'domain strategy', 'domain migration']
 ---

--- a/content/blog/en/from-facebook-com-to-meta-com.md
+++ b/content/blog/en/from-facebook-com-to-meta-com.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'branding', 'startups', 'domain-upgrades']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: name-change-game-change
+seriesOrder: 13
+format: case-study
 description: 'How Facebook, Inc. became Meta in October 2021, why Meta.com was already a Zuckerberg-related asset forwarding from a science search engine, and how a separate $60M deal bought the "Meta" name from a Sioux Falls bank — while the Facebook app kept Facebook.com.'
 keywords: ['facebook.com', 'meta.com', 'meta rebrand', 'facebook meta name change', 'meta.org', 'chan zuckerberg initiative meta', 'meta financial group', 'beige key llc', 'metaverse pivot', 'domain acquisition', 'company rebrand', 'premium domain', 'domain strategy', 'parent company rename']
 ---

--- a/content/blog/en/from-getdropbox-com-to-dropbox-com.md
+++ b/content/blog/en/from-getdropbox-com-to-dropbox-com.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'branding', 'startups', 'domain-upgrades']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: name-change-game-change
+seriesOrder: 4
+format: case-study
 description: 'How Dropbox launched on GetDropbox.com because Dropbox.com was taken, fought a trademark and squatting battle, and finally bought the exact-match Dropbox.com for a reported $300,000 in cash.'
 keywords: ['getdropbox.com', 'dropbox.com', 'dropbox domain name', 'drew houston', 'y combinator dropbox', 'domain upgrade', 'startup naming', 'brand naming', 'premium domain', 'domain strategy', 'exact match domain', 'domain acquisition', 'evenflow dropbox']
 ---

--- a/content/blog/en/from-instagr-am-to-instagram-com.md
+++ b/content/blog/en/from-instagr-am-to-instagram-com.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'branding', 'startups', 'domain-upgrades']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: name-change-game-change
+seriesOrder: 14
+format: case-study
 description: 'How Instagram launched in 2010 on the instagr.am domain hack — borrowing Armenia''s .am ccTLD to spell its own name — then paid $100,000 to consolidate on Instagram.com, and what the tradeoffs of a clever ccTLD hack teach founders.'
 keywords: ['instagr.am', 'instagram.com', 'instagram domain name', 'domain hack', 'ccTLD domain hack', '.am armenia domain', 'kevin systrom', 'mike krieger', 'domain upgrade', 'startup naming', 'brand naming', 'premium domain', 'domain strategy', 'instagram history']
 ---

--- a/content/blog/en/from-jambajuice-com-to-jamba-com.md
+++ b/content/blog/en/from-jambajuice-com-to-jamba-com.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'branding', 'startups', 'domain-upgrades']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: name-change-game-change
+seriesOrder: 15
+format: case-study
 description: 'How Jamba Juice spent 29 years explaining itself with the word "Juice," why it dropped that word in 2019 to become simply "Jamba," and the quiet advantage almost no one noticed: the company had owned the exact-match Jamba.com since the 1990s.'
 keywords: ['jambajuice.com', 'jamba.com', 'jamba juice domain name', 'jamba rebrand', 'domain upgrade', 'jamba juice name change', 'kirk perron', 'focus brands jamba', 'exact match domain', 'startup naming', 'brand naming', 'premium domain', 'domain strategy', 'category-defining domain']
 ---

--- a/content/blog/en/from-massdrop-com-to-drop-com.md
+++ b/content/blog/en/from-massdrop-com-to-drop-com.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'branding', 'startups', 'domain-upgrades']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: name-change-game-change
+seriesOrder: 16
+format: case-study
 description: 'How Massdrop spent seven years building an enthusiast group-buying community, then rebranded to Drop in 2019 — quietly acquiring the premium Drop.com domain (asking price once $800,000) before the rename, and why dropping "Mass" mattered.'
 keywords: ['massdrop.com', 'drop.com', 'drop domain name', 'massdrop rebrand', 'domain upgrade', 'group buying', 'mechanical keyboards', 'audiophile community', 'startup naming', 'brand naming', 'premium domain', 'domain strategy', 'exact match domain', 'community commerce']
 ---

--- a/content/blog/en/from-mona-co-to-crypto-com.md
+++ b/content/blog/en/from-mona-co-to-crypto-com.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'branding', 'startups', 'domain-upgrades']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: name-change-game-change
+seriesOrder: 17
+format: case-study
 description: 'How the crypto-card startup Monaco rebranded to Crypto.com in 2018 by buying the ultra-premium Crypto.com domain — registered in 1993 by cryptographer Matt Blaze, who refused to sell for 25 years — in a deal experts valued at up to $10 million.'
 keywords: ['mona.co', 'crypto.com', 'crypto.com domain', 'monaco mco', 'matt blaze crypto.com', 'kris marszalek', 'domain upgrade', 'premium domain', 'category domain', 'domain acquisition', 'crypto rebrand', 'exact match domain', 'branding']
 ---

--- a/content/blog/en/from-mrchewy-com-to-chewy-com.md
+++ b/content/blog/en/from-mrchewy-com-to-chewy-com.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'branding', 'startups', 'domain-upgrades']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: name-change-game-change
+seriesOrder: 18
+format: case-study
 description: 'How a 2011 pet startup launched as "Mr. Chewy" on MrChewy.com, dropped the "Mr." to become Chewy on the exact-match Chewy.com, and why that one-word domain upgrade quietly became part of a brand PetSmart bought for $3.35 billion.'
 keywords: ['mrchewy.com', 'chewy.com', 'chewy domain name', 'mr chewy', 'domain upgrade', 'ryan cohen', 'michael day', 'frank schilling', 'exact match domain', 'startup naming', 'brand naming', 'premium domain', 'domain strategy', 'pet ecommerce']
 ---

--- a/content/blog/en/from-slackhq-com-to-slack-com.md
+++ b/content/blog/en/from-slackhq-com-to-slack-com.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'branding', 'startups', 'domain-upgrades']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: name-change-game-change
+seriesOrder: 5
+format: case-study
 description: 'How Slack launched on SlackHQ.com because someone else had Slack.com, paid a reported $60,000 to buy the exact-match domain, dropped the "HQ" — and why @SlackHQ still survives on social to this day.'
 keywords: ['slackhq.com', 'slack.com', 'slack domain name', 'domain upgrade', 'stewart butterfield', 'tiny speck', 'exact match domain', 'startup naming', 'brand naming', 'premium domain', 'domain strategy', 'slack history', 'domain acquisition', 'category-defining domain']
 ---

--- a/content/blog/en/from-snapchat-com-to-snap-com.md
+++ b/content/blog/en/from-snapchat-com-to-snap-com.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'branding', 'startups', 'domain-upgrades']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: name-change-game-change
+seriesOrder: 6
+format: case-study
 description: 'How Snapchat quietly bought Snap.com from Idealab for a reported $5M in 2014, then in September 2016 renamed itself Snap Inc., "a camera company," and let the short exact-match domain carry an identity bigger than any single app.'
 keywords: ['snapchat.com', 'snap.com', 'snap inc', 'snap domain name', 'domain upgrade', 'startup naming', 'brand naming', 'premium domain', 'domain strategy', 'snapchat rebrand', 'camera company', 'idealab snap.com', 'domain acquisition', 'category-defining domain']
 ---

--- a/content/blog/en/from-teslamotors-com-to-tesla-com.md
+++ b/content/blog/en/from-teslamotors-com-to-tesla-com.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'branding', 'startups', 'domain-upgrades']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: name-change-game-change
+seriesOrder: 2
+format: case-study
 description: 'How Tesla spent over a decade and a reported $11M to move from TeslaMotors.com to the exact-match Tesla.com, and why the domain upgrade arrived right before the company dropped "Motors" from its name.'
 keywords: ['teslamotors.com', 'tesla.com', 'tesla domain name', 'domain upgrade', 'elon musk domain', 'exact match domain', 'startup naming', 'brand naming', 'premium domain', 'domain strategy', 'tesla rebrand', 'tesla motors name change', 'domain acquisition', 'category-defining domain']
 ---

--- a/content/blog/en/from-thefacebook-com-to-facebook-com.md
+++ b/content/blog/en/from-thefacebook-com-to-facebook-com.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'branding', 'startups', 'domain-upgrades']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: name-change-game-change
+seriesOrder: 1
+format: case-study
 description: 'How Facebook dropped TheFacebook.com, bought Facebook.com for $200K, later paid $8.5M for FB.com, and turned domain upgrades into brand infrastructure.'
 keywords: ['thefacebook.com', 'facebook.com', 'fb.com', 'facebook domain name', 'domain upgrade', 'startup naming', 'brand naming', 'premium domain', 'domain strategy', 'facebook history', 'domain acquisition', 'company rebrand', 'category-defining domain']
 ---

--- a/content/blog/en/from-twitter-com-to-x-com.md
+++ b/content/blog/en/from-twitter-com-to-x-com.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'branding', 'startups', 'domain-upgrades']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: name-change-game-change
+seriesOrder: 19
+format: case-study
 description: 'How Elon Musk built X.com in 1999, lost it when PayPal took his old name, bought it back in 2017 for sentimental value, and finally moved a $44B social network onto it — making Twitter.com redirect to X.com.'
 keywords: ['twitter.com', 'x.com', 'twitter rebrand x', 'elon musk x.com', 'x.com history', 'paypal x.com domain', 'twitter to x name change', 'domain redirect', 'domain upgrade', 'single letter domain', 'everything app', 'brand naming', 'premium domain']
 ---

--- a/content/blog/en/from-ubercab-com-to-uber-com.md
+++ b/content/blog/en/from-ubercab-com-to-uber-com.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'branding', 'startups', 'domain-upgrades']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: name-change-game-change
+seriesOrder: 7
+format: case-study
 description: 'How a 2010 cease-and-desist forced UberCab to drop "Cab," how Uber bought Uber.com from Universal Music for 2% equity worth $107K, and why that domain upgrade became one of the most consequential trades in startup history.'
 keywords: ['ubercab.com', 'uber.com', 'uber domain name', 'domain upgrade', 'ubercab cease and desist', 'universal music uber domain', 'startup naming', 'brand naming', 'premium domain', 'domain strategy', 'uber history', 'equity for domain', 'domain acquisition', 'category-defining domain']
 ---

--- a/content/blog/en/from-urbancompass-com-to-compass-com.md
+++ b/content/blog/en/from-urbancompass-com-to-compass-com.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'branding', 'startups', 'domain-upgrades']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: name-change-game-change
+seriesOrder: 20
+format: case-study
 description: 'How Urban Compass launched in 2012 as a New York rental app on UrbanCompass.com, dropped "Urban" in its February 2015 rebrand, and upgraded to the exact-match Compass.com — a domain that had been listed at auction for $1 million — right as it set out to go national.'
 keywords: ['urbancompass.com', 'compass.com', 'compass domain name', 'domain upgrade', 'urban compass rebrand', 'robert reffkin', 'ori allon', 'startup naming', 'brand naming', 'premium domain', 'domain strategy', 'compass real estate', 'real estate startup', 'exact match domain']
 ---

--- a/content/blog/en/google-unveils-universal-commerce-protocol-to-power-the-next-generation-of-ai-shopping-agents.md
+++ b/content/blog/en/google-unveils-universal-commerce-protocol-to-power-the-next-generation-of-ai-shopping-agents.md
@@ -5,6 +5,8 @@ language: en
 tags: ['Infrastructure', 'AI Agents', 'Digital Commerce']
 authors: ['namefiteam']
 draft: false
+cluster: web3-foundations
+format: news
 description: UCP is Google’s bid to power agent-native commerce, letting AI assistants shop and check out across the open web.
 keywords: [‘Universal Commerce Protocol’, ‘UCP’, ‘Google UCP’, ‘AI shopping agents’, ‘AI-powered commerce’, ‘agentic commerce’, ‘AI ecommerce protocol’, ‘conversational commerce’, ‘AI checkout’, ‘future of ecommerce’, ‘agent-based shopping’, ‘open commerce standards’, ‘Google AI’, ‘Gemini AI’, ‘Agent Engine Optimization’]
 ---

--- a/content/blog/en/how-domain-hijacking-actually-happens.md
+++ b/content/blog/en/how-domain-hijacking-actually-happens.md
@@ -5,6 +5,10 @@ language: en
 tags: ['security', 'domains', 'registrar', 'incident-response']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+series: domain-apocalypse
+seriesOrder: 1
+format: case-study
 description: A practical walk-through of the five ways attackers actually take over domains in the real world—social engineering, registrar account compromise, DNS provider takeover, NS hijacks, and expired-domain reclamation—and the specific controls that block each one.
 ogImage: ../../assets/how-domain-hijacking-actually-happens-og.jpg
 keywords: ['domain hijacking', 'domain security', 'registrar lock', 'transfer lock', 'dnssec', 'two factor authentication', 'social engineering', 'dangling dns', 'namefi']

--- a/content/blog/en/how-to-name-your-project.md
+++ b/content/blog/en/how-to-name-your-project.md
@@ -5,6 +5,8 @@ language: en
 tags: ['branding', 'startups', 'guide', 'naming', 'domains']
 authors: ['namefiteam']
 draft: false
+cluster: domain-basics
+format: guide
 description: "A practical, research-backed guide for founders naming a project, product, or company: clear it legally, make it easy to say, generate strong candidates, check it across cultures, and run the searches that matter before you commit."
 ogImage: ../../assets/how-to-name-your-project-og.jpg
 keywords: ['how to name your startup', 'how to name your project', 'how to name a company', 'naming a product', 'brand name ideas', 'choosing a business name', 'domain name selection', 'trademark search', 'brandable domain', 'startup branding', 'pronounceable brand name', 'processing fluency', 'brand naming guide', 'pick a name for your project', 'check domain availability']

--- a/content/blog/en/how-to-sell-a-domain-name-you-own.md
+++ b/content/blog/en/how-to-sell-a-domain-name-you-own.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'guide', 'domain-investing', 'outbound']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: domain-investor-field-guide
+seriesOrder: 1
+format: guide
 description: "A practical, seller-first checklist for pricing a domain, finding likely buyers, handling outreach, avoiding scams, and closing the transfer safely."
 ogImage: ../../assets/how-to-sell-a-domain-name-you-own-og.png
 keywords: ['how to sell a domain name', 'sell domain name', 'domain selling checklist', 'domain valuation', 'domain sale escrow', 'domain transfer', 'domain outbound sales', 'find domain buyers', 'domain negotiation', 'sell a domain you own', 'Namefi Outbound', 'domain aftermarket', 'domain sale process', 'domain sales outreach', 'domain seller guide']

--- a/content/blog/en/how-to-tokenize-your-com.md
+++ b/content/blog/en/how-to-tokenize-your-com.md
@@ -5,6 +5,10 @@ language: en
 tags: ['guide']
 authors: ['namefiteam']
 draft: false
+cluster: domain-tokenization
+series: tokenize-your-com
+seriesOrder: 1
+format: guide
 description: A practical, step-by-step walkthrough for tokenizing a domain you already own — eligibility, wallets, fees, time, and what to expect on each screen. Written for owners, not protocol nerds.
 keywords: ['how to tokenize a domain', 'how to tokenize a .com', 'tokenize my domain', 'tokenize an existing domain', 'tokenize a domain step by step', 'domain tokenization tutorial', 'tokenize .com guide', 'tokenize .xyz', 'tokenize .io', 'namefi tokenize', 'NFT domain how to', 'transfer domain to NFT', 'domain to NFT', 'domain tokenization process', 'tokenized domain setup', 'tokenize ICANN domain']
 ---

--- a/content/blog/en/how-tokenized-marketplaces-replace-escrow.md
+++ b/content/blog/en/how-tokenized-marketplaces-replace-escrow.md
@@ -5,6 +5,10 @@ language: en
 tags: ['guide']
 authors: ['namefiteam']
 draft: false
+cluster: domain-tokenization
+series: tokenize-your-com
+seriesOrder: 3
+format: explainer
 description: How tokenized-domain marketplaces let buyers and sellers settle atomically on-chain — no escrow service, no auth codes, no five-day registrar lock. What replaces each piece of the traditional flow, and what risks shift to other layers.
 keywords: ['domain marketplace blockchain', 'atomic domain transfer', 'tokenized domain marketplace', 'replace domain escrow', 'no escrow domain sale', 'domain sale crypto', 'tokenized domain sale process', 'sell tokenized domain', 'buy tokenized domain', 'on-chain domain sale', 'domain NFT settlement', 'domain marketplace 2026', 'tokenized domain liquidity']
 ---

--- a/content/blog/en/perfect-vs-computational-zero-knowledge.md
+++ b/content/blog/en/perfect-vs-computational-zero-knowledge.md
@@ -5,6 +5,8 @@ language: en
 tags: ['cryptography', 'zero-knowledge', 'zk-snark', 'theory']
 authors: ['namefiteam']
 draft: false
+cluster: web3-foundations
+format: explainer
 description: Zero-knowledge proofs come in three flavors—perfect, statistical, and computational—and the difference matters more than most engineering discussions admit. This post explains each in plain language, why nearly every production ZK system in 2026 is computational, and what that buys and costs.
 ogImage: ../../assets/perfect-vs-computational-zero-knowledge-og.jpg
 keywords: ['zero knowledge proof', 'perfect zero knowledge', 'computational zero knowledge', 'zk snark', 'zk stark', 'cryptography', 'simulator', 'commitment scheme', 'namefi']

--- a/content/blog/en/premium-web3-tlds.md
+++ b/content/blog/en/premium-web3-tlds.md
@@ -5,6 +5,8 @@ language: en
 tags: ['guide']
 authors: ['namefiteam']
 draft: false
+cluster: choosing-a-tld
+format: roundup
 description: A clear 2026 guide to premium Web3 TLDs—what "Web3 TLD" really means, why tokenized ICANN extensions like .com, .ai, and .io beat blockchain-only names, and which domain extensions hold the most value.
 keywords: ['premium web3 tld', 'premium web3 tlds', 'web3 tld', 'web3 tlds', 'premium web3 domains', 'best web3 domains', 'web3 domain extensions', 'web3 domain', 'web3 domains', 'tokenized domain extensions', 'premium domain extensions', 'most valuable domain extensions', 'tokenized tld', 'tokenized domains', 'ICANN tld', 'blockchain tld', 'NFT domain', 'premium .com', 'premium .ai', 'premium .io', 'premium .xyz', 'best domain extensions 2026', 'crypto tld', 'web3 naming', 'domain tld investment', 'namefi']
 ---

--- a/content/blog/en/recovering-a-tokenized-domain-after-wallet-loss.md
+++ b/content/blog/en/recovering-a-tokenized-domain-after-wallet-loss.md
@@ -5,6 +5,10 @@ language: en
 tags: ['guide', 'security']
 authors: ['namefiteam']
 draft: false
+cluster: domain-tokenization
+series: domain-apocalypse
+seriesOrder: 3
+format: case-study
 description: What actually happens if you lose access to the wallet that holds your tokenized domain — and the operational steps to reduce the chance of getting there in the first place. Backups, multisig, hardware wallets, social recovery, and the limits of what any platform can do.
 keywords: ['recover NFT domain', 'lost wallet domain', 'tokenized domain wallet lost', 'wallet recovery domain', 'NFT domain backup', 'tokenized domain hardware wallet', 'multisig tokenized domain', 'tokenized domain key recovery', 'lost seed phrase domain', 'NFT domain security', 'tokenized domain backup', 'domain key management', 'wallet loss recovery']
 ---

--- a/content/blog/en/route402-x402-facilitator-router.md
+++ b/content/blog/en/route402-x402-facilitator-router.md
@@ -5,6 +5,8 @@ language: en
 tags: ['infrastructure', 'payments', 'x402']
 authors: ['namefiteam']
 draft: false
+cluster: web3-foundations
+format: explainer
 description: A multi-tenant router that lets you integrate x402 once and route requests by policy and live signals, without pushing routing logic into your app.
 keywords: ['Route402', 'x402', 'payments routing', 'facilitator router', 'multi-tenant payments', 'RBAC', 'credential encryption', 'capability routing', 'sticky settlement', 'payments infrastructure', 'YAML routing rules']
 ---

--- a/content/blog/en/tax-and-accounting-questions-for-tokenized-domains.md
+++ b/content/blog/en/tax-and-accounting-questions-for-tokenized-domains.md
@@ -5,6 +5,10 @@ language: en
 tags: ['guide']
 authors: ['namefiteam']
 draft: false
+cluster: domain-tokenization
+series: tokenize-your-com
+seriesOrder: 4
+format: faq
 description: A non-advice, plain-language survey of the tax and accounting questions tokenized domain owners commonly ask — cost basis, sales, holding period, business vs personal, gifting, estates. Bring these questions to a real professional.
 keywords: ['NFT domain tax', 'tokenized domain cost basis', 'tokenized domain accounting', 'tokenized domain capital gains', 'sell tokenized domain tax', 'NFT domain capital gains', 'domain NFT accounting', 'domain as asset tax', 'gift tokenized domain tax', 'estate tokenized domain', 'tokenized domain business expense', 'domain tokenization tax questions', 'tax NFT domain US', 'crypto domain tax']
 ---

--- a/content/blog/en/the-12-dollar-minute-someone-owned-google-com.md
+++ b/content/blog/en/the-12-dollar-minute-someone-owned-google-com.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'security', 'dns', 'domain-security']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+series: domain-apocalypse
+seriesOrder: 4
+format: case-study
 description: 'In September 2015, a former Google employee bought google.com through Google Domains for $12 and held administrative control of the world''s most valuable domain for about a minute. The story of Sanmay Ved, the $6,006.13 bounty, and what one minute of ownership reveals about who really controls a domain.'
 keywords: ['google.com domain', 'sanmay ved', 'google domains bug', 'domain security', 'who owns google.com', 'domain hijacking', 'webmaster tools access', 'google bug bounty', '6006.13 reward', 'domain registration vulnerability', 'domain control', 'dns security', 'domain ownership verification']
 ---

--- a/content/blog/en/the-2020-twitter-bitcoin-account-takeover.md
+++ b/content/blog/en/the-2020-twitter-bitcoin-account-takeover.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'security', 'dns', 'domain-security']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+series: domain-apocalypse
+seriesOrder: 5
+format: case-study
 description: 'On July 15, 2020, attackers phoned their way into Twitter, hijacked the verified accounts of Obama, Biden, Musk, Gates, Apple and Uber, and ran a Bitcoin doubling scam — netting about $118,000. A deep-dive on how control of an online identity was stolen, and what it teaches about owning a name.'
 keywords: ['2020 twitter hack', 'twitter bitcoin scam', 'graham ivan clark', 'vishing', 'phone spear phishing', 'social engineering', 'account takeover', 'online identity security', 'verified account hijacking', 'twitter admin tool', 'agent tool', 'insider risk', 'domain security', 'ny dfs twitter report']
 ---

--- a/content/blog/en/the-2024-squarespace-defi-domain-hijacks.md
+++ b/content/blog/en/the-2024-squarespace-defi-domain-hijacks.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'security', 'dns', 'domain-security']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+series: domain-apocalypse
+seriesOrder: 6
+format: case-study
 description: 'In July 2024, a registrar migration from Google Domains to Squarespace turned weak default authentication into a mass attack surface. Attackers hijacked the domains of crypto and DeFi projects — Compound Finance, Celer Network, Pendle, Unstoppable Domains — and pointed them at wallet-drainer phishing sites. Here is how a "seamless" migration created hundreds of unlocked front doors, and what it teaches about registrar security and MFA.'
 keywords: ['squarespace domain hijack', 'google domains migration', 'defi dns hijack', 'compound finance hijack', 'celer network hijack', 'wallet drainer', 'inferno drainer', 'domain security', 'registrar migration', 'mfa multi-factor authentication', 'oauth account takeover', 'dns hijacking', 'crypto phishing']
 ---

--- a/content/blog/en/the-badgerdao-frontend-attack.md
+++ b/content/blog/en/the-badgerdao-frontend-attack.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'security', 'dns', 'domain-security']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+series: domain-apocalypse
+seriesOrder: 7
+format: case-study
 description: 'In December 2021, attackers compromised BadgerDAO''s Cloudflare account and injected one malicious script into its website front-end. The audited smart contracts were never touched — yet ~$120M walked out the door through wallet approvals users signed without knowing. A deep-dive on why the website is part of your security surface.'
 keywords: ['badgerdao hack', 'badgerdao front-end attack', 'cloudflare api key compromise', 'injected script attack', 'web3 front-end security', 'ice phishing', 'increaseAllowance attack', 'token approval exploit', 'dns and domain security', 'cloudflare workers exploit', 'defi security', 'supply chain attack web3', 'website tampering', 'domain security']
 ---

--- a/content/blog/en/the-bitcoin-org-dns-hijack.md
+++ b/content/blog/en/the-bitcoin-org-dns-hijack.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'security', 'dns', 'domain-security']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+series: domain-apocalypse
+seriesOrder: 8
+format: case-study
 description: 'In September 2021, Bitcoin.org — the long-time informational home of Bitcoin run by the pseudonymous operator Cobra — was hijacked at the DNS layer and turned into a fake "double your Bitcoin" giveaway, netting scammers around $17,000 before the site was pulled offline. A Domain Mayday deep-dive into what happened, how, and what it teaches about even crypto-native sites depending on DNS.'
 keywords: ['bitcoin.org', 'bitcoin.org hack', 'dns hijack', 'domain hijacking', 'double your bitcoin scam', 'crypto giveaway scam', 'cobra bitcoin.org', 'cloudflare dns', 'namecheap', 'dns security', 'domain security', 'nameserver hijack', 'whois change attack']
 ---

--- a/content/blog/en/the-curve-finance-dns-hijack.md
+++ b/content/blog/en/the-curve-finance-dns-hijack.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'security', 'dns', 'domain-security']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+series: domain-apocalypse
+seriesOrder: 9
+format: case-study
 description: 'In August 2022, Curve Finance''s smart contracts were untouched — but attackers hijacked the curve.fi domain at its registrar, cloned the site, and drained roughly $570K from users. A deep-dive into the DNS attack on a DeFi front-end, and what it teaches about domain security.'
 keywords: ['curve finance dns hijack', 'curve.fi hijack', 'dns hijacking defi', 'iwantmyname compromise', 'nameserver compromise', 'wallet drainer', 'defi front-end attack', 'domain security', 'dns security', 'crypto phishing', 'cloned website attack', 'registrar account compromise', 'domain mayday']
 ---

--- a/content/blog/en/the-dnspionage-campaign.md
+++ b/content/blog/en/the-dnspionage-campaign.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'security', 'dns', 'domain-security']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+series: domain-apocalypse
+seriesOrder: 10
+format: case-study
 description: 'In late 2018, Cisco Talos disclosed DNSpionage — a campaign later tied to Iranian interests that rewrote government DNS records, rerouted email and VPN traffic to attacker servers, and minted valid TLS certificates to stay invisible. It helped trigger the first emergency directive of its kind from the US government.'
 keywords: ['dnspionage', 'dns hijacking', 'dns redirection', 'cisco talos', 'cisa emergency directive 19-01', 'sea turtle dns', 'iran dns hijacking', 'fireeye dns hijacking', 'lets encrypt certificate abuse', 'dns security', 'domain security', 'nation state cyber espionage', 'mitigate dns infrastructure tampering']
 ---

--- a/content/blog/en/the-dyn-dns-mirai-attack.md
+++ b/content/blog/en/the-dyn-dns-mirai-attack.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'security', 'dns', 'domain-security']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+series: domain-apocalypse
+seriesOrder: 11
+format: case-study
 description: 'On October 21, 2016, a DDoS attack powered by the Mirai IoT botnet hit DNS provider Dyn in three waves, knocking Twitter, Netflix, Reddit, Spotify, GitHub, Airbnb and PayPal offline for hours — a Domain Mayday case study in DNS provider concentration.'
 keywords: ['dyn dns attack', 'mirai botnet', 'october 21 2016 ddos', 'dns ddos attack', 'iot botnet', 'dns provider outage', 'domain security', 'dns single point of failure', 'dyn ddos 2016', 'mirai malware', 'internet outage 2016', 'dns redundancy', 'hacked iot cameras']
 ---

--- a/content/blog/en/the-fox-it-dns-hijack.md
+++ b/content/blog/en/the-fox-it-dns-hijack.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'security', 'dns', 'domain-security']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+series: domain-apocalypse
+seriesOrder: 12
+format: case-study
 description: 'In September 2017, attackers logged into Dutch security firm Fox-IT''s third-party domain registrar, changed its DNS, fraudulently obtained a TLS certificate, and ran a 10-hour man-in-the-middle on client traffic — until Fox-IT caught it and published one of the most transparent post-mortems in the industry.'
 keywords: ['fox-it dns hijack', 'fox-it man in the middle', 'fox-it incident 2017', 'dns hijacking', 'registrar account compromise', 'fraudulent ssl certificate', 'man-in-the-middle attack', 'domain registrar security', 'two-factor authentication dns', 'dnssec', 'registry lock', 'domain security', 'ncc group fox-it']
 ---

--- a/content/blog/en/the-godaddy-multi-year-breach.md
+++ b/content/blog/en/the-godaddy-multi-year-breach.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'security', 'dns', 'domain-security']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+series: domain-apocalypse
+seriesOrder: 13
+format: case-study
 description: 'Between 2020 and 2022, a single threat actor group lived inside GoDaddy''s infrastructure — stealing source code, exposing 1.2 million Managed WordPress customers, and intermittently redirecting customer websites to malicious sites. A deep-dive on registrar concentration risk and what it teaches about single points of failure.'
 keywords: ['godaddy breach', 'godaddy data breach', 'managed wordpress breach', 'registrar security', 'domain security', 'multi-year breach', 'cpanel malware', 'website redirect attack', 'ssl private key exposure', 'sftp password breach', 'sec 10-k cybersecurity', 'registrar concentration risk', 'single point of failure']
 ---

--- a/content/blog/en/the-icann-spear-phishing-breach.md
+++ b/content/blog/en/the-icann-spear-phishing-breach.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'security', 'dns', 'domain-security']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+series: domain-apocalypse
+seriesOrder: 14
+format: case-study
 description: 'In late 2014, ICANN — the body that coordinates the internet domain name system — admitted that a spear-phishing email spoofing its own domain had harvested staff credentials and handed attackers administrative access to the Centralized Zone Data System. A Domain Mayday deep-dive into how the DNS authority itself got phished, what was exposed, and why it still matters.'
 keywords: ['icann breach', 'icann spear phishing', 'czds', 'centralized zone data system', 'dns security', 'domain security', 'spear phishing attack', 'credential phishing', 'zone files', 'iana', 'salted password hashes', 'domain name system breach', 'icann 2014 hack']
 ---

--- a/content/blog/en/the-lenovo-com-dns-hijack.md
+++ b/content/blog/en/the-lenovo-com-dns-hijack.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'security', 'dns', 'domain-security']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+series: domain-apocalypse
+seriesOrder: 15
+format: case-study
 description: 'On February 25, 2015, Lizard Squad hijacked Lenovo.com by compromising the registrar Webnic, rerouting the world''s largest PC maker''s domain to a webcam slideshow and intercepting its email — days after the Superfish scandal. A Domain Mayday deep-dive on why the registrar is your real perimeter.'
 keywords: ['lenovo.com dns hijack', 'lizard squad', 'webnic registrar', 'web commerce communications', 'dns hijacking', 'superfish', 'domain registrar security', 'registrar compromise', 'epp auth code', 'email interception', 'google vietnam hijack', 'domain security', 'registrar lock']
 ---

--- a/content/blog/en/the-malaysia-airlines-dns-hijack.md
+++ b/content/blog/en/the-malaysia-airlines-dns-hijack.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'security', 'dns', 'domain-security']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+series: domain-apocalypse
+seriesOrder: 16
+format: case-study
 description: 'In January 2015, Lizard Squad hijacked the DNS of malaysiaairlines.com and replaced the airline site with a tuxedo-wearing lizard and the taunt "404 — Plane Not Found." No server was breached — the attackers simply changed where the domain pointed. A Domain Mayday deep-dive into how DNS became the airline''s most exposed front door.'
 keywords: ['malaysia airlines dns hijack', 'lizard squad', 'cyber caliphate', '404 plane not found', 'dns hijacking', 'domain hijacking', 'registrar compromise', 'webnic', 'malaysiaairlines.com', 'domain security', 'dns redirection', 'registry lock', 'mh370']
 ---

--- a/content/blog/en/the-manifesto-of-digital-trust.md
+++ b/content/blog/en/the-manifesto-of-digital-trust.md
@@ -7,6 +7,7 @@ language: en
 tags: ['vision', 'digital-trust']
 authors: ['namefiteam']
 draft: false
+format: opinion
 description: A vision statement of D3Serve — why digitizing trust, much like the digitization of information before it, promises a leap in productivity, loss-less precision, lower cost, and automation.
 keywords: ['digital trust', 'D3Serve', 'blockchain', 'web3', 'smart contracts', 'cryptography', 'consensus', 'manifesto', 'vision', 'trust digitization', 'group trust', 'automation']
 ---

--- a/content/blog/en/the-myetherwallet-bgp-dns-attack.md
+++ b/content/blog/en/the-myetherwallet-bgp-dns-attack.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'security', 'dns', 'domain-security']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+series: domain-apocalypse
+seriesOrder: 17
+format: case-study
 description: 'On April 24, 2018, attackers hijacked the internet routing for Amazon Route 53, poisoned DNS answers for myetherwallet.com, and served a phishing clone behind a self-signed certificate — draining roughly $150,000 in Ethereum. A Domain Mayday deep-dive into why DNS rides on a routing layer that trusts by default.'
 keywords: ['myetherwallet', 'bgp hijack', 'dns hijacking', 'amazon route 53', 'route 53 hijack', 'dns security', 'bgp routing security', 'ethereum phishing', 'self-signed certificate', 'enet as10297', 'rpki roa', 'crypto wallet phishing', 'domain security']
 ---

--- a/content/blog/en/the-panix-com-domain-hijack.md
+++ b/content/blog/en/the-panix-com-domain-hijack.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'security', 'dns', 'domain-security']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+series: domain-apocalypse
+seriesOrder: 18
+format: case-study
 description: 'In January 2005, panix.com — the domain of New York''s oldest commercial ISP — was fraudulently transferred to a registrar in Australia using stolen credit cards, knocking web and email offline for days. The auto-approve inter-registrar transfer rules of the era made it possible, and the cleanup reshaped domain-transfer policy.'
 keywords: ['panix.com', 'panix domain hijack', 'domain hijacking', 'inter-registrar transfer', 'Melbourne IT', 'Dotster', 'Fibranet', 'ICANN transfer policy', 'registrar lock', 'clientTransferProhibited', 'domain security', 'DNS hijacking', 'EPP auth code']
 ---

--- a/content/blog/en/the-perl-com-domain-theft.md
+++ b/content/blog/en/the-perl-com-domain-theft.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'security', 'dns', 'domain-security']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+series: domain-apocalypse
+seriesOrder: 19
+format: case-study
 description: 'In late January 2021, perl.com — a decades-old home of the Perl programming community — was stolen via a registrar-level account compromise, transferred through China, pointed at a malware-linked IP, and listed for $190,000. Here is how it happened, how it was recovered, and what it teaches about registrar account security.'
 keywords: ['perl.com', 'perl.com domain theft', 'domain hijacking', 'domain theft', 'registrar account compromise', 'social engineering', 'Network Solutions', 'Tom Christiansen', 'brian d foy', 'DNS hijack', 'domain security', 'account takeover', 'BizCN']
 ---

--- a/content/blog/en/the-sea-turtle-dns-espionage.md
+++ b/content/blog/en/the-sea-turtle-dns-espionage.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'security', 'dns', 'domain-security']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+series: domain-apocalypse
+seriesOrder: 20
+format: case-study
 description: 'How "Sea Turtle," a state-sponsored campaign disclosed by Cisco Talos in 2019, hijacked DNS by compromising registrars, registries, and DNS providers — redirecting governments, ministries, and energy firms to attacker servers, forging valid certificates, and even breaching a national TLD registry.'
 keywords: ['sea turtle dns hijacking', 'cisco talos sea turtle', 'dns hijacking attack', 'state-sponsored dns attack', 'registry compromise', 'registrar compromise', 'dns espionage campaign', 'lets encrypt mitm certificate', 'netnod compromise', 'ics-forth greece ccTLD', 'cisa emergency directive 19-01', 'dns security', 'domain ownership security', 'nation state cyberattack']
 ---

--- a/content/blog/en/the-sex-com-heist-the-forged-letter.md
+++ b/content/blog/en/the-sex-com-heist-the-forged-letter.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'security', 'dns', 'domain-security']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+series: domain-apocalypse
+seriesOrder: 21
+format: case-study
 description: 'In 1995 a con man named Stephen Cohen stole sex.com from rightful owner Gary Kremen with a single forged letter to Network Solutions. The years-long fight to win it back ended in a $65 million judgment, a fugitive in Mexico, and a landmark ruling that domains are property.'
 keywords: ['sex.com', 'domain theft', 'Stephen Cohen', 'Gary Kremen', 'Kremen v. Cohen', 'Network Solutions', 'forged letter', 'domain hijacking', 'Sharon Dimmick letter', 'domain security', 'domain as property', '$65 million judgment', 'domain transfer fraud', 'Domain Mayday']
 ---

--- a/content/blog/en/the-sushiswap-miso-insider-attack.md
+++ b/content/blog/en/the-sushiswap-miso-insider-attack.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'security', 'dns', 'domain-security']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+series: domain-apocalypse
+seriesOrder: 22
+format: case-study
 description: 'In September 2021 an anonymous contractor slipped their own wallet address into SushiSwap''s MISO launchpad front-end via a malicious commit, diverting 864.8 ETH (~$3M) from the Jay Pegs Auto Mart auction. A Domain Mayday deep-dive on code supply chains, front-end trust, and what it teaches about verifiable ownership.'
 keywords: ['sushiswap miso hack', 'miso supply chain attack', 'aristok3', 'jay pegs auto mart', 'defi front-end attack', '864.8 eth', 'software supply chain', 'malicious commit', 'insider threat', 'auctionwallet', 'joseph delong', 'web supply chain security', 'domain security']
 ---

--- a/content/blog/en/the-syrian-electronic-army-nyt-hijack.md
+++ b/content/blog/en/the-syrian-electronic-army-nyt-hijack.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'security', 'dns', 'domain-security']
 authors: ['namefiteam']
 draft: false
+cluster: domain-security
+series: domain-apocalypse
+seriesOrder: 23
+format: case-study
 description: 'On August 27, 2013, the Syrian Electronic Army phished a Melbourne IT reseller, rewrote the DNS records for nytimes.com and Twitter''s domains, and took the New York Times offline for hours. A deep dive into how a registrar-chain weak link became a newspaper''s front-door failure — and what registry locks would have changed.'
 keywords: ['nytimes.com hack', 'syrian electronic army', 'melbourne it', 'dns hijack', 'domain hijacking', 'registrar security', 'reseller phishing', 'registry lock', 'dns records', 'domain name server attack', 'twitter dns 2013', 'domain security', 'serverupdateprohibited']
 ---

--- a/content/blog/en/tokenized-domain-use-cases-2026.md
+++ b/content/blog/en/tokenized-domain-use-cases-2026.md
@@ -5,6 +5,8 @@ language: en
 tags: ['thesis']
 authors: ['namefiteam']
 draft: false
+cluster: domain-tokenization
+format: opinion
 description: A platform-neutral tour of what tokenized domains are actually being used for in 2026 — DeFi lending, leasing, fractional ownership, AI agent identity, and the use cases that haven't quite landed yet.
 keywords: ['tokenized domain use cases', 'DomainFi', 'tokenized domain lending', 'tokenized domain collateral', 'lease tokenized domain', 'fractional domain ownership', 'AI agent domain', 'domain DeFi', 'tokenized domain marketplace', 'tokenized domain applications', 'NFT domain use cases', 'why tokenize domain 2026', 'domain on-chain use', 'tokenized domain examples']
 ---

--- a/content/blog/en/tokenized-domain-vs-web3-domain.md
+++ b/content/blog/en/tokenized-domain-vs-web3-domain.md
@@ -5,6 +5,8 @@ language: en
 tags: ['comparison']
 authors: ['namefiteam']
 draft: false
+cluster: domain-tokenization
+format: comparison
 description: A clear, practical comparison of tokenized ICANN domains (like a tokenized .com) and Web3-native names (like name.eth, name.crypto). When does each one work? Where do they overlap? Why do many people hold both?
 keywords: ['tokenized domain vs web3 domain', 'tokenized domain vs ENS', 'ICANN domain vs ENS', '.com vs .eth', 'tokenized .com vs .crypto', 'tokenized domain vs unstoppable', 'web3 domain comparison', 'ENS vs tokenized domain', 'NFT domain vs ENS', 'web3 naming', 'on-chain naming difference', 'browser support web3 domain', 'web3 domain resolution']
 ---

--- a/content/blog/en/top-domain-trader-forums.md
+++ b/content/blog/en/top-domain-trader-forums.md
@@ -5,6 +5,10 @@ language: en
 tags: ['domains', 'community', 'domain-investing', 'forums']
 authors: ['namefiteam']
 draft: false
+cluster: domain-investing
+series: domain-investor-field-guide
+seriesOrder: 4
+format: roundup
 description: A practical guide to the English-language forums and communities where domain investors actually congregate in 2026 — from NamePros and DNForum to the Twitter/X and Telegram channels that have quietly replaced them.
 ogImage: ../../assets/top-domain-trader-forums-og.jpg
 keywords: ['domain forums', 'namepros', 'dnforum', 'domain investing community', 'domain trader forum', 'domaining', 'domain investor twitter', 'domain telegram groups']

--- a/content/blog/en/top-tlds-to-secure-for-your-accounting-firm.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-accounting-firm.md
@@ -5,6 +5,10 @@ language: en
 tags: ['tld', 'domains']
 authors: ['namefiteam']
 draft: false
+cluster: choosing-a-tld
+series: best-tlds-by-industry
+seriesOrder: 5
+format: guide
 ogImage: ../../assets/top-tlds-to-secure-for-your-accounting-firm-og.jpg
 description: 'The best TLDs to secure for your accounting firm — from restricted .cpa to defensive .com, .net, and .org registrations that protect your brand and build client trust.'
 keywords: ['TLDs for accounting firm', 'accounting firm domain names', '.cpa domain eligibility', 'best domains for accountants', 'defensive domain registration', 'accounting firm brand protection', '.accountant domain', '.tax domain', 'register accounting domains', 'accountant TLD options']

--- a/content/blog/en/top-tlds-to-secure-for-your-business.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-business.md
@@ -5,6 +5,10 @@ language: en
 tags: ['tld', 'domains']
 authors: ['namefiteam']
 draft: false
+cluster: choosing-a-tld
+series: best-tlds-by-industry
+seriesOrder: 4
+format: guide
 ogImage: ../../assets/top-tlds-to-secure-for-your-business-og.jpg
 description: 'Discover the top TLDs to secure for your business, why defensive domain registration protects your brand, and how to register them the smart way.'
 keywords: ['top TLDs to secure for your business', 'best domain extensions for business', 'defensive domain registration', 'brand protection domains', 'business TLDs', 'register a domain for business', 'typosquatting protection', 'domain extensions for companies', 'choose a TLD', 'gTLD vs ccTLD']

--- a/content/blog/en/top-tlds-to-secure-for-your-ecommerce-store.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-ecommerce-store.md
@@ -5,6 +5,10 @@ language: en
 tags: ['tld', 'domains']
 authors: ['namefiteam']
 draft: false
+cluster: choosing-a-tld
+series: best-tlds-by-industry
+seriesOrder: 3
+format: guide
 ogImage: ../../assets/top-tlds-to-secure-for-your-ecommerce-store-og.jpg
 description: 'The top 10 TLDs to secure for your e-commerce store, from .com to .shop and .store, plus a defensive registration strategy to protect your retail brand.'
 keywords: ['top TLDs for e-commerce', 'best domain extensions for online store', 'ecommerce domain names', '.shop domain', '.store domain', 'defensive domain registration', 'retail TLDs', 'brand protection domains', 'typosquatting protection', 'domain extensions for retail', 'register ecommerce domains']

--- a/content/blog/en/top-tlds-to-secure-for-your-fashion-brand.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-fashion-brand.md
@@ -5,6 +5,10 @@ language: en
 tags: ['tld', 'domains']
 authors: ['namefiteam']
 draft: false
+cluster: choosing-a-tld
+series: best-tlds-by-industry
+seriesOrder: 8
+format: guide
 ogImage: ../../assets/top-tlds-to-secure-for-your-fashion-brand-og.jpg
 description: 'A practical guide to the top 10 TLDs to secure for your fashion brand, covering brand protection, retail intent, and defensive domain registration strategy.'
 keywords: ['TLDs for fashion brand', 'fashion brand domain names', 'best TLDs for retail', 'defensive domain registration', 'brand protection domains', '.fashion domain', '.boutique domain', '.shop domain', '.store domain', 'fashion ecommerce domains', 'typosquatting protection', 'trademark domain protection']

--- a/content/blog/en/top-tlds-to-secure-for-your-law-firm.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-law-firm.md
@@ -5,6 +5,10 @@ language: en
 tags: ['tld', 'domains']
 authors: ['namefiteam']
 draft: false
+cluster: choosing-a-tld
+series: best-tlds-by-industry
+seriesOrder: 6
+format: guide
 ogImage: ../../assets/top-tlds-to-secure-for-your-law-firm-og.jpg
 description: 'The top 10 TLDs to secure for your law firm, including why .law is the only legal TLD restricted to verified attorneys (while .esq, .legal, .attorney, and .lawyer are open), plus a defensive strategy.'
 keywords: ['tlds for law firms', 'best domains for lawyers', '.law domain', 'is .esq restricted', 'legal domain extensions', 'defensive domain registration', 'attorney domain names', 'law firm branding', 'restricted legal TLDs', 'register law firm domains']

--- a/content/blog/en/top-tlds-to-secure-for-your-real-estate-business.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-real-estate-business.md
@@ -5,6 +5,10 @@ language: en
 tags: ['tld', 'domains']
 authors: ['namefiteam']
 draft: false
+cluster: choosing-a-tld
+series: best-tlds-by-industry
+seriesOrder: 7
+format: guide
 ogImage: ../../assets/top-tlds-to-secure-for-your-real-estate-business-og.jpg
 description: 'The top 10 TLDs every realtor should secure for brand protection, including .realtor eligibility rules, defensive registration tips, and where to register.'
 keywords: ['tlds for realtors', 'real estate domain names', '.realtor domain', 'best domain extensions for real estate', 'defensive domain registration', 'realtor brand protection', 'real estate TLDs', '.realty domain', 'register real estate domains', 'domain extensions for agents']

--- a/content/blog/en/top-tlds-to-secure-for-your-saas.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-saas.md
@@ -5,6 +5,10 @@ language: en
 tags: ['tld', 'domains']
 authors: ['namefiteam']
 draft: false
+cluster: choosing-a-tld
+series: best-tlds-by-industry
+seriesOrder: 2
+format: guide
 ogImage: ../../assets/top-tlds-to-secure-for-your-saas-og.jpg
 description: 'The top 10 TLDs to secure for your SaaS — from .com and .io to .app and .ai — with defensive registration tips and authoritative registry facts.'
 keywords: ['top TLDs for SaaS', 'best domain extensions for SaaS', 'TLDs to secure for startup', 'defensive domain registration', '.io for SaaS', '.ai domain', '.app domain HTTPS', '.dev domain', 'SaaS domain strategy', 'brand protection domains', 'which TLD to choose', 'register SaaS domains']

--- a/content/blog/en/top-tlds-to-secure-for-your-startup.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-startup.md
@@ -5,6 +5,10 @@ language: en
 tags: ['tld', 'domains']
 authors: ['namefiteam']
 draft: false
+cluster: choosing-a-tld
+series: best-tlds-by-industry
+seriesOrder: 1
+format: guide
 ogImage: ../../assets/top-tlds-to-secure-for-your-startup-og.jpg
 description: 'Discover the top TLDs to secure for your startup, from .com to .ai, plus a defensive registration strategy to protect your brand from typosquatters.'
 keywords: ['top TLDs for startups', 'best domain extensions for startups', 'startup domain names', 'defensive domain registration', 'TLDs to secure', '.com vs .io', '.ai domain for startups', 'brand protection domains', 'tech startup domains', 'how to choose a TLD']

--- a/content/blog/en/what-are-stablecoins.md
+++ b/content/blog/en/what-are-stablecoins.md
@@ -5,6 +5,8 @@ language: 'en'
 tags: ['web3', 'cryptocurrency', 'defi', 'blockchain', 'finance']
 authors: ['namefiteam']
 draft: false
+cluster: web3-foundations
+format: explainer
 description: 'Discover how stablecoins bridge the gap between traditional fiat and cryptocurrency, offering stability for Web3 transactions and domain investing.'
 keywords: ['what are stablecoins', 'stablecoin definition', 'USDT vs USDC', 'crypto volatility', 'web3 payments', 'blockchain domains', 'decentralized finance', 'fiat-collateralized', 'buy domains with crypto', 'namefi']
 ---

--- a/content/blog/en/what-are-tokenized-domains.md
+++ b/content/blog/en/what-are-tokenized-domains.md
@@ -6,6 +6,8 @@ language: en
 tags: ['faq']
 authors: ['namefiteam']
 draft: false
+cluster: domain-tokenization
+format: explainer
 description: Tokenized domains explained in plain language. Learn what a tokenized domain is, how to tokenize a domain, how domain tokenization works, and how tokenized domain ownership differs from traditional domains and Web3 names like ENS.
 keywords: ['tokenized domains', 'tokenized domain', 'tokenize a domain', 'tokenize a domain name', 'tokenize domains', 'tokenize domain', 'tokenizing a domain', 'tokenizing domains', 'domain tokenization', 'tokenization of domains', 'tokenization of a domain', 'domain name tokenization', 'how to tokenize a domain', 'what is a tokenized domain', 'what are tokenized domains', 'tokenized domain ownership explained', 'domain ownership tokens', 'tokenized domain ownership', 'NFT domains', 'NFT domain', 'on-chain domains', 'on-chain domain', 'blockchain domains', 'blockchain domain', 'DNS', 'ICANN domains', 'web3 domains', 'web3 domain', 'domain NFT', 'domain as NFT', 'namefi', 'domain ownership', 'domain asset tokenization', 'Namefi', 'D3', 'D3 Global Inc', 'D3 Inc', 'Doma', 'Doma Protocol', 'Domora', 'WebUnited', 'GBM', 'GBM Auctions', 'ENS', 'Ethereum Name Service', 'Unstoppable Domains', 'Freename', 'GoDaddy', 'Identity Digital', 'Namefi vs ENS', 'Namefi vs Unstoppable Domains', 'Namefi vs D3', 'tokenized domain vs ENS', 'tokenized domain vs web3 domain', 'ICANN domain vs web3 domain', 'compare tokenized domain platforms']
 ---

--- a/content/blog/en/what-are-xstocks.md
+++ b/content/blog/en/what-are-xstocks.md
@@ -6,6 +6,8 @@ language: en
 tags: ['faq', 'domains', 'tokenization']
 authors: ['namefiteam']
 draft: false
+cluster: web3-foundations
+format: explainer
 description: A clear explainer on xStocks—tokenized stocks (tokenized equities) on Solana, issued by Backed Finance. Learn what xStocks are, how they work, how they differ from traditional stocks, the risks, and how they fit the broader real-world-asset (RWA) tokenization trend that tokenized domains are part of.
 keywords: ['xStocks', 'what are xStocks', 'what is xStocks', 'xStocks crypto', 'tokenized stocks', 'tokenized equities', 'was sind xStocks', 'xStocks是什么', '什么是xstocks', 'que son los xStocks', 'unterschied xStocks traditionelle Aktien', 'Backed Finance', 'Kraken xStocks', 'Bybit xStocks', 'Solana tokenized stocks', 'on-chain equities', 'tokenization of real-world assets', 'RWA tokenization', 'tokenized domains', 'domain tokenization', 'Namefi']
 ---

--- a/content/blog/en/what-is-a-tld.md
+++ b/content/blog/en/what-is-a-tld.md
@@ -5,6 +5,8 @@ language: en
 tags: ['guide']
 authors: ['namefiteam']
 draft: false
+cluster: choosing-a-tld
+format: explainer
 description: A TLD is the part of a domain after the last dot, like .com or .io. Learn what a TLD is, the types (gTLD, ccTLD, sponsored, new gTLD, IDN), and how to choose one.
 keywords: ['tld', 'tld meaning', 'what is a tld', 'what is a top level domain', 'top-level domain', 'tld def', 'tld definition', 'que es un tld', "qu'est-ce qu'un tld", 'types of tld', 'gtld vs cctld', 'tld examples', 'what is a domain extension', 'domain extension', 'gTLD', 'ccTLD', 'sponsored TLD', 'new gTLD', 'IDN TLD', 'ICANN', 'IANA', 'domain registry', 'domain registrar', 'choosing a TLD', 'popular TLDs', 'namefi']
 ---

--- a/content/blog/en/what-is-domain.md
+++ b/content/blog/en/what-is-domain.md
@@ -5,6 +5,8 @@ language: en
 tags: ['faq']
 authors: ['namefiteam']
 draft: false
+cluster: domain-basics
+format: explainer
 description: A domain name is the foundation of your online presence.
 keywords: ['domain name', 'DNS', 'Domain Name System', 'IP address', 'web address', 'internet basics', 'domain registration', 'website address', 'URL', 'namefi']
 ---

--- a/content/blog/en/what-is-udrp.md
+++ b/content/blog/en/what-is-udrp.md
@@ -5,6 +5,8 @@ language: en
 tags: ['guide']
 authors: ['namefiteam']
 draft: false
+cluster: domain-basics
+format: explainer
 description: "UDRP explained for domain owners and investors: the three elements a complainant must prove, the process and timeline, outcomes, UDRP vs URS vs court, and how to respond."
 keywords: ['udrp', 'what is udrp', 'udrp process', 'udrp policy', 'udrp complaint', 'udrp verfahren', 'udrp-verfahren', 'uniform domain-name dispute-resolution policy', 'domain dispute', 'domain name dispute', 'cybersquatting', 'reverse domain name hijacking', 'bad faith registration', 'icann udrp', 'wipo', 'urs', 'uniform rapid suspension', 'trademark domain dispute', 'domain investor legal', 'respond to udrp complaint']
 ---

--- a/content/blog/en/why-are-io-domains-expensive.md
+++ b/content/blog/en/why-are-io-domains-expensive.md
@@ -5,6 +5,8 @@ language: 'en'
 tags: ['guide']
 authors: ['namefiteam']
 draft: false
+cluster: choosing-a-tld
+format: explainer
 description: "Why are .io domains so expensive? A clear breakdown of registry wholesale pricing, startup and tech demand, short-name scarcity, renewals, and the new Chagos sovereignty question."
 keywords: ['why are io domains expensive', 'why are .io domains expensive', 'io domain expensive', 'why io domains expensive', 'why are .io domains so expensive', 'why use .io domain', 'io domain for startups', 'io domain price', 'io domain cost', 'io domain renewal cost', 'are io domains worth it', 'io vs com', 'io vs ai domain', 'cost of io domain', 'why io domains cost more', 'io domain pricing explained', 'should I buy an io domain', 'io ccTLD', 'Chagos io domain', 'buy io domain']
 ---

--- a/content/blog/en/why-tokenize-domains.md
+++ b/content/blog/en/why-tokenize-domains.md
@@ -5,6 +5,8 @@ language: en
 tags: ['faq']
 authors: ['namefiteam']
 draft: false
+cluster: domain-tokenization
+format: opinion
 description: This article explains why traditional domains should be tokenized on-chain and highlights the benefits such as clearer ownership, financial composability, and freer, faster trading.
 keywords: ['domain tokenization', 'blockchain domains', 'NFT domains', 'on-chain domains', 'domain ownership', 'decentralized domains', 'domain trading', 'web3 domains', 'smart contracts', 'domain composability', 'DNS tokenization', 'digital assets']
 ---


### PR DESCRIPTION
## Summary / Solution

PR3 of the resources **topic-cluster + series** information architecture — the content half. It backfills the taxonomy frontmatter that the astra schema (namefi-astra#4651) defined, so the upcoming `/topics` and `/series` hub pages have data to group.

Adds four optional fields to **all 83 English blog posts** (`content/blog/en/*.md`):

- **`cluster`** — one of the 6 pillars (`domain-tokenization`, `domain-basics`, `domain-security`, `choosing-a-tld`, `domain-investing`, `web3-foundations`). The 2 brand-POV posts (`the-manifesto-of-digital-trust`, `building-for-people-not-wallets`) intentionally have **no** cluster — they belong to an "Our Thesis" rail, not an SEO pillar.
- **`series` + `seriesOrder`** — 5 editorial series. The two large series are ordered by publish date with the cornerstone seeds pinned first:
  - `name-change-game-change` ×20 (Facebook #1, Tesla #2, then the rest)
  - `domain-apocalypse` ×23 (how-domain-hijacking #1, then the rest; spans the `the-*` incident set + 3 cross-listed posts)
  - `tokenize-your-com` ×4, `best-tlds-by-industry` ×8, `domain-investor-field-guide` ×4
- **`format`** — article type (explainer/guide/comparison/case-study/faq/roundup/opinion/news/analysis), separated from topical `tags`.

Purely additive frontmatter — no body content, no slugs, no URLs changed.

**EN-only by design:** taxonomy is language-independent, so it lives on the English source of truth. Translated locales inherit it via the content loader (a small astra change that ships with the hub pages in PR4), avoiding duplicated taxonomy across ~hundreds of localized files.

## Test plan

- `bun run data:validate` → passes (only pre-existing empty-keyword warnings on unrelated files).
- Verified every written value is in the astra controlled vocabulary (6 clusters / 5 series / 9 formats) and every `seriesOrder` is a positive integer, so astra's build-time `parsePostTaxonomyFields` validator will accept all 83.
- Cluster counts sum to 83 (13/5/24/24/10/5 + 2 no-cluster); series counts 20/23/4/8/4.
- Astra-side build validation runs when the submodule pointer is bumped (follow-up astra PR).

## Claude session summary

- **Main prompts (paraphrased):** locate the Cloudflare/GoDaddy-style topic-cluster work, then build and ship the full taxonomy (schema → backfill → hubs → series → polish) through review and merge, merging each PR once green.
- **This PR (PR3):** derived the live 83-post set (the original 45-post plan plus ~38 newer series posts), assigned cluster/series/format deterministically (explicit map + from-*/the-* patterns), computed seriesOrder by date with seeds pinned, and validated against the schema vocabulary.
- **Redaction:** no secrets/credentials/PII involved.
- **Timestamps (ISO-8601 UTC):** design agreed 2026-06-17; backfill committed `2026-06-19T18:49:31Z`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only changes to markdown frontmatter with no runtime or routing logic in this PR; wrong values would surface at build/hub time rather than affecting production behavior immediately.
> 
> **Overview**
> Adds **taxonomy frontmatter only** to all **83** English posts under `content/blog/en/` — no body edits, slug changes, or URL updates.
> 
> Each post now gets a **`format`** (explainer, guide, comparison, case-study, etc.) separate from topical **`tags`**. **81** posts also get a **`cluster`** pillar (`domain-tokenization`, `domain-basics`, `domain-security`, `choosing-a-tld`, `domain-investing`, `web3-foundations`); **`the-manifesto-of-digital-trust`** and **`building-for-people-not-wallets`** stay without `cluster` for a brand “Our Thesis” rail.
> 
> **59** posts are wired into **five editorial series** via **`series`** + **`seriesOrder`**: `name-change-game-change` (20 startup domain-upgrade stories), `domain-apocalypse` (23 security incident pieces), `tokenize-your-com` (4), `best-tlds-by-industry` (8), and `domain-investor-field-guide` (4). This is the content backfill for upcoming `/topics` and `/series` hubs and schema validation in astra.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc07166516e3c5304dcaa684920d0e43185bec15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->