### PR TITLE
fix(content): positive 1-based seriesOrder for domain-flipping-skills (unblocks astra build)

### DIFF
--- a/content/blog/en/domain-flipping.md
+++ b/content/blog/en/domain-flipping.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 draft: true
 cluster: domain-investing
 series: domain-flipping-skills
-seriesOrder: 0
+seriesOrder: 1
 format: guide
 description: "What domain flipping really is — buying names low and selling high — and the stack of skills behind the trade, from sourcing and appraisal to selling."
 ogImage: ../../assets/domain-flipping-og.jpg

--- a/content/blog/en/domain-hacks-explained.md
+++ b/content/blog/en/domain-hacks-explained.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 draft: true
 cluster: domain-investing
 series: domain-flipping-skills
-seriesOrder: 12
+seriesOrder: 3
 format: explainer
 description: "What a domain hack is, why brands and flippers prize these clever short domains, the ccTLD risks behind them, and how to value one."
 ogImage: ../../assets/domain-hacks-explained-og.jpg

--- a/content/blog/en/how-to-value-a-domain-name.md
+++ b/content/blog/en/how-to-value-a-domain-name.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 draft: true
 cluster: domain-investing
 series: domain-flipping-skills
-seriesOrder: 6
+seriesOrder: 2
 format: guide
 description: "How to appraise a domain name: the value factors, what appraisal tools get wrong, how to read comparable sales, and the end-user vs reseller spread."
 ogImage: ../../assets/how-to-value-a-domain-name-og.jpg


### PR DESCRIPTION
Fixes the astra resources build break: `Post "domain-flipping" has an invalid "seriesOrder": 0`. The astra loader requires a positive 1-based `seriesOrder`; standalone `data:validate` does not check this, so it slipped through in #75. Renumbers the 3 Wave-1 posts to contiguous `1` (hub) / `2` (appraisal) / `3` (flagship). Unblocks the submodule-bump build (astra #4747).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontmatter-only metadata fix with no runtime or content changes beyond series ordering.
> 
> **Overview**
> Fixes the **astra** resources build failure caused by `domain-flipping` using **`seriesOrder: 0`**, which the astra post loader rejects (positive 1-based values only).
> 
> Updates frontmatter on three Wave-1 **`domain-flipping-skills`** drafts so ordering is contiguous: **`domain-flipping`** → `1` (hub), **`how-to-value-a-domain-name`** → `2`, **`domain-hacks-explained`** → `3`. No article body changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0204b8498bac944f1bd3887dd7fd41498121c075. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->