### PR TITLE
content: cross-link blog batch 08 (5 English posts)

### DIFF
--- a/content/blog/en/from-instagr-am-to-instagram-com.md
+++ b/content/blog/en/from-instagr-am-to-instagram-com.md
@@ -15,9 +15,9 @@ keywords: ['instagr.am', 'instagram.com', 'instagram domain name', 'domain hack'
 
 Before Instagram became a billion-user platform, a verb for taking pictures, and one of the most valuable apps Facebook ever bought, it had a name that was also a piece of clever engineering: **instagr.am**.
 
-That address was not a typo and not a redirect trick. It was a *domain hack* — a domain name where the extension itself finishes the word. Wikipedia defines the form precisely: a domain hack is [a domain name that suggests a word, phrase, or name when concatenating two or more adjacent levels of that domain](https://en.wikipedia.org/wiki/Domain_hacks#:~:text=a%20domain%20name%20that%20suggests%20a%20word%2C%20phrase%2C%20or%20name), and it names Instagram's as a textbook case: [instagr.am makes use of the ccTLD .am (Armenia) to spell the name of photo-sharing service "Instagram"](https://en.wikipedia.org/wiki/Domain_hacks#:~:text=instagr.am%20makes%20use%20of%20the%20ccTLD%20.am%20%28Armenia%29%20to%20spell%20the%20name).
+That address was not a typo and not a redirect trick. It was a [*domain hack*](/en/blog/domain-hacks-explained/) — a domain name where the extension itself finishes the word. Wikipedia defines the form precisely: a domain hack is [a domain name that suggests a word, phrase, or name when concatenating two or more adjacent levels of that domain](https://en.wikipedia.org/wiki/Domain_hacks#:~:text=a%20domain%20name%20that%20suggests%20a%20word%2C%20phrase%2C%20or%20name), and it names Instagram's as a textbook case: [instagr.am makes use of the ccTLD .am (Armenia) to spell the name of photo-sharing service "Instagram"](https://en.wikipedia.org/wiki/Domain_hacks#:~:text=instagr.am%20makes%20use%20of%20the%20ccTLD%20.am%20%28Armenia%29%20to%20spell%20the%20name).
 
-Read that again. To spell its own brand, a San Francisco photo app borrowed the country-code top-level domain of **Armenia**, a country roughly 7,000 miles away. The "am" in Instagram lived, technically, in Yerevan.
+Read that again. To spell its own brand, a San Francisco photo app borrowed the country-code [top-level domain](/en/glossary/tld/) of **Armenia**, a country roughly 7,000 miles away. The "am" in Instagram lived, technically, in Yerevan.
 
 For a tiny startup launching into a crowded App Store, the hack was a gift. It was short, it was exact, it read as one word, and — crucially — it was *available* when the obvious address, Instagram.com, was not.
 
@@ -41,7 +41,7 @@ To understand why instagr.am was so attractive, you have to understand what `.am
 
 For a 2010 startup, the appeal was obvious:
 
-- **It was exact.** "instagr" + ".am" reads as the full brand, with nothing extra to explain — the holy grail of an unfunded launch.
+- **It was exact.** "instagr" + "[.am](/en/tld/am/)" reads as the full brand, with nothing extra to explain — the holy grail of an unfunded launch.
 - **It was short and shareable.** A photo app lives or dies on how easily a link gets passed around. instagr.am was tight enough to print, text, and tweet.
 - **It was available right now.** Instagram.com was already owned by someone else, and a brand-new app had neither the cash nor the leverage to pry it loose on day one.
 

--- a/content/blog/en/from-jambajuice-com-to-jamba-com.md
+++ b/content/blog/en/from-jambajuice-com-to-jamba-com.md
@@ -21,7 +21,7 @@ Then, in 2019, after almost three decades of explaining itself, the company drop
 
 The reasoning was that "Juice" had stopped describing the business — and started shrinking it. The chain now sold bowls, plant-based bites, and boosts, not just blended drinks, and the word "juice" had quietly turned into a liability in a more sugar-conscious era.
 
-But here's the detail that makes this case different from almost every other story in this series: **Jamba didn't have to buy its exact-match domain.** Unlike Tesla, which paid $11 million for Tesla.com, or Uber, which traded equity for Uber.com, Jamba had quietly owned **Jamba.com for decades** — the snapshot record shows the site live and reading [Welcome to Jamba.com](http://web.archive.org/web/19990125090358/http://jamba.com:80/) back in January 1999. When the rebrand came, the hardest, most expensive part of a name change was already done.
+But here's the detail that makes this case different from almost every other story in this series: **Jamba didn't have to buy its exact-match domain.** Unlike Tesla, which paid $11 million for [Tesla.com](/en/blog/from-teslamotors-com-to-tesla-com/), or Uber, which traded equity for [Uber.com](/en/blog/from-ubercab-com-to-uber-com/), Jamba had quietly owned **Jamba.com for decades** — the snapshot record shows the site live and reading [Welcome to Jamba.com](http://web.archive.org/web/19990125090358/http://jamba.com:80/) back in January 1999. When the rebrand came, the hardest, most expensive part of a name change was already done.
 
 ## 1990–1995: the Juice Club that became Jamba Juice
 
@@ -101,7 +101,7 @@ A company's core domain shows up in places the marketing team never directly con
 
 Every one of those repetitions either adds friction or removes it. JambaJuice.com made each mention longer and pinned it to a single, increasingly loaded word. Jamba.com made each mention shorter, cleaner, and category-free — letting "bowls" and "boosts" and "plant-based" coexist with the name instead of fighting it.
 
-And the crucial point: **Jamba could make that switch instantly, because it already owned the destination.** Its own SEC filings list, in plain language, that [the Company has registered and maintains numerous Internet domain names, including "jamba.com" and "jambajuice.com."](https://www.sec.gov/Archives/edgar/data/1316898/000114420414014228/v369380_10k.htm) — a sentence on the record years *before* the 2019 rebrand. The expensive, slow part of a name change — securing the exact-match .com — had been quietly handled since the late 1990s.
+And the crucial point: **Jamba could make that switch instantly, because it already owned the destination.** Its own SEC filings list, in plain language, that [the Company has registered and maintains numerous Internet domain names, including "jamba.com" and "jambajuice.com."](https://www.sec.gov/Archives/edgar/data/1316898/000114420414014228/v369380_10k.htm) — a sentence on the record years *before* the 2019 rebrand. The expensive, slow part of a name change — securing the exact-match [.com](/en/tld/com/) — had been quietly handled since the late 1990s.
 
 Is there a public price for Jamba.com? No. Because there was no headline acquisition to put a number on. Jamba registered and held the name itself, so unlike the eleven-million-dollar Tesla.com deal or the equity-for-Uber.com trade, there is simply no public sale figure — and we won't invent one. The story here isn't what the domain cost. It's that owning it early made the rebrand almost free to execute.
 

--- a/content/blog/en/from-massdrop-com-to-drop-com.md
+++ b/content/blog/en/from-massdrop-com-to-drop-com.md
@@ -21,7 +21,7 @@ For that first audience, Massdrop.com was perfect. It named the move.
 
 But the company underneath the name kept changing. By 2019, Massdrop was no longer just a coordinator of bulk orders. It was designing its own keyboards and headphones, running a real commerce platform, and preparing to ship to new markets. The "Mass" — the word that made the model legible on day one — had started to describe a smaller, older company than the one it had become.
 
-So in April 2019, Massdrop did what a surprising number of growing companies eventually do: it dropped half its name. It became simply **Drop**, and it moved to the exact-match domain it had quietly secured ahead of time — **Drop.com**, a premium one-word .com that had once carried an [asking price of $800,000](https://domaininvesting.com/massdrop-rebrands-as-drop-with-drop-com-domain-name/#:~:text=the%20asking%20price%20for%20Drop.com%20was%20%24800%2C000).
+So in April 2019, Massdrop did what a surprising number of growing companies eventually do: it dropped half its name. It became simply **Drop**, and it moved to the exact-match domain it had quietly secured ahead of time — **Drop.com**, a premium one-word [.com](/en/tld/com/) that had once carried an [asking price of $800,000](https://domaininvesting.com/massdrop-rebrands-as-drop-with-drop-com-domain-name/#:~:text=the%20asking%20price%20for%20Drop.com%20was%20%24800%2C000).
 
 ## 2012–2019: the "Mass" that did real work
 
@@ -97,7 +97,7 @@ That is the subtle art of a good rename: cut the word that limits you, keep the 
 
 The order of events is what makes this case instructive.
 
-The $800,000 asking price for Drop.com surfaced in early 2017. The domain went behind Whois privacy in [August of 2017](https://domaininvesting.com/massdrop-rebrands-as-drop-with-drop-com-domain-name/#:~:text=Whois%20privacy%20enabled%20at%20GoDaddy%20since%20August%20of%202017). The public rebrand to Drop didn't happen until [29 April, 2019](https://www.notebookcheck.net/Massdrop-becomes-Drop-announces-new-range-of-own-brand-products.419780.0.html#:~:text=29%20April%2C%202019). The expensive, externally-owned asset was locked down well before the name went live.
+The $800,000 asking price for Drop.com surfaced in early 2017. The domain went behind [Whois](/en/glossary/whois/) privacy in [August of 2017](https://domaininvesting.com/massdrop-rebrands-as-drop-with-drop-com-domain-name/#:~:text=Whois%20privacy%20enabled%20at%20GoDaddy%20since%20August%20of%202017). The public rebrand to Drop didn't happen until [29 April, 2019](https://www.notebookcheck.net/Massdrop-becomes-Drop-announces-new-range-of-own-brand-products.419780.0.html#:~:text=29%20April%2C%202019). The expensive, externally-owned asset was locked down well before the name went live.
 
 Notice the dependency. Massdrop couldn't credibly *be* "Drop" while its website lived at Massdrop.com and someone else owned Drop.com. The brand, the social handles, and the domain had to move together — and the piece least under the company's control was the domain, because it had a price tag and an owner. Securing Drop.com (and the @Drop handles) is what let the company flip the switch in a single announcement, with [Massdrop.com now directs to Drop.com](https://smartbranding.com/massdrop-rebrands-to-drop/#:~:text=Massdrop.com%20now%20directs%20to%20Drop.com) on day one.
 

--- a/content/blog/en/from-mona-co-to-crypto-com.md
+++ b/content/blog/en/from-mona-co-to-crypto-com.md
@@ -13,9 +13,9 @@ description: 'How the crypto-card startup Monaco rebranded to Crypto.com in 2018
 keywords: ['mona.co', 'crypto.com', 'crypto.com domain', 'monaco mco', 'matt blaze crypto.com', 'kris marszalek', 'domain upgrade', 'premium domain', 'category domain', 'domain acquisition', 'crypto rebrand', 'exact match domain', 'branding']
 ---
 
-For its first couple of years, one of the most aggressive brands in crypto lived at a quietly clever address: **Mona.co** — the company "Monaco," spelled out across a domain and a country-code TLD, the way bit.ly or goo.gl turned a `.ly` or `.gl` into part of the word.
+For its first couple of years, one of the most aggressive brands in crypto lived at a quietly clever address: **Mona.co** — the company "Monaco," spelled out across a domain and a country-code [TLD](/en/glossary/tld/), the way bit.ly or goo.gl turned a `.ly` or `.gl` into part of the word.
 
-The name was a pun, and a good one. The startup, founded in Hong Kong in 2016, was building a Visa card and wallet for spending cryptocurrency. "Monaco" evoked wealth, luxury, the Riviera — and the `.co` let the brand sit on a short, memorable URL while the team waited to see how big the idea could get. Mona.co told you the company's name. It didn't tell you the category.
+The name was a pun, and a good one. The startup, founded in Hong Kong in 2016, was building a Visa card and [wallet](/en/glossary/wallet/) for spending cryptocurrency. "Monaco" evoked wealth, luxury, the Riviera — and the `.co` let the brand sit on a short, memorable URL while the team waited to see how big the idea could get. Mona.co told you the company's name. It didn't tell you the category.
 
 That was the gap. Monaco wasn't trying to be a luxury card company. It was trying to be *the* place ordinary people touched cryptocurrency for the first time. And the single word that named that entire category — the word every headline, every regulator, every newcomer already used — wasn't "Monaco." It was **crypto**.
 
@@ -108,13 +108,13 @@ A company's core domain shows up in places the marketing team never directly con
 - In search results and the browser bar — where "crypto.com" is something a newcomer might type *before* they know any brand at all.
 - In every word-of-mouth recommendation: "just go to crypto dot com."
 
-Every one of those repetitions either adds friction or removes it. Mona.co required a tiny act of translation — *Monaco, spelled with the .co* — and told a first-timer nothing about the category. Crypto.com removed the translation entirely and pre-loaded the category into the name. For a company whose whole strategy was to be the default on-ramp for people who knew nothing about the space, that pre-loading was the product.
+Every one of those repetitions either adds friction or removes it. Mona.co required a tiny act of translation — *Monaco, spelled with the [.co](/en/tld/co/)* — and told a first-timer nothing about the category. Crypto.com removed the translation entirely and pre-loaded the category into the name. For a company whose whole strategy was to be the default on-ramp for people who knew nothing about the space, that pre-loading was the product.
 
 The domain didn't build Crypto.com's brand. But once Crypto.com was the address, every future mention of the category — in headlines, in conversations, in the panicked first search of someone who just heard about Bitcoin at a dinner party — had a chance of landing on the company's front door instead of someone else's.
 
 ## What founders should learn from Case 20
 
-The easy takeaway — "buy the category-defining .com" — is the wrong lesson, because almost no founder *can*. Crypto.com existed for 25 years and was unbuyable for 24 of them. The useful lessons are narrower:
+The easy takeaway — "buy the category-defining [.com](/en/tld/com/)" — is the wrong lesson, because almost no founder *can*. Crypto.com existed for 25 years and was unbuyable for 24 of them. The useful lessons are narrower:
 
 1. **A clever brand-hack domain is a fine on-ramp.** Mona.co did genuine work: short, premium, memorable, cheap relative to the exact match. A `.co` pun or a modifier domain is a reasonable starting line, not a failure.
 2. **Know the difference between your name and your category.** Most domain upgrades trade a descriptive name for the brand. The rarest and most powerful upgrade trades the brand for the *category* — but it only pays off if you intend to be the default, not a boutique.

--- a/content/blog/en/from-mrchewy-com-to-chewy-com.md
+++ b/content/blog/en/from-mrchewy-com-to-chewy-com.md
@@ -55,7 +55,7 @@ By the time the money arrived, the brand had to be ready to scale — and a bran
 
 It is tempting to look at "Chewy" and "Chewy.com" and assume the one-word name was always obvious, always cheap, always inevitable. It wasn't.
 
-In 2011 and 2012, Chewy was a self-funded startup running on the founders' own cash and small loans, in a category investors actively avoided. A premium, exact-match, one-word .com — hand-registered in 2004 and parked inside a top-tier domain portfolio — is not the kind of asset a cash-strapped pet store buys casually. Whatever the undisclosed price was, it was being weighed against payroll, inventory, and the customer-service infrastructure that would actually become the company's moat.
+In 2011 and 2012, Chewy was a self-funded startup running on the founders' own cash and small loans, in a category investors actively avoided. A premium, exact-match, one-word [.com](/en/tld/com/) — hand-registered in 2004 and parked inside a top-tier domain portfolio — is not the kind of asset a cash-strapped pet store buys casually. Whatever the undisclosed price was, it was being weighed against payroll, inventory, and the customer-service infrastructure that would actually become the company's moat.
 
 That is the right frame for any domain decision: not "what is this name worth at the end of the story," but "what is it worth to a company that doesn't yet know if it will survive the year." Chewy chose to consolidate on the clean name early, while it was still small enough that the decision was a real cost — and that, more than hindsight, is what made it a strategic choice rather than a vanity one.
 


### PR DESCRIPTION
English-only cross-linking pass over 5 `from-X-to-Y` domain-rebranding case studies (domain-investing cluster). In-body prose links added at the first meaningful mention; no frontmatter/headings/code/disclaimer touched. Locales are a separate manual batch.

## Links added per file

| File | Anchor → Target |
| --- | --- |
| from-instagr-am-to-instagram-com | `domain hack` → /en/blog/domain-hacks-explained/ · `top-level domain` → /en/glossary/tld/ · `.am` → /en/tld/am/ |
| from-jambajuice-com-to-jamba-com | `Tesla.com` → /en/blog/from-teslamotors-com-to-tesla-com/ · `Uber.com` → /en/blog/from-ubercab-com-to-uber-com/ · `.com` → /en/tld/com/ |
| from-massdrop-com-to-drop-com | `.com` → /en/tld/com/ · `Whois` → /en/glossary/whois/ |
| from-mona-co-to-crypto-com | `TLD` → /en/glossary/tld/ · `wallet` → /en/glossary/wallet/ · `.co` → /en/tld/co/ · `.com` → /en/tld/com/ |
| from-mrchewy-com-to-chewy-com | `.com` → /en/tld/com/ |

12 links total across 5 files.

## Notable rejections
- `marketplace` → /en/glossary/marketplace/ (NFT/OpenSea-specific entry; prose meant a traditional domain broker)
- `branding` → a sibling case-study blog (generic word mismapped)
- `did` verb, `ownership`/`peer-to-peer` → web3, `portfolio` → domain-bundle, `Premium domains` → terminology-guide, `corporate identity` → tld/airbus, `goo.gl`/`domain price`/`domain portfolio` — generic/forced false positives
- `.am`/`.co`/`.com` in inline code (backticks) left unlinked; linked only the first non-code plain-prose mention

## Validation (touched files)
- link-audit: **0 broken**, 0 locale-mismatch, 0 cross-locale
- `data:validate`: passed (19 pre-existing unrelated warnings)
- eslint: exit 0

Note: English-first; locales are a separate manual batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only internal linking with no app or auth changes; PR validation reported zero broken links.
> 
> **Overview**
> Adds **12 in-body markdown links** across five English `from-X-to-Y` posts in the domain-investing cluster, wiring the first meaningful mention of terms to glossary, TLD, and sibling case-study pages.
> 
> Coverage includes **Instagram** (`domain hack`, TLD, `.am`), **Jamba** (Tesla/Uber rebrand articles and `.com`), **Massdrop/Drop** (`.com`, Whois), **Monaco/Crypto.com** (TLD, wallet, `.co`, `.com`), and **Chewy** (`.com`). Frontmatter, headings, and inline code mentions are unchanged; locales are out of scope for this batch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 667c810bb77300ea2474f7d7ffe99b701b4bdee2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->