### PR TITLE
content: cross-link blog batch 05 (5 English posts)

### DIFF
--- a/content/blog/en/domain-portfolio-management.md
+++ b/content/blog/en/domain-portfolio-management.md
@@ -36,7 +36,7 @@ Before you optimize anything, you have to be able to see it. The foundation of r
 - **Asking price and any offers received.** What you're listing at, and the real demand signal of what anyone has actually offered.
 - **Status.** Live and listed, parked, in negotiation, or marked for the drop. Status is what turns the ledger into a to-do list.
 
-The cost-basis and renewal columns aren't just operational hygiene; they're the raw material for the tax side of the business, where holding period and basis determine what you owe when a name finally sells. We go deeper on that in [taxes and accounting for domain investors](/en/blog/taxes-and-accounting-for-domain-investors/). And the registrar column earns its keep on the day a buyer wants to inspect a name — a portfolio where [WHOIS](/en/glossary/whois/) records, contact emails, and DNS are all current looks like an asset; one with bounced contacts and broken nameservers looks like a risk, and a risk sells for less.
+The cost-basis and renewal columns aren't just operational hygiene; they're the raw material for the tax side of the business, where holding period and basis determine what you owe when a name finally sells. We go deeper on that in [taxes and accounting for domain investors](/en/blog/taxes-and-accounting-for-domain-investors/). And the registrar column earns its keep on the day a buyer wants to inspect a name — a portfolio where [WHOIS](/en/glossary/whois/) records, contact emails, and [DNS](/en/glossary/dns/) are all current looks like an asset; one with bounced contacts and broken nameservers looks like a risk, and a risk sells for less.
 
 ## Sell-through rate: the one number that tells the truth
 
@@ -76,7 +76,7 @@ That frame also keeps you honest about scale. Doubling your portfolio doubles yo
 
 A clean ledger and a disciplined drop list answer *what* you own and *whether* to keep it. They don't, on their own, make the ownership itself easy to prove or move. When a buyer finally appears for one of your tracked names, the trade still hinges on the old standoff: the seller won't transfer before payment, the buyer won't pay before transfer, and a six-figure name sitting at a registrar is only as auditable as a WHOIS record and an [auth code](/en/glossary/auth-code/) you email over.
 
-This is the layer [Namefi](https://namefi.io) is built for. Tokenizing a real ICANN domain makes ownership verifiable and transferable as an on-chain asset, with DNS continuity so the name keeps resolving cleanly through the handover. For a portfolio operator, that means inventory whose control is provable rather than asserted, and exits that close with less friction — the natural endpoint of treating the whole book like a business.
+This is the layer [Namefi](https://namefi.io) is built for. [Tokenizing](/en/glossary/tokenize/) a real [ICANN](/en/glossary/icann/) domain makes ownership verifiable and transferable as an on-chain asset, with DNS continuity so the name keeps resolving cleanly through the handover. For a portfolio operator, that means inventory whose control is provable rather than asserted, and exits that close with less friction — the natural endpoint of treating the whole book like a business.
 
 ## Friendly Disclaimer (Read Me!)
 

--- a/content/blog/en/domain-pricing-psychology-buy-now-vs-make-offer.md
+++ b/content/blog/en/domain-pricing-psychology-buy-now-vs-make-offer.md
@@ -82,7 +82,7 @@ The extension feeds in too: the same word on a [`.com`](/en/tld/com/) carries a 
 
 Pricing a domain is one decision made twice: once when you pick the listing mode, and once on every number you name inside it. Choose buy-now when speed and a clean ceiling beat the hunt for a perfect buyer; choose make-offer when a premium name's upside justifies the friction, and put a floor under it so no number doesn't anchor you down. Let inbound, motivated buyers name the first figure. Ladder your concessions so each step says "almost there." Shape the number to signal the buyer you want. And watch your own endowment effect like the liability it is.
 
-The price is a message. Make sure it says what you mean. Once a deal closes, getting paid safely — [escrow](/en/glossary/escrow/), the [auth-code](/en/glossary/auth-code/) handoff, DNS continuity — is its own discipline; tokenized rails like [Namefi](https://namefi.io) aim to make settlement less nerve-racking so more agreed deals finish. But the money only gets that far if the number on the listing did its job first.
+The price is a message. Make sure it says what you mean. Once a deal closes, getting paid safely — [escrow](/en/glossary/escrow/), the [auth-code](/en/glossary/auth-code/) handoff, [DNS](/en/glossary/dns/) continuity — is its own discipline; tokenized rails like [Namefi](https://namefi.io) aim to make settlement less nerve-racking so more agreed deals finish. But the money only gets that far if the number on the listing did its job first.
 
 ## Friendly Disclaimer (Read Me!)
 

--- a/content/blog/en/domain-renewal-costs-and-sell-through-rate.md
+++ b/content/blog/en/domain-renewal-costs-and-sell-through-rate.md
@@ -78,7 +78,7 @@ Do all three and the renewal bill stops being a vague dread and becomes a manage
 
 The economics above decide *whether* to hold a name. The other half of every flip is the mechanics of moving it when a sale finally lands — and that's where a hard-won sale can still slip. High-value transfers carry the classic standoff: the seller won't hand over the name before payment, the buyer won't pay before delivery, which is the whole reason [escrow](/en/glossary/escrow/) exists. We walk that workflow in [domain escrow explained](/en/blog/domain-escrow-explained/).
 
-[Namefi](https://namefi.io) narrows that friction at the settlement step. Tokenized ownership makes control of a real ICANN domain easier to verify and transfer, with DNS continuity so a live name keeps resolving through the handover. For the math in this article, less settlement friction means the rare sale that's supposed to fund a year of renewals is more likely to actually close — and a sale that closes cleanly is the only kind that pays the bill.
+[Namefi](https://namefi.io) narrows that friction at the settlement step. [Tokenized](/en/glossary/tokenize/) ownership makes control of a real [ICANN](/en/glossary/icann/) domain easier to verify and transfer, with [DNS](/en/glossary/dns/) continuity so a live name keeps resolving through the handover. For the math in this article, less settlement friction means the rare sale that's supposed to fund a year of renewals is more likely to actually close — and a sale that closes cleanly is the only kind that pays the bill.
 
 ## Friendly Disclaimer (Read Me!)
 

--- a/content/blog/en/domain-terminology-guide.md
+++ b/content/blog/en/domain-terminology-guide.md
@@ -20,7 +20,7 @@ Whether you're a beginner exploring domain investing or an experienced professio
 ## **🎯 Domain Investment & Trading**
 
 ### **Domain Flipping**
-The practice of buying domain names at a lower price and then selling them at a higher price for profit. Domain flippers often look for underpriced or high-potential domain names in auctions, expired lists, or direct sales.
+The practice of buying domain names at a lower price and then selling them at a higher price for profit. Domain flippers often look for underpriced or high-potential domain names in [auctions](/en/glossary/auction/), expired lists, or direct sales.
 
 **Example**: Purchasing `TechStartup.com` for $500 and selling it to a startup company for $5,000.
 
@@ -67,9 +67,9 @@ A platform or service where domain names are sold through competitive bidding. T
 **Popular Platforms**: GoDaddy Auctions, NameJet, Sedo Auctions, SnapNames
 
 ### **Escrow Service**
-A trusted third-party service used to facilitate the safe exchange of money and domain ownership during a domain sale. The buyer pays the escrow service, and once the domain is transferred, the funds are released to the seller.
+A trusted third-party service used to facilitate the safe exchange of money and [domain ownership](/en/glossary/domain-ownership/) during a domain sale. The buyer pays the [escrow](/en/glossary/escrow/) service, and once the domain is transferred, the funds are released to the seller.
 
-**Popular Services**: Escrow.com (recommended by ICANN), PayPal, Dan.com
+**Popular Services**: Escrow.com (recommended by [ICANN](/en/glossary/icann/)), PayPal, Dan.com
 
 ---
 
@@ -91,12 +91,12 @@ An individual or business that buys domain names in bulk and resells them to end
 ## **⚙️ Technical Terms**
 
 ### **TLD (Top-Level Domain)**
-The part of a domain name that comes after the last dot (e.g., .com, .org, .net, .ai, etc.). The choice of TLD can affect the value and perception of a domain name.
+The part of a domain name that comes after the last dot (e.g., [.com](/en/tld/com/), [.org](/en/tld/org/), [.net](/en/tld/net/), [.ai](/en/tld/ai/), etc.). The choice of TLD can affect the value and perception of a domain name.
 
 **Categories**:
-- **Generic TLDs**: .com, .org, .net, .info
+- **Generic TLDs**: .com, .org, .net, [.info](/en/tld/info/)
 - **Country Code TLDs**: .us, .uk, .de, .cn
-- **New TLDs**: .ai, .io, .tech, .shop
+- **New TLDs**: .ai, [.io](/en/tld/io/), [.tech](/en/tld/tech/), [.shop](/en/tld/shop/)
 
 ### **Subdomain**
 A domain that is part of a larger domain. For example, "blog.example.com" is a subdomain of "example.com." Subdomains can be used to organize different sections of a website.
@@ -109,13 +109,13 @@ The system that translates human-readable domain names into IP addresses that co
 **Function**: Converts `namefi.io` to `192.168.1.1` for browser communication
 
 ### **WHOIS**
-A protocol used to query databases that store registered domain name information. WHOIS provides details like the domain's owner, registration dates, and contact information.
+A protocol used to query databases that store registered domain name information. [WHOIS](/en/glossary/whois/) provides details like the domain's owner, registration dates, and contact information.
 
 **Information Provided**:
 - Domain owner details
 - Registration and expiration dates
 - Name servers
-- Registrar information
+- [Registrar](/en/glossary/registrar/) information
 
 ---
 
@@ -195,7 +195,7 @@ Ready to start your domain investing journey or secure your perfect domain name?
 - **Expert Support**: Guidance for domain investors
 - **Secure Transactions**: Safe buying and selling platform
 
-👉 **Visit [namefi.io](https://namefi.io) and start building your domain portfolio today.**
+👉 **Visit [namefi.io](https://namefi.io) and start building your [domain portfolio](/en/blog/domain-portfolio-management/) today.**
 
 Master these terms, understand the market, and make informed decisions in your domain investing journey. Knowledge is your most valuable asset in the domain industry!
 

--- a/content/blog/en/end-user-vs-reseller-domain-pricing.md
+++ b/content/blog/en/end-user-vs-reseller-domain-pricing.md
@@ -28,7 +28,7 @@ The **reseller (wholesale) price** is what another investor will pay you. They a
 
 The **end-user (retail) price** is what the business that will actually *use* the name pays. They are not buying an asset to flip; they are buying the front door to their company, and they value it against what that name is worth to *their* operation: their brand, their marketing, the deal they're trying to close this quarter. They're comparing the price not to other domains but to the cost of launching with a worse name. This is the **high number**.
 
-Same string of letters, same WHOIS record, two prices, because two completely different buyers are doing two completely different kinds of math.
+Same string of letters, same [WHOIS](/en/glossary/whois/) record, two prices, because two completely different buyers are doing two completely different kinds of math.
 
 ## Why the gap exists at all
 
@@ -84,7 +84,7 @@ Three habits keep the two-price reality working for you instead of against you.
 
 Knowing your number is half the job. The other half is collecting it without getting hurt — and the higher the end-user price, the sharper the risk at the moment of transfer. The classic standoff: the buyer doesn't want to wire money before they control the name, and you don't want to release the name before you've confirmed the money. That trust gap is where high-value [domain trading](/en/glossary/domain-trading/) gets nervous, and it's the same whether you're collecting a wholesale price from a peer or an end-user price from a first-time buyer who has never bought a domain before. The traditional fix is a neutral [escrow](/en/glossary/escrow/) workflow so neither side has to move first, which we cover in [domain escrow explained](/en/blog/domain-escrow-explained/).
 
-This is the gap [Namefi](https://namefi.io) is built to narrow. Tokenizing a real ICANN domain makes [ownership](/en/glossary/domain-ownership/) easier to verify and transfer, so the handoff at closing is auditable and the name keeps resolving through the change. Price the name to the right buyer; then make the trade safe. The number you fought to get is only real once it clears.
+This is the gap [Namefi](https://namefi.io) is built to narrow. [Tokenizing](/en/glossary/tokenize/) a real [ICANN](/en/glossary/icann/) domain makes [ownership](/en/glossary/domain-ownership/) easier to verify and transfer, so the handoff at closing is auditable and the name keeps resolving through the change. Price the name to the right buyer; then make the trade safe. The number you fought to get is only real once it clears.
 
 ## Friendly Disclaimer (Read Me!)
 


### PR DESCRIPTION
English-only cross-linking pass over 5 domain-investing blog posts: add in-body prose links to existing glossary/TLD/blog pages at the first meaningful mention only. No frontmatter, headings, code, or disclaimer touched.

## Links added per file

| File | Links added (anchor → target) |
|------|-------------------------------|
| domain-portfolio-management.md | DNS → /en/glossary/dns/ · Tokenizing → /en/glossary/tokenize/ · ICANN → /en/glossary/icann/ |
| domain-pricing-psychology-buy-now-vs-make-offer.md | DNS → /en/glossary/dns/ |
| domain-renewal-costs-and-sell-through-rate.md | Tokenized → /en/glossary/tokenize/ · ICANN → /en/glossary/icann/ · DNS → /en/glossary/dns/ |
| domain-terminology-guide.md | auctions → /en/glossary/auction/ · domain ownership → /en/glossary/domain-ownership/ · escrow → /en/glossary/escrow/ · ICANN → /en/glossary/icann/ · .com/.org/.net/.ai/.info/.io/.tech/.shop → /en/tld/… · WHOIS → /en/glossary/whois/ · Registrar → /en/glossary/registrar/ · domain portfolio → /en/blog/domain-portfolio-management/ |
| end-user-vs-reseller-domain-pricing.md | WHOIS → /en/glossary/whois/ · Tokenizing → /en/glossary/tokenize/ · ICANN → /en/glossary/icann/ |

## Notable rejections
- portfolio → /en/glossary/domain-bundle/, ownership → /en/glossary/web3/, ledger → /en/glossary/hardware-wallet/, "did" verb → /en/glossary/did/ (all mismapped substring false-positives)
- generic "marketplace" e-commerce prose → /en/glossary/marketplace/ (NFT-marketplace entry); generic "domain names" / "branding" / "GoDaddy" → blog case studies (stretch)
- Sources-section Wikipedia link titles skipped (inside existing links)

## Validation
- link-audit (5 files): **0 broken**, 0 locale-mismatch
- `data:validate`: passed (19 pre-existing keyword warnings)
- `eslint` (5 files): exit 0

Note: English-first; the 6 translated locales are handled in a separate manual batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only SEO cross-linking in blog content with no application logic, config, or auth changes; link-audit reportedly shows zero broken links.
> 
> **Overview**
> Adds **in-body internal links** across five English domain-investing blog posts, linking the first meaningful mention of terms to existing `/en/glossary/`, `/en/tld/`, and related `/en/blog/` pages.
> 
> **`domain-terminology-guide.md`** gets the largest pass: auctions, escrow/domain ownership, ICANN, WHOIS, registrar, several TLD examples, and a CTA link to domain portfolio management.
> 
> The other four posts add smaller, targeted links—**DNS**, **tokenize/tokenizing**, and **ICANN** in portfolio, renewal-costs, and end-user vs reseller pricing pieces, plus **DNS** in the buy-now vs make-offer post.
> 
> Frontmatter, headings, disclaimers, and existing external/source links are unchanged; translated locales are out of scope for this batch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2488550f5519a5e28abde35476b9b0407ce316e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added hyperlinks to glossary terms across blog articles for improved navigation between related content
  * Enhanced terminology guide with internal cross-references to key domain concepts (DNS, WHOIS, ICANN, TLD, escrow)
  * Improved connectivity between domain pricing and portfolio management articles for easier reference discovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->