### PR TITLE
fix(careers): drop placeholder validThrough so job posts never expire

### DIFF
--- a/content/careers/en/build-design-2026-05.md
+++ b/content/careers/en/build-design-2026-05.md
@@ -8,7 +8,6 @@ draft: false
 type: job
 description: Drive product decisions, user experience, and design quality with AI agents as core collaborators in your daily workflow.
 employmentType: FULL_TIME
-validThrough: '2026-08-31'
 team: Product
 location: Remote (Worldwide)
 compensation: Competitive pay with equity

--- a/content/careers/en/build-dns-2026-05.md
+++ b/content/careers/en/build-dns-2026-05.md
@@ -8,7 +8,6 @@ draft: false
 type: job
 description: Lead technical depth in DNS and EPP domains while contributing broadly as a full-stack engineer, amplified by AI-assisted development workflows.
 employmentType: FULL_TIME
-validThrough: '2026-08-31'
 team: Engineering
 location: Remote (Worldwide)
 compensation: Competitive pay with equity

--- a/content/careers/en/build-gen-2026-05.md
+++ b/content/careers/en/build-gen-2026-05.md
@@ -8,7 +8,6 @@ draft: false
 type: job
 description: Deliver end-to-end product features across the entire stack, leveraging AI agents and the latest AI tooling to ship faster and smarter.
 employmentType: FULL_TIME
-validThrough: '2026-08-31'
 team: Engineering
 location: Remote (Worldwide)
 compensation: Competitive pay with equity

--- a/content/careers/en/build-nontraditional-2026-05.md
+++ b/content/careers/en/build-nontraditional-2026-05.md
@@ -8,7 +8,6 @@ draft: false
 type: job
 description: Turn high AI and agent fluency into real product output — no conventional background required, just the ability to deliver with cutting-edge tools.
 employmentType: FULL_TIME
-validThrough: '2026-08-31'
 team: Engineering
 location: Remote (Worldwide)
 compensation: Competitive pay with equity

--- a/content/careers/en/build-security-2026-05.md
+++ b/content/careers/en/build-security-2026-05.md
@@ -8,7 +8,6 @@ draft: false
 type: job
 description: Apply security-first thinking across everything we ship while contributing as a hands-on engineer, amplified by AI-augmented tooling.
 employmentType: FULL_TIME
-validThrough: '2026-08-31'
 team: Engineering
 location: Remote (Worldwide)
 compensation: Competitive pay with equity

--- a/content/careers/en/build-web3-2026-05.md
+++ b/content/careers/en/build-web3-2026-05.md
@@ -8,7 +8,6 @@ draft: false
 type: job
 description: Bring deep Web3 and smart contract expertise across the full product surface, using AI agents to accelerate on-chain and off-chain delivery.
 employmentType: FULL_TIME
-validThrough: '2026-08-31'
 team: Engineering
 location: Remote (Worldwide)
 compensation: Competitive pay with equity

--- a/content/careers/en/conn-bd-2026-05.md
+++ b/content/careers/en/conn-bd-2026-05.md
@@ -8,7 +8,6 @@ draft: false
 type: job
 description: Build relationships, identify opportunities, and expand our reach across industries and ecosystems, powered by AI-driven research and outreach workflows.
 employmentType: FULL_TIME
-validThrough: '2026-08-31'
 team: Business
 location: Remote (Worldwide)
 compensation: Competitive pay with equity

--- a/content/careers/en/conn-community-2026-05.md
+++ b/content/careers/en/conn-community-2026-05.md
@@ -8,7 +8,6 @@ draft: false
 type: job
 description: Grow and nurture our community with meaningful engagement, using AI agents to stay responsive and surface insights at scale.
 employmentType: FULL_TIME
-validThrough: '2026-08-31'
 team: Community
 location: Remote (Worldwide)
 compensation: Competitive pay with equity

--- a/content/careers/en/conn-creative-2026-05.md
+++ b/content/careers/en/conn-creative-2026-05.md
@@ -8,7 +8,6 @@ draft: false
 type: job
 description: Create content and media that amplify our brand across every channel, using the latest AI and generative tools to move at creative speed.
 employmentType: FULL_TIME
-validThrough: '2026-08-31'
 team: Marketing
 location: Remote (Worldwide)
 compensation: Competitive pay with equity

--- a/content/careers/en/intern-builder-2026-05.md
+++ b/content/careers/en/intern-builder-2026-05.md
@@ -8,7 +8,6 @@ draft: false
 type: job
 description: Contribute to real product work from day one, learning fast with AI agents and the latest development tools alongside experienced builders.
 employmentType: INTERN
-validThrough: '2026-08-31'
 team: Engineering
 location: Remote (Worldwide)
 compensation: Generally unpaid with exceptions

--- a/content/careers/en/intern-connector-2026-05.md
+++ b/content/careers/en/intern-connector-2026-05.md
@@ -8,7 +8,6 @@ draft: false
 type: job
 description: Get hands-on experience in content, partnerships, or community while developing AI-agent-powered communication and outreach skills.
 employmentType: INTERN
-validThrough: '2026-08-31'
 team: Marketing
 location: Remote (Worldwide)
 compensation: Generally unpaid with exceptions


### PR DESCRIPTION
## Summary / Solution

All 11 career job posts shared a single hardcoded `validThrough: '2026-08-31'`.
These are evergreen, always-open roles, so that placeholder makes Google flag
**every** posting as expired/invalid the moment the date passes — a
self-inflicted, simultaneous outage of the JobPosting rich result.

Per Google's [JobPosting guidance](https://developers.google.com/search/docs/appearance/structured-data/job-posting),
`validThrough` should be **omitted** when a posting doesn't expire. This PR
removes the field from all 11 job posts. The astra renderer
(`job-posting-jsonld.tsx`) already emits `validThrough` only when present, so no
renderer change is needed for this part.

**Part 1 of 2.** The companion PR in `namefi-astra` fixes the primary "invalid"
cause (the `description` field + location format). After this merges, the astra
submodule pointer (`apps/resources/data`) is bumped to pick up this content.

## Test plan

- `grep -rc '^validThrough:' content/careers/en/` → 0 across all job files.
- Diff is exactly 11 single-line deletions (`-validThrough: '2026-08-31'`); no
  other frontmatter touched.
- After deploy + submodule bump, re-run a live careers URL through Google's Rich
  Results Test to confirm no expired/`validThrough` warning.

## Claude session summary

Main prompts (paraphrased, not verbatim):
- Investigate why Google considers all Namefi job postings invalid; inspect the
  namefi-resources careers content and the astra JobPosting renderer.
- Confirmed all 11 posts share one placeholder `validThrough`; user decided
  these roles never expire — remove the field.
- Ship the fixes as PRs following the repo's bare-repo + worktree conventions.

No keys, secrets, tokens, or PII were involved in this change.

- Session work started: `2026-06-20T03:58:27Z`
- Last updated (this commit): `2026-06-20T04:07Z`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only frontmatter edits with no application logic or security impact.
> 
> **Overview**
> Removes the shared **`validThrough: '2026-08-31'`** frontmatter line from all **11** English career job posts so evergreen roles are not modeled with a fake expiry date.
> 
> That aligns with Google JobPosting guidance to omit `validThrough` when a listing does not expire, avoiding rich-result warnings once the placeholder date passes. No other frontmatter or body copy changes; structured data is expected to omit the field when it is absent in content (renderer handled elsewhere).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 344a3843e9e24eac5b7e46a584c299b299f08240. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->