### PR TITLE
feat(skills): programmatic link-suggest + English-first cross-link workflow

### DIFF
--- a/.agents/skills/cross-link/SKILL.md
+++ b/.agents/skills/cross-link/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cross-link
-description: Cross-link Namefi resources content whenever a blog post, glossary term, TLD page, or partner page is created or updated. Wires the new/updated page outward to relevant existing pages, pulls inbound links from existing pages that should mention it, and keeps every internal link pointing at its own-locale counterpart across all 7 locales. Use this in the namefi-resources repository after writing or editing any content under content/{blog,glossary,tld,partners}/<locale>/.
+description: Cross-link Namefi resources content whenever a blog post, glossary term, TLD page, or partner page is created or updated. Discovers links on the ENGLISH page only (outbound to relevant existing pages, inbound from pages that should mention it), then propagates the same links into every translated locale (each pointing at its own-locale counterpart) and keeps all internal links locale-correct. Use this in the namefi-resources repository after writing or editing any content under content/{blog,glossary,tld,partners}/.
 ---
 
 # cross-link
@@ -10,13 +10,21 @@ internal link graph dense, relevant, and locale-correct. Cross-linking is what t
 isolated articles into a hub-and-spoke knowledge base that readers (and LLM/Google crawlers)
 traverse — and it is the easiest thing to forget when you add or edit one page.
 
-A cross-link pass works in **three directions**:
+**English is the single source of truth for the link graph.** Do all link *discovery* on the `en`
+pages only — the other six locales are *derived* from English, not cross-linked independently. This
+mirrors how the repo already works: `en` is the translation source, `translate-blog.yml` regenerates
+locales on `content/blog/en/**` changes, and the renderer doesn't auto-localize hrefs.
 
-1. **Outbound** — the page you just touched should link *out* to relevant existing pages
-   (glossary terms it mentions, the cluster cornerstone, series siblings, related TLDs).
-2. **Inbound** — existing pages that naturally reference this page's topic should link *in* to it.
-3. **i18n parity** — every internal link must point at the **same-locale** counterpart that
-   actually exists, and the link set should mirror across all translated counterparts.
+So a pass works in **two discovery directions on English, then one derivation step**:
+
+1. **Outbound** (en) — the `en` page you just touched should link *out* to relevant existing `en`
+   pages (glossary terms it mentions, the cluster cornerstone, series siblings, related TLDs).
+2. **Inbound** (en) — existing `en` pages that naturally reference this page's topic should link
+   *in* to it.
+3. **Derive locales** — propagate the English link set into the translated counterparts (via
+   re-translation or by mirroring the same links), then run the auditor's `--fix` so every internal
+   link points at its **own-locale** counterpart (falling back to `/en/...` only where no counterpart
+   exists). You never hand-discover links in a non-English page.
 
 ## Repository conventions (read before editing)
 
@@ -64,57 +72,92 @@ It classifies every internal link:
 The full repo currently carries thousands of `LOCALE_MISMATCH` links — do **not** mass-fix the whole
 repo in a content PR. Scope `--fix` to the paths you actually created or edited.
 
+## Candidate discovery: `link-suggest.ts`
+
+Don't read every article by hand to find what should link where — that part is mechanical too.
+`link-suggest.ts` precomputes link candidates from frontmatter (`keywords`, `cluster`, `series`) and
+glossary/TLD canonical terms, so your job narrows to **judging and placing** a ranked shortlist
+instead of *discovering* from scratch.
+
+```bash
+bun .agents/skills/cross-link/link-suggest.ts content/blog/<locale>/<slug>.md   # all candidates
+bun .agents/skills/cross-link/link-suggest.ts --min=high <path>                 # only rock-solid term hits
+bun .agents/skills/cross-link/link-suggest.ts --json <path>                     # machine-readable
+```
+
+It prints three locale-scoped sections for the target page:
+
+- **`OUTBOUND`** — existing pages whose canonical term appears in the target's prose (with `L<line>`
+  and the exact anchor phrase). Every phrase resolves to **one** canonical destination: a glossary
+  title head (`escrow`), its parenthetical (`Non-Fungible Token`), or a TLD extension (`.com`).
+  Already-linked targets are excluded.
+- **`INBOUND`** — existing same-locale pages whose prose mentions the target's distinctive term and
+  don't link back yet (`file:line`). This is the big win when you add a **glossary term**: it finds
+  every post that should now link to it.
+- **`RELATED`** — pages ranked by shared `keywords` + same `cluster`/`series`. No exact anchor; you
+  decide whether/where to weave them in.
+
+Confidence is `high` (canonical term), `medium` (sole-owner keyword), or `low`. It is a **candidate
+generator**, not an editor — it never writes files, and some `medium`/`low` noise is expected and
+cheap to reject. Use `--min=high` for a near-zero-noise pass. Matching is boundary-aware for Latin
+scripts and substring for CJK/RTL.
+
 ## Workflow
 
-### 0. Scope the change
-Identify exactly what was created/updated and limit the blast radius to it plus its direct neighbors.
+### 0. Scope the change — on English
+Identify what was created/updated and resolve it to its **English** page(s). All discovery happens on
+`en`; the translated counterparts are derived in step 3, never cross-linked independently.
 ```bash
 git -C <repo> status --porcelain content/   # what changed
 ```
-For each changed file note: collection, locale, slug, `title`, `description`, `keywords`, and
-`cluster`/`series` if present. If only the `en` page changed, the translated counterparts still need
-the same link treatment (step 4).
+For each changed `en` file note: collection, slug, `title`, `description`, `keywords`, and
+`cluster`/`series` if present. (If a non-`en` page changed on its own, map back to its `en`
+counterpart and discover there.)
 
-### 1. Outbound — link the changed page → existing pages
-Read the body. For each concept the prose *already mentions*, add a link to the existing page for it,
-on the **first meaningful mention only**:
-- **Glossary terms** — the highest-value, lowest-risk links. If the prose says "escrow", "registrar",
-  "auth code", "NFT", etc. and `content/glossary/<locale>/<that-slug>.md` exists, link the first
-  mention: `[escrow](/<locale>/glossary/escrow/)`.
-- **Related blog posts** — especially the **cluster cornerstone** and **same-series** posts (from the
-  `cluster`/`series` frontmatter), plus any post whose topic the prose references.
-- **TLD pages** — when the prose discusses a specific extension (`.com`, `.io`, `.ai`) and a
-  `content/tld/<locale>/<ext>.md` page exists.
-
-Rules: only link where the prose *naturally* names the concept (never invent a sentence to host a
-link); link the first occurrence, not every one; keep anchor text the natural words already there.
-
-### 2. Inbound — link existing pages → the changed page
-Find existing pages (same locale) whose prose references the new page's topic but don't yet link to
-it, and add a link at the first natural mention. Search by the new page's title/keywords:
+### 1. Outbound — link the English page → existing English pages
+Run the suggester on the **`en`** file and work its `OUTBOUND` + `RELATED` sections:
 ```bash
-grep -rniE "<keyword1>|<keyword2>" content/<collection>/<locale> --include='*.md'
+bun .agents/skills/cross-link/link-suggest.ts content/<collection>/en/<slug>.md
 ```
-Prioritize: the cluster cornerstone, same-cluster/same-series posts, then anything that mentions the
-topic. **Cap the blast radius** — pick the few most relevant pages (typically ≤5), not every file
-that happens to contain the word. Report what you linked and what you deliberately skipped.
+Take the `high` (and good `medium`) `OUTBOUND` hits and add the link at the cited line, on the
+**first meaningful mention only**. Glossary terms are the highest-value, lowest-risk links
+(`[escrow](/en/glossary/escrow/)`); also pull in the **cluster cornerstone** / **same-series** posts
+surfaced under `RELATED`, and TLD pages for any specific extension the prose discusses.
 
-### 3. i18n parity — fix locale and broken links
-```bash
-bun .agents/skills/cross-link/link-audit.ts <changed-paths>          # review
-bun .agents/skills/cross-link/link-audit.ts --fix <changed-paths>    # auto-repoint mismatches
-```
-Then resolve any `BROKEN` findings by hand. Leave `CROSS_LOCALE` fallbacks as-is unless you're also
-adding the missing translation in this change.
+Rules: only link where the prose *naturally* names the concept (the suggester gives you the line —
+confirm it reads naturally; never invent a sentence to host a link); link the first occurrence, not
+every one; keep anchor text the natural words already there; reject `medium`/`low` noise.
 
-### 4. Mirror across locale counterparts
-Every outbound/inbound link you added in the `en` page must be reflected in each translated
-counterpart that exists — pointing at *that locale's own* counterpart of the target (or the `/en/...`
-fallback when the target isn't translated in that locale). The same applies to inbound links: if you
-added a back-link in the `en` post, add it in the translated copies of that same post. Re-run the
-auditor on the translated paths to confirm parity.
+### 2. Inbound — link existing English pages → the English page
+The suggester's `INBOUND` section lists `en` pages that mention the changed page's distinctive term
+but don't link back — each with `file:line`. Add a link at the cited mention. (Or run the suggester
+directly against a glossary term you just added to find every `en` post that should now cite it.)
+Prioritize the cluster cornerstone and same-cluster/same-series posts. **Cap the blast radius** — pick
+the few most relevant pages (typically ≤5), not every match. Report what you linked and skipped.
 
-### 5. Validate
+### 3. Derive the other locales — apply the SAME links, per language
+For **every** English page you edited in steps 1–2 (the changed page *and* any `en` pages that gained
+an inbound link), propagate the new links into all translated counterparts. Don't re-discover — apply
+the exact same link set, localized. Two paths:
+
+- **Re-translate (preferred, mechanical).** Regenerate the locale files from the now-linked English so
+  the markdown links carry over verbatim, then repoint prefixes:
+  ```bash
+  bun scripts/translate-blog.ts        # or dispatch the translate-blog workflow
+  bun .agents/skills/cross-link/link-audit.ts --fix content/<collection>/<L>/<slug>.md   # per locale
+  ```
+- **Mirror by hand (no re-translation).** In each existing locale counterpart of the article, find the
+  translated term and link it. The anchor in locale `L` is the **target page's title in `L`** (e.g.
+  `/en/glossary/smart-contract/` → zh title `智能合约`, so link `智能合约` → `/zh/glossary/smart-contract/`).
+  Point at `/<L>/<collection>/<slug>/` when that counterpart exists, else fall back to `/en/...`.
+
+Either way, finish with `link-audit.ts --fix` on the locale paths to guarantee every link points at
+its own-locale counterpart, and resolve any `BROKEN` by hand. Concretely: if the English edit linked
+`smart contract` → `/en/glossary/smart-contract/`, then the `zh`, `ar`, `de`, … counterparts of that
+article must each link their translation of the term to their own glossary page (or the `/en/` fallback
+where no counterpart exists).
+
+### 4. Validate
 ```bash
 TMPDIR=/private/tmp bun run data:validate
 TMPDIR=/private/tmp bun run lint:mdx
@@ -131,7 +174,10 @@ bun .agents/skills/cross-link/link-audit.ts <changed-paths>   # 0 broken on touc
   counterpart; fall back to `/en/...` only when no local counterpart exists.
 - **Idempotent.** Re-running must not double-link an already-linked first mention.
 - **Scope `--fix` to changed paths**, never the whole repo, inside a content PR.
-- **English first, then mirror** into translations. Never force-push.
+- **Discover on English only; apply to every locale.** Never scan each locale for candidates. Find
+  the link on `en`, then mirror it into every translated counterpart (own-locale target, or `/en/`
+  fallback). `bun .agents/skills/cross-link/link-suggest.ts --term=/en/<coll>/<slug>/` prints each
+  locale's anchor term + counterpart href for the mirror. Never force-push.
 
 ## Report format
 Summarize the pass as a short table: per touched file, the **outbound** links added, **inbound**

--- a/.agents/skills/cross-link/link-suggest.ts
+++ b/.agents/skills/cross-link/link-suggest.ts
@@ -1,0 +1,413 @@
+#!/usr/bin/env bun
+/**
+ * cross-link candidate suggester for namefi-resources.
+ *
+ * The auditor (link-audit.ts) is fully deterministic but only inspects links
+ * that ALREADY exist. This script does the other half — it *discovers* link
+ * candidates mechanically from frontmatter + prose, so the model only has to
+ * judge and place a ranked shortlist instead of reading every article to find
+ * candidates from scratch.
+ *
+ * For a target page it emits three sections, all scoped to the page's locale:
+ *
+ *   OUTBOUND  Existing pages whose canonical term appears in the target's
+ *             prose (unlinked) -> link OUT from the target.
+ *   INBOUND   Existing pages whose prose mentions the target's distinctive
+ *             term/keyword (and don't link to it yet) -> add a back-link THERE.
+ *   RELATED   Pages ranked by shared keywords + same cluster/series. No exact
+ *             anchor; the model decides whether/where to weave them in.
+ *
+ * Precision model — every phrase resolves to ONE canonical destination:
+ *   - A glossary title head ("Escrow") / its parenthetical ("Non-Fungible
+ *     Token") and a tld extension (".com") are TERMS — unique, high confidence.
+ *   - A keyword phrase is only used when the page is its SOLE owner (or the
+ *     keyword is in the page's slug); keywords shared across many pages are
+ *     dropped from OUTBOUND/INBOUND (too generic to point anywhere) and instead
+ *     power the RELATED ranking.
+ *
+ * Matching is locale-scoped, boundary-aware for Latin scripts, substring for
+ * CJK/RTL. It is a CANDIDATE generator: some noise is expected and cheap to
+ * reject — it never edits files. Confidence is high | medium | low.
+ *
+ * Usage (from the namefi-resources repo root):
+ *   bun .agents/skills/cross-link/link-suggest.ts content/blog/en/<slug>.md
+ *   bun .agents/skills/cross-link/link-suggest.ts content/glossary/en/escrow.md
+ *   bun .agents/skills/cross-link/link-suggest.ts --json <path>
+ *   bun .agents/skills/cross-link/link-suggest.ts --min=medium <path>   # hide low
+ *   bun .agents/skills/cross-link/link-suggest.ts --no-inbound <path>
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import matter from 'gray-matter';
+
+const LOCALES = ['en', 'es', 'de', 'fr', 'zh', 'ar', 'hi'] as const;
+const COLLECTIONS = ['blog', 'glossary', 'tld', 'partners'] as const;
+const COLLECTION_PRIORITY: Record<string, number> = { glossary: 0, blog: 1, tld: 2, partners: 3 };
+const MD_EXT = new Set(['.md', '.mdx']);
+const CONFIDENCE_RANK = { high: 3, medium: 2, low: 1 } as const;
+type Confidence = keyof typeof CONFIDENCE_RANK;
+
+// --- args ------------------------------------------------------------------
+const argv = process.argv.slice(2);
+const JSON_OUT = argv.includes('--json');
+const NO_INBOUND = argv.includes('--no-inbound');
+const NO_RELATED = argv.includes('--no-related');
+const minArg = (argv.find((a) => a.startsWith('--min=')) ?? '--min=low').slice(6);
+const MIN: Confidence = (['high', 'medium', 'low'].includes(minArg) ? minArg : 'low') as Confidence;
+const termArgs = argv.filter((a) => a.startsWith('--term=')).map((a) => a.slice(7));
+const targets = argv.filter((a) => !a.startsWith('--'));
+if (targets.length === 0 && termArgs.length === 0) {
+  console.error('Usage: bun .agents/skills/cross-link/link-suggest.ts <content/...md> [--json] [--min=medium] [--no-inbound] [--no-related]');
+  console.error('       bun .agents/skills/cross-link/link-suggest.ts --term=/en/glossary/<slug>/   # per-locale anchor + counterpart table');
+  process.exit(2);
+}
+const passConf = (c: Confidence) => CONFIDENCE_RANK[c] >= CONFIDENCE_RANK[MIN];
+
+// --- locate content/ root --------------------------------------------------
+function findContentRoot(): string {
+  for (const c of [path.join(process.cwd(), 'content'), path.resolve(import.meta.dir, '../../..', 'content')]) {
+    try {
+      if (statSync(c).isDirectory()) return c;
+    } catch {
+      /* next */
+    }
+  }
+  console.error('Could not find content/. Run from the namefi-resources repo root.');
+  process.exit(2);
+}
+const CONTENT_ROOT = findContentRoot();
+const REPO_ROOT = path.dirname(CONTENT_ROOT);
+const rel = (f: string) => path.relative(REPO_ROOT, f).split(path.sep).join('/');
+
+// --- page model ------------------------------------------------------------
+type Page = {
+  file: string;
+  collection: (typeof COLLECTIONS)[number];
+  locale: (typeof LOCALES)[number];
+  slug: string;
+  href: string;
+  title: string;
+  keywords: string[];
+  cluster?: string;
+  series?: string;
+  raw: string;
+  prose: string;
+};
+
+function stripNonProse(raw: string): string {
+  let body = raw.replace(/^---\n[\s\S]*?\n---\n?/, (m) => m.replace(/[^\n]/g, ' '));
+  body = body.replace(/^([ \t]*)(`{3,}|~{3,})[\s\S]*?\n\1\2[^\n]*$/gm, (m) => m.replace(/[^\n]/g, ' '));
+  body = body.replace(/`[^`\n]*`/g, (m) => m.replace(/[^\n]/g, ' '));
+  return body;
+}
+
+function listMarkdown(dir: string): string[] {
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const e of entries) {
+    const full = path.join(dir, e);
+    if (statSync(full).isDirectory()) out.push(...listMarkdown(full));
+    else if (MD_EXT.has(path.extname(e))) out.push(full);
+  }
+  return out;
+}
+
+function loadPage(file: string): Page | null {
+  const r = rel(file);
+  const m = r.match(/^content\/([^/]+)\/([^/]+)\/(.+)\.(md|mdx)$/);
+  if (!m) return null;
+  const [, collection, locale, slug] = m;
+  if (!(COLLECTIONS as readonly string[]).includes(collection)) return null;
+  if (!(LOCALES as readonly string[]).includes(locale)) return null;
+  const raw = readFileSync(file, 'utf8');
+  let data: Record<string, unknown> = {};
+  try {
+    data = matter(raw).data as Record<string, unknown>;
+  } catch {
+    /* keep empty */
+  }
+  const keywords = Array.isArray(data.keywords)
+    ? (data.keywords as unknown[]).filter((k): k is string => typeof k === 'string').map((k) => k.trim())
+    : [];
+  return {
+    file,
+    collection: collection as Page['collection'],
+    locale: locale as Page['locale'],
+    slug,
+    href: `/${locale}/${collection}/${slug}/`,
+    title: typeof data.title === 'string' ? data.title.trim() : '',
+    keywords,
+    cluster: typeof data.cluster === 'string' ? data.cluster : undefined,
+    series: typeof data.series === 'string' ? data.series : undefined,
+    raw,
+    prose: stripNonProse(raw),
+  };
+}
+
+const corpus: Page[] = [];
+for (const collection of COLLECTIONS)
+  for (const locale of LOCALES)
+    for (const f of listMarkdown(path.join(CONTENT_ROOT, collection, locale))) {
+      const p = loadPage(f);
+      if (p) corpus.push(p);
+    }
+const byHref = new Map(corpus.map((p) => [p.href, p]));
+
+// keyword owner counts, per locale, for "sole owner" distinctiveness test
+const kwOwners = new Map<string, Set<string>>(); // `${locale}::${kw}` -> set of hrefs
+for (const p of corpus)
+  for (const k of p.keywords) {
+    const key = `${p.locale}::${k.toLowerCase()}`;
+    if (!kwOwners.has(key)) kwOwners.set(key, new Set());
+    kwOwners.get(key)!.add(p.href);
+  }
+
+// --- phrase derivation -----------------------------------------------------
+const GENERIC = new Set(['domain', 'domains', 'crypto', 'web3', 'guide', 'seo', 'namefi', 'blockchain', 'name']);
+const isLatin = (s: string) => /[A-Za-z]/.test(s) && /^[\x00-\x7f]*$/.test(s);
+const slugified = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+
+function keywordOk(k: string): boolean {
+  const t = k.trim();
+  if (t.length < 3 || GENERIC.has(t.toLowerCase())) return false;
+  if (isLatin(t)) return t.includes(' ') || t.length >= 6;
+  return t.length >= 3;
+}
+
+type Phrase = { text: string; confidence: Confidence; kind: 'term' | 'keyword' };
+
+// Distinctive phrases: terms (always) + keywords the page solely owns or that
+// live in its slug. Generic shared keywords are excluded — they can't point
+// at a unique destination.
+function distinctivePhrases(p: Page): Phrase[] {
+  const out: Phrase[] = [];
+  const seen = new Set<string>();
+  const add = (text: string, confidence: Confidence, kind: Phrase['kind']) => {
+    const t = text.trim();
+    const key = t.toLowerCase();
+    if (t.length < 2 || seen.has(key)) return;
+    seen.add(key);
+    out.push({ text: t, confidence, kind });
+  };
+  if (p.collection === 'glossary' && p.title) {
+    const head = p.title.split('(')[0].trim().replace(/[?.!,;:]+$/, '');
+    add(head, head.length <= 3 ? 'medium' : 'high', 'term');
+    const paren = p.title.match(/\(([^)]+)\)/);
+    if (paren) add(paren[1], 'high', 'term');
+  }
+  if (p.collection === 'tld') add(`.${p.slug}`, 'high', 'term');
+  for (const k of p.keywords) {
+    if (!keywordOk(k)) continue;
+    const sole = (kwOwners.get(`${p.locale}::${k.toLowerCase()}`)?.size ?? 0) <= 1;
+    const inSlug = slugified(p.slug).includes(slugified(k));
+    if (sole || inSlug) add(k, 'medium', 'keyword');
+  }
+  return out;
+}
+
+// --- global outbound index: phrase -> single canonical target --------------
+type Resolved = { target: Page; confidence: Confidence; kind: Phrase['kind'] };
+const outboundIndex = new Map<string, Resolved>(); // `${locale}::${lowerphrase}` -> resolved
+function betterThan(a: Resolved, b: Resolved): boolean {
+  if (a.kind !== b.kind) return a.kind === 'term';
+  if (CONFIDENCE_RANK[a.confidence] !== CONFIDENCE_RANK[b.confidence]) return CONFIDENCE_RANK[a.confidence] > CONFIDENCE_RANK[b.confidence];
+  return COLLECTION_PRIORITY[a.target.collection] < COLLECTION_PRIORITY[b.target.collection];
+}
+for (const p of corpus)
+  for (const ph of distinctivePhrases(p)) {
+    const key = `${p.locale}::${ph.text.toLowerCase()}`;
+    const cand: Resolved = { target: p, confidence: ph.confidence, kind: ph.kind };
+    const cur = outboundIndex.get(key);
+    if (!cur || betterThan(cand, cur)) outboundIndex.set(key, cand);
+  }
+
+// --- matching helpers ------------------------------------------------------
+const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+function buildScanner(phrases: string[]): { latin?: RegExp; other?: RegExp } {
+  const latin = phrases.filter(isLatin).sort((a, b) => b.length - a.length);
+  const other = phrases.filter((p) => !isLatin(p)).sort((a, b) => b.length - a.length);
+  const res: { latin?: RegExp; other?: RegExp } = {};
+  if (latin.length) res.latin = new RegExp(`(?<![A-Za-z0-9])(?:${latin.map(escapeRe).join('|')})(?![A-Za-z0-9])`, 'gi');
+  if (other.length) res.other = new RegExp(`(?:${other.map(escapeRe).join('|')})`, 'g');
+  return res;
+}
+
+function lineOf(prose: string, index: number): number {
+  let line = 1;
+  for (let i = 0; i < index && i < prose.length; i++) if (prose[i] === '\n') line++;
+  return line;
+}
+
+function alreadyLinks(fromRaw: string, toHref: string): boolean {
+  const noSlash = toHref.replace(/\/$/, '');
+  return fromRaw.includes(`](${toHref}`) || fromRaw.includes(`](${noSlash}`);
+}
+
+// First occurrence (lowest index) of each distinct matched phrase in prose.
+function scanFirst(prose: string, scanner: { latin?: RegExp; other?: RegExp }): Map<string, number> {
+  const first = new Map<string, number>();
+  for (const re of [scanner.latin, scanner.other]) {
+    if (!re) continue;
+    for (const m of prose.matchAll(re)) {
+      const key = m[0].toLowerCase();
+      const idx = m.index ?? 0;
+      if (!first.has(key) || idx < first.get(key)!) first.set(key, idx);
+    }
+  }
+  return first;
+}
+
+// --- per-target analysis ---------------------------------------------------
+type OutboundCand = { target: string; phrase: string; line: number; confidence: Confidence };
+type InboundCand = { source: string; phrase: string; line: number; confidence: Confidence };
+type RelatedCand = { target: string; score: number; reasons: string[] };
+type Report = { target: string; outbound: OutboundCand[]; inbound: InboundCand[]; related: RelatedCand[] };
+
+function analyze(target: Page): Report {
+  // OUTBOUND — scan target prose against the global phrase index for its locale.
+  const localePhrases = [...outboundIndex.keys()].filter((k) => k.startsWith(`${target.locale}::`)).map((k) => k.slice(target.locale.length + 2));
+  const scanner = buildScanner(localePhrases);
+  const matched = scanFirst(target.prose, scanner);
+  const outByTarget = new Map<string, OutboundCand>();
+  for (const [phrase, idx] of matched) {
+    const res = outboundIndex.get(`${target.locale}::${phrase}`);
+    if (!res || res.target.href === target.href) continue;
+    if (!passConf(res.confidence) || alreadyLinks(target.raw, res.target.href)) continue;
+    const cand: OutboundCand = { target: res.target.href, phrase, line: lineOf(target.prose, idx), confidence: res.confidence };
+    const prev = outByTarget.get(res.target.href);
+    if (!prev || CONFIDENCE_RANK[cand.confidence] > CONFIDENCE_RANK[prev.confidence] || cand.line < prev.line) outByTarget.set(res.target.href, cand);
+  }
+  const outbound = [...outByTarget.values()].sort((a, b) => CONFIDENCE_RANK[b.confidence] - CONFIDENCE_RANK[a.confidence] || a.line - b.line);
+
+  // INBOUND — scan every same-locale page for the target's distinctive phrases.
+  const inbound: InboundCand[] = [];
+  const myPhrases = distinctivePhrases(target).filter((p) => passConf(p.confidence));
+  if (!NO_INBOUND && myPhrases.length) {
+    const myScanner = buildScanner(myPhrases.map((p) => p.text));
+    const confOf = new Map(myPhrases.map((p) => [p.text.toLowerCase(), p.confidence]));
+    for (const other of corpus) {
+      if (other.locale !== target.locale || other.href === target.href) continue;
+      if (alreadyLinks(other.raw, target.href)) continue;
+      const hits = scanFirst(other.prose, myScanner);
+      if (hits.size === 0) continue;
+      let best: { phrase: string; idx: number; conf: Confidence } | null = null;
+      for (const [phrase, idx] of hits) {
+        const conf = confOf.get(phrase) ?? 'medium';
+        if (!best || CONFIDENCE_RANK[conf] > CONFIDENCE_RANK[best.conf] || (CONFIDENCE_RANK[conf] === CONFIDENCE_RANK[best.conf] && idx < best.idx)) best = { phrase, idx, conf };
+      }
+      if (best) inbound.push({ source: rel(other.file), phrase: best.phrase, line: lineOf(other.prose, best.idx), confidence: best.conf });
+    }
+    inbound.sort((a, b) => CONFIDENCE_RANK[b.confidence] - CONFIDENCE_RANK[a.confidence] || a.source.localeCompare(b.source));
+  }
+
+  // RELATED — keyword overlap + cluster/series boost.
+  const related: RelatedCand[] = [];
+  if (!NO_RELATED) {
+    const mine = new Set(target.keywords.map((k) => k.toLowerCase()));
+    for (const other of corpus) {
+      if (other.locale !== target.locale || other.href === target.href) continue;
+      const shared = other.keywords.filter((k) => mine.has(k.toLowerCase()));
+      let score = shared.length;
+      const reasons: string[] = [];
+      if (shared.length) reasons.push(`${shared.length} shared keyword(s): ${shared.slice(0, 3).join(', ')}`);
+      if (target.cluster && other.cluster === target.cluster) {
+        score += 2;
+        reasons.push(`same cluster: ${target.cluster}`);
+      }
+      if (target.series && other.series === target.series) {
+        score += 3;
+        reasons.push(`same series: ${target.series}`);
+      }
+      if (score > 0) related.push({ target: other.href, score, reasons });
+    }
+    related.sort((a, b) => b.score - a.score);
+  }
+
+  return { target: target.href, outbound, inbound, related: related.slice(0, 8) };
+}
+
+// --- --term mode: per-locale anchor + counterpart table -------------------
+// Supports the "apply the link in every language" step: discovery is English
+// only, but the link must be mirrored into each locale. For a link target this
+// prints, per locale, whether a counterpart exists, its href, and the anchor
+// text to look for (that locale's title of the target).
+if (termArgs.length) {
+  const tty = process.stdout.isTTY;
+  const c = (code: string, s: string) => (tty ? `\x1b[${code}m${s}\x1b[0m` : s);
+  for (const t of termArgs) {
+    let collection: string | undefined;
+    let slug: string | undefined;
+    const hrefM = t.match(/^\/[a-z]{2}\/([a-z]+)\/(.+?)\/?$/);
+    if (hrefM) {
+      collection = hrefM[1];
+      slug = hrefM[2];
+    } else {
+      const p = loadPage(path.resolve(process.cwd(), t));
+      if (p) {
+        collection = p.collection;
+        slug = p.slug;
+      }
+    }
+    if (!collection || !(COLLECTIONS as readonly string[]).includes(collection) || !slug) {
+      console.error(`--term: cannot resolve "${t}" to a <collection>/<slug>`);
+      continue;
+    }
+    const enPage = byHref.get(`/en/${collection}/${slug}/`);
+    console.log(c('1', `\n# ${collection}/${slug}  `) + (enPage ? c('2', `(en: ${enPage.title})`) : c('31', '(no en page!)')));
+    for (const locale of LOCALES) {
+      const pg = byHref.get(`/${locale}/${collection}/${slug}/`);
+      if (pg) console.log(`  ${locale}  ${c('32', '✓')}  /${locale}/${collection}/${slug}/  ${c('2', '→ anchor:')} "${pg.title}"`);
+      else console.log(`  ${locale}  ${c('31', '✗')}  ${c('2', `no counterpart → keep /en/${collection}/${slug}/`)}`);
+    }
+  }
+  console.log('');
+  process.exit(0);
+}
+
+// --- run -------------------------------------------------------------------
+const reports: Report[] = [];
+for (const t of targets) {
+  const abs = path.resolve(process.cwd(), t);
+  const page = corpus.find((p) => p.file === abs) ?? loadPage(abs);
+  if (!page) {
+    console.error(`skip (not a content page): ${t}`);
+    continue;
+  }
+  reports.push(analyze(page));
+}
+
+if (JSON_OUT) {
+  console.log(JSON.stringify(reports, null, 2));
+} else {
+  const tty = process.stdout.isTTY;
+  const c = (code: string, s: string) => (tty ? `[${code}m${s}[0m` : s);
+  const cc: Record<Confidence, string> = { high: '32', medium: '33', low: '2' };
+  for (const r of reports) {
+    const tp = byHref.get(r.target);
+    console.log(c('1', `\n# ${r.target}  ${tp ? c('2', `(${tp.title})`) : ''}`));
+
+    console.log(c('1', `\nOUTBOUND — add links IN this page (it mentions these existing pages):`));
+    if (r.outbound.length === 0) console.log('  (none)');
+    for (const o of r.outbound) console.log(`  ${c(cc[o.confidence], o.confidence.padEnd(6))} L${o.line}  "${o.phrase}"  → ${o.target}`);
+
+    if (!NO_INBOUND) {
+      console.log(c('1', `\nINBOUND — add a back-link to this page FROM (they mention its terms):`));
+      if (r.inbound.length === 0) console.log('  (none)');
+      for (const i of r.inbound) console.log(`  ${c(cc[i.confidence], i.confidence.padEnd(6))} ${i.source}:L${i.line}  "${i.phrase}"`);
+    }
+
+    if (!NO_RELATED) {
+      console.log(c('1', `\nRELATED — by keyword/cluster/series (model picks which to weave in):`));
+      if (r.related.length === 0) console.log('  (none)');
+      for (const rc of r.related) console.log(`  ${c('36', `score ${rc.score}`)}  ${rc.target}  ${c('2', `— ${rc.reasons.join('; ')}`)}`);
+    }
+  }
+  console.log('');
+}

--- a/.agents/skills/cross-link/link-suggest.ts
+++ b/.agents/skills/cross-link/link-suggest.ts
@@ -102,6 +102,9 @@ function stripNonProse(raw: string): string {
   // Blank whole markdown links/images so phrases can't match inside existing
   // anchor text or href slugs — we only want to surface UNLINKED prose mentions.
   body = body.replace(/!?\[[^\]\n]*\]\([^)\n]*\)/g, (m) => m.replace(/[^\n]/g, ' '));
+  // Blank ATX heading lines — the skill forbids links in headings, so a term in
+  // a heading must not be cited as the first mention.
+  body = body.replace(/^#{1,6} .*$/gm, (m) => m.replace(/[^\n]/g, ' '));
   return body;
 }
 

--- a/.agents/skills/cross-link/link-suggest.ts
+++ b/.agents/skills/cross-link/link-suggest.ts
@@ -207,9 +207,10 @@ function distinctivePhrases(p: Page): Phrase[] {
     out.push({ text: t, confidence, kind });
   };
   if (p.collection === 'glossary' && p.title) {
-    const head = p.title.split('(')[0].trim().replace(/[?.!,;:]+$/, '');
+    // Handle ASCII (Escrow) and full-width CJK （非同质化代币） parentheses.
+    const head = p.title.split(/[(（]/)[0].trim().replace(/[?.!,;:，。！？；：]+$/, '');
     add(head, head.length <= 3 ? 'medium' : 'high', 'term');
-    const paren = p.title.match(/\(([^)]+)\)/);
+    const paren = p.title.match(/[(（]([^)）]+)[)）]/);
     if (paren) add(paren[1], 'high', 'term');
   }
   if (p.collection === 'tld') add(`.${p.slug}`, 'high', 'term');
@@ -223,8 +224,8 @@ function distinctivePhrases(p: Page): Phrase[] {
 }
 
 // --- global outbound index: phrase -> single canonical target --------------
-type Resolved = { target: Page; confidence: Confidence; kind: Phrase['kind'] };
-const outboundIndex = new Map<string, Resolved>(); // `${locale}::${lowerphrase}` -> resolved
+type Resolved = { target: Page; confidence: Confidence; kind: Phrase['kind']; phrase: string };
+const outboundIndex = new Map<string, Resolved>(); // `${locale}::${lowerphrase}` -> resolved (phrase keeps original case)
 function betterThan(a: Resolved, b: Resolved): boolean {
   if (a.kind !== b.kind) return a.kind === 'term';
   if (CONFIDENCE_RANK[a.confidence] !== CONFIDENCE_RANK[b.confidence]) return CONFIDENCE_RANK[a.confidence] > CONFIDENCE_RANK[b.confidence];
@@ -233,7 +234,7 @@ function betterThan(a: Resolved, b: Resolved): boolean {
 for (const p of corpus)
   for (const ph of distinctivePhrases(p)) {
     const key = `${p.locale}::${ph.text.toLowerCase()}`;
-    const cand: Resolved = { target: p, confidence: ph.confidence, kind: ph.kind };
+    const cand: Resolved = { target: p, confidence: ph.confidence, kind: ph.kind, phrase: ph.text };
     const cur = outboundIndex.get(key);
     if (!cur || betterThan(cand, cur)) outboundIndex.set(key, cand);
   }
@@ -287,7 +288,10 @@ type Report = { target: string; outbound: OutboundCand[]; inbound: InboundCand[]
 
 function analyze(target: Page): Report {
   // OUTBOUND — scan target prose against the global phrase index for its locale.
-  const localePhrases = [...outboundIndex.keys()].filter((k) => k.startsWith(`${target.locale}::`)).map((k) => k.slice(target.locale.length + 2));
+  // Build the scanner from ORIGINAL-case phrases (not the lowercased keys) so
+  // mixed-script phrases like "ccTLD 市场份额" — routed to the case-sensitive
+  // non-Latin regex — still match the original casing in prose.
+  const localePhrases = [...outboundIndex.entries()].filter(([k]) => k.startsWith(`${target.locale}::`)).map(([, v]) => v.phrase);
   const scanner = buildScanner(localePhrases);
   const matched = scanFirst(target.prose, scanner);
   const outByTarget = new Map<string, OutboundCand>();

--- a/.agents/skills/cross-link/link-suggest.ts
+++ b/.agents/skills/cross-link/link-suggest.ts
@@ -353,9 +353,20 @@ function analyze(target: Page): Report {
 // only, but the link must be mirrored into each locale. For a link target this
 // prints, per locale, whether a counterpart exists, its href, and the anchor
 // text to look for (that locale's title of the target).
+type TermLocale = { locale: string; exists: boolean; href: string; anchor: string | null };
+type TermResult = { collection: string; slug: string; enTitle: string | null; locales: TermLocale[] };
+const termResults: TermResult[] = [];
 if (termArgs.length) {
-  const tty = process.stdout.isTTY;
-  const c = (code: string, s: string) => (tty ? `\x1b[${code}m${s}\x1b[0m` : s);
+  // The mirror anchor is the page's canonical matched phrase(s) — the same
+  // distinctive terms OUTBOUND/INBOUND link on — NOT the full frontmatter title
+  // (a TLD title is a long explainer, but the linked token is ".com").
+  const anchorFor = (pg: Page): string => {
+    const ph = distinctivePhrases(pg);
+    const terms = ph.filter((p) => p.kind === 'term').map((p) => p.text);
+    if (terms.length) return terms.join(' / ');
+    const all = ph.map((p) => p.text);
+    return all.length ? all.slice(0, 3).join(' / ') : pg.title;
+  };
   for (const t of termArgs) {
     let collection: string | undefined;
     let slug: string | undefined;
@@ -374,18 +385,34 @@ if (termArgs.length) {
       console.error(`--term: cannot resolve "${t}" to a <collection>/<slug>`);
       continue;
     }
-    const enPage = byHref.get(`/en/${collection}/${slug}/`);
-    console.log(c('1', `\n# ${collection}/${slug}  `) + (enPage ? c('2', `(en: ${enPage.title})`) : c('31', '(no en page!)')));
-    for (const locale of LOCALES) {
-      const pg = byHref.get(`/${locale}/${collection}/${slug}/`);
-      if (pg) console.log(`  ${locale}  ${c('32', '✓')}  /${locale}/${collection}/${slug}/  ${c('2', '→ anchor:')} "${pg.title}"`);
-      else console.log(`  ${locale}  ${c('31', '✗')}  ${c('2', `no counterpart → keep /en/${collection}/${slug}/`)}`);
-    }
+    const coll = collection;
+    const sl = slug;
+    const enPage = byHref.get(`/en/${coll}/${sl}/`);
+    const locales: TermLocale[] = LOCALES.map((locale) => {
+      const pg = byHref.get(`/${locale}/${coll}/${sl}/`);
+      return { locale, exists: !!pg, href: `/${locale}/${coll}/${sl}/`, anchor: pg ? anchorFor(pg) : null };
+    });
+    termResults.push({ collection: coll, slug: sl, enTitle: enPage ? enPage.title : null, locales });
   }
-  console.log('');
-  // Only stop here if there are no positional file targets; otherwise fall
-  // through and also run candidate analysis for those files.
-  if (targets.length === 0) process.exit(0);
+  if (!JSON_OUT) {
+    const tty = process.stdout.isTTY;
+    const c = (code: string, s: string) => (tty ? `\x1b[${code}m${s}\x1b[0m` : s);
+    for (const tr of termResults) {
+      console.log(c('1', `\n# ${tr.collection}/${tr.slug}  `) + (tr.enTitle ? c('2', `(en: ${tr.enTitle})`) : c('31', '(no en page!)')));
+      for (const l of tr.locales) {
+        if (l.exists) console.log(`  ${l.locale}  ${c('32', '✓')}  ${l.href}  ${c('2', '→ anchor:')} "${l.anchor}"`);
+        else console.log(`  ${l.locale}  ${c('31', '✗')}  ${c('2', `no counterpart → keep /en/${tr.collection}/${tr.slug}/`)}`);
+      }
+    }
+    console.log('');
+  }
+  // With no positional file targets this is the whole run: emit term results
+  // (as JSON when requested) and stop. Otherwise fall through and also analyze
+  // the files; --json then emits a single combined { terms, reports } document.
+  if (targets.length === 0) {
+    if (JSON_OUT) console.log(JSON.stringify(termResults, null, 2));
+    process.exit(0);
+  }
 }
 
 // --- run -------------------------------------------------------------------
@@ -401,7 +428,7 @@ for (const t of targets) {
 }
 
 if (JSON_OUT) {
-  console.log(JSON.stringify(reports, null, 2));
+  console.log(JSON.stringify(termResults.length ? { terms: termResults, reports } : reports, null, 2));
 } else {
   const tty = process.stdout.isTTY;
   const c = (code: string, s: string) => (tty ? `\x1b[${code}m${s}\x1b[0m` : s);

--- a/.agents/skills/cross-link/link-suggest.ts
+++ b/.agents/skills/cross-link/link-suggest.ts
@@ -99,6 +99,9 @@ function stripNonProse(raw: string): string {
   let body = raw.replace(/^---\n[\s\S]*?\n---\n?/, (m) => m.replace(/[^\n]/g, ' '));
   body = body.replace(/^([ \t]*)(`{3,}|~{3,})[\s\S]*?\n\1\2[^\n]*$/gm, (m) => m.replace(/[^\n]/g, ' '));
   body = body.replace(/`[^`\n]*`/g, (m) => m.replace(/[^\n]/g, ' '));
+  // Blank whole markdown links/images so phrases can't match inside existing
+  // anchor text or href slugs — we only want to surface UNLINKED prose mentions.
+  body = body.replace(/!?\[[^\]\n]*\]\([^)\n]*\)/g, (m) => m.replace(/[^\n]/g, ' '));
   return body;
 }
 
@@ -282,7 +285,7 @@ function analyze(target: Page): Report {
     if (!passConf(res.confidence) || alreadyLinks(target.raw, res.target.href)) continue;
     const cand: OutboundCand = { target: res.target.href, phrase, line: lineOf(target.prose, idx), confidence: res.confidence };
     const prev = outByTarget.get(res.target.href);
-    if (!prev || CONFIDENCE_RANK[cand.confidence] > CONFIDENCE_RANK[prev.confidence] || cand.line < prev.line) outByTarget.set(res.target.href, cand);
+    if (!prev || CONFIDENCE_RANK[cand.confidence] > CONFIDENCE_RANK[prev.confidence] || (CONFIDENCE_RANK[cand.confidence] === CONFIDENCE_RANK[prev.confidence] && cand.line < prev.line)) outByTarget.set(res.target.href, cand);
   }
   const outbound = [...outByTarget.values()].sort((a, b) => CONFIDENCE_RANK[b.confidence] - CONFIDENCE_RANK[a.confidence] || a.line - b.line);
 
@@ -387,7 +390,7 @@ if (JSON_OUT) {
   console.log(JSON.stringify(reports, null, 2));
 } else {
   const tty = process.stdout.isTTY;
-  const c = (code: string, s: string) => (tty ? `[${code}m${s}[0m` : s);
+  const c = (code: string, s: string) => (tty ? `\x1b[${code}m${s}\x1b[0m` : s);
   const cc: Record<Confidence, string> = { high: '32', medium: '33', low: '2' };
   for (const r of reports) {
     const tp = byHref.get(r.target);

--- a/.agents/skills/cross-link/link-suggest.ts
+++ b/.agents/skills/cross-link/link-suggest.ts
@@ -91,6 +91,7 @@ type Page = {
   keywords: string[];
   cluster?: string;
   series?: string;
+  draft: boolean;
   raw: string;
   prose: string;
 };
@@ -151,6 +152,7 @@ function loadPage(file: string): Page | null {
     keywords,
     cluster: typeof data.cluster === 'string' ? data.cluster : undefined,
     series: typeof data.series === 'string' ? data.series : undefined,
+    draft: data.draft === true || data.draft === 'true',
     raw,
     prose: stripNonProse(raw),
   };
@@ -161,7 +163,10 @@ for (const collection of COLLECTIONS)
   for (const locale of LOCALES)
     for (const f of listMarkdown(path.join(CONTENT_ROOT, collection, locale))) {
       const p = loadPage(f);
-      if (p) corpus.push(p);
+      // Exclude drafts: they must never become link targets or inbound sources.
+      // An explicitly-passed draft target is still analyzed via the loadPage
+      // fallback in the run loop below.
+      if (p && !p.draft) corpus.push(p);
     }
 const byHref = new Map(corpus.map((p) => [p.href, p]));
 
@@ -378,7 +383,9 @@ if (termArgs.length) {
     }
   }
   console.log('');
-  process.exit(0);
+  // Only stop here if there are no positional file targets; otherwise fall
+  // through and also run candidate analysis for those files.
+  if (targets.length === 0) process.exit(0);
 }
 
 // --- run -------------------------------------------------------------------

--- a/.agents/skills/cross-link/link-suggest.ts
+++ b/.agents/skills/cross-link/link-suggest.ts
@@ -257,14 +257,18 @@ function alreadyLinks(fromRaw: string, toHref: string): boolean {
 }
 
 // First occurrence (lowest index) of each distinct matched phrase in prose.
-function scanFirst(prose: string, scanner: { latin?: RegExp; other?: RegExp }): Map<string, number> {
-  const first = new Map<string, number>();
+// Returns lowercased-key -> { index, text }: the key dedupes case-insensitively
+// and joins the phrase indexes, while `text` keeps the prose's ORIGINAL casing
+// so the reported anchor matches what's actually on the page.
+function scanFirst(prose: string, scanner: { latin?: RegExp; other?: RegExp }): Map<string, { index: number; text: string }> {
+  const first = new Map<string, { index: number; text: string }>();
   for (const re of [scanner.latin, scanner.other]) {
     if (!re) continue;
     for (const m of prose.matchAll(re)) {
       const key = m[0].toLowerCase();
       const idx = m.index ?? 0;
-      if (!first.has(key) || idx < first.get(key)!) first.set(key, idx);
+      const prev = first.get(key);
+      if (!prev || idx < prev.index) first.set(key, { index: idx, text: m[0] });
     }
   }
   return first;
@@ -282,11 +286,11 @@ function analyze(target: Page): Report {
   const scanner = buildScanner(localePhrases);
   const matched = scanFirst(target.prose, scanner);
   const outByTarget = new Map<string, OutboundCand>();
-  for (const [phrase, idx] of matched) {
+  for (const [phrase, hit] of matched) {
     const res = outboundIndex.get(`${target.locale}::${phrase}`);
     if (!res || res.target.href === target.href) continue;
     if (!passConf(res.confidence) || alreadyLinks(target.raw, res.target.href)) continue;
-    const cand: OutboundCand = { target: res.target.href, phrase, line: lineOf(target.prose, idx), confidence: res.confidence };
+    const cand: OutboundCand = { target: res.target.href, phrase: hit.text, line: lineOf(target.prose, hit.index), confidence: res.confidence };
     const prev = outByTarget.get(res.target.href);
     if (!prev || CONFIDENCE_RANK[cand.confidence] > CONFIDENCE_RANK[prev.confidence] || (CONFIDENCE_RANK[cand.confidence] === CONFIDENCE_RANK[prev.confidence] && cand.line < prev.line)) outByTarget.set(res.target.href, cand);
   }
@@ -304,9 +308,9 @@ function analyze(target: Page): Report {
       const hits = scanFirst(other.prose, myScanner);
       if (hits.size === 0) continue;
       let best: { phrase: string; idx: number; conf: Confidence } | null = null;
-      for (const [phrase, idx] of hits) {
+      for (const [phrase, hit] of hits) {
         const conf = confOf.get(phrase) ?? 'medium';
-        if (!best || CONFIDENCE_RANK[conf] > CONFIDENCE_RANK[best.conf] || (CONFIDENCE_RANK[conf] === CONFIDENCE_RANK[best.conf] && idx < best.idx)) best = { phrase, idx, conf };
+        if (!best || CONFIDENCE_RANK[conf] > CONFIDENCE_RANK[best.conf] || (CONFIDENCE_RANK[conf] === CONFIDENCE_RANK[best.conf] && hit.index < best.idx)) best = { phrase: hit.text, idx: hit.index, conf };
       }
       if (best) inbound.push({ source: rel(other.file), phrase: best.phrase, line: lineOf(other.prose, best.idx), confidence: best.conf });
     }


### PR DESCRIPTION
## Summary

Follow-up to #79. Two improvements to the `cross-link` skill, both driven by feedback:

1. **Make candidate discovery programmatic, not LLM-only.** A new `link-suggest.ts` precomputes link candidates from frontmatter + canonical terms, so the model only *judges and places* a ranked shortlist instead of *reading every article* to discover candidates.
2. **English is the single source of truth for the link graph.** Discovery runs on the `en` page only; the other six locales are *derived* — the same link is applied to every translated counterpart (each pointing at its own-locale target, `/en/` fallback otherwise). We never scan each locale for candidates.

## `link-suggest.ts`

For a target page it prints three locale-scoped sections:

- **`OUTBOUND`** — existing pages whose canonical term appears in the page's prose, with `L<line>` + exact anchor. Every phrase resolves to **one** canonical destination (glossary title head like `escrow`, its parenthetical like `Non-Fungible Token`, or a TLD extension like `.com`) — no keyword fan-out. Already-linked targets excluded.
- **`INBOUND`** — same-locale pages that mention the target's distinctive term but don't link back (`file:line`). The big win when adding a **glossary term**: finds every post that should now cite it.
- **`RELATED`** — pages ranked by shared `keywords` + same `cluster`/`series`.

Confidence is `high` (canonical term) / `medium` (sole-owner keyword) / `low`. It's a candidate generator — never edits files; `--min=high` gives a near-zero-noise pass. Also:

- `--term=/en/<coll>/<slug>/` prints each locale's **anchor term** (the target's title in that locale, e.g. `smart contract` → zh `智能合约`, ar `عقد ذكي`) and counterpart href — the checklist for applying a link across languages.

## Workflow change (SKILL.md)

`Scope (en) → Outbound (en) → Inbound (en) → Derive locales → Validate`. The derive step propagates each English link into all translated counterparts (re-translate, or hand-mirror using `--term`), then `link-audit.ts --fix` repoints prefixes. Concretely: if the English edit links `smart contract` → `/en/glossary/smart-contract/`, then the zh/ar/de/… counterparts each link their translation of the term to their own glossary page.

## Test plan / validation

- `link-suggest.ts content/blog/en/domain-escrow-explained.md --min=high` → 5 clean glossary-term outbound hits (`escrow`, `icann`, `marketplace`, `on-chain`, `wallet`), already-linked terms (`registrar`, `auth-code`) correctly excluded.
- `link-suggest.ts content/glossary/en/escrow.md` → INBOUND lists the posts that mention "Escrow" and should link to the glossary (domain-escrow-explained, domain-terminology-guide, how-to-sell-a-domain, …).
- `--term=/en/glossary/smart-contract/` → correct per-locale anchors for all 7 locales; `--term=/en/glossary/defi/` → correct `/en/` fallback (untranslated).
- `bun data:validate` passes (warnings only); `bun lint:mdx` exit 0. Additive tooling — no content files changed.

---

<details>
<summary>Claude Code session summary (redacted)</summary>

- **2026-06-22** — On feedback that discovery should be more programmatic and English-first: built `link-suggest.ts` (keyword/term/cluster/series candidate generation), fixed a keyword fan-out bug so each phrase resolves to one canonical owner, validated OUTBOUND/INBOUND/RELATED + CJK matching against live content, and added `--term` per-locale anchor lookup.
- **2026-06-22** — Reframed `SKILL.md` to discover on English only and apply links to every locale; ran `data:validate` + `lint:mdx` green; committed and opened this PR.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive agent-skill tooling and documentation only; no runtime app or content markdown changes.
> 
> **Overview**
> Adds **`link-suggest.ts`**, a Bun CLI that scans the content corpus and ranks **OUTBOUND**, **INBOUND**, and **RELATED** link candidates from glossary/TLD canonical terms and frontmatter (`keywords`, `cluster`, `series`), with line numbers and confidence tiers. It complements **`link-audit.ts`** (which only validates existing links) and includes **`--term`** for per-locale anchor text when mirroring links across locales.
> 
> **`SKILL.md`** is reframed so **English is the only discovery surface**: outbound/inbound work happens on `en`, then the same link set is derived into other locales (re-translate or hand-mirror + `link-audit --fix`). Manual grep-style discovery steps are replaced by running the suggester on English pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07375708e5e0c0ec3c57770393eba05c6e936127. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->