### PR TITLE
feat(scripts): glossary termbase tooling (Wave 0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,39 @@ All content lives under the `content/` directory (e.g., `content/blog/en/...`).
   - `bun lint:mdx` to lint markdown/MDX frontmatter and formatting.
 - CI runs validation and MDX lint on every pull request.
 
+## Glossary & termbase tooling
+
+The glossary doubles as the site's **canonical bilingual termbase**: each entry's
+per-locale `title` is the *standard* translation of that concept. A few scripts
+maintain that contract (run from the repo root):
+
+- `bun translate:glossary [slug…]` — translate glossary entries from `en` into the
+  other locales (path/batch mode, fills missing locales, termbase-aware prompt).
+  `translate:blog` is blog-only and cannot do this. Needs `GEMINI_API_KEY`.
+- `bun termbase:build` — regenerate `content/termbase.json` (the flattened
+  `slug → {en, titles, aliasesByLocale}` lookup). `bun termbase:check` verifies it
+  is committed up to date.
+- `bun glossary:mentions` — per-term distinct-post mention counts (the demand
+  metric that gates L1→L2 promotion; reuses the cross-link `link-suggest` INBOUND).
+- `bun check:termbase` — advisory linter that flags translated prose using a
+  *known* non-canonical variant of a glossary term (tracked per entry in
+  `aliasesByLocale`), so content stays consistent with the termbase.
+
+### Build-time-only glossary frontmatter
+
+`astra`'s glossary loader (`normaliseGlossaryFrontmatter`) whitelists a fixed set
+of fields, so these extra keys are read by the scripts above (via gray-matter) but
+ignored by the renderer — they are safe to add and do **not** break the build:
+
+```yaml
+level: 1            # maturity (1 = stub, 2 = full article); drives promotion
+sources:            # canonical primary sources for the entry
+  - https://www.icann.org/en/accredited-registrars
+aliasesByLocale:    # per-locale non-canonical variants to normalise away
+  zh: ['注册服务商']
+  de: ['Registrierungsdienst']
+```
+
 ## Automation
 
 - On every push to `main`, a workflow dispatches a `resources-updated` event to `namefi-astra`.

--- a/content/glossary/en/registrar.md
+++ b/content/glossary/en/registrar.md
@@ -6,6 +6,12 @@ tags: ['glossary']
 authors: ['namefiteam']
 description: What is a domain registrar and how does it differ from on-chain domain management?
 keywords: ['registrar', 'domain registration', 'ICANN', 'centralized control', 'domain management']
+level: 1
+sources:
+  - https://www.icann.org/en/accredited-registrars
+aliasesByLocale:
+  zh: ['注册服务商']
+  de: ['Registrierungsdienst']
 ---
 
 A **registrar** is an [ICANN](/en/glossary/icann/)-accredited organization authorized to register and manage domain names within the traditional [DNS](/en/glossary/dns/) system. Registrars like GoDaddy, Namecheap, or Cloudflare act as intermediaries between domain holders and registry operators. They control renewals, transfers, and nameserver changes through their own policies and interfaces. With Namefi's tokenization, while the underlying domain may still be managed by a registrar for [DNS](/en/glossary/dns/) purposes, the ownership and transfer rights become decentralized—giving you direct control through your [wallet](/en/glossary/wallet/) rather than being subject to a registrar's terms and dashboard limitations.

--- a/content/termbase.json
+++ b/content/termbase.json
@@ -1,0 +1,545 @@
+{
+  "ai-agent": {
+    "en": "AI Agent",
+    "titles": {
+      "en": "AI Agent"
+    }
+  },
+  "atomic-transfer": {
+    "en": "Atomic transfer",
+    "titles": {
+      "en": "Atomic transfer",
+      "es": "Transferencia atómica",
+      "de": "Atomarer Transfer",
+      "fr": "Transfert atomique",
+      "zh": "原子传输",
+      "ar": "التحويل الذري",
+      "hi": "एटॉमिक ट्रांसफर"
+    }
+  },
+  "auction": {
+    "en": "Auction (Dutch, English, dynamic)",
+    "titles": {
+      "en": "Auction (Dutch, English, dynamic)",
+      "es": "Subasta (holandesa, inglesa, dinámica)",
+      "de": "Auktion (holländische, englische, dynamische)",
+      "fr": "Enchère (hollandaise, anglaise, dynamique)",
+      "zh": "拍卖（荷兰式、英式、动态）",
+      "ar": "المزاد (الهولندي، الإنجليزي، الديناميكي)",
+      "hi": "नीलामी (डच, इंग्लिश, डायनामिक)"
+    }
+  },
+  "auth-code": {
+    "en": "Auth Code (EPP Code, Transfer Code)",
+    "titles": {
+      "en": "Auth Code (EPP Code, Transfer Code)"
+    }
+  },
+  "automated-delegation": {
+    "en": "Automated delegation",
+    "titles": {
+      "en": "Automated delegation",
+      "es": "Delegación automatizada",
+      "de": "Automatisierte Delegierung",
+      "fr": "Délégation automatisée",
+      "zh": "自动化委托",
+      "ar": "التفويض التلقائي",
+      "hi": "स्वचालित डेलिगेशन"
+    }
+  },
+  "censorship-free": {
+    "en": "Censorship-free",
+    "titles": {
+      "en": "Censorship-free",
+      "es": "Sin censura",
+      "de": "Zensurfrei",
+      "fr": "Sans censure",
+      "zh": "抗审查",
+      "ar": "مقاومة للرقابة",
+      "hi": "सेंसरशिप-मुक्त"
+    }
+  },
+  "collateral": {
+    "en": "Collateral",
+    "titles": {
+      "en": "Collateral",
+      "es": "Garantía",
+      "de": "Sicherheit (Collateral)",
+      "fr": "Collatéral",
+      "zh": "抵押品",
+      "ar": "الضمان",
+      "hi": "कोलैटरल (गिरवी)"
+    }
+  },
+  "composability": {
+    "en": "Composability",
+    "titles": {
+      "en": "Composability",
+      "es": "Componibilidad",
+      "de": "Komponierbarkeit",
+      "fr": "Composabilité",
+      "zh": "可组合性",
+      "ar": "قابلية التركيب",
+      "hi": "कम्पोज़िबिलिटी"
+    }
+  },
+  "cross-registrar-transfer": {
+    "en": "Cross-registrar transfer",
+    "titles": {
+      "en": "Cross-registrar transfer",
+      "es": "Transferencia entre registradores",
+      "de": "Cross-Registrar-Transfer",
+      "fr": "Transfert inter-registrar",
+      "zh": "跨注册商转移",
+      "ar": "نقل النطاق بين المسجلين",
+      "hi": "क्रॉस-रजिस्ट्रार ट्रांसफर"
+    }
+  },
+  "cryptographic-security": {
+    "en": "Cryptographic security",
+    "titles": {
+      "en": "Cryptographic security",
+      "es": "Seguridad criptográfica",
+      "de": "Kryptografische Sicherheit",
+      "fr": "Sécurité cryptographique",
+      "zh": "加密安全性",
+      "ar": "الأمن التشفيري",
+      "hi": "क्रिप्टोग्राफिक सुरक्षा"
+    }
+  },
+  "custodial-ownership": {
+    "en": "Custodial ownership",
+    "titles": {
+      "en": "Custodial ownership",
+      "es": "Propiedad custodial",
+      "de": "Verwahrte Eigentümerschaft",
+      "fr": "Propriété custodiale",
+      "zh": "托管所有权",
+      "ar": "الملكية الحفظية",
+      "hi": "कस्टोडियल स्वामित्व"
+    }
+  },
+  "dao": {
+    "en": "DAO (Decentralized Autonomous Organization)",
+    "titles": {
+      "en": "DAO (Decentralized Autonomous Organization)",
+      "es": "DAO (Organización Autónoma Descentralizada)",
+      "de": "DAO (Dezentrale Autonome Organisation)",
+      "fr": "DAO (Organisation autonome décentralisée)",
+      "zh": "DAO（去中心化自治组织）",
+      "ar": "DAO (منظمة ذاتية لامركزية)",
+      "hi": "DAO (विकेंद्रीकृत स्वायत्त संगठन)"
+    }
+  },
+  "defi": {
+    "en": "DeFi (Decentralized Finance)",
+    "titles": {
+      "en": "DeFi (Decentralized Finance)"
+    }
+  },
+  "did": {
+    "en": "DID (Decentralized Identity)",
+    "titles": {
+      "en": "DID (Decentralized Identity)",
+      "es": "DID (Identidad Descentralizada)",
+      "de": "DID (Dezentrale Identität)",
+      "fr": "DID (Identité Décentralisée)",
+      "zh": "DID (去中心化身份)",
+      "ar": "DID (الهوية اللامركزية)",
+      "hi": "डीआईडी (विकेन्द्रीकृत पहचान)"
+    }
+  },
+  "dns": {
+    "en": "DNS (Domain Name System)",
+    "titles": {
+      "en": "DNS (Domain Name System)",
+      "es": "DNS (Sistema de Nombres de Dominio)",
+      "de": "DNS (Domain Name System)",
+      "fr": "DNS (Système de Noms de Domaine)",
+      "zh": "DNS (域名系统)",
+      "ar": "DNS (نظام أسماء النطاقات)",
+      "hi": "DNS (डोमेन नेम सिस्टम)"
+    }
+  },
+  "dnssec": {
+    "en": "DNSSEC (Domain Name System Security Extensions)",
+    "titles": {
+      "en": "DNSSEC (Domain Name System Security Extensions)"
+    }
+  },
+  "domain-bundle": {
+    "en": "Domain bundle",
+    "titles": {
+      "en": "Domain bundle",
+      "es": "Paquete de dominios",
+      "de": "Domain-Paket",
+      "fr": "Lot de domaines",
+      "zh": "域名捆绑包",
+      "ar": "حزمة النطاقات",
+      "hi": "डोमेन बंडल"
+    }
+  },
+  "domain-ownership": {
+    "en": "Domain ownership",
+    "titles": {
+      "en": "Domain ownership",
+      "es": "Propiedad de dominio",
+      "de": "Domain-Eigentum",
+      "fr": "Propriété de domaine",
+      "zh": "域名所有权",
+      "ar": "ملكية النطاق",
+      "hi": "डोमेन स्वामित्व"
+    }
+  },
+  "domain-trading": {
+    "en": "Domain trading",
+    "titles": {
+      "en": "Domain trading",
+      "es": "Comercio de dominios",
+      "de": "Domain-Handel",
+      "fr": "Trading de domaines",
+      "zh": "域名交易",
+      "ar": "تداول النطاقات",
+      "hi": "डोमेन ट्रेडिंग"
+    }
+  },
+  "ens": {
+    "en": "ENS (Ethereum Name Service)",
+    "titles": {
+      "en": "ENS (Ethereum Name Service)"
+    }
+  },
+  "erc-721": {
+    "en": "ERC-721 (NFT Standard)",
+    "titles": {
+      "en": "ERC-721 (NFT Standard)"
+    }
+  },
+  "escrow": {
+    "en": "Escrow",
+    "titles": {
+      "en": "Escrow",
+      "es": "Depósito en Garantía (Escrow)",
+      "de": "Treuhand",
+      "fr": "Séquestre",
+      "zh": "托管",
+      "ar": "الضمان (Escrow)",
+      "hi": "एस्क्रो"
+    }
+  },
+  "farcaster": {
+    "en": "Farcaster",
+    "titles": {
+      "en": "Farcaster",
+      "es": "Farcaster",
+      "de": "Farcaster",
+      "fr": "Farcaster",
+      "zh": "Farcaster",
+      "ar": "Farcaster",
+      "hi": "Farcaster"
+    }
+  },
+  "fractional-ownership": {
+    "en": "Fractional ownership",
+    "titles": {
+      "en": "Fractional ownership",
+      "es": "Propiedad fraccionada",
+      "de": "Teileigentum",
+      "fr": "Propriété fractionnée",
+      "zh": "部分所有权",
+      "ar": "الملكية الجزئية",
+      "hi": "आंशिक स्वामित्व"
+    }
+  },
+  "gas": {
+    "en": "Gas (Transaction Fees)",
+    "titles": {
+      "en": "Gas (Transaction Fees)"
+    }
+  },
+  "hardware-wallet": {
+    "en": "Hardware Wallet",
+    "titles": {
+      "en": "Hardware Wallet"
+    }
+  },
+  "icann": {
+    "en": "ICANN",
+    "titles": {
+      "en": "ICANN",
+      "es": "ICANN",
+      "de": "ICANN",
+      "fr": "ICANN",
+      "zh": "ICANN",
+      "ar": "ICANN",
+      "hi": "आईसीएएनएन"
+    }
+  },
+  "internet-native-asset": {
+    "en": "Internet-native asset",
+    "titles": {
+      "en": "Internet-native asset",
+      "es": "Activo nativo de Internet",
+      "de": "Internet-natives Asset",
+      "fr": "Actif natif d'Internet",
+      "zh": "互联网原生资产",
+      "ar": "أصل رقمي أصيل للإنترنت",
+      "hi": "इंटरनेट-नेटिव एसेट"
+    }
+  },
+  "leasing": {
+    "en": "Leasing",
+    "titles": {
+      "en": "Leasing",
+      "es": "Arrendamiento",
+      "de": "Leasing",
+      "fr": "Location (Leasing)",
+      "zh": "租赁",
+      "ar": "تأجير",
+      "hi": "लीजिंग"
+    }
+  },
+  "lending-protocol": {
+    "en": "Lending protocol",
+    "titles": {
+      "en": "Lending protocol",
+      "es": "Protocolo de préstamo",
+      "de": "Lending-Protokoll",
+      "fr": "Protocole de prêt",
+      "zh": "借贷协议",
+      "ar": "بروتوكول الإقراض",
+      "hi": "लेंडिंग प्रोटोकॉल"
+    }
+  },
+  "lens": {
+    "en": "Lens",
+    "titles": {
+      "en": "Lens",
+      "es": "Lens",
+      "de": "Lens",
+      "fr": "Lens",
+      "zh": "Lens",
+      "ar": "لينس",
+      "hi": "लेंस"
+    }
+  },
+  "marketplace": {
+    "en": "Marketplace (e.g., OpenSea, Blur)",
+    "titles": {
+      "en": "Marketplace (e.g., OpenSea, Blur)",
+      "es": "Mercado (ej. OpenSea, Blur)",
+      "de": "Marktplatz (z.B. OpenSea, Blur)",
+      "fr": "Place de marché (ex: OpenSea, Blur)",
+      "zh": "市场 (例如 OpenSea, Blur)",
+      "ar": "السوق (مثل OpenSea، Blur)",
+      "hi": "मार्केटप्लेस (जैसे OpenSea, Blur)"
+    }
+  },
+  "multi-sig": {
+    "en": "Multi-sig",
+    "titles": {
+      "en": "Multi-sig",
+      "es": "Multifirma (Multi-sig)",
+      "de": "Multi-Sig (Multi-Signatur)",
+      "fr": "Multi-signature (Multi-sig)",
+      "zh": "多重签名",
+      "ar": "التوقيع المتعدد (Multi-sig)",
+      "hi": "मल्टी-सिग"
+    }
+  },
+  "nft": {
+    "en": "NFT (Non-Fungible Token)",
+    "titles": {
+      "en": "NFT (Non-Fungible Token)",
+      "es": "NFT (Token No Fungible)",
+      "de": "NFT (Non-Fungible Token)",
+      "fr": "NFT (Jeton Non Fongible)",
+      "zh": "NFT（非同质化代币）",
+      "ar": "NFT (رمز غير قابل للاستبدال)",
+      "hi": "NFT (नॉन-फंजीबल टोकन)"
+    }
+  },
+  "on-chain": {
+    "en": "On-chain",
+    "titles": {
+      "en": "On-chain",
+      "es": "En cadena (On-chain)",
+      "de": "On-Chain",
+      "fr": "On-chain",
+      "zh": "链上 (On-chain)",
+      "ar": "على السلسلة (On-chain)",
+      "hi": "ऑन-चेन"
+    }
+  },
+  "permissionless": {
+    "en": "Permissionless",
+    "titles": {
+      "en": "Permissionless",
+      "es": "Sin Permiso",
+      "de": "Permissionless (Erlaubnisfrei)",
+      "fr": "Sans permission",
+      "zh": "无许可",
+      "ar": "بلا تصريح",
+      "hi": "अनुमति-रहित"
+    }
+  },
+  "protocol-asset": {
+    "en": "Protocol asset",
+    "titles": {
+      "en": "Protocol asset",
+      "es": "Activo de protocolo",
+      "de": "Protokoll-Asset",
+      "fr": "Actif de protocole",
+      "zh": "协议资产",
+      "ar": "أصل البروتوكول",
+      "hi": "प्रोटोकॉल एसेट"
+    }
+  },
+  "registrar": {
+    "en": "Registrar",
+    "titles": {
+      "en": "Registrar",
+      "es": "Registrador",
+      "de": "Registrar",
+      "fr": "Registraire",
+      "zh": "注册商",
+      "ar": "مسجل النطاقات",
+      "hi": "रजिस्ट्रार"
+    },
+    "level": 1,
+    "aliasesByLocale": {
+      "zh": [
+        "注册服务商"
+      ],
+      "de": [
+        "Registrierungsdienst"
+      ]
+    }
+  },
+  "rent-to-own": {
+    "en": "Rent-to-own",
+    "titles": {
+      "en": "Rent-to-own",
+      "es": "Alquiler con Opción a Compra",
+      "de": "Mietkauf",
+      "fr": "Location-vente",
+      "zh": "先租后买",
+      "ar": "الإيجار المنتهي بالتملك",
+      "hi": "रेंट-टू-ओन"
+    }
+  },
+  "revenue-sharing": {
+    "en": "Revenue-sharing",
+    "titles": {
+      "en": "Revenue-sharing",
+      "es": "Reparto de Ingresos",
+      "de": "Umsatzbeteiligung",
+      "fr": "Partage de revenus",
+      "zh": "收益分享",
+      "ar": "مشاركة الإيرادات",
+      "hi": "राजस्व-साझाकरण"
+    }
+  },
+  "seed-phrase": {
+    "en": "Seed Phrase (Recovery Phrase, Mnemonic)",
+    "titles": {
+      "en": "Seed Phrase (Recovery Phrase, Mnemonic)"
+    }
+  },
+  "seo": {
+    "en": "SEO (Search Engine Optimization)",
+    "titles": {
+      "en": "SEO (Search Engine Optimization)",
+      "es": "SEO (Optimización para Motores de Búsqueda)",
+      "de": "SEO (Suchmaschinenoptimierung)",
+      "fr": "SEO (Optimisation pour les moteurs de recherche)",
+      "zh": "SEO（搜索引擎优化）",
+      "ar": "تحسين محركات البحث (SEO)",
+      "hi": "एसईओ (सर्च इंजन ऑप्टिमाइजेशन)"
+    }
+  },
+  "smart-contract": {
+    "en": "Smart contract",
+    "titles": {
+      "en": "Smart contract",
+      "es": "Contrato inteligente",
+      "de": "Smart Contract",
+      "fr": "Smart contract",
+      "zh": "智能合约",
+      "ar": "عقد ذكي",
+      "hi": "स्मार्ट कॉन्ट्रैक्ट"
+    }
+  },
+  "stablecoin": {
+    "en": "Stablecoin",
+    "titles": {
+      "en": "Stablecoin"
+    }
+  },
+  "tld": {
+    "en": "TLD (Top-Level Domain)",
+    "titles": {
+      "en": "TLD (Top-Level Domain)"
+    }
+  },
+  "tokenize": {
+    "en": "Tokenize",
+    "titles": {
+      "en": "Tokenize",
+      "es": "Tokenizar",
+      "de": "Tokenisierung",
+      "fr": "Tokeniser",
+      "zh": "代币化",
+      "ar": "ترميز",
+      "hi": "टोकनाइज़ करें"
+    }
+  },
+  "udrp": {
+    "en": "UDRP (Uniform Domain-Name Dispute-Resolution Policy)",
+    "titles": {
+      "en": "UDRP (Uniform Domain-Name Dispute-Resolution Policy)",
+      "es": "UDRP (Política Uniforme de Resolución de Disputas de Nombres de Dominio)",
+      "de": "UDRP (Uniform Domain-Name Dispute-Resolution Policy)",
+      "fr": "UDRP (Uniform Domain-Name Dispute-Resolution Policy)",
+      "zh": "UDRP (统一域名争议解决政策)",
+      "ar": "UDRP (السياسة الموحدة لتسوية منازعات أسماء النطاقات)",
+      "hi": "UDRP (यूनिफ़ॉर्म डोमेन-नेम विवाद-समाधान नीति)"
+    }
+  },
+  "wallet": {
+    "en": "Wallet",
+    "titles": {
+      "en": "Wallet",
+      "es": "Billetera",
+      "de": "Wallet",
+      "fr": "Portefeuille",
+      "zh": "钱包",
+      "ar": "محفظة",
+      "hi": "वॉलेट"
+    }
+  },
+  "web3": {
+    "en": "Web3",
+    "titles": {
+      "en": "Web3",
+      "es": "Web3",
+      "de": "Web3",
+      "fr": "Web3",
+      "zh": "Web3",
+      "ar": "Web3",
+      "hi": "वेब3"
+    }
+  },
+  "whois": {
+    "en": "WHOIS (and RDAP)",
+    "titles": {
+      "en": "WHOIS (and RDAP)"
+    }
+  },
+  "x402": {
+    "en": "x402",
+    "titles": {
+      "en": "x402"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,12 @@
   "scripts": {
     "data:validate": "bun scripts/validate-data.ts",
     "translate:blog": "bun scripts/translate-blog.ts",
+    "translate:glossary": "bun scripts/translate-glossary.ts",
     "generate:blog": "bun scripts/generate-blog.ts",
+    "termbase:build": "bun scripts/build-termbase.ts",
+    "termbase:check": "bun scripts/build-termbase.ts --check",
+    "glossary:mentions": "bun scripts/glossary-mentions.ts",
+    "check:termbase": "bun scripts/check-termbase.ts",
     "lint:mdx": "bunx eslint \"content/**/*.{md,mdx}\""
   },
   "dependencies": {

--- a/scripts/build-termbase.ts
+++ b/scripts/build-termbase.ts
@@ -71,7 +71,9 @@ function readTitle(locale: Locale, slug: string): string | null {
     }
     const { data } = matter(readFileSync(file, 'utf8'));
     const title = typeof data.title === 'string' ? data.title.trim() : '';
-    return title || null;
+    if (title) return title;
+    // .md exists but has no usable title — keep trying the .mdx sibling rather
+    // than dropping the slug outright.
   }
   return null;
 }

--- a/scripts/build-termbase.ts
+++ b/scripts/build-termbase.ts
@@ -30,9 +30,10 @@
  *   bun scripts/build-termbase.ts --check    # verify it is up to date (CI)
  */
 
-import { readdirSync, readFileSync, writeFileSync, statSync } from 'node:fs';
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import matter from 'gray-matter';
+import { resolveEntryFile } from './glossary-fs.ts';
 
 const LOCALES = ['en', 'es', 'de', 'fr', 'zh', 'ar', 'hi'] as const;
 type Locale = (typeof LOCALES)[number];
@@ -66,24 +67,19 @@ function listSlugs(locale: Locale): string[] {
   }
 }
 
-// Resolve a (locale, slug) to a SINGLE entry file and read everything (title +
-// build-time frontmatter) from it, so level/aliases can never come from a
-// different file than the title. Prefers the first extension that has a usable
-// title; falls back to the sibling if the first exists but is titleless.
+// Resolve a (locale, slug) to the ONE canonical file (shared resolver, .md
+// preferred) and read title + build-time frontmatter from it, so level/aliases
+// can never come from a different file than the title — and so every script
+// agrees on which file a slug maps to. A titleless canonical file yields null
+// (the entry is malformed and should be fixed in content, not patched over by
+// silently reading a sibling — that is exactly what caused script divergence).
 function readEntry(locale: Locale, slug: string): { title: string; data: Record<string, unknown> } | null {
-  for (const ext of ['.md', '.mdx']) {
-    const file = path.join(GLOSSARY_ROOT, locale, slug + ext);
-    try {
-      statSync(file);
-    } catch {
-      continue;
-    }
-    const data = matter(readFileSync(file, 'utf8')).data as Record<string, unknown>;
-    const title = typeof data.title === 'string' ? data.title.trim() : '';
-    if (title) return { title, data };
-    // file exists but has no usable title — try the sibling extension.
-  }
-  return null;
+  const file = resolveEntryFile(path.join(GLOSSARY_ROOT, locale), slug);
+  if (!file) return null;
+  const data = matter(readFileSync(file, 'utf8')).data as Record<string, unknown>;
+  const title = typeof data.title === 'string' ? data.title.trim() : '';
+  if (!title) return null;
+  return { title, data };
 }
 
 function normaliseAliases(raw: unknown): Partial<Record<Locale, string[]>> | undefined {

--- a/scripts/build-termbase.ts
+++ b/scripts/build-termbase.ts
@@ -53,15 +53,24 @@ type Entry = {
 function listSlugs(locale: Locale): string[] {
   const dir = path.join(GLOSSARY_ROOT, locale);
   try {
-    return readdirSync(dir)
-      .filter((f) => f.endsWith('.md') || f.endsWith('.mdx'))
-      .map((f) => f.replace(/\.mdx?$/, ''));
+    // Dedup: a slug present as both .md and .mdx must list once, not twice.
+    return [
+      ...new Set(
+        readdirSync(dir)
+          .filter((f) => f.endsWith('.md') || f.endsWith('.mdx'))
+          .map((f) => f.replace(/\.mdx?$/, '')),
+      ),
+    ];
   } catch {
     return [];
   }
 }
 
-function readTitle(locale: Locale, slug: string): string | null {
+// Resolve a (locale, slug) to a SINGLE entry file and read everything (title +
+// build-time frontmatter) from it, so level/aliases can never come from a
+// different file than the title. Prefers the first extension that has a usable
+// title; falls back to the sibling if the first exists but is titleless.
+function readEntry(locale: Locale, slug: string): { title: string; data: Record<string, unknown> } | null {
   for (const ext of ['.md', '.mdx']) {
     const file = path.join(GLOSSARY_ROOT, locale, slug + ext);
     try {
@@ -69,26 +78,12 @@ function readTitle(locale: Locale, slug: string): string | null {
     } catch {
       continue;
     }
-    const { data } = matter(readFileSync(file, 'utf8'));
+    const data = matter(readFileSync(file, 'utf8')).data as Record<string, unknown>;
     const title = typeof data.title === 'string' ? data.title.trim() : '';
-    if (title) return title;
-    // .md exists but has no usable title — keep trying the .mdx sibling rather
-    // than dropping the slug outright.
+    if (title) return { title, data };
+    // file exists but has no usable title — try the sibling extension.
   }
   return null;
-}
-
-function readEnFrontmatter(slug: string): Record<string, unknown> {
-  for (const ext of ['.md', '.mdx']) {
-    const file = path.join(GLOSSARY_ROOT, 'en', slug + ext);
-    try {
-      statSync(file);
-    } catch {
-      continue;
-    }
-    return matter(readFileSync(file, 'utf8')).data as Record<string, unknown>;
-  }
-  return {};
 }
 
 function normaliseAliases(raw: unknown): Partial<Record<Locale, string[]>> | undefined {
@@ -109,19 +104,18 @@ function build(): Record<string, Entry> {
   const termbase: Record<string, Entry> = {};
 
   for (const slug of enSlugs) {
-    const enTitle = readTitle('en', slug);
-    if (!enTitle) continue; // en is the source of truth
+    const en = readEntry('en', slug);
+    if (!en) continue; // en is the source of truth
 
-    const fm = readEnFrontmatter(slug);
     const titles: Partial<Record<Locale, string>> = {};
     for (const locale of LOCALES) {
-      const t = readTitle(locale, slug);
-      if (t) titles[locale] = t;
+      const e = readEntry(locale, slug);
+      if (e) titles[locale] = e.title;
     }
 
-    const entry: Entry = { en: enTitle, titles };
-    if (typeof fm.level === 'number') entry.level = fm.level;
-    const aliases = normaliseAliases(fm.aliasesByLocale);
+    const entry: Entry = { en: en.title, titles };
+    if (typeof en.data.level === 'number') entry.level = en.data.level;
+    const aliases = normaliseAliases(en.data.aliasesByLocale);
     if (aliases) entry.aliasesByLocale = aliases;
 
     termbase[slug] = entry;

--- a/scripts/build-termbase.ts
+++ b/scripts/build-termbase.ts
@@ -1,0 +1,167 @@
+#!/usr/bin/env bun
+/**
+ * build-termbase.ts — generate content/termbase.json from the glossary.
+ *
+ * The glossary is the canonical bilingual termbase for the whole resources
+ * site: each entry's per-locale `title` is the *standard* translation of that
+ * concept in that locale. This script flattens every glossary entry into a
+ * single lookup artifact so other tooling (translate-glossary, check:termbase)
+ * and AI crawlers (/llms.txt) can read one file instead of re-scanning 7×N
+ * markdown files.
+ *
+ * Output schema (content/termbase.json), sorted by slug:
+ *   {
+ *     "<slug>": {
+ *       "en": "<english title>",
+ *       "level": 1,
+ *       "titles": { "en": "...", "zh": "...", "ar": "...", ... },
+ *       "aliasesByLocale": { "zh": ["注册中心", ...], "de": [...] }
+ *     }
+ *   }
+ *
+ * `en` is the source of truth: a slug only enters the termbase if an English
+ * entry exists. Missing locale titles are simply absent (the gap a future
+ * translate-glossary run fills). `aliasesByLocale` is harvested from the EN
+ * entry's build-time-only frontmatter (the curated non-canonical variants to
+ * normalise away — read by check:termbase).
+ *
+ * Usage (from repo root):
+ *   bun scripts/build-termbase.ts            # write content/termbase.json
+ *   bun scripts/build-termbase.ts --check    # verify it is up to date (CI)
+ */
+
+import { readdirSync, readFileSync, writeFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import matter from 'gray-matter';
+
+const LOCALES = ['en', 'es', 'de', 'fr', 'zh', 'ar', 'hi'] as const;
+type Locale = (typeof LOCALES)[number];
+
+const REPO_ROOT = process.cwd();
+const GLOSSARY_ROOT = path.join(REPO_ROOT, 'content', 'glossary');
+const OUT_PATH = path.join(REPO_ROOT, 'content', 'termbase.json');
+
+const CHECK = process.argv.includes('--check');
+
+type Entry = {
+  en: string;
+  level?: number;
+  titles: Partial<Record<Locale, string>>;
+  aliasesByLocale?: Partial<Record<Locale, string[]>>;
+};
+
+function listSlugs(locale: Locale): string[] {
+  const dir = path.join(GLOSSARY_ROOT, locale);
+  try {
+    return readdirSync(dir)
+      .filter((f) => f.endsWith('.md') || f.endsWith('.mdx'))
+      .map((f) => f.replace(/\.mdx?$/, ''));
+  } catch {
+    return [];
+  }
+}
+
+function readTitle(locale: Locale, slug: string): string | null {
+  for (const ext of ['.md', '.mdx']) {
+    const file = path.join(GLOSSARY_ROOT, locale, slug + ext);
+    try {
+      statSync(file);
+    } catch {
+      continue;
+    }
+    const { data } = matter(readFileSync(file, 'utf8'));
+    const title = typeof data.title === 'string' ? data.title.trim() : '';
+    return title || null;
+  }
+  return null;
+}
+
+function readEnFrontmatter(slug: string): Record<string, unknown> {
+  for (const ext of ['.md', '.mdx']) {
+    const file = path.join(GLOSSARY_ROOT, 'en', slug + ext);
+    try {
+      statSync(file);
+    } catch {
+      continue;
+    }
+    return matter(readFileSync(file, 'utf8')).data as Record<string, unknown>;
+  }
+  return {};
+}
+
+function normaliseAliases(raw: unknown): Partial<Record<Locale, string[]>> | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const out: Partial<Record<Locale, string[]>> = {};
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    if (!(LOCALES as readonly string[]).includes(k)) continue;
+    const list = Array.isArray(v)
+      ? v.filter((x): x is string => typeof x === 'string').map((s) => s.trim()).filter(Boolean)
+      : [];
+    if (list.length) out[k as Locale] = list;
+  }
+  return Object.keys(out).length ? out : undefined;
+}
+
+function build(): Record<string, Entry> {
+  const enSlugs = listSlugs('en').sort();
+  const termbase: Record<string, Entry> = {};
+
+  for (const slug of enSlugs) {
+    const enTitle = readTitle('en', slug);
+    if (!enTitle) continue; // en is the source of truth
+
+    const fm = readEnFrontmatter(slug);
+    const titles: Partial<Record<Locale, string>> = {};
+    for (const locale of LOCALES) {
+      const t = readTitle(locale, slug);
+      if (t) titles[locale] = t;
+    }
+
+    const entry: Entry = { en: enTitle, titles };
+    if (typeof fm.level === 'number') entry.level = fm.level;
+    const aliases = normaliseAliases(fm.aliasesByLocale);
+    if (aliases) entry.aliasesByLocale = aliases;
+
+    termbase[slug] = entry;
+  }
+
+  return termbase;
+}
+
+function serialise(tb: Record<string, Entry>): string {
+  return JSON.stringify(tb, null, 2) + '\n';
+}
+
+function main() {
+  const termbase = build();
+  const json = serialise(termbase);
+  const slugCount = Object.keys(termbase).length;
+
+  if (CHECK) {
+    let current = '';
+    try {
+      current = readFileSync(OUT_PATH, 'utf8');
+    } catch {
+      console.error(`❌ ${path.relative(REPO_ROOT, OUT_PATH)} is missing. Run: bun scripts/build-termbase.ts`);
+      process.exitCode = 1;
+      return;
+    }
+    if (current !== json) {
+      console.error(`❌ ${path.relative(REPO_ROOT, OUT_PATH)} is out of date. Run: bun scripts/build-termbase.ts`);
+      process.exitCode = 1;
+      return;
+    }
+    console.log(`✅ termbase.json is up to date (${slugCount} concepts).`);
+    return;
+  }
+
+  writeFileSync(OUT_PATH, json, 'utf8');
+  const localeCoverage = LOCALES.map((l) => {
+    const n = Object.values(termbase).filter((e) => e.titles[l]).length;
+    return `${l}=${n}`;
+  }).join(' ');
+  console.log(`✅ Wrote ${path.relative(REPO_ROOT, OUT_PATH)} — ${slugCount} concepts.`);
+  console.log(`   Title coverage: ${localeCoverage}`);
+}
+
+main();

--- a/scripts/check-termbase.ts
+++ b/scripts/check-termbase.ts
@@ -38,7 +38,13 @@ const TERMBASE_PATH = path.join(CONTENT_ROOT, 'termbase.json');
 
 const argv = process.argv.slice(2);
 const STRICT = argv.includes('--strict');
-const localeArg = argv.find((a) => a.startsWith('--locale='))?.slice(9) as Locale | undefined;
+const localeArgRaw = argv.find((a) => a.startsWith('--locale='))?.slice(9);
+if (localeArgRaw !== undefined && !(LOCALES as readonly string[]).includes(localeArgRaw)) {
+  // A typo'd locale must not silently scan zero files and report "0 deviations".
+  console.error(`Error: --locale=${localeArgRaw} is not a known locale (${LOCALES.join(', ')}).`);
+  process.exit(1);
+}
+const localeArg = localeArgRaw as Locale | undefined;
 const fileArgs = argv.filter((a) => !a.startsWith('--'));
 
 type TermbaseEntry = {

--- a/scripts/check-termbase.ts
+++ b/scripts/check-termbase.ts
@@ -1,0 +1,212 @@
+#!/usr/bin/env bun
+/**
+ * check-termbase.ts — advisory consistency linter for canonical terminology.
+ *
+ * The glossary's per-locale `title` is the canonical term for a concept in that
+ * locale. When a translated post renders the concept with a KNOWN non-canonical
+ * variant (tracked per entry in `aliasesByLocale`), this linter flags it so the
+ * prose can be reconciled to the canonical term (allowing grammatical inflection
+ * only — 除语法词性变化).
+ *
+ * It proves "no listed alias remains", not absolute consistency — it can only
+ * catch variants we have explicitly harvested into `aliasesByLocale`. Like
+ * check:i18n:convention it is ADVISORY (exit 0) by default; pass --strict to
+ * make it fail CI.
+ *
+ * Matching mirrors the cross-link skill: prose only (frontmatter / code / links
+ * / headings blanked), boundary-aware for Latin scripts, substring for CJK/RTL.
+ *
+ * Usage (from repo root):
+ *   bun scripts/check-termbase.ts                 # advisory scan of all locales
+ *   bun scripts/check-termbase.ts --strict        # exit 1 if any variant found
+ *   bun scripts/check-termbase.ts --locale=zh     # one locale only
+ *   bun scripts/check-termbase.ts content/blog/zh/foo.md   # specific files
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import matter from 'gray-matter';
+
+const LOCALES = ['en', 'es', 'de', 'fr', 'zh', 'ar', 'hi'] as const;
+type Locale = (typeof LOCALES)[number];
+const COLLECTIONS = ['blog', 'glossary', 'tld', 'partners'] as const;
+const MD_EXT = new Set(['.md', '.mdx']);
+
+const REPO_ROOT = process.cwd();
+const CONTENT_ROOT = path.join(REPO_ROOT, 'content');
+const TERMBASE_PATH = path.join(CONTENT_ROOT, 'termbase.json');
+
+const argv = process.argv.slice(2);
+const STRICT = argv.includes('--strict');
+const localeArg = argv.find((a) => a.startsWith('--locale='))?.slice(9) as Locale | undefined;
+const fileArgs = argv.filter((a) => !a.startsWith('--'));
+
+type TermbaseEntry = {
+  en: string;
+  titles: Partial<Record<Locale, string>>;
+  aliasesByLocale?: Partial<Record<Locale, string[]>>;
+};
+
+function loadTermbase(): Record<string, TermbaseEntry> {
+  try {
+    return JSON.parse(readFileSync(TERMBASE_PATH, 'utf8'));
+  } catch {
+    console.error(`❌ Could not read ${path.relative(REPO_ROOT, TERMBASE_PATH)}. Run: bun scripts/build-termbase.ts`);
+    process.exit(2);
+  }
+}
+
+// Blank out everything that isn't human-readable prose so a variant can't match
+// inside frontmatter, code, an existing link/href, or a heading.
+function stripNonProse(raw: string): string {
+  let body = raw.replace(/^---\n[\s\S]*?\n---\n?/, (m) => m.replace(/[^\n]/g, ' '));
+  body = body.replace(/^([ \t]*)(`{3,}|~{3,})[\s\S]*?\n\1\2[^\n]*$/gm, (m) => m.replace(/[^\n]/g, ' '));
+  body = body.replace(/`[^`\n]*`/g, (m) => m.replace(/[^\n]/g, ' '));
+  body = body.replace(/!?\[[^\]\n]*\]\([^)\n]*\)/g, (m) => m.replace(/[^\n]/g, ' '));
+  body = body.replace(/^#{1,6} .*$/gm, (m) => m.replace(/[^\n]/g, ' '));
+  return body;
+}
+
+function isLatin(s: string): boolean {
+  return /[A-Za-z]/.test(s) && !/[؀-ۿ一-鿿ऀ-ॿ]/.test(s);
+}
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildScanner(variants: string[]): { latin?: RegExp; other?: RegExp } {
+  const latin = variants.filter(isLatin).sort((a, b) => b.length - a.length);
+  const other = variants.filter((v) => !isLatin(v)).sort((a, b) => b.length - a.length);
+  const res: { latin?: RegExp; other?: RegExp } = {};
+  if (latin.length) res.latin = new RegExp(`(?<![A-Za-z0-9])(?:${latin.map(escapeRe).join('|')})(?![A-Za-z0-9])`, 'gi');
+  if (other.length) res.other = new RegExp(`(?:${other.map(escapeRe).join('|')})`, 'g');
+  return res;
+}
+
+function lineOf(prose: string, index: number): number {
+  let line = 1;
+  for (let i = 0; i < index && i < prose.length; i++) if (prose[i] === '\n') line++;
+  return line;
+}
+
+function listMarkdown(dir: string): string[] {
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const e of entries) {
+    const full = path.join(dir, e);
+    if (statSync(full).isDirectory()) out.push(...listMarkdown(full));
+    else if (MD_EXT.has(path.extname(e))) out.push(full);
+  }
+  return out;
+}
+
+function localeOf(file: string): Locale | null {
+  const rel = path.relative(CONTENT_ROOT, file).split(path.sep);
+  // content/<collection>/<locale>/<slug>.md
+  const loc = rel[1];
+  return (LOCALES as readonly string[]).includes(loc) ? (loc as Locale) : null;
+}
+
+type Finding = { file: string; line: number; variant: string; slug: string; canonical: string };
+
+function main() {
+  const termbase = loadTermbase();
+
+  // variant -> { slug, canonical } per locale
+  const variantIndex: Record<Locale, Map<string, { slug: string; canonical: string }>> = {
+    en: new Map(), es: new Map(), de: new Map(), fr: new Map(), zh: new Map(), ar: new Map(), hi: new Map(),
+  };
+  for (const [slug, entry] of Object.entries(termbase)) {
+    const aliases = entry.aliasesByLocale;
+    if (!aliases) continue;
+    for (const locale of LOCALES) {
+      const list = aliases[locale];
+      const canonical = entry.titles[locale];
+      if (!list || !canonical) continue;
+      for (const v of list) variantIndex[locale].set(v, { slug, canonical });
+    }
+  }
+
+  const scanners: Partial<Record<Locale, { latin?: RegExp; other?: RegExp }>> = {};
+  for (const locale of LOCALES) {
+    const variants = [...variantIndex[locale].keys()];
+    if (variants.length) scanners[locale] = buildScanner(variants);
+  }
+
+  const totalVariants = LOCALES.reduce((n, l) => n + variantIndex[l].size, 0);
+  if (totalVariants === 0) {
+    console.log('ℹ️  No aliasesByLocale variants are tracked yet — nothing to check.');
+    console.log('   Harvest variants into glossary frontmatter as the reconciliation sweep finds them.');
+    return;
+  }
+
+  // Files to scan
+  let files: string[];
+  if (fileArgs.length) {
+    files = fileArgs.map((f) => path.resolve(REPO_ROOT, f));
+  } else {
+    files = [];
+    for (const col of COLLECTIONS) {
+      for (const locale of LOCALES) {
+        if (localeArg && locale !== localeArg) continue;
+        files.push(...listMarkdown(path.join(CONTENT_ROOT, col, locale)));
+      }
+    }
+  }
+
+  const findings: Finding[] = [];
+  for (const file of files) {
+    const locale = localeOf(file);
+    if (!locale) continue;
+    if (localeArg && locale !== localeArg) continue;
+    const scanner = scanners[locale];
+    if (!scanner) continue;
+    let raw: string;
+    try {
+      raw = readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    const prose = stripNonProse(raw);
+    const seen = new Set<string>();
+    for (const re of [scanner.latin, scanner.other]) {
+      if (!re) continue;
+      for (const m of prose.matchAll(re)) {
+        const key = m[0].toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        const hit = variantIndex[locale].get(m[0]) ?? variantIndex[locale].get(m[0].toLowerCase())
+          ?? [...variantIndex[locale].entries()].find(([v]) => v.toLowerCase() === key)?.[1];
+        if (!hit) continue;
+        findings.push({
+          file: path.relative(REPO_ROOT, file),
+          line: lineOf(prose, m.index ?? 0),
+          variant: m[0],
+          slug: hit.slug,
+          canonical: hit.canonical,
+        });
+      }
+    }
+  }
+
+  if (findings.length === 0) {
+    console.log(`✅ check:termbase — 0 known-variant deviations across ${files.length} files (${totalVariants} tracked variants).`);
+    return;
+  }
+
+  findings.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line);
+  console.log(`${STRICT ? '❌' : '⚠️ '} check:termbase — ${findings.length} known-variant deviation(s):`);
+  for (const f of findings) {
+    console.log(`   • ${f.file}:${f.line}  "${f.variant}" → use canonical "${f.canonical}" (${f.slug})`);
+  }
+  console.log(`\n   Reconcile to the canonical term (grammatical inflection allowed — 除语法词性变化).`);
+  if (STRICT) process.exitCode = 1;
+}
+
+main();

--- a/scripts/glossary-fs.ts
+++ b/scripts/glossary-fs.ts
@@ -1,0 +1,24 @@
+// Shared glossary file-resolution so every script agrees on the ONE file that
+// represents a slug. Resolution is deterministic and existence-based: `.md`
+// wins over `.mdx` when both are present. Keeping this in one place is what
+// prevents build-termbase, glossary-mentions, and translate-glossary from each
+// picking a different file for the same slug.
+
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+const EXTS = ['.md', '.mdx'] as const;
+
+/** The canonical content file for `slug` inside `dir`, or null if none exists. */
+export function resolveEntryFile(dir: string, slug: string): string | null {
+  for (const ext of EXTS) {
+    const file = path.join(dir, slug + ext);
+    if (existsSync(file)) return file;
+  }
+  return null;
+}
+
+/** True if any extension of `slug` already exists in `dir`. */
+export function entryExists(dir: string, slug: string): boolean {
+  return resolveEntryFile(dir, slug) !== null;
+}

--- a/scripts/glossary-mentions.ts
+++ b/scripts/glossary-mentions.ts
@@ -130,10 +130,12 @@ function main() {
   const rows: { slug: string; mentions: number; linked: number; candidates: number }[] = [];
 
   const failed: string[] = [];
+  const missing: string[] = [];
   let done = 0;
   for (const slug of slugs) {
     const candidates = inboundCount(slug);
     if (candidates === SLUG_MISSING) {
+      missing.push(slug);
       if (!JSON_OUT) console.error(`   (skip ${slug}: no en entry)`);
       continue;
     }
@@ -151,6 +153,14 @@ function main() {
 
   rows.sort((a, b) => b.mentions - a.mentions || a.slug.localeCompare(b.slug));
   const filtered = rows.filter((r) => r.mentions >= MIN);
+
+  // Explicit slug args that ALL lack an en entry must fail loudly — a typo must
+  // not read as "0 mentions". (No args = scan everything, where empty is fine.)
+  const allRequestedMissing = slugArgs.length > 0 && rows.length === 0 && failed.length === 0;
+  if (allRequestedMissing) {
+    console.error(`Error: none of the requested slug(s) have an en glossary entry: ${missing.join(', ')}`);
+    process.exit(1);
+  }
 
   if (JSON_OUT) {
     console.log(JSON.stringify({ ranked: filtered, failed }, null, 2));

--- a/scripts/glossary-mentions.ts
+++ b/scripts/glossary-mentions.ts
@@ -43,6 +43,24 @@ function listEnSlugs(): string[] {
     .sort();
 }
 
+// Recursive markdown walk — link-suggest builds its inbound corpus this way, so
+// the linked-count half must match it (nested posts count too).
+function listMarkdownRec(dir: string): string[] {
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const e of entries) {
+    const full = path.join(dir, e);
+    if (statSync(full).isDirectory()) out.push(...listMarkdownRec(full));
+    else if (e.endsWith('.md') || e.endsWith('.mdx')) out.push(full);
+  }
+  return out;
+}
+
 // Resolve an en glossary entry to its actual file, honouring both extensions
 // (build-termbase.ts and translate-glossary.ts already do) so an .mdx-only term
 // is never mistaken for missing.
@@ -68,14 +86,7 @@ function countAlreadyLinking(slug: string): number {
   let count = 0;
   const enRoots = ['blog', 'tld', 'partners', 'glossary'].map((c) => path.join(REPO_ROOT, 'content', c, 'en'));
   for (const root of enRoots) {
-    let files: string[] = [];
-    try {
-      files = readdirSync(root).filter((f) => f.endsWith('.md') || f.endsWith('.mdx'));
-    } catch {
-      continue;
-    }
-    for (const f of files) {
-      const full = path.join(root, f);
+    for (const full of listMarkdownRec(root)) {
       if (selfEntry && full === selfEntry) continue; // don't count the entry itself
       let raw: string;
       try {

--- a/scripts/glossary-mentions.ts
+++ b/scripts/glossary-mentions.ts
@@ -25,6 +25,7 @@ import { readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import matter from 'gray-matter';
+import { resolveEntryFile } from './glossary-fs.ts';
 
 const REPO_ROOT = process.cwd();
 const GLOSSARY_EN = path.join(REPO_ROOT, 'content', 'glossary', 'en');
@@ -65,20 +66,10 @@ function listMarkdownRec(dir: string): string[] {
   return out;
 }
 
-// Resolve an en glossary entry to its actual file, honouring both extensions
-// (build-termbase.ts and translate-glossary.ts already do) so an .mdx-only term
-// is never mistaken for missing.
+// Resolve an en glossary entry to its canonical file via the shared resolver,
+// so this script targets the same file as build-termbase / translate-glossary.
 function resolveEnEntry(slug: string): string | null {
-  for (const ext of ['.md', '.mdx']) {
-    const f = path.join(GLOSSARY_EN, slug + ext);
-    try {
-      statSync(f);
-      return f;
-    } catch {
-      /* next */
-    }
-  }
-  return null;
+  return resolveEntryFile(GLOSSARY_EN, slug);
 }
 
 // link-suggest INBOUND counts pages that mention but DON'T yet link the term.

--- a/scripts/glossary-mentions.ts
+++ b/scripts/glossary-mentions.ts
@@ -24,6 +24,7 @@
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
+import matter from 'gray-matter';
 
 const REPO_ROOT = process.cwd();
 const GLOSSARY_EN = path.join(REPO_ROOT, 'content', 'glossary', 'en');
@@ -77,6 +78,15 @@ function countAlreadyLinking(slug: string): number {
       const full = path.join(root, f);
       if (selfEntry && full === selfEntry) continue; // don't count the entry itself
       const raw = readFileSync(full, 'utf8');
+      // link-suggest excludes drafts from its inbound corpus; mirror that here so
+      // a draft page linking the term can't inflate demand past the cross-link metric.
+      let isDraft = false;
+      try {
+        isDraft = matter(raw).data?.draft === true;
+      } catch {
+        /* unparseable frontmatter — treat as non-draft, same as the loader */
+      }
+      if (isDraft) continue;
       if (raw.includes(`](${href}`) || raw.includes(`](${noSlash}`)) count++;
     }
   }

--- a/scripts/glossary-mentions.ts
+++ b/scripts/glossary-mentions.ts
@@ -37,10 +37,14 @@ const MIN = minArg ? parseInt(minArg, 10) : 0;
 const slugArgs = argv.filter((a) => !a.startsWith('--')).map((s) => s.replace(/\.mdx?$/, '').replace(/.*\//, ''));
 
 function listEnSlugs(): string[] {
-  return readdirSync(GLOSSARY_EN)
-    .filter((f) => f.endsWith('.md') || f.endsWith('.mdx'))
-    .map((f) => f.replace(/\.mdx?$/, ''))
-    .sort();
+  // Dedup: a slug present as both .md and .mdx must yield one row, not two.
+  return [
+    ...new Set(
+      readdirSync(GLOSSARY_EN)
+        .filter((f) => f.endsWith('.md') || f.endsWith('.mdx'))
+        .map((f) => f.replace(/\.mdx?$/, '')),
+    ),
+  ].sort();
 }
 
 // Recursive markdown walk — link-suggest builds its inbound corpus this way, so

--- a/scripts/glossary-mentions.ts
+++ b/scripts/glossary-mentions.ts
@@ -66,25 +66,34 @@ function countAlreadyLinking(slug: string): number {
   return count;
 }
 
-function inboundCount(slug: string): number {
+// Returns the distinct-inbound-mention count, or null when link-suggest could
+// not be run/parsed (non-zero exit, empty stdout, or unparseable JSON). null is
+// NOT 0 — a failed subprocess that silently counted as 0 would drop every prose
+// mention that tool would have found and skew the promotion ranking.
+const SLUG_MISSING = Symbol('slug-missing');
+function inboundCount(slug: string): number | null | typeof SLUG_MISSING {
   const file = path.join(GLOSSARY_EN, `${slug}.md`);
   try {
     statSync(file);
   } catch {
-    return -1;
+    return SLUG_MISSING;
   }
   const res = spawnSync('bun', [LINK_SUGGEST, '--json', '--no-related', file], {
     encoding: 'utf8',
     maxBuffer: 64 * 1024 * 1024,
   });
-  if (res.status !== 0 || !res.stdout) return 0;
+  if (res.status !== 0 || !res.stdout) {
+    process.stderr.write(`\n   ⚠️  link-suggest failed for ${slug} (exit ${res.status ?? '?'}); mention count unknown.\n`);
+    return null;
+  }
   try {
     const parsed = JSON.parse(res.stdout);
     const report = Array.isArray(parsed) ? parsed[0] : parsed.reports?.[0] ?? parsed;
     const inbound = report?.inbound;
-    return Array.isArray(inbound) ? inbound.length : 0;
+    return Array.isArray(inbound) ? inbound.length : null;
   } catch {
-    return 0;
+    process.stderr.write(`\n   ⚠️  link-suggest output for ${slug} was unparseable; mention count unknown.\n`);
+    return null;
   }
 }
 
@@ -92,11 +101,17 @@ function main() {
   const slugs = slugArgs.length ? slugArgs : listEnSlugs();
   const rows: { slug: string; mentions: number; linked: number; candidates: number }[] = [];
 
+  const failed: string[] = [];
   let done = 0;
   for (const slug of slugs) {
     const candidates = inboundCount(slug);
-    if (candidates < 0) {
+    if (candidates === SLUG_MISSING) {
       if (!JSON_OUT) console.error(`   (skip ${slug}: no en entry)`);
+      continue;
+    }
+    if (candidates === null) {
+      failed.push(slug); // link-suggest failed — do NOT silently treat as 0
+      done++;
       continue;
     }
     const linked = countAlreadyLinking(slug);
@@ -110,7 +125,8 @@ function main() {
   const filtered = rows.filter((r) => r.mentions >= MIN);
 
   if (JSON_OUT) {
-    console.log(JSON.stringify(filtered, null, 2));
+    console.log(JSON.stringify({ ranked: filtered, failed }, null, 2));
+    if (failed.length) process.exitCode = 1;
     return;
   }
 
@@ -122,6 +138,11 @@ function main() {
   });
   const over = filtered.filter((r) => r.mentions >= 8).length;
   console.log(`\n  ${over} term(s) at/above the ≥8 promotion gate.`);
+  if (failed.length) {
+    console.error(`\n  ⚠️  ${failed.length} term(s) could not be counted (link-suggest failed): ${failed.join(', ')}`);
+    console.error(`      Their ranking is UNKNOWN, not zero — re-run before trusting the gate.`);
+    process.exitCode = 1;
+  }
 }
 
 main();

--- a/scripts/glossary-mentions.ts
+++ b/scripts/glossary-mentions.ts
@@ -1,0 +1,127 @@
+#!/usr/bin/env bun
+/**
+ * glossary-mentions.ts — per-term DEMAND metric for L1→L2 promotion.
+ *
+ * "Demand" is the number of DISTINCT posts whose prose mentions a glossary term
+ * — NOT the number of links actually added (the cross-link skill caps those at
+ * ≤5 per term by design). So a term like `registry` can be *mentioned* by 53
+ * posts while only ~5 get a back-link. The mention count is the promotion gate
+ * (GOAL: promote L1→L2 at ≥ 8 distinct mentions, plus structural anchors).
+ *
+ * To stay consistent with the cross-link skill's notion of a "mention", this
+ * reuses `link-suggest.ts --json` and counts its INBOUND candidates (one per
+ * distinct source page that mentions the term but doesn't link it yet) PLUS
+ * pages that already link it (those are mentions too — they just aren't
+ * candidates anymore). It scopes counting to the `en` corpus by default.
+ *
+ * Usage (from repo root):
+ *   bun scripts/glossary-mentions.ts                 # ranked table, all en terms
+ *   bun scripts/glossary-mentions.ts --json          # machine-readable
+ *   bun scripts/glossary-mentions.ts --min=8         # only terms at/above gate
+ *   bun scripts/glossary-mentions.ts registry udrp   # specific slugs
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const REPO_ROOT = process.cwd();
+const GLOSSARY_EN = path.join(REPO_ROOT, 'content', 'glossary', 'en');
+const LINK_SUGGEST = path.join(REPO_ROOT, '.agents', 'skills', 'cross-link', 'link-suggest.ts');
+
+const argv = process.argv.slice(2);
+const JSON_OUT = argv.includes('--json');
+const minArg = argv.find((a) => a.startsWith('--min='))?.slice(6);
+const MIN = minArg ? parseInt(minArg, 10) : 0;
+const slugArgs = argv.filter((a) => !a.startsWith('--')).map((s) => s.replace(/\.mdx?$/, '').replace(/.*\//, ''));
+
+function listEnSlugs(): string[] {
+  return readdirSync(GLOSSARY_EN)
+    .filter((f) => f.endsWith('.md') || f.endsWith('.mdx'))
+    .map((f) => f.replace(/\.mdx?$/, ''))
+    .sort();
+}
+
+// link-suggest INBOUND counts pages that mention but DON'T yet link the term.
+// Pages that already link it are mentions too — count those from the raw href.
+function countAlreadyLinking(slug: string): number {
+  const href = `/en/glossary/${slug}/`;
+  const noSlash = href.replace(/\/$/, '');
+  let count = 0;
+  const enRoots = ['blog', 'tld', 'partners', 'glossary'].map((c) => path.join(REPO_ROOT, 'content', c, 'en'));
+  for (const root of enRoots) {
+    let files: string[] = [];
+    try {
+      files = readdirSync(root).filter((f) => f.endsWith('.md') || f.endsWith('.mdx'));
+    } catch {
+      continue;
+    }
+    for (const f of files) {
+      const full = path.join(root, f);
+      if (path.basename(full) === `${slug}.md`) continue; // don't count the entry itself
+      const raw = readFileSync(full, 'utf8');
+      if (raw.includes(`](${href}`) || raw.includes(`](${noSlash}`)) count++;
+    }
+  }
+  return count;
+}
+
+function inboundCount(slug: string): number {
+  const file = path.join(GLOSSARY_EN, `${slug}.md`);
+  try {
+    statSync(file);
+  } catch {
+    return -1;
+  }
+  const res = spawnSync('bun', [LINK_SUGGEST, '--json', '--no-related', file], {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (res.status !== 0 || !res.stdout) return 0;
+  try {
+    const parsed = JSON.parse(res.stdout);
+    const report = Array.isArray(parsed) ? parsed[0] : parsed.reports?.[0] ?? parsed;
+    const inbound = report?.inbound;
+    return Array.isArray(inbound) ? inbound.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function main() {
+  const slugs = slugArgs.length ? slugArgs : listEnSlugs();
+  const rows: { slug: string; mentions: number; linked: number; candidates: number }[] = [];
+
+  let done = 0;
+  for (const slug of slugs) {
+    const candidates = inboundCount(slug);
+    if (candidates < 0) {
+      if (!JSON_OUT) console.error(`   (skip ${slug}: no en entry)`);
+      continue;
+    }
+    const linked = countAlreadyLinking(slug);
+    rows.push({ slug, mentions: candidates + linked, linked, candidates });
+    done++;
+    if (!JSON_OUT) process.stderr.write(`\r   counting… ${done}/${slugs.length}`);
+  }
+  if (!JSON_OUT) process.stderr.write('\r' + ' '.repeat(40) + '\r');
+
+  rows.sort((a, b) => b.mentions - a.mentions || a.slug.localeCompare(b.slug));
+  const filtered = rows.filter((r) => r.mentions >= MIN);
+
+  if (JSON_OUT) {
+    console.log(JSON.stringify(filtered, null, 2));
+    return;
+  }
+
+  console.log(`Glossary mention demand (en corpus) — gate for L1→L2 is ≥ 8 distinct posts.\n`);
+  console.log(`  ${'#'.padStart(4)}  ${'mentions'.padStart(8)}  ${'(linked'.padStart(7)} ${'unlinked)'.padEnd(9)}  term`);
+  filtered.forEach((r, i) => {
+    const gate = r.mentions >= 8 ? '★' : ' ';
+    console.log(`  ${String(i + 1).padStart(4)}  ${String(r.mentions).padStart(8)}  ${String(r.linked).padStart(7)} ${String(r.candidates).padEnd(9)} ${gate} ${r.slug}`);
+  });
+  const over = filtered.filter((r) => r.mentions >= 8).length;
+  console.log(`\n  ${over} term(s) at/above the ≥8 promotion gate.`);
+}
+
+main();

--- a/scripts/glossary-mentions.ts
+++ b/scripts/glossary-mentions.ts
@@ -42,11 +42,28 @@ function listEnSlugs(): string[] {
     .sort();
 }
 
+// Resolve an en glossary entry to its actual file, honouring both extensions
+// (build-termbase.ts and translate-glossary.ts already do) so an .mdx-only term
+// is never mistaken for missing.
+function resolveEnEntry(slug: string): string | null {
+  for (const ext of ['.md', '.mdx']) {
+    const f = path.join(GLOSSARY_EN, slug + ext);
+    try {
+      statSync(f);
+      return f;
+    } catch {
+      /* next */
+    }
+  }
+  return null;
+}
+
 // link-suggest INBOUND counts pages that mention but DON'T yet link the term.
 // Pages that already link it are mentions too — count those from the raw href.
 function countAlreadyLinking(slug: string): number {
   const href = `/en/glossary/${slug}/`;
   const noSlash = href.replace(/\/$/, '');
+  const selfEntry = resolveEnEntry(slug); // the glossary entry itself — never count it
   let count = 0;
   const enRoots = ['blog', 'tld', 'partners', 'glossary'].map((c) => path.join(REPO_ROOT, 'content', c, 'en'));
   for (const root of enRoots) {
@@ -58,7 +75,7 @@ function countAlreadyLinking(slug: string): number {
     }
     for (const f of files) {
       const full = path.join(root, f);
-      if (path.basename(full) === `${slug}.md`) continue; // don't count the entry itself
+      if (selfEntry && full === selfEntry) continue; // don't count the entry itself
       const raw = readFileSync(full, 'utf8');
       if (raw.includes(`](${href}`) || raw.includes(`](${noSlash}`)) count++;
     }
@@ -72,12 +89,8 @@ function countAlreadyLinking(slug: string): number {
 // mention that tool would have found and skew the promotion ranking.
 const SLUG_MISSING = Symbol('slug-missing');
 function inboundCount(slug: string): number | null | typeof SLUG_MISSING {
-  const file = path.join(GLOSSARY_EN, `${slug}.md`);
-  try {
-    statSync(file);
-  } catch {
-    return SLUG_MISSING;
-  }
+  const file = resolveEnEntry(slug);
+  if (!file) return SLUG_MISSING;
   const res = spawnSync('bun', [LINK_SUGGEST, '--json', '--no-related', file], {
     encoding: 'utf8',
     maxBuffer: 64 * 1024 * 1024,

--- a/scripts/glossary-mentions.ts
+++ b/scripts/glossary-mentions.ts
@@ -77,7 +77,12 @@ function countAlreadyLinking(slug: string): number {
     for (const f of files) {
       const full = path.join(root, f);
       if (selfEntry && full === selfEntry) continue; // don't count the entry itself
-      const raw = readFileSync(full, 'utf8');
+      let raw: string;
+      try {
+        raw = readFileSync(full, 'utf8');
+      } catch {
+        continue; // one unreadable corpus file shouldn't abort the whole count
+      }
       // link-suggest excludes drafts from its inbound corpus; mirror that here so
       // a draft page linking the term can't inflate demand past the cross-link metric.
       let isDraft = false;

--- a/scripts/translate-glossary.ts
+++ b/scripts/translate-glossary.ts
@@ -228,7 +228,15 @@ async function main() {
   const enDir = path.join(GLOSSARY_DIR, SOURCE_LOCALE);
   let files: string[];
   try {
-    files = (await fs.readdir(enDir)).filter((f) => f.endsWith('.md') || f.endsWith('.mdx'));
+    const all = (await fs.readdir(enDir)).filter((f) => f.endsWith('.md') || f.endsWith('.mdx'));
+    // Dedup by slug, preferring .md, so a slug present as both extensions is
+    // translated once (not twice from two different sources).
+    const bySlug = new Map<string, string>();
+    for (const f of all) {
+      const slug = f.replace(/\.mdx?$/, '');
+      if (!bySlug.has(slug) || f.endsWith('.md')) bySlug.set(slug, f);
+    }
+    files = [...bySlug.values()];
   } catch {
     console.error(`Could not read source directory: ${enDir}`);
     process.exit(1);

--- a/scripts/translate-glossary.ts
+++ b/scripts/translate-glossary.ts
@@ -28,10 +28,10 @@
 
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import fs from 'node:fs/promises';
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import pLimit from 'p-limit';
-import matter from 'gray-matter';
+import { resolveEntryFile, entryExists } from './glossary-fs.ts';
 
 const apiKey = process.env.GEMINI_API_KEY;
 if (!apiKey) {
@@ -142,12 +142,15 @@ async function callGeminiThrottled(prompt: string, locale: string, filename: str
 }
 
 async function translateFile(filename: string, targetLocale: string, tb: Termbase) {
+  const slug = filename.replace(/\.mdx?$/, '');
   const sourcePath = path.join(GLOSSARY_DIR, SOURCE_LOCALE, filename);
   const targetDir = path.join(GLOSSARY_DIR, targetLocale);
   const targetPath = path.join(targetDir, filename);
   await fs.mkdir(targetDir, { recursive: true });
 
-  if (!FORCE && existsSync(targetPath)) return; // fill-missing by default
+  // Fill-missing: skip if the locale already has this slug under EITHER
+  // extension, so we never add a sibling file for a concept that already exists.
+  if (!FORCE && entryExists(targetDir, slug)) return;
 
   console.log(`Translating glossary/${filename} → ${targetLocale}...`);
   let fileContent: string;
@@ -229,14 +232,14 @@ async function main() {
   let files: string[];
   try {
     const all = (await fs.readdir(enDir)).filter((f) => f.endsWith('.md') || f.endsWith('.mdx'));
-    // Dedup by slug, preferring .md, so a slug present as both extensions is
-    // translated once (not twice from two different sources).
-    const bySlug = new Map<string, string>();
-    for (const f of all) {
-      const slug = f.replace(/\.mdx?$/, '');
-      if (!bySlug.has(slug) || f.endsWith('.md')) bySlug.set(slug, f);
-    }
-    files = [...bySlug.values()];
+    // Map each unique slug to its ONE canonical source file via the shared
+    // resolver, so a slug present as both extensions is translated once from the
+    // same file every other script uses.
+    const slugs = [...new Set(all.map((f) => f.replace(/\.mdx?$/, '')))];
+    files = slugs
+      .map((s) => resolveEntryFile(enDir, s))
+      .filter((p): p is string => p !== null)
+      .map((p) => path.basename(p));
   } catch {
     console.error(`Could not read source directory: ${enDir}`);
     process.exit(1);

--- a/scripts/translate-glossary.ts
+++ b/scripts/translate-glossary.ts
@@ -59,11 +59,31 @@ const slugArgs = argv
   .filter((a) => !a.startsWith('--'))
   .map((a) => a.replace(/\.mdx?$/, '').replace(/.*\//, ''));
 
-// --- rate limiter (mirrors translate-blog.ts) ------------------------------
+// --- rate limiter ----------------------------------------------------------
 const CONCURRENCY = 5;
 const REQUESTS_PER_MINUTE = 15;
 const MIN_INTERVAL_MS = (60 * 1000) / REQUESTS_PER_MINUTE;
 let lastRequestTime = 0;
+
+// Serialise the spacing decision. With pLimit(CONCURRENCY) several workers run
+// at once; if each independently read `lastRequestTime` and slept, they could
+// all clear the check together and burst past the per-minute cap. Chaining each
+// reservation onto the previous one makes the read-update atomic, so requests
+// are guaranteed at least MIN_INTERVAL_MS apart.
+let throttleGate: Promise<void> = Promise.resolve();
+function reserveSlot(): Promise<void> {
+  const wait = throttleGate.then(async () => {
+    const delta = lastRequestTime + MIN_INTERVAL_MS - Date.now();
+    if (delta > 0) await new Promise((r) => setTimeout(r, delta));
+    lastRequestTime = Date.now();
+  });
+  throttleGate = wait.catch(() => {});
+  return wait;
+}
+
+// Files that could not be written (rate-limit exhaustion or a hard error) —
+// reported at the end so a partial run never masquerades as complete.
+const failures: string[] = [];
 
 // --- termbase: locked canonical titles to keep translations consistent -----
 type Termbase = Record<string, { en: string; titles: Record<string, string> }>;
@@ -85,12 +105,7 @@ function termbaseHint(locale: string, tb: Termbase): string {
 }
 
 async function callGeminiThrottled(prompt: string, locale: string, filename: string) {
-  const now = Date.now();
-  const timeSinceLast = now - lastRequestTime;
-  if (timeSinceLast < MIN_INTERVAL_MS) {
-    await new Promise((r) => setTimeout(r, MIN_INTERVAL_MS - timeSinceLast));
-  }
-  lastRequestTime = Date.now();
+  await reserveSlot();
 
   try {
     const result = await model.generateContent(prompt);
@@ -175,10 +190,15 @@ ${fileContent}
         delay *= 2;
       } else {
         console.error(`✗ Error translating ${filename} → ${targetLocale}:`, e);
+        failures.push(`${targetLocale}/${filename}`);
         return;
       }
     }
   }
+  // Fell out of the retry loop without writing — record it so the run is not
+  // reported as complete with this locale silently missing.
+  console.error(`✗ Gave up on ${targetLocale}/${filename} after ${maxAttempts} rate-limit retries.`);
+  failures.push(`${targetLocale}/${filename}`);
 }
 
 async function main() {
@@ -209,6 +229,13 @@ async function main() {
     }
   }
   await Promise.all(tasks);
+
+  if (failures.length) {
+    console.error(`\n❌ ${failures.length} file(s) were NOT translated: ${failures.join(', ')}`);
+    console.error('Re-run translate-glossary.ts to fill the gaps before building the termbase.');
+    process.exitCode = 1;
+    return;
+  }
   console.log('Glossary translation complete. Re-run build-termbase.ts to lock the new titles.');
 }
 

--- a/scripts/translate-glossary.ts
+++ b/scripts/translate-glossary.ts
@@ -128,6 +128,10 @@ async function callGeminiThrottled(prompt: string, locale: string, filename: str
       .replace(/^<content>\s*\n/, '')
       .replace(/\n?<\/content>\s*$/, '')
       .trim();
+    // A blank or whitespace-only response (e.g. a safety block) must NOT be saved
+    // as a `---\n` stub that looks like a successful translation — reject it so
+    // translateFile records a failure instead of writing an invalid file.
+    if (!text) throw new Error('EMPTY_OUTPUT');
     if (!text.startsWith('---')) text = '---\n' + text;
     return text;
   } catch (error) {

--- a/scripts/translate-glossary.ts
+++ b/scripts/translate-glossary.ts
@@ -235,6 +235,11 @@ async function main() {
     files = files.filter((f) => wanted.has(f.replace(/\.mdx?$/, '')));
     const found = new Set(files.map((f) => f.replace(/\.mdx?$/, '')));
     for (const s of slugArgs) if (!found.has(s)) console.warn(`⚠️ no en glossary entry for "${s}"`);
+    // Explicit slugs that match nothing must fail, not look like a clean run.
+    if (files.length === 0) {
+      console.error(`Error: none of the requested slug(s) matched an en glossary entry: ${slugArgs.join(', ')}`);
+      process.exit(1);
+    }
   }
 
   console.log(`Translating ${files.length} glossary entr${files.length === 1 ? 'y' : 'ies'} → [${TARGET_LOCALES.join(', ')}]${FORCE ? ' (force overwrite)' : ' (fill missing)'}.`);

--- a/scripts/translate-glossary.ts
+++ b/scripts/translate-glossary.ts
@@ -1,0 +1,215 @@
+#!/usr/bin/env bun
+/**
+ * translate-glossary.ts — glossary translator (translate-blog.ts is blog-only).
+ *
+ * Differences from translate-blog.ts that make it usable for the termbase
+ * build-out:
+ *   • Scans content/glossary/en (not content/blog/en).
+ *   • PATH/BATCH mode — translate a specific subset by slug or path, not just
+ *     "scan everything":  bun scripts/translate-glossary.ts registry registrant
+ *   • --locales=zh,ar to restrict target locales; --force to overwrite.
+ *   • TERMBASE-AWARE prompt — injects the already-locked canonical titles from
+ *     content/termbase.json so any cross-linked glossary term renders with its
+ *     standard per-locale translation (keeps the corpus internally consistent).
+ *   • Fills only MISSING locale files by default (like translate-blog), so it is
+ *     safe to re-run after adding new EN entries.
+ *
+ * The per-locale glossary `title` it produces IS the canonical term for that
+ * concept — review it (zh signed off, ar Egyptian register) before locking the
+ * termbase with build-termbase.ts.
+ *
+ * Usage (from repo root, GEMINI_API_KEY in env — same secret as translate:blog):
+ *   bun scripts/translate-glossary.ts                       # fill all missing locales
+ *   bun scripts/translate-glossary.ts registry registrant   # only these slugs
+ *   bun scripts/translate-glossary.ts content/glossary/en/registry.md
+ *   bun scripts/translate-glossary.ts --locales=zh,ar registry
+ *   bun scripts/translate-glossary.ts --force registry      # overwrite existing
+ */
+
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import fs from 'node:fs/promises';
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import pLimit from 'p-limit';
+import matter from 'gray-matter';
+
+const apiKey = process.env.GEMINI_API_KEY;
+if (!apiKey) {
+  console.error('Error: GEMINI_API_KEY environment variable is required.');
+  process.exit(1);
+}
+
+const genAI = new GoogleGenerativeAI(apiKey);
+const MODEL_NAME = process.env.GEMINI_MODEL || 'gemini-3.1-pro-preview';
+const model = genAI.getGenerativeModel({ model: MODEL_NAME });
+
+const ALL_TARGETS = ['zh', 'ar', 'fr', 'hi', 'de', 'es'] as const;
+const SOURCE_LOCALE = 'en';
+const GLOSSARY_DIR = path.join(process.cwd(), 'content', 'glossary');
+const TERMBASE_PATH = path.join(process.cwd(), 'content', 'termbase.json');
+
+// --- args ------------------------------------------------------------------
+const argv = process.argv.slice(2);
+const FORCE = argv.includes('--force');
+const localesArg = argv.find((a) => a.startsWith('--locales='))?.slice(10);
+const TARGET_LOCALES = localesArg
+  ? localesArg.split(',').map((s) => s.trim()).filter((l) => (ALL_TARGETS as readonly string[]).includes(l))
+  : [...ALL_TARGETS];
+const slugArgs = argv
+  .filter((a) => !a.startsWith('--'))
+  .map((a) => a.replace(/\.mdx?$/, '').replace(/.*\//, ''));
+
+// --- rate limiter (mirrors translate-blog.ts) ------------------------------
+const CONCURRENCY = 5;
+const REQUESTS_PER_MINUTE = 15;
+const MIN_INTERVAL_MS = (60 * 1000) / REQUESTS_PER_MINUTE;
+let lastRequestTime = 0;
+
+// --- termbase: locked canonical titles to keep translations consistent -----
+type Termbase = Record<string, { en: string; titles: Record<string, string> }>;
+function loadTermbase(): Termbase {
+  try {
+    return JSON.parse(readFileSync(TERMBASE_PATH, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+function termbaseHint(locale: string, tb: Termbase): string {
+  const pairs: string[] = [];
+  for (const entry of Object.values(tb)) {
+    const target = entry.titles?.[locale];
+    if (entry.en && target) pairs.push(`  - "${entry.en}" → "${target}"`);
+  }
+  if (!pairs.length) return '';
+  return `\n\n**Canonical termbase (use these EXACT ${locale} translations when the concept appears):**\n${pairs.join('\n')}`;
+}
+
+async function callGeminiThrottled(prompt: string, locale: string, filename: string) {
+  const now = Date.now();
+  const timeSinceLast = now - lastRequestTime;
+  if (timeSinceLast < MIN_INTERVAL_MS) {
+    await new Promise((r) => setTimeout(r, MIN_INTERVAL_MS - timeSinceLast));
+  }
+  lastRequestTime = Date.now();
+
+  try {
+    const result = await model.generateContent(prompt);
+    const response = await result.response;
+    let text = response.text();
+    text = text.trim()
+      .replace(/^```[a-zA-Z]*\s*\n/, '')
+      .replace(/\n```\s*$/, '')
+      .replace(/^<content>\s*\n/, '')
+      .replace(/\n?<\/content>\s*$/, '')
+      .trim();
+    if (!text.startsWith('---')) text = '---\n' + text;
+    return text;
+  } catch (error) {
+    if (String(error).includes('429')) throw new Error('RATE_LIMIT');
+    console.error(`Failed to translate ${filename} to ${locale}:`, error);
+    throw error;
+  }
+}
+
+async function translateFile(filename: string, targetLocale: string, tb: Termbase) {
+  const sourcePath = path.join(GLOSSARY_DIR, SOURCE_LOCALE, filename);
+  const targetDir = path.join(GLOSSARY_DIR, targetLocale);
+  const targetPath = path.join(targetDir, filename);
+  await fs.mkdir(targetDir, { recursive: true });
+
+  if (!FORCE && existsSync(targetPath)) return; // fill-missing by default
+
+  console.log(`Translating glossary/${filename} → ${targetLocale}...`);
+  const fileContent = await fs.readFile(sourcePath, 'utf-8');
+
+  const dialectNote = targetLocale === 'ar'
+    ? '\n    -   **Arabic dialect**: write in modern Egyptian Arabic (اللهجة المصرية المعاصرة) — the natural register an Egyptian reader expects for a tech/business blog — NOT formal MSA, while keeping technical terms clear.'
+    : '';
+
+  const prompt = `
+You are a professional translator and technical content writer for Namefi, a domain name company.
+Translate the following Markdown GLOSSARY entry from English to ${targetLocale}.
+
+**Instructions:**
+1.  **Frontmatter**:
+    -   Preserve the YAML frontmatter structure exactly.
+    -   Translate the 'title', 'description', and 'keywords' values. The translated 'title' is the CANONICAL term for this concept in ${targetLocale} — choose it deliberately and idiomatically; it will be reused site-wide.
+    -   Keep 'date', 'tags', 'authors', 'draft', 'level', 'sources', 'aliasesByLocale' EXACTLY as in the source (do not translate or alter them).
+    -   Ensure 'language' is '${targetLocale}'.
+    -   **YAML quoting**: properly quote strings containing colons/special characters. If a single-quoted YAML string must contain an apostrophe, escape it by DOUBLING it ('') — NEVER with a backslash.
+
+2.  **Content**:
+    -   Translate the body to ${targetLocale} with natural, fluent, idiomatic phrasing and a confident, concrete tone (not stiff machine translation).${dialectNote}
+    -   Use consistent, standard domain-industry terminology throughout.
+    -   Preserve all Markdown formatting (headers, bold, lists, code blocks, links, image syntax).
+    -   Keep ALL links EXACTLY as-is, BUT swap the locale prefix on internal links from /en/ to /${targetLocale}/ (e.g. /en/glossary/registry/ → /${targetLocale}/glossary/registry/). Never change the slug after the locale. Keep citation URLs and any #:~:text= fragments verbatim.
+    -   Keep image references and asset paths (../../assets/...) exactly as is.
+    -   Do not translate domain names, brand names, code, or figures (e.g. GoDaddy, Verisign, ICANN, .com, $30 million) — keep them verbatim.${termbaseHint(targetLocale, tb)}
+
+3.  **Output**:
+    -   Return ONLY the complete translated markdown file (frontmatter + body).
+    -   Do not include \`\`\`markdown fences.
+
+**Original English Content:**
+\`\`\`markdown
+${fileContent}
+\`\`\`
+`;
+
+  let attempts = 0;
+  const maxAttempts = 3;
+  let delay = 5000;
+  while (attempts < maxAttempts) {
+    try {
+      const translated = await callGeminiThrottled(prompt, targetLocale, filename);
+      if (translated) {
+        await fs.writeFile(targetPath, translated, 'utf-8');
+        console.log(`✓ Created: ${targetLocale}/${filename}`);
+        return;
+      }
+    } catch (e: any) {
+      if (e.message === 'RATE_LIMIT') {
+        attempts++;
+        console.log(`⚠️ Rate limit ${filename} (${targetLocale}). Retry in ${delay / 1000}s...`);
+        await new Promise((r) => setTimeout(r, delay));
+        delay *= 2;
+      } else {
+        console.error(`✗ Error translating ${filename} → ${targetLocale}:`, e);
+        return;
+      }
+    }
+  }
+}
+
+async function main() {
+  const enDir = path.join(GLOSSARY_DIR, SOURCE_LOCALE);
+  let files: string[];
+  try {
+    files = (await fs.readdir(enDir)).filter((f) => f.endsWith('.md') || f.endsWith('.mdx'));
+  } catch {
+    console.error(`Could not read source directory: ${enDir}`);
+    process.exit(1);
+  }
+
+  if (slugArgs.length) {
+    const wanted = new Set(slugArgs);
+    files = files.filter((f) => wanted.has(f.replace(/\.mdx?$/, '')));
+    const found = new Set(files.map((f) => f.replace(/\.mdx?$/, '')));
+    for (const s of slugArgs) if (!found.has(s)) console.warn(`⚠️ no en glossary entry for "${s}"`);
+  }
+
+  console.log(`Translating ${files.length} glossary entr${files.length === 1 ? 'y' : 'ies'} → [${TARGET_LOCALES.join(', ')}]${FORCE ? ' (force overwrite)' : ' (fill missing)'}.`);
+
+  const tb = loadTermbase();
+  const limit = pLimit(CONCURRENCY);
+  const tasks = [];
+  for (const file of files) {
+    for (const locale of TARGET_LOCALES) {
+      tasks.push(limit(() => translateFile(file, locale, tb)));
+    }
+  }
+  await Promise.all(tasks);
+  console.log('Glossary translation complete. Re-run build-termbase.ts to lock the new titles.');
+}
+
+main().catch(console.error);

--- a/scripts/translate-glossary.ts
+++ b/scripts/translate-glossary.ts
@@ -52,9 +52,20 @@ const TERMBASE_PATH = path.join(process.cwd(), 'content', 'termbase.json');
 const argv = process.argv.slice(2);
 const FORCE = argv.includes('--force');
 const localesArg = argv.find((a) => a.startsWith('--locales='))?.slice(10);
-const TARGET_LOCALES = localesArg
-  ? localesArg.split(',').map((s) => s.trim()).filter((l) => (ALL_TARGETS as readonly string[]).includes(l))
-  : [...ALL_TARGETS];
+function resolveTargetLocales(): string[] {
+  if (localesArg === undefined) return [...ALL_TARGETS];
+  const requested = localesArg.split(',').map((s) => s.trim()).filter(Boolean);
+  const valid = requested.filter((l) => (ALL_TARGETS as readonly string[]).includes(l));
+  const unknown = requested.filter((l) => !(ALL_TARGETS as readonly string[]).includes(l));
+  if (unknown.length) console.warn(`⚠️ Ignoring unknown locale(s): ${unknown.join(', ')}`);
+  if (valid.length === 0) {
+    // A typo must not look like a completed run that wrote nothing.
+    console.error(`Error: --locales=${localesArg} matched no valid locales (allowed: ${ALL_TARGETS.join(', ')}).`);
+    process.exit(1);
+  }
+  return valid;
+}
+const TARGET_LOCALES = resolveTargetLocales();
 const slugArgs = argv
   .filter((a) => !a.startsWith('--'))
   .map((a) => a.replace(/\.mdx?$/, '').replace(/.*\//, ''));

--- a/scripts/translate-glossary.ts
+++ b/scripts/translate-glossary.ts
@@ -146,7 +146,15 @@ async function translateFile(filename: string, targetLocale: string, tb: Termbas
   if (!FORCE && existsSync(targetPath)) return; // fill-missing by default
 
   console.log(`Translating glossary/${filename} → ${targetLocale}...`);
-  const fileContent = await fs.readFile(sourcePath, 'utf-8');
+  let fileContent: string;
+  try {
+    fileContent = await fs.readFile(sourcePath, 'utf-8');
+  } catch (e) {
+    // One unreadable source must not abort the whole batch or vanish silently.
+    console.error(`✗ Could not read source ${filename}:`, e);
+    failures.push(`${targetLocale}/${filename}`);
+    return;
+  }
 
   const dialectNote = targetLocale === 'ar'
     ? '\n    -   **Arabic dialect**: write in modern Egyptian Arabic (اللهجة المصرية المعاصرة) — the natural register an Egyptian reader expects for a tech/business blog — NOT formal MSA, while keeping technical terms clear.'
@@ -250,4 +258,8 @@ async function main() {
   console.log('Glossary translation complete. Re-run build-termbase.ts to lock the new titles.');
 }
 
-main().catch(console.error);
+main().catch((e) => {
+  // A rejected run must surface a non-zero exit, never a false success.
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary / Solution

Wave 0 foundation for the **tiered glossary build-out** (grow 51 → ~140 entries, each translated to all 7 locales, with the glossary doubling as the canonical termbase). This PR builds the tooling that *does not exist today* — `translate-blog.ts` is blog-only and cannot translate glossary entries — and proves the build-time-only frontmatter is tolerated.

**New scripts:**
- **`scripts/translate-glossary.ts`** (`bun translate:glossary [slug…]`) — glossary translator: path/batch mode, fills only missing locales by default, termbase-aware prompt (injects locked canonical titles so cross-linked terms stay consistent), rewrites internal `/en/` links to `/<locale>/`, Egyptian-Arabic register for `ar`. Same `GEMINI_API_KEY` secret as `translate:blog`.
- **`scripts/build-termbase.ts`** (`bun termbase:build` / `termbase:check`) — flattens the glossary into `content/termbase.json` (`slug → {en, level, titles, aliasesByLocale}`); `--check` fails if the committed file is stale.
- **`scripts/glossary-mentions.ts`** (`bun glossary:mentions`) — per-term distinct-post mention counts, the demand metric that gates L1→L2 promotion (reuses the cross-link skill's `link-suggest --json` INBOUND so "mention" means the same thing in both tools). Mentions ≠ links added (the skill caps links at ≤5/term).
- **`scripts/check-termbase.ts`** (`bun check:termbase`) — **advisory** linter (like `check:i18n:convention`) flagging translated prose that uses a *known* non-canonical variant of a term (tracked per entry in `aliasesByLocale`). Prose-only matching, boundary-aware for Latin, substring for CJK/RTL — mirrors the cross-link skill.

**Frontmatter tolerance (proven):** `content/glossary/en/registrar.md` gains `level` / `sources` / `aliasesByLocale`. astra's `normaliseGlossaryFrontmatter` builds a fresh object from a fixed whitelist (`title, summary, description, tags, authors, date, draft, language, keywords`), so these extra keys are read by the scripts via gray-matter but **never reach the renderer** — safe to add, do not break the build. Documented in the README.

`content/termbase.json` is generated (51 concepts) and lives at the content root (outside the per-collection dirs), so the astra content loader never treats it as an entry; it can also ship in `/llms.txt` for AI crawlers.

## Test plan
- `bun data:validate` → passes (19 pre-existing warnings, none new) — confirms `level`/`sources`/`aliasesByLocale` are tolerated.
- `bun lint:mdx` → clean (CI gate).
- `bun termbase:build` → writes 51 concepts; `bun termbase:check` → up to date.
- `bun check:termbase` → 0 deviations across 1680 files (and verified it correctly surfaces real variants when an alias is present, e.g. `注册服务商` for *registrar*).
- `bun glossary:mentions registrar dns icann tld` → ranks real demand (dns 199, registrar 176, …).
- `scripts/translate-glossary.ts` parse-checks and guards cleanly on a missing `GEMINI_API_KEY`.

CI here runs `data:validate` + `lint:mdx` only (not `bun test`); the scripts are verified functionally against the full corpus.

## Claude session summary
- **Main prompts (paraphrased):** Execute the local GOAL doc `GOAL-resources-glossary-buildout.md` autonomously, wave by wave; for each batch, get Bugbot green, run the PR feedback loop, then admin-merge.
- **This PR (Wave 0a):** verified the pre-flight facts (stale checkout → fresh worktree off `origin/main`; 51-vs-38 locale gap; blog-only translator; astra frontmatter whitelist), then built the four scripts + package scripts + README docs + the tolerance proof.
- **Redaction:** no secrets/credentials/PII involved.
- **Timestamps (UTC):** session start ≈ 2026-06-23T05:35:00Z; last updated 2026-06-23T05:54:48Z.

Part of the glossary build-out initiative (Wave 0 of 0→3 + Wave T). Follow-ups: backfill the 13 EN-only entries, retrofit the 51, then the new-term waves.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and generated JSON plus optional glossary frontmatter; no runtime site or auth changes. CI still only runs existing validate/lint unless termbase:check is added later.
> 
> **Overview**
> **Wave 0** adds glossary-as-termbase automation so the tiered glossary build-out can scale beyond blog-only translation.
> 
> New **Bun scripts** (wired in `package.json`): **`translate-glossary`** (batch/slug translation with termbase-aware Gemini prompts), **`build-termbase`** / **`termbase:check`** (flatten glossary → committed **`content/termbase.json`**), **`glossary-mentions`** (distinct-post demand for L1→L2, aligned with cross-link `link-suggest`), and advisory **`check:termbase`** (flags known non-canonical variants from **`aliasesByLocale`**). Shared **`glossary-fs`** keeps `.md`/`.mdx` resolution consistent across tools.
> 
> **Content/docs:** initial **51-concept** `termbase.json`; **`registrar.md`** proves build-time frontmatter (`level`, `sources`, `aliasesByLocale`) that astra ignores at render time; README documents the workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f12ce824fa65de7e33aa859f56c643a5420d57c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded the README with a new “Glossary & termbase tooling” section, including how termbase tooling works and which glossary frontmatter fields are used at build time.

* **New Features**
  * Updated the multilingual termbase data (including the “Registrar” entry) with enriched metadata and localized titles/aliases.

* **Chores**
  * Added glossary/termbase automation scripts for building and checking termbase output, translating glossary entries, computing glossary mention demand, and validating alias consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->