### PR TITLE
chore(ci): make blog translation workflow manual-only

### DIFF
--- a/.github/workflows/translate-blog.yml
+++ b/.github/workflows/translate-blog.yml
@@ -1,11 +1,9 @@
 name: Translate Blog Posts
 
+# Manual-only: translations run on demand (Actions → Run workflow), not
+# automatically on every English-content merge. English-first is the workflow;
+# translate a batch deliberately after the English posts are reviewed.
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'content/blog/en/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary / Solution

Makes the **Translate Blog Posts** workflow **manual-only**: removes the `push` trigger (which fired on every `content/blog/en/**` merge to `main`) and keeps `workflow_dispatch`.

**Why:** the auto-trigger opened an unreviewed Gemini-translation PR (#76) the moment English content merged — the opposite of the intended **English-first** flow. Now translations run deliberately, on demand (Actions → "Translate Blog Posts" → Run workflow), after the English posts are reviewed.

No change to the translation script itself — only when it runs.

## Test plan
- YAML is valid; `on: workflow_dispatch:` is the only trigger.
- After merge: editing `content/blog/en/**` no longer auto-opens a translation PR; the workflow is still runnable from the Actions tab / `gh workflow run translate-blog.yml`.

## Claude session summary (redacted)
- **Prompt (paraphrased):** stop the GitHub bot from auto-opening translation PRs; chose the manual-only option.
- **Change:** drop the `push` trigger from `translate-blog.yml`, keep `workflow_dispatch`.
- **Timestamp (UTC):** committed 2026-06-21.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger-only change with no impact on runtime app code or translation script behavior.
> 
> **Overview**
> **Translate Blog Posts** no longer runs when English blog content merges to `main`. The `push` trigger on `content/blog/en/**` is removed; the workflow only starts via **workflow_dispatch** (Actions → Run workflow).
> 
> Comments in `translate-blog.yml` document the **English-first** intent: run translations deliberately after English posts are reviewed, instead of auto-opening Gemini translation PRs on every merge. Translation steps, secrets, and PR creation are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dacb1d5e594051942e2c41b0d1b17241bbb9dd32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->