### PR TITLE
content: cross-link blog batch 02 (5 English posts)

### DIFF
--- a/content/blog/en/choosing-a-domain-tokenization-platform.md
+++ b/content/blog/en/choosing-a-domain-tokenization-platform.md
@@ -35,9 +35,9 @@ These categories overlap. Some platforms span more than one. But "what camp does
 
 **Best for:** owners who want a real `.com`/`.xyz`/`.io` [tokenized](/en/glossary/tokenize/) on Ethereum or Base, with broad NFT-marketplace and [DeFi](/en/glossary/defi/)-lending support, and DNS management that doesn't feel like a step backward from Cloudflare.
 
-**Notable:** [ICANN](/en/glossary/icann/)-recognized domains across many [TLDs](/en/glossary/tld/), on-chain ownership via standard [NFTs](/en/glossary/nft/) ([ERC-721](/en/glossary/erc-721/), so wallets, marketplaces, and on-chain tooling Just Work), full DNS management including [DNSSEC](/en/glossary/dnssec/), an in-app [marketplace](/en/glossary/marketplace/), and integrations with on-chain payments ([x402](/en/glossary/x402/)). Multi-chain. Self-custody from day one.
+**Notable:** [ICANN](/en/glossary/icann/)-recognized domains across many [TLDs](/en/glossary/tld/), [on-chain](/en/glossary/on-chain/) ownership via standard [NFTs](/en/glossary/nft/) ([ERC-721](/en/glossary/erc-721/), so wallets, marketplaces, and on-chain tooling Just Work), full DNS management including [DNSSEC](/en/glossary/dnssec/), an in-app [marketplace](/en/glossary/marketplace/), and integrations with on-chain payments ([x402](/en/glossary/x402/)). Multi-chain. Self-custody from day one.
 
-**Less suited for:** people who want a brand-new TLD they don't already own, or people who only want a Web3-native name like `name.eth`.
+**Less suited for:** people who want a brand-new TLD they don't already own, or people who only want a [Web3](/en/glossary/web3/)-native name like `name.eth`.
 
 ### Doma Protocol
 
@@ -81,7 +81,7 @@ These categories overlap. Some platforms span more than one. But "what camp does
 
 ### GBM (GBM Auctions)
 
-**Best for:** selling tokenized domains via "bid to earn" auction mechanics.
+**Best for:** selling tokenized domains via "bid to earn" [auction](/en/glossary/auction/) mechanics.
 
 **Notable:** auction infrastructure, not a tokenization platform itself. Often used in combination with one of the above to handle the sale step.
 
@@ -94,13 +94,13 @@ These categories overlap. Some platforms span more than one. But "what camp does
 When you're deciding between platforms, the marketing pages won't tell you which is right. These questions will:
 
 - **TLD coverage.** Does the platform support the specific TLDs you care about (`.com`, `.io`, `.xyz`, `.art`, ccTLDs like `.de`/`.uk`)?
-- **Chain coverage.** Ethereum mainnet, Base, Polygon, others? Where does the NFT live? Where is gas paid?
+- **Chain coverage.** Ethereum mainnet, Base, Polygon, others? Where does the NFT live? Where is [gas](/en/glossary/gas/) paid?
 - **NFT standards.** Standard ERC-721? That matters for marketplace compatibility (OpenSea, Blur, Magic Eden, etc.) and on-chain lending.
 - **DNS management.** Can you manage DNS in-platform? Use external nameservers (Cloudflare, Route53)? DNSSEC supported?
 - **Lending / collateralization.** Can you borrow against the tokenized domain on existing money markets, or only inside a platform-specific silo?
 - **Marketplace compatibility.** Will Blur, OpenSea, etc. show the listing, or is it only visible inside the platform's own marketplace?
-- **Custody model.** Self-custody (your wallet, your keys, your problem) or platform-custodied? Both have trade-offs.
-- **Renewal flow.** Who pays the registrar? How is annual renewal billed? What happens if you stop paying?
+- **Custody model.** Self-custody (your [wallet](/en/glossary/wallet/), your keys, your problem) or platform-custodied? Both have trade-offs.
+- **Renewal flow.** Who pays the [registrar](/en/glossary/registrar/)? How is annual renewal billed? What happens if you stop paying?
 - **Exit path.** If you ever want to *de-tokenize* and go back to a plain registrar setup, can you?
 - **Fees.** Mint fee, marketplace fee, transfer fee, renewal fee, gas. Add them up for your specific scenario before you commit.
 
@@ -132,7 +132,7 @@ There is no universal "best" platform. The right answer depends on:
 - What TLDs you care about.
 - Whether you're an owner, a developer, or a marketplace.
 - How much you value self-custody.
-- Whether you want to use the domain as DeFi collateral or just hold it.
+- Whether you want to use the domain as DeFi [collateral](/en/glossary/collateral/) or just hold it.
 - How much you trust any single platform.
 
 We obviously think Namefi is the right answer for a lot of owners. But the best thing you can do is **try at least one besides us**. If we're better, you'll know after a side-by-side. If something else is better for your use case, you should use that.

--- a/content/blog/en/cybersquatting-vs-domaining-udrp-acpa.md
+++ b/content/blog/en/cybersquatting-vs-domaining-udrp-acpa.md
@@ -29,7 +29,7 @@ The trouble starts when a name's value comes *from* a brand rather than from the
 
 ## The UDRP three-part conjunctive test
 
-The first and most common system is the [UDRP](/en/glossary/udrp/), the Uniform Domain-Name Dispute-Resolution Policy. Every accredited registrar makes you agree to it when you register a name, which is why a private arbitration panel, not a court, can order your domain transferred away. We cover the full process, timeline, and outcomes in [what is UDRP](/en/blog/what-is-udrp/); here the focus is the test itself, because the test is where flippers win or lose.
+The first and most common system is the [UDRP](/en/glossary/udrp/), the Uniform Domain-Name Dispute-Resolution Policy. Every accredited [registrar](/en/glossary/registrar/) makes you agree to it when you register a name, which is why a private arbitration panel, not a court, can order your domain transferred away. We cover the full process, timeline, and outcomes in [what is UDRP](/en/blog/what-is-udrp/); here the focus is the test itself, because the test is where flippers win or lose.
 
 A complainant must prove **all three** of the following. This is a *conjunctive* test, which is the single most important fact about it. Fail any one element and the complaint is denied, no matter how strong the other two are.
 
@@ -70,7 +70,7 @@ Most of staying safe is decided before you spend a dollar. A handful of habits k
 - **Keep records, and keep parking clean.** Save your registration date and reasoning, since bad faith generally must exist at registration. Avoid PPC ads that compete with any trademark owner, which can turn a generic name into evidence of bad-faith use.
 - **Handle inbound offers carefully.** If a brand approaches you, do not demand a number framed around *their* need for the name. That framing is easily recast as "registered primarily to sell to the trademark owner."
 
-When the name is clean and the records are clean, the transfer itself is the last variable. High-value sales settle through neutral [escrow](/en/glossary/escrow/) precisely so neither side has to move first, and a verifiable chain of custody is part of what makes a name defensible if its history is ever questioned. [Namefi](https://namefi.io) leans into that: tokenized ownership gives a name a durable, auditable provenance record while keeping it fully ICANN-compliant, so the underlying domain stays squarely inside the system the UDRP and ACPA govern. Tokenization strengthens your evidence and your control. It does not place a name outside trademark law, and no honest tool would claim otherwise.
+When the name is clean and the records are clean, the transfer itself is the last variable. High-value sales settle through neutral [escrow](/en/glossary/escrow/) precisely so neither side has to move first, and a verifiable chain of custody is part of what makes a name defensible if its history is ever questioned. [Namefi](https://namefi.io) leans into that: tokenized ownership gives a name a durable, auditable provenance record while keeping it fully [ICANN](/en/glossary/icann/)-compliant, so the underlying domain stays squarely inside the system the UDRP and ACPA govern. Tokenization strengthens your evidence and your control. It does not place a name outside trademark law, and no honest tool would claim otherwise.
 
 ## The bottom line
 

--- a/content/blog/en/dns-is-the-control-plane.md
+++ b/content/blog/en/dns-is-the-control-plane.md
@@ -25,7 +25,7 @@ That said, the Namefi engineering team reviews global outages like this and lear
 
 ## What actually went wrong in AWS—without the jargon
 
-Every app and website needs a way to “look up” where to connect. That address book of the internet is called DNS—short for Domain Name System. On Oct 20, a naming problem inside AWS meant some computers couldn’t find a key AWS database service by name. If the address book can’t provide the right entry at the right moment, even healthy systems can’t talk to each other.
+Every app and website needs a way to “look up” where to connect. That address book of the internet is called DNS—short for [Domain Name System](/en/glossary/dns/). On Oct 20, a naming problem inside AWS meant some computers couldn’t find a key AWS database service by name. If the address book can’t provide the right entry at the right moment, even healthy systems can’t talk to each other.
 
 AWS fixed the immediate naming problem within a couple of hours and then spent the rest of the day letting backlogs clear and easing systems back to normal. By late afternoon (Pacific time), AWS said everything was operating normally again, though some services took longer to catch up.
 

--- a/content/blog/en/dns-on-tokenized-domains.md
+++ b/content/blog/en/dns-on-tokenized-domains.md
@@ -13,7 +13,7 @@ description: A practical look at how regular DNS — nameservers, A/AAAA, MX, TX
 keywords: ['DNS tokenized domain', 'DNSSEC NFT domain', 'tokenized domain nameservers', 'tokenized domain email', 'MX records NFT domain', 'CAA records tokenized domain', 'tokenized domain DNS management', 'on-chain domain DNS', 'NFT domain MX', 'NFT domain DNSSEC', 'tokenized domain Cloudflare', 'tokenized domain Route53', 'how DNS works tokenized', 'tokenized domain resolution']
 ---
 
-A common worry about tokenizing a domain: *"Will my website still work? Will my email still work? Will I have to learn a whole new DNS stack?"*
+A common worry about [tokenizing](/en/glossary/tokenize/) a domain: *"Will my website still work? Will my email still work? Will I have to learn a whole new DNS stack?"*
 
 Short answer: **yes, yes, no.** A tokenized domain is still a real ICANN domain. DNS keeps doing exactly what DNS does. This post is a tour of what changes (a little) and what doesn't (most of it).
 

--- a/content/blog/en/dns-over-https-vs-enterprise-split-horizon-dns.md
+++ b/content/blog/en/dns-over-https-vs-enterprise-split-horizon-dns.md
@@ -12,7 +12,7 @@ ogImage: ../../assets/dns-over-https-vs-enterprise-split-horizon-dns-og.jpg
 keywords: ['dns over https', 'doh', 'split horizon dns', 'enterprise dns', 'dot', 'encrypted dns', 'internal dns', 'name resolution', 'namefi']
 ---
 
-For most of the internet's history, DNS queries traveled in cleartext over port 53. Anyone on the network path could read them, log them, and modify them. That was a privacy problem the IETF eventually addressed with two encrypted alternatives: [DNS over TLS (DoT, RFC 7858)](https://datatracker.ietf.org/doc/html/rfc7858) in 2016 and [DNS over HTTPS (DoH, RFC 8484)](https://datatracker.ietf.org/doc/html/rfc8484) in 2018.
+For most of the internet's history, [DNS](/en/glossary/dns/) queries traveled in cleartext over port 53. Anyone on the network path could read them, log them, and modify them. That was a privacy problem the IETF eventually addressed with two encrypted alternatives: [DNS over TLS (DoT, RFC 7858)](https://datatracker.ietf.org/doc/html/rfc7858) in 2016 and [DNS over HTTPS (DoH, RFC 8484)](https://datatracker.ietf.org/doc/html/rfc8484) in 2018.
 
 DoH in particular changed the game, because it hides DNS *inside* a regular HTTPS stream. To a network observer, a DoH query looks identical to any other TLS connection to a content server. That is great for users browsing on a hostile coffee-shop network. It is much less great for a corporate IT team that depends on seeing—and steering—every DNS query that crosses the perimeter.
 
@@ -111,7 +111,7 @@ If you run a domain that is consumed by enterprises—a SaaS app, a developer to
 
 ## How Namefi fits in
 
-Namefi treats DNS as the public-facing control plane—the place where global naming meets local policy. Our DNS workflows assume queries can come from any resolver, including DoH endpoints we cannot enumerate, and the names we publish work consistently regardless. For customers running split-horizon internally, we sit on the public side: the authoritative answer for `example.com` is what we serve, and what the internal resolver overrides for internal users is between them and their endpoint policy.
+Namefi treats DNS as the public-facing [control plane](/en/blog/dns-is-the-control-plane/)—the place where global naming meets local policy. Our DNS workflows assume queries can come from any resolver, including DoH endpoints we cannot enumerate, and the names we publish work consistently regardless. For customers running split-horizon internally, we sit on the public side: the authoritative answer for `example.com` is what we serve, and what the internal resolver overrides for internal users is between them and their endpoint policy.
 
 The deeper point: encrypted DNS is here to stay, and so is enterprise visibility. The way to reconcile them is not to fight the standards, but to move the policy enforcement point from the network to the operating system. The standards bodies, Microsoft, Apple, Google, and Mozilla have all converged on that answer. The work left is mostly operational.
 


### PR DESCRIPTION
English-only cross-linking pass (batch 02) — added in-body prose links to existing glossary/blog pages at first meaningful mention. Locales are a separate manual translate batch.

## Links added per file

| File | Anchor → Target |
|---|---|
| choosing-a-domain-tokenization-platform | `on-chain` → /en/glossary/on-chain/ · `Web3` → /en/glossary/web3/ · `auction` → /en/glossary/auction/ · `gas` → /en/glossary/gas/ · `wallet` → /en/glossary/wallet/ · `registrar` → /en/glossary/registrar/ · `collateral` → /en/glossary/collateral/ |
| cybersquatting-vs-domaining-udrp-acpa | `registrar` → /en/glossary/registrar/ · `ICANN` → /en/glossary/icann/ |
| dns-is-the-control-plane | `Domain Name System` → /en/glossary/dns/ |
| dns-on-tokenized-domains | `tokenizing` → /en/glossary/tokenize/ |
| dns-over-https-vs-enterprise-split-horizon-dns | `DNS` → /en/glossary/dns/ · `control plane` → /en/blog/dns-is-the-control-plane/ |

## Notable rejections (substring/false positives)
- `wallet` in cybersquatting post L52 ("hit your wallet" = figurative cost) — skipped.
- `security` → /en/glossary/collateral/ (generic "security tooling", not financial collateral) — skipped in files 4 & 5.
- `DNSSEC` in dns-is-the-control-plane: only mention is inside a Sources/citation bullet — skipped to keep body-prose quality.
- Various weak `medium` mismatches (liquidity→domain-trading, Self-custody→hardware-wallet, interoperability→composability, Namecheap→bitcoin-org-dns-hijack, "did" substring→did, portfolio→domain-bundle, etc.) — rejected.

## Validation
- `link-audit.ts` (5 changed paths): **0 broken**, 0 locale-mismatch, 0 cross-locale.
- `bun run data:validate`: **passed** (19 pre-existing keyword warnings).
- `eslint` (5 paths): **exit 0**.

Note: English-first; the six translated locales are a separate manual translate batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only internal links in English blog content; no application logic, routing, or auth changes.
> 
> **Overview**
> **English-only in-body cross-linking** across five blog posts: first meaningful mentions now point at existing `/en/glossary/*` pages and one related post, without changing copy beyond wrapping terms in links.
> 
> **choosing-a-domain-tokenization-platform** adds glossary links for `on-chain`, `Web3`, `auction`, `gas`, `wallet`, `registrar`, and `collateral` in the comparison checklist and platform blurbs.
> 
> **cybersquatting-vs-domaining-udrp-acpa**, **dns-is-the-control-plane**, and **dns-on-tokenized-domains** each get one or two targeted links (`registrar` / `ICANN`, `Domain Name System` → DNS glossary, `tokenizing` → tokenize glossary).
> 
> **dns-over-https-vs-enterprise-split-horizon-dns** links opening `DNS` to the glossary and **`control plane`** to `/en/blog/dns-is-the-control-plane/` for cluster continuity.
> 
> Translated locales are out of scope for this batch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a41937317602546b1557d354d83581b15f5ba6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->