### PR TITLE
fix(skills): cross-link --fix no longer mislocalizes en-only slugs; missing translation is a warning

### DIFF
--- a/.agents/skills/cross-link/SKILL.md
+++ b/.agents/skills/cross-link/SKILL.md
@@ -59,15 +59,24 @@ bun .agents/skills/cross-link/link-audit.ts --fix <paths>   # repoint LOCALE_MIS
 bun .agents/skills/cross-link/link-audit.ts --json <paths>  # machine-readable
 ```
 
-It classifies every internal link:
+It classifies every internal link. The resources app **falls back to the default locale (`en`)
+at runtime** — requesting `/<loc>/.../<slug>` when that locale lacks the slug serves the English
+entry (HTTP 200) with `rel=canonical` → the `en` URL (the `load*Entry` fallback in
+`apps/resources/src/lib/content.ts`). So a missing translation is **not** a 404; only the absence of
+the `en` fallback is. The severities mirror that:
 
-- **`BROKEN`** — target slug exists in no locale → 404. **Must be fixed by hand** (create the
-  missing translation, or repoint to `/en/...` if that's the only existing copy). The auditor never
-  auto-fixes these because the right answer is editorial.
+- **`BROKEN`** — slug exists in neither the link locale **nor** the `en` fallback → genuine 404.
+  **Must be fixed by hand** (create the term, or repoint to a locale that has it). Never auto-fixed
+  (the right answer is editorial). The only severity that fails the run (exit 1).
 - **`LOCALE_MISMATCH`** — link locale ≠ file locale and the file's own locale *has* the counterpart.
   **Auto-fixable** with `--fix` (repoints to the file's locale).
-- **`CROSS_LOCALE`** — link locale ≠ file locale and the file's locale has *no* counterpart. An
-  acceptable `/en/...` fallback; surfaced as a dim warning, never auto-fixed.
+- **`MISSING_TRANSLATION`** — the link locale lacks the slug but `en` has it, so the app renders it
+  via the `en` fallback (200, canonical → `en`). A warning, not a 404: ideally translate the term,
+  or link `/en/...` explicitly for a self-canonical URL. Never auto-fixed (translate-vs-repoint is
+  an editorial call).
+- **`CROSS_LOCALE`** — link locale ≠ file locale, the linked page genuinely exists, and the file's
+  locale has *no* counterpart (the term is only translated in the linked locale). An acceptable
+  `/en/...`-style fallback; a dim warning, never auto-fixed.
 
 The full repo currently carries thousands of `LOCALE_MISMATCH` links — do **not** mass-fix the whole
 repo in a content PR. Scope `--fix` to the paths you actually created or edited.

--- a/.agents/skills/cross-link/link-audit.test.ts
+++ b/.agents/skills/cross-link/link-audit.test.ts
@@ -112,3 +112,48 @@ test('--fix never leaves a link whose target is absent from slugIndex', () => {
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test('an un-translated slug is MISSING_TRANSLATION (warning, exit 0), not BROKEN', () => {
+  const root = scaffold();
+  try {
+    // zh lacks `dnssec`, but en has it → the app serves it via the en
+    // fallback (200). A warning, never a 404.
+    writeFileSync(
+      path.join(root, 'content/glossary/zh/probe.md'),
+      `---\ntitle: probe\n---\nSee [DNSSEC](/zh/glossary/dnssec/).\n`,
+    );
+    const audit = run(root, ['--json', 'content/glossary/zh/probe.md']);
+    const report = JSON.parse(audit.stdout) as {
+      findings: { severity: string; href: string }[];
+    };
+    const finding = report.findings.find(
+      (f) => f.href === '/zh/glossary/dnssec/',
+    );
+    expect(finding?.severity).toBe('MISSING_TRANSLATION');
+    expect(report.findings.some((f) => f.severity === 'BROKEN')).toBe(false);
+    expect(audit.code).toBe(0); // warnings never fail the run
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a slug absent from every locale (no en fallback) is BROKEN (exit 1)', () => {
+  const root = scaffold();
+  try {
+    writeFileSync(
+      path.join(root, 'content/glossary/zh/probe.md'),
+      `---\ntitle: probe\n---\nSee [Ghost](/zh/glossary/ghost/).\n`,
+    );
+    const audit = run(root, ['--json', 'content/glossary/zh/probe.md']);
+    const report = JSON.parse(audit.stdout) as {
+      findings: { severity: string; href: string }[];
+    };
+    const finding = report.findings.find(
+      (f) => f.href === '/zh/glossary/ghost/',
+    );
+    expect(finding?.severity).toBe('BROKEN');
+    expect(audit.code).toBe(1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/.agents/skills/cross-link/link-audit.test.ts
+++ b/.agents/skills/cross-link/link-audit.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Fixture tests for link-audit.ts --fix.
+ *
+ * Regression guard for the en-only mislocalization bug: `--fix` used to
+ * substring-replace `](${href}`, so repointing a fixable slug whose name is a
+ * PREFIX of a sibling (e.g. `dns` ⊂ `dnssec`, `com` ⊂ `company`) also clobbered
+ * the sibling — turning a valid `/en/glossary/dnssec/` cross-locale fallback
+ * into a `/zh/glossary/dnssec/` 404. The bug fired only for the no-trailing-
+ * slash form of the fixable link, so we exercise both forms here.
+ *
+ * Run: bun test .agents/skills/cross-link/link-audit.test.ts
+ */
+import { test, expect } from 'bun:test';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const SCRIPT = path.join(import.meta.dir, 'link-audit.ts');
+
+/**
+ * Build a throwaway content/ tree reproducing the en-only collision:
+ *   glossary: dns exists en+zh (fixable) · dnssec en-only · whois en-only
+ *   tld:      com exists en+zh (fixable) · company en-only
+ * `dns` is a prefix of `dnssec`; `com` is a prefix of `company` — the exact
+ * shape that broke the old substring rewrite.
+ */
+function scaffold(): string {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'crosslink-'));
+  const write = (relPath: string, body: string) => {
+    const full = path.join(root, relPath);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, body);
+  };
+  const doc = (title: string) => `---\ntitle: ${title}\n---\n${title}.\n`;
+
+  write('content/glossary/en/dns.md', doc('DNS'));
+  write('content/glossary/en/dnssec.md', doc('DNSSEC'));
+  write('content/glossary/en/whois.md', doc('WHOIS'));
+  write('content/glossary/zh/dns.md', doc('DNS zh'));
+  write('content/tld/en/com.md', doc('com'));
+  write('content/tld/en/company.md', doc('company'));
+  write('content/tld/zh/com.md', doc('com zh'));
+
+  // A zh post linking to fixable + en-only siblings on the same line. The
+  // fixable links (`dns`, `com`) use the no-trailing-slash form that triggered
+  // the prefix collision; the en-only fallbacks use the trailing-slash form.
+  write(
+    'content/glossary/zh/post.md',
+    `---\ntitle: post\n---\n` +
+      `See [DNS](/en/glossary/dns) and [DNSSEC](/en/glossary/dnssec/) and ` +
+      `[WHOIS](/en/glossary/whois/).\n` +
+      `Also [company](/en/tld/company/) after [com](/en/tld/com).\n`,
+  );
+  return root;
+}
+
+function run(root: string, args: string[]) {
+  const r = Bun.spawnSync(['bun', SCRIPT, ...args], { cwd: root });
+  return {
+    code: r.exitCode,
+    stdout: r.stdout.toString(),
+    stderr: r.stderr.toString(),
+  };
+}
+
+test('--fix repoints fixable siblings but leaves en-only fallbacks on /en/', () => {
+  const root = scaffold();
+  try {
+    const res = run(root, ['--fix', 'content/glossary', 'content/tld']);
+    expect(res.code).toBe(0);
+    const post = readFileSync(
+      path.join(root, 'content/glossary/zh/post.md'),
+      'utf8',
+    );
+
+    // Fixable: the file's own locale (zh) has the slug → repointed to /zh/.
+    expect(post).toContain('](/zh/glossary/dns)');
+    expect(post).toContain('](/zh/tld/com)');
+
+    // En-only fallbacks: zh has no counterpart → MUST stay on /en/.
+    expect(post).toContain('](/en/glossary/dnssec/)');
+    expect(post).toContain('](/en/glossary/whois/)');
+    expect(post).toContain('](/en/tld/company/)');
+
+    // The bug repointed these to non-existent /zh/ targets.
+    expect(post).not.toContain('/zh/glossary/dnssec');
+    expect(post).not.toContain('/zh/tld/company');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('--fix never leaves a link whose target is absent from slugIndex', () => {
+  const root = scaffold();
+  try {
+    run(root, ['--fix', 'content/glossary', 'content/tld']);
+    // Re-audit the fixed tree: zero BROKEN and a clean (exit 0) run.
+    const audit = run(root, ['--json', 'content/glossary', 'content/tld']);
+    const report = JSON.parse(audit.stdout) as {
+      findings: { severity: string; href: string }[];
+    };
+    const broken = report.findings.filter((f) => f.severity === 'BROKEN');
+    expect(broken).toEqual([]);
+    expect(audit.code).toBe(0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/.agents/skills/cross-link/link-audit.ts
+++ b/.agents/skills/cross-link/link-audit.ts
@@ -157,9 +157,29 @@ function localeOfFile(file: string): string | null {
   return m ? m[1] : null;
 }
 
+// Every internal-link href in `content` whose exact target
+// (`<collection>/<linkLocale>/<slug>`) is absent from slugIndex — i.e. a 404.
+// Used by the --fix self-check to prove a rewrite never *introduces* a dead
+// link (the en-only mislocalization bug). Returns raw hrefs (may repeat).
+function findAbsentTargets(content: string): string[] {
+  const prose = stripNonProse(content);
+  const out: string[] = [];
+  for (const m of prose.matchAll(LINK_RE)) {
+    const href = m[1];
+    const parts = href.match(HREF_PARTS_RE);
+    if (!parts) continue;
+    const [, linkLocale, collection, slugRaw] = parts;
+    const slug = decodeURIComponent(slugRaw);
+    if (!slugIndex.has(`${collection}/${linkLocale}/${slug}`)) out.push(href);
+  }
+  return out;
+}
+
 // --- audit -----------------------------------------------------------------
 const findings: Finding[] = [];
 const filesToRewrite = new Map<string, string>();
+// Count of files where --fix would have created a dead link and was refused.
+let selfCheckFailures = 0;
 
 for (const file of auditFiles) {
   const fileLocale = localeOfFile(file);
@@ -183,8 +203,12 @@ for (const file of auditFiles) {
     return lo + 1;
   };
 
-  let mutated = raw;
-  let changed = false;
+  // Collected --fix rewrites as exact byte spans into `raw`. prose is built by
+  // stripNonProse, which blanks frontmatter/code char-for-char (length and
+  // newlines preserved), so a match index in `prose` is the same index in
+  // `raw`. Splicing exact spans — rather than the old substring replace —
+  // is what makes the fix immune to prefix collisions (see below).
+  const edits: { start: number; end: number; replacement: string }[] = [];
 
   for (const m of prose.matchAll(LINK_RE)) {
     const href = m[1];
@@ -194,24 +218,23 @@ for (const file of auditFiles) {
     const slug = decodeURIComponent(slugRaw);
 
     const literalExists = slugIndex.has(`${collection}/${linkLocale}/${slug}`);
+    // The file's OWN locale having the slug is the single source of truth for
+    // "auto-fixable": it guarantees the repointed /<fileLocale>/ href resolves
+    // to a real slug, so --fix can never localize an en-only term into a 404.
     const sameLocaleExists = slugIndex.has(
       `${collection}/${fileLocale}/${slug}`,
-    );
-    const anyLocaleExists = (LOCALES as readonly string[]).some((l) =>
-      slugIndex.has(`${collection}/${l}/${slug}`),
     );
 
     let severity: Severity | null = null;
     let fixedHref: string | undefined;
 
     if (!literalExists) {
+      // The linked locale itself lacks the slug → this exact href 404s.
       if (sameLocaleExists) {
         severity = 'LOCALE_MISMATCH';
         fixedHref = href.replace(`/${linkLocale}/`, `/${fileLocale}/`);
-      } else if (!anyLocaleExists) {
-        severity = 'BROKEN';
       } else {
-        // points at a locale that lacks the slug, and our locale lacks it too
+        // Missing in the linked locale and in ours — not auto-fixable.
         severity = 'BROKEN';
       }
     } else if (linkLocale !== fileLocale) {
@@ -219,6 +242,7 @@ for (const file of auditFiles) {
         severity = 'LOCALE_MISMATCH';
         fixedHref = href.replace(`/${linkLocale}/`, `/${fileLocale}/`);
       } else {
+        // Term only translated in the linked locale — acceptable fallback.
         severity = 'CROSS_LOCALE';
       }
     }
@@ -238,12 +262,43 @@ for (const file of auditFiles) {
     });
 
     if (FIX && severity === 'LOCALE_MISMATCH' && fixedHref) {
-      mutated = mutated.split(`](${href}`).join(`](${fixedHref}`);
-      changed = true;
+      // Rewrite ONLY this href occurrence. The previous implementation did
+      // `content.split(`](${href}`).join(...)`, a substring replace that also
+      // rewrote any longer href sharing this one as a prefix: fixing
+      // `](/en/glossary/dns` clobbered the sibling `](/en/glossary/dnssec/)`,
+      // repointing an en-only fallback to a /zh/ 404 (and doing so only for
+      // the no-trailing-slash form). LINK_RE puts m.index at the `]`, so the
+      // href begins two chars later, at `](`.length.
+      const start = (m.index ?? 0) + 2;
+      edits.push({ start, end: start + href.length, replacement: fixedHref });
     }
   }
 
-  if (changed) filesToRewrite.set(file, mutated);
+  if (FIX && edits.length > 0) {
+    // Apply right-to-left so earlier offsets stay valid as we splice.
+    edits.sort((a, b) => b.start - a.start);
+    let mutated = raw;
+    for (const e of edits) {
+      mutated = mutated.slice(0, e.start) + e.replacement + mutated.slice(e.end);
+    }
+    // Guard: --fix must never INTRODUCE a link whose target is absent from
+    // slugIndex. Pre-existing BROKEN links are allowed to remain (we don't
+    // invent translations), so compare against the original rather than
+    // requiring zero. If the rewrite would create a new dead link, refuse to
+    // write the file and fail the run loudly instead of shipping a 404.
+    const before = new Set(findAbsentTargets(raw));
+    const introduced = findAbsentTargets(mutated).filter((h) => !before.has(h));
+    if (introduced.length > 0) {
+      console.error(
+        `✗ self-check failed for ${rel(file)}: --fix would create dead ` +
+          `link(s) absent from slugIndex: ${introduced.join(', ')}. ` +
+          `Refusing to write this file.`,
+      );
+      selfCheckFailures++;
+    } else {
+      filesToRewrite.set(file, mutated);
+    }
+  }
 }
 
 if (FIX) {
@@ -289,6 +344,12 @@ if (JSON_OUT) {
   if (!FIX && mismatch > 0) {
     console.log('Re-run with --fix to repoint locale-mismatch links automatically.');
   }
+  if (selfCheckFailures > 0) {
+    console.log(
+      c('31', `${selfCheckFailures} file(s) skipped: --fix self-check failed.`),
+    );
+  }
 }
 
-process.exitCode = findings.some((f) => f.severity === 'BROKEN') ? 1 : 0;
+process.exitCode =
+  selfCheckFailures > 0 || findings.some((f) => f.severity === 'BROKEN') ? 1 : 0;

--- a/.agents/skills/cross-link/link-audit.ts
+++ b/.agents/skills/cross-link/link-audit.ts
@@ -4,22 +4,36 @@
  *
  * Deterministic backbone of the `cross-link` skill. It does NOT invent
  * editorial links (that is the model's judgement job) — it audits the
- * internal links that already exist and finds the two mechanical failure
- * modes a human eye misses across 7 locales x 4 collections:
+ * internal links that already exist and finds the mechanical failure modes a
+ * human eye misses across 7 locales x 4 collections.
  *
- *   BROKEN          target slug does not exist in ANY locale -> 404.
- *   LOCALE_MISMATCH link locale != file locale AND a same-locale counterpart
- *                   exists. e.g. a `zh` post links to `/en/glossary/dns/`
- *                   while `/zh/glossary/dns/` exists. Auto-fixable: repoint
- *                   the link to the file's own locale.
- *   CROSS_LOCALE    link locale != file locale and NO same-locale counterpart
- *                   exists (the term is only translated in the linked locale).
- *                   Acceptable fallback — surfaced as a warning, never auto-fixed.
+ * Severity model — the resources app falls back to the DEFAULT locale (en) at
+ * runtime: requesting /<loc>/<coll>/<slug> when that locale lacks the slug
+ * serves the English entry (200) with rel=canonical -> the en URL (see the
+ * load*Entry default-locale fallback in apps/resources/src/lib/content.ts).
+ * So "the linked locale lacks the slug" is NOT automatically a 404 — only the
+ * absence of the en fallback is. The classifier mirrors that:
+ *
+ *   BROKEN              slug exists in neither the link locale NOR the default
+ *                      locale (en) -> the runtime fallback can't save it, real
+ *                      404. Must be fixed by hand. (Exit code 1.)
+ *   LOCALE_MISMATCH    link locale != file locale AND a same-locale counterpart
+ *                      exists. e.g. a `zh` post links to `/en/glossary/dns/`
+ *                      while `/zh/glossary/dns/` exists. Auto-fixable: repoint
+ *                      the link to the file's own locale.
+ *   MISSING_TRANSLATION the link locale lacks the slug but the default locale
+ *                      (en) has it, so the app renders it via the en fallback.
+ *                      A warning (not a 404): translate the term, or link /en/
+ *                      explicitly for a self-canonical URL. Never auto-fixed.
+ *   CROSS_LOCALE       link locale != file locale, the linked page genuinely
+ *                      exists, and no same-locale counterpart does (the term is
+ *                      only translated in the linked locale). Acceptable — a
+ *                      warning, never auto-fixed.
  *
  * Internal links are written as absolute, locale-prefixed, trailing-slash
- * paths: /<locale>/<collection>/<slug>/ . The resources app does NOT
- * auto-localize hrefs (see apps/resources/src/mdx-components.tsx), so the
- * locale in the href is authoritative: a mismatch is a real bug, not cosmetic.
+ * paths: /<locale>/<collection>/<slug>/ . The app does NOT auto-localize hrefs
+ * (see apps/resources/src/mdx-components.tsx), so the locale in the href is
+ * authoritative for which page is served / canonicalized.
  *
  * Usage (run from the namefi-resources repo root):
  *   bun .agents/skills/cross-link/link-audit.ts                 # audit everything
@@ -27,17 +41,26 @@
  *   bun .agents/skills/cross-link/link-audit.ts --fix <paths>   # repoint LOCALE_MISMATCH
  *   bun .agents/skills/cross-link/link-audit.ts --json <paths>  # machine-readable
  *
- * Exit code is 1 when BROKEN links remain (after --fix), else 0.
+ * Exit code is 1 when BROKEN links remain (after --fix), else 0. Warnings
+ * (MISSING_TRANSLATION, CROSS_LOCALE) never affect the exit code.
  */
 
 import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 const LOCALES = ['en', 'es', 'de', 'fr', 'zh', 'ar', 'hi'] as const;
+// Mirrors i18n.defaultLocale in apps/resources: the locale every other locale
+// falls back to at runtime when it lacks a slug. A link the default locale can
+// satisfy is never a hard 404.
+const DEFAULT_LOCALE = 'en';
 const COLLECTIONS = ['blog', 'glossary', 'tld', 'partners'] as const;
 const MD_EXT = new Set(['.md', '.mdx']);
 
-type Severity = 'BROKEN' | 'LOCALE_MISMATCH' | 'CROSS_LOCALE';
+type Severity =
+  | 'BROKEN'
+  | 'LOCALE_MISMATCH'
+  | 'MISSING_TRANSLATION'
+  | 'CROSS_LOCALE';
 type Finding = {
   file: string;
   line: number;
@@ -224,17 +247,28 @@ for (const file of auditFiles) {
     const sameLocaleExists = slugIndex.has(
       `${collection}/${fileLocale}/${slug}`,
     );
+    // The default locale (en) is the runtime fallback target: if it has the
+    // slug, the app serves /<linkLocale>/.../<slug> via that fallback (200),
+    // so the link is at worst a missing translation, never a hard 404.
+    const defaultLocaleExists = slugIndex.has(
+      `${collection}/${DEFAULT_LOCALE}/${slug}`,
+    );
 
     let severity: Severity | null = null;
     let fixedHref: string | undefined;
 
     if (!literalExists) {
-      // The linked locale itself lacks the slug → this exact href 404s.
+      // The linked locale itself lacks the slug.
       if (sameLocaleExists) {
+        // ...but the file's own locale has it → repoint to it (best target).
         severity = 'LOCALE_MISMATCH';
         fixedHref = href.replace(`/${linkLocale}/`, `/${fileLocale}/`);
+      } else if (defaultLocaleExists) {
+        // The en fallback covers it: the app renders en at this URL (200).
+        // Not a 404 — a warning to translate or link /en/ explicitly.
+        severity = 'MISSING_TRANSLATION';
       } else {
-        // Missing in the linked locale and in ours — not auto-fixable.
+        // Missing in the linked locale AND in the en fallback — real 404.
         severity = 'BROKEN';
       }
     } else if (linkLocale !== fileLocale) {
@@ -314,6 +348,7 @@ if (JSON_OUT) {
   const tag: Record<Severity, string> = {
     BROKEN: c('31', '✗ BROKEN'),
     LOCALE_MISMATCH: c('33', '⚠ LOCALE'),
+    MISSING_TRANSLATION: c('33', '⚠ MISSING-TR'),
     CROSS_LOCALE: c('2', '· x-locale'),
   };
   const byFile = new Map<string, Finding[]>();
@@ -333,12 +368,16 @@ if (JSON_OUT) {
   }
   const broken = findings.filter((f) => f.severity === 'BROKEN').length;
   const mismatch = findings.filter((f) => f.severity === 'LOCALE_MISMATCH').length;
+  const missingTr = findings.filter(
+    (f) => f.severity === 'MISSING_TRANSLATION',
+  ).length;
   const xloc = findings.filter((f) => f.severity === 'CROSS_LOCALE').length;
   console.log('');
   console.log(
     `Audited ${auditFiles.length} file(s): ` +
       `${c('31', `${broken} broken`)}, ` +
       `${c('33', `${mismatch} locale-mismatch`)}${FIX ? ` (${filesToRewrite.size} file(s) rewritten)` : ''}, ` +
+      `${c('33', `${missingTr} missing-translation`)}, ` +
       `${c('2', `${xloc} cross-locale fallback`)}.`,
   );
   if (!FIX && mismatch > 0) {


### PR DESCRIPTION
This PR does two related things to `.agents/skills/cross-link/link-audit.ts`:

1. **Fixes `--fix` mislocalizing en-only slugs** (the headline bug).
2. **Aligns the severity model with the app's runtime `en` fallback** — a missing translation is now a **warning**, not a fake `BROKEN`/404.

## 1. Problem — `--fix` mislocalized en-only slugs

`--fix` mislocalized internal links to **en-only slugs** — slugs that exist only in `content/<coll>/en/` with no locale counterpart (e.g. `glossary/dnssec`, `tld/shopping`, `tld/company`). When `--fix` rewrote a locale file, it turned a valid `/en/glossary/dnssec/` cross-locale fallback into `/zh/glossary/dnssec/`. A fresh audit then flagged these, so the damage was detectable but had to be hand-reverted after every sweep (this bit the cross-link + TLD content work three times).

### Root cause

The severity **classification was already correct** — en-only slugs are reported `· x-locale`, never `fixed→`. The bug was purely in the mutation step:

```js
mutated = mutated.split(`](${href}`).join(`](${fixedHref}`);  // substring replace
```

A substring replace: fixing `](/en/glossary/dns` (a real `LOCALE_MISMATCH`) also rewrote the sibling `](/en/glossary/dnssec/)` because `dns` is a string **prefix** of `dnssec`. It only triggered for the **no-trailing-slash** form of the fixable href — which is exactly why `dnssec` broke but `whois` (no fixable prefix) didn't, and why behavior differed by trailing slash. Same shape for `com` ⊂ `company`, `shop` ⊂ `shopping`.

### Fix

- **Exact positional splices** instead of substring replace. `prose` is index-aligned to `raw` (`stripNonProse` preserves length char-for-char), so each match's href span `[m.index+2, +href.length)` is spliced precisely — immune to prefix collisions regardless of trailing-slash form. Edits applied right-to-left so offsets stay valid.
- **`sameLocaleExists` is the single source of truth** for "auto-fixable". `--fix` only ever localizes to a target the file's own locale genuinely has in `slugIndex`, so it can never manufacture a `/loc/` 404.
- **Self-check guard** (`findAbsentTargets`): after a rewrite, if `--fix` would introduce any *new* slugIndex-absent target, the file is refused and the run exits 1.

## 2. Severity model — missing translation is a warning, not a 404

The resources app **falls back to the default locale (`en`) at runtime**: requesting `/<loc>/<coll>/<slug>` when that locale lacks the slug serves the English entry (HTTP **200**, `rel=canonical` → the `en` URL) via the `load*Entry` fallback in `apps/resources/src/lib/content.ts`. Verified in production:

```
/r/zh/glossary/dnssec       -> 200  (English term, <html lang="zh">, canonical .../r/en/glossary/dnssec)
/r/zh/glossary/nope-xyz-123 -> 404  (slug in no locale — genuine miss)
```

The auditor's pure file-existence model called the first case `BROKEN`, crying wolf. Now:

- **`MISSING_TRANSLATION`** (new, **warning**, exit 0) — the link locale lacks the slug but `en` has it, so the app renders it via the `en` fallback. Ideal action is to translate the term (or link `/en/…` explicitly for a self-canonical URL), but it is **not** a 404. Never auto-fixed (translate-vs-repoint is editorial).
- **`BROKEN`** (exit 1) — now reserved for genuine 404s: slug absent from **both** the link locale **and** the `en` fallback. Classified via `defaultLocaleExists`, the actual runtime-fallback predicate.

## Verification

- Reproduced the bug on the pre-fix script (created 2 `BROKEN`: `/zh/glossary/dnssec/`, `/zh/tld/company/`); after the fix the same input keeps `dnssec`/`whois`/`company` on `/en/` and still fixes `dns`/`com` → **0 broken, exit 0**.
- Grafted the guard onto the original buggy script and confirmed it catches `/zh/glossary/dnssec/` and refuses the write.
- `bun test .agents/skills/cross-link/link-audit.test.ts` → **4 pass, 0 fail** (en-only splice across both slash forms; `MISSING_TRANSLATION` warning; genuine `BROKEN`).
- Read-only audit of the real **1,633-file** tree (`blog`+`glossary`+`tld`): **0 broken**, 1 missing-translation, 779 cross-locale — i.e. the former false-positive "broken" count is gone and the tool now matches verified production behavior. No content files touched.

## Scope

Skill-tool fix only (`.agents/skills/cross-link/`), independent of content PRs. No content was modified.

---

<details>
<summary>Claude Code session summary (2026-06-22, redacted)</summary>

- Confirmed the canonical skill source: `.agents/skills/cross-link/` lives inside this repo (merged via #79), byte-identical across worktrees — not a separate skills repo.
- Localized the en-only bug to the `--fix` substring replace, not the `literalExists`/`sameLocaleExists` classification; reproduced it in an isolated sandbox mirroring the real `dns`/`dnssec` + `com`/`company` collisions.
- Implemented positional splicing + the `sameLocaleExists`-only gate + the `findAbsentTargets` self-check guard; added fixture tests.
- On review of the app, found the resources content loader (`apps/resources/src/lib/content.ts`) already falls back to the default locale, and **verified live in production** that `/r/zh/glossary/dnssec` returns 200 (en content, canonical → en) while a slug in no locale 404s.
- Added the `MISSING_TRANSLATION` warning severity and reserved `BROKEN` for genuine 404s, so the auditor stops reporting fallback-covered links as broken; extended docs + tests.
- Worked in a dedicated worktree off `origin/main` (`.worktrees/cross-link-skill-fix`), branch `fix/cross-link-en-only-slug-localize`.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the cross-link skill auditor and its docs/tests; no app or content files are modified, though CI/content workflows that treat former “broken” missing-translation links as failures may see fewer hard failures.
> 
> **Overview**
> **`link-audit.ts --fix`** no longer uses substring `](href)` replacement (which could rewrite sibling hrefs when one slug is a prefix of another, e.g. `dns` vs `dnssec`). It now splices **exact href byte spans** (index-aligned with stripped prose) and only auto-fixes when the file’s locale has the slug in `slugIndex`.
> 
> A **`--fix` self-check** (`findAbsentTargets`) refuses to write a file if the rewrite would introduce new slugIndex-absent targets; exit **1** on self-check failure or remaining **`BROKEN`** links.
> 
> **Severity model** now matches runtime **en fallback**: links missing in the link locale but present in **`en`** are **`MISSING_TRANSLATION`** (warning, exit 0); only slugs missing everywhere count as **`BROKEN`**.
> 
> Adds **`link-audit.test.ts`** regression fixtures and updates **`SKILL.md`** to document the severities and fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0e3ca9dde3381baf222670a9c64b850e19726f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed link rewriting to prevent accidental corruption of similar link patterns
  * Added validation to prevent generating broken links during fixes
  * Improved error reporting and exit codes

* **Tests**
  * Added regression test coverage for link audit fixes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
