### PR TITLE
content: cross-link blog batch 11 (5 English posts)

### DIFF
--- a/content/blog/en/how-tld-affects-domain-value.md
+++ b/content/blog/en/how-tld-affects-domain-value.md
@@ -76,9 +76,9 @@ One verified anchor keeps the premium concrete. The highest publicly disclosed d
 
 ## The Namefi angle
 
-Once you've decided which extension a name should live on, the other half of the trade is moving it cleanly, and that's where the extension matters again in a practical way. Transferring a high-value name means proving who controls it and handing it over without the site going dark, and the mechanics differ across registries and country codes. That friction is the same one behind any high-value [domain trade](/en/glossary/domain-trading/), and it's sharper across registrar and ccTLD boundaries.
+Once you've decided which extension a name should live on, the other half of the trade is moving it cleanly, and that's where the extension matters again in a practical way. Transferring a high-value name means proving who controls it and handing it over without the site going dark, and the mechanics differ across registries and country codes. That friction is the same one behind any high-value [domain trade](/en/glossary/domain-trading/), and it's sharper across [registrar](/en/glossary/registrar/) and ccTLD boundaries.
 
-This is the gap [Namefi](https://namefi.io) is built to narrow. Tokenized ownership makes control of a real ICANN domain easier to verify and transfer, with DNS continuity so the name keeps resolving through the handover. Choosing the right extension is the appraisal call; making the transfer of that name auditable is what lets you actually trade on the call.
+This is the gap [Namefi](https://namefi.io) is built to narrow. Tokenized ownership makes control of a real [ICANN](/en/glossary/icann/) domain easier to verify and transfer, with [DNS](/en/glossary/dns/) continuity so the name keeps resolving through the handover. Choosing the right extension is the appraisal call; making the transfer of that name auditable is what lets you actually trade on the call.
 
 ## Friendly Disclaimer (Read Me!)
 

--- a/content/blog/en/how-to-find-domains-to-flip.md
+++ b/content/blog/en/how-to-find-domains-to-flip.md
@@ -66,7 +66,7 @@ One more boundary sits above all the filters: the legal line. Hand-registering o
 
 ## The Namefi angle
 
-Sourcing decides *what* you buy. The other half of every flip is moving the name cleanly when it sells — proving you hold it, handing it over without the site going dark, and trusting that the money and the asset change hands together. That settlement friction is sharpest on exactly the high-value names good sourcing produces. It's the gap [Namefi](https://namefi.io) is built to narrow: tokenized ownership makes control of a real ICANN domain easier to verify and transfer, with DNS continuity so the name keeps resolving through the handover. Source well, then trade on names whose ownership is auditable rather than taken on trust.
+Sourcing decides *what* you buy. The other half of every flip is moving the name cleanly when it sells — proving you hold it, handing it over without the site going dark, and trusting that the money and the asset change hands together. That settlement friction is sharpest on exactly the high-value names good sourcing produces. It's the gap [Namefi](https://namefi.io) is built to narrow: tokenized ownership makes control of a real [ICANN](/en/glossary/icann/) domain easier to verify and transfer, with [DNS](/en/glossary/dns/) continuity so the name keeps resolving through the handover. Source well, then trade on names whose ownership is auditable rather than taken on trust.
 
 ## Friendly Disclaimer (Read Me!)
 

--- a/content/blog/en/how-to-name-your-project.md
+++ b/content/blog/en/how-to-name-your-project.md
@@ -43,7 +43,7 @@ Before you fall in love, spend twenty minutes here:
 
 - **Plain web search.** If page one is already crowded with a company doing something adjacent, stop. You will fight them for attention forever.
 - **Trademark databases.** Search the [USPTO trademark search system](https://www.uspto.gov/trademarks/search) for the U.S., the [EUIPO database](https://www.euipo.europa.eu/en/trade-marks/before-applying) for the EU, and [WIPO's Global Brand Database](https://branddb.wipo.int/) for an international sweep. You are not doing a lawyer's clearance — you are catching the obvious collisions for free.
-- **Domains.** The `.com` still anchors credibility for most ventures. On [Namefi](https://namefi.io) you can check availability, see **how long a `.com` has been registered** (a name held continuously since 2009 is a very different signal than one registered last month), and see **how many TLDs the name is already registered across**. A name taken on 30 extensions is contested territory; a name free almost everywhere is open road. Treat that spread as a quick "how crowded is this word" gauge.
+- **Domains.** The `.com` still anchors credibility for most ventures. On [Namefi](https://namefi.io) you can check availability, see **how long a `.com` has been registered** (a name held continuously since 2009 is a very different signal than one registered last month), and see **how many [TLDs](/en/glossary/tld/) the name is already registered across**. A name taken on 30 extensions is contested territory; a name free almost everywhere is open road. Treat that spread as a quick "how crowded is this word" gauge.
 - **Handles.** Check the [GitHub](https://github.com) org, plus X, Reddit, LinkedIn, and whichever platform your users actually live on. Consistent handles across the web ("handle uniformity") are worth a surprising amount for an early project — and they are first-come, first-served.
 
 If a candidate clears the category, the trademark sweep, a usable domain, and the handles, it has earned the right to be judged on craft.
@@ -138,7 +138,7 @@ Run the checks. Then trust the one you can't stop saying.
 
 ## How Namefi Helps
 
-Naming and owning are two halves of the same decision. [Namefi](https://namefi.io) is built for the "can I actually own this?" half: check `.com` and alternative-TLD availability, see **how long a name has been registered** and **how many extensions it spans** (your contested-vs-open signal), explore brandable names, and — when you find the one — secure and even tokenize ownership so the asset behind your brand is verifiably yours. Pick a name you love; make sure it's a name you can hold.
+Naming and owning are two halves of the same decision. [Namefi](https://namefi.io) is built for the "can I actually own this?" half: check `.com` and alternative-TLD availability, see **how long a name has been registered** and **how many extensions it spans** (your contested-vs-open signal), explore brandable names, and — when you find the one — secure and even [tokenize](/en/glossary/tokenize/) ownership so the asset behind your brand is verifiably yours. Pick a name you love; make sure it's a name you can hold.
 
 ## Sources and further reading
 

--- a/content/blog/en/how-to-read-comparable-domain-sales.md
+++ b/content/blog/en/how-to-read-comparable-domain-sales.md
@@ -82,7 +82,7 @@ What you end up with is a *range* anchored to a cluster of genuinely similar sal
 
 Reading comps tells you what a name is worth. The other half of the trade is proving the name actually changed hands cleanly once you've agreed on the number. High-value [domain trades](/en/glossary/domain-trading/) stall on the same trust gap every time: the buyer doesn't want to pay before they control the asset, and the seller doesn't want to release it before the money clears.
 
-This is the gap [Namefi](https://namefi.io) is built to narrow. Tokenizing a real ICANN domain makes ownership auditable and transferable, with DNS continuity so the name keeps resolving through the handover. Comps give you a number you can defend; a clean, verifiable transfer is what turns that number into a closed deal without either side moving first on faith.
+This is the gap [Namefi](https://namefi.io) is built to narrow. Tokenizing a real [ICANN](/en/glossary/icann/) domain makes ownership auditable and transferable, with [DNS](/en/glossary/dns/) continuity so the name keeps resolving through the handover. Comps give you a number you can defend; a clean, verifiable transfer is what turns that number into a closed deal without either side moving first on faith.
 
 ## Friendly Disclaimer (Read Me!)
 

--- a/content/blog/en/how-to-sell-a-domain-name-you-own.md
+++ b/content/blog/en/how-to-sell-a-domain-name-you-own.md
@@ -31,7 +31,7 @@ If you only remember one flow, make it this:
 5. Use [Namefi Outbound](https://namefi.io/outbound) to research possible buyers, buyer angles, public contacts when available, and editable first-message drafts.
 6. Send short, specific outreach only to people who might actually care.
 7. Negotiate in writing: price, fee split, transfer method, included assets, and timeline.
-8. Close through a secure payment or escrow workflow, transfer the domain, then keep the records.
+8. Close through a secure payment or [escrow](/en/glossary/escrow/) workflow, transfer the domain, then keep the records.
 
 The transfer is the last step. Buyer fit is the first one.
 
@@ -58,7 +58,7 @@ Also check the uncomfortable stuff early:
 
 - Does the domain look confusingly similar to someone else's trademark?
 - Did you register it mainly because of a specific company's brand?
-- Is the current website, parking page, or ad content creating confusion?
+- Is the current website, [parking page](/en/blog/domain-parking-and-monetization/), or ad content creating confusion?
 - Is the domain close to expiration?
 - Is it locked from transfer because it was recently registered or transferred?
 
@@ -74,7 +74,7 @@ Still, a defensible price usually comes from five inputs:
 
 | Input | What to Check |
 | --- | --- |
-| Comparable sales | Recent sales with similar length, word count, category, and TLD |
+| Comparable sales | Recent sales with similar length, word count, category, and [TLD](/en/glossary/tld/) |
 | TLD strength | Whether the extension is liquid globally or useful mainly in a niche |
 | Buyer use case | How directly the name helps a real business, campaign, product, or category |
 | Existing value | Traffic, backlinks, revenue, age, clean history, or developed assets |
@@ -92,7 +92,7 @@ Then choose the pricing style:
 
 - **Fixed price / buy now:** best when you want speed and less back-and-forth.
 - **Make offer:** best when the domain is unusual or buyer value varies widely.
-- **Auction:** best when there is visible demand from multiple buyers.
+- **[Auction](/en/glossary/auction/):** best when there is visible demand from multiple buyers.
 - **Private negotiation:** best when the buyer pool is small and strategic.
 
 The bigger the domain, the more important it is to know your walk-away number before the first reply arrives. Negotiation is much calmer when you are not inventing your price in the middle of it.
@@ -111,7 +111,7 @@ If the domain is close to expiration, renew it before serious outreach. A buyer 
 
 ### Check transfer status
 
-ICANN explains that registrars may deny transfers in certain cases, including when a domain is in lock status, within 60 days of initial registration, or within 60 days of a previous transfer. You will also need an [AuthInfo/auth code](/en/glossary/auth-code/) for many cross-registrar transfers, and ICANN says registrars must either let you create one or provide it within five calendar days of request.
+ICANN explains that registrars may deny transfers in certain cases, including when a domain is in lock status, within 60 days of initial registration, or within 60 days of a previous transfer. You will also need an [AuthInfo/auth code](/en/glossary/auth-code/) for many [cross-registrar transfers](/en/glossary/cross-registrar-transfer/), and [ICANN](/en/glossary/icann/) says registrars must either let you create one or provide it within five calendar days of request.
 
 That does not mean every sale has to wait. If the buyer is willing to receive the domain at the current registrar, a same-registrar account push or change of ownership may be possible. But you need to know the transfer path before you promise a closing date.
 
@@ -272,7 +272,7 @@ In the U.S., the IRS treats sales of assets under tax rules that depend on how t
 
 If your domain is a [tokenized domain](/en/blog/what-are-tokenized-domains/), the closing mechanics can be different.
 
-In a traditional sale, escrow exists because payment and registrar transfer happen in separate steps. In a tokenized-domain sale, ownership may be represented by an [NFT](/en/glossary/nft/) and transferred through an [on-chain](/en/glossary/on-chain/) transaction. That can compress settlement, but it does not remove every risk. You still need buyer fit, clean legal posture, wallet security, tax records, and a clear understanding of what the buyer expects to receive.
+In a traditional sale, escrow exists because payment and registrar transfer happen in separate steps. In a tokenized-domain sale, ownership may be represented by an [NFT](/en/glossary/nft/) and transferred through an [on-chain](/en/glossary/on-chain/) transaction. That can compress settlement, but it does not remove every risk. You still need buyer fit, clean legal posture, [wallet](/en/glossary/wallet/) security, tax records, and a clear understanding of what the buyer expects to receive.
 
 For more on how tokenized sales change escrow mechanics, read [From Listing to Settlement: How Tokenized Marketplaces Replace Escrow](/en/blog/how-tokenized-marketplaces-replace-escrow/).
 


### PR DESCRIPTION
English cross-linking pass (batch 11) — adds in-body prose links to existing glossary/TLD/blog pages at the first meaningful mention only. No frontmatter, headings, code, or disclaimer touched.

## Links added per file

| File | Links added (anchor → target) |
| --- | --- |
| how-tld-affects-domain-value.md | registrar → /en/glossary/registrar/ · ICANN → /en/glossary/icann/ · DNS → /en/glossary/dns/ |
| how-to-find-domains-to-flip.md | ICANN → /en/glossary/icann/ · DNS → /en/glossary/dns/ |
| how-to-name-your-project.md | TLDs → /en/glossary/tld/ · tokenize → /en/glossary/tokenize/ |
| how-to-read-comparable-domain-sales.md | ICANN → /en/glossary/icann/ · DNS → /en/glossary/dns/ |
| how-to-sell-a-domain-name-you-own.md | escrow → /en/glossary/escrow/ · parking page → /en/blog/domain-parking-and-monetization/ · TLD → /en/glossary/tld/ · Auction → /en/glossary/auction/ · cross-registrar transfers → /en/glossary/cross-registrar-transfer/ · ICANN → /en/glossary/icann/ · wallet → /en/glossary/wallet/ |

## Notable rejections
- `marketplace` → /en/glossary/marketplace/ rejected on all 3 candidate pages: that glossary entry is the NFT marketplace ("Marketplace (e.g., OpenSea, Blur)"), not domain marketplaces — guardrail mismap.
- `lens` (how-to-find-domains-to-flip) rejected: figurative "a useful lens on…" + glossary entry is the Lens web3 protocol.
- `.com` → /en/tld/com/ skipped in how-to-read-comparable-domain-sales: every mention is inside inline code.
- `did`/`Did` (verb), `portfolio`→domain-bundle, `ownership`→web3, `security`→collateral, `open access`→permissionless, and Sources-citation / publication-name false positives (GoDaddy, Domain Name Wire, Sex.com) all rejected per guardrails.

## Validation
- `link-audit.ts` on the 5 files: **0 broken**, 0 locale-mismatch, 0 cross-locale.
- `bun run data:validate`: **Data validation passed** (19 pre-existing keyword warnings, unrelated).
- `eslint` on the 5 files: **exit 0**.

English-first pass; locales are handled as a separate manual batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial markdown-only changes with no application logic, auth, or data model impact; main risk is a wrong glossary target, which the PR’s link audit was meant to catch.
> 
> **Overview**
> Adds **in-body internal links** across five English blog posts so the first meaningful mention of domain terms points at existing `/en/glossary/` and `/en/blog/` pages. Frontmatter, headings, disclaimers, and code blocks are unchanged.
> 
> Coverage is uneven by article: **how-tld-affects-domain-value**, **how-to-find-domains-to-flip**, and **how-to-read-comparable-domain-sales** mainly wire **registrar**, **ICANN**, and **DNS** in Namefi closing sections; **how-to-name-your-project** links **TLDs** and **tokenize**; **how-to-sell-a-domain-name-you-own** gets the richest pass (**escrow**, **TLD**, **auction**, **cross-registrar transfer**, **ICANN**, **wallet**, plus **domain parking** for “parking page”).
> 
> This matches the described guardrails (e.g. skipping NFT-marketplace “marketplace” and figurative “lens”); validation was run on link targets only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78403e8298c50eb98c7d7d8d0660d3e9d8d5444f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->