### PR TITLE
content(glossary): Wave 0c — retrofit 51 EN entries to L1 bar

### DIFF
--- a/content/glossary/en/ai-agent.md
+++ b/content/glossary/en/ai-agent.md
@@ -4,8 +4,11 @@ date: '2026-05-22'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is an AI agent, and how do tokenized domains give it an identity?
+description: Software powered by an AI model that acts on a user's behalf — making purchases, calling APIs, and increasingly transacting with other agents.
 keywords: ['AI agent', 'autonomous agent', 'agent identity', 'agent commerce', 'on-chain agent', 'agentic AI']
+level: 1
+sources:
+  - https://modelcontextprotocol.io/
 ---
 
 An **AI agent** is software powered by a large language model (or similar AI) that takes actions in the world on a user's behalf — booking flights, making purchases, sending messages, calling APIs, and increasingly transacting with other agents. Unlike a chatbot that only produces text, an agent reads state, reasons, and writes back. As agents move from demos to real economic activity, they need persistent identifiers and a way to receive and send payments. [Tokenized domains](/en/blog/what-are-tokenized-domains/) plug into this nicely: the domain serves as a recognizable name, the controlling [wallet](/en/glossary/wallet/) provides a payment endpoint (including via [x402](/en/glossary/x402/)), and the [on-chain](/en/glossary/on-chain/) history acts as reputational scaffolding. Standards efforts in this area include Anthropic's [Model Context Protocol](https://modelcontextprotocol.io) and emerging agent-commerce protocols. See [Use Cases for Tokenized Domains in 2026](/en/blog/tokenized-domain-use-cases-2026/) for how the agent identity pattern is being built.

--- a/content/glossary/en/atomic-transfer.md
+++ b/content/glossary/en/atomic-transfer.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is an atomic transfer and how does it ensure secure domain transactions?
+description: A transaction that completes fully or not at all, never in a partial state, so an asset and its payment swap in one indivisible on-chain step.
 keywords: ['atomic transfer', 'blockchain transaction', 'all-or-nothing', 'secure exchange', 'smart contract']
+level: 1
+sources:
+  - https://ethereum.org/en/developers/docs/transactions/
 ---
 
 An **atomic transfer** is a transaction that either completes entirely or fails completely—there's no partial execution. The term "atomic" comes from the concept that the operation cannot be divided into smaller parts. In traditional domain transfers, the process often involves multiple steps across different systems, creating risks of partial completion or disputes. With tokenized domains, atomic transfers ensure that when you trade a domain [NFT](/en/glossary/nft/), the ownership change and any associated payments happen simultaneously within a single blockchain transaction. This eliminates counterparty risk and ensures that both parties receive what they agreed to exchange, or the entire transaction is reversed.

--- a/content/glossary/en/auction.md
+++ b/content/glossary/en/auction.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What are the different types of auctions used for domain sales?
+description: A competitive sale format where buyers bid to set the price, run as English (ascending), Dutch (descending), or dynamic timed auctions.
 keywords: ['auction', 'Dutch auction', 'English auction', 'dynamic auction', 'price discovery', 'domain sales']
+level: 1
+sources:
+  - https://www.investopedia.com/terms/a/auction.asp
 ---
 
 **Auctions** are competitive bidding processes used to determine market price and sell domains. **English auctions** start with a low price and bidders compete by raising bids until only one remains—common on platforms like eBay. **Dutch auctions** start with a high price that gradually decreases until someone accepts—ensuring quick sales at market-clearing prices. **Dynamic auctions** adjust their mechanics based on demand, participation, or other factors. [Smart contract](/en/glossary/smart-contract/)-based auctions for tokenized domains can implement any of these models transparently and automatically, enabling fair price discovery while eliminating the need for trusted intermediaries to hold funds or facilitate transfers.

--- a/content/glossary/en/auth-code.md
+++ b/content/glossary/en/auth-code.md
@@ -4,8 +4,11 @@ date: '2026-05-22'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is a domain auth code (EPP code) and when do you need one?
+description: A short per-domain secret a registrar issues to authorize moving a domain to another registrar, also called an EPP code or transfer code.
 keywords: ['auth code', 'EPP code', 'transfer code', 'domain transfer', 'authorization code', 'AuthInfo code']
+level: 1
+sources:
+  - https://datatracker.ietf.org/doc/html/rfc5731
 ---
 
 An **auth code** — also called an **EPP code**, **AuthInfo code**, or **transfer code** — is a short shared secret that a [registrar](/en/glossary/registrar/) issues for a specific domain to authorize a [cross-registrar transfer](/en/glossary/cross-registrar-transfer/). EPP (Extensible Provisioning Protocol) is the standard underlying registry protocol; the auth code is the per-domain credential within it. To transfer a domain from one registrar to another, the gaining registrar must present a valid auth code obtained by the registrant from the losing registrar. The code is usually visible inside the registrar's control panel, sometimes hidden behind a "Transfer Out" or "Get EPP Code" button. For [tokenized domains](/en/blog/what-are-tokenized-domains/), the on-chain ownership transfer **does not** require an auth code — the [NFT](/en/glossary/nft/) transfer is atomic on-chain. Auth codes are only relevant when moving a domain between registrars in the traditional [DNS](/en/glossary/dns/) world.

--- a/content/glossary/en/automated-delegation.md
+++ b/content/glossary/en/automated-delegation.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is automated delegation and how do smart contracts manage domain control?
+description: Handing control of a domain or its records to a smart contract that enforces rules automatically, with no human approving each change.
 keywords: ['automated delegation', 'smart contracts', 'domain management', 'programmable control', 'automation']
+level: 1
+sources:
+  - https://ethereum.org/en/developers/docs/smart-contracts/
 ---
 
 **Automated delegation** refers to using [smart contracts](/en/glossary/smart-contract/) to automatically manage domain control and delegation based on predefined rules or conditions. Traditional domain delegation requires manual intervention to change nameservers or [DNS](/en/glossary/dns/) settings. With [tokenized](/en/glossary/tokenize/) domains, [smart contracts](/en/glossary/smart-contract/) can automatically delegate control based on factors like payment status, time-based conditions, or governance decisions. For example, a [leased](/en/glossary/leasing/) domain could automatically revert control to the owner if lease payments stop, or a [DAO](/en/glossary/dao/)-owned domain could automatically update its configuration based on community votes. This automation reduces manual overhead, eliminates human error, and enables sophisticated domain management strategies that execute reliably without intermediaries.

--- a/content/glossary/en/censorship-free.md
+++ b/content/glossary/en/censorship-free.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What does censorship-free mean for domain ownership and management?
+description: A property where no single authority can unilaterally seize, block, or alter ownership, because control rests with the holder's keys on a public ledger.
 keywords: ['censorship-free', 'censorship resistance', 'decentralized', 'freedom', 'unstoppable']
+level: 1
+sources:
+  - https://ethereum.org/en/web3/
 ---
 
 **Censorship-free** refers to systems that resist attempts by authorities or intermediaries to restrict access, transfer, or usage. Traditional [domain ownership](/en/glossary/domain-ownership/) can be subject to censorship through [registrar](/en/glossary/registrar/) policies, government seizure, or payment processor restrictions. [Tokenized](/en/glossary/tokenize/) domains on decentralized blockchains are more censorship-resistant because ownership is secured by cryptography rather than corporate policies. While the underlying [DNS](/en/glossary/dns/) system may still be subject to regulation, the ownership token itself can be transferred and held without permission from centralized authorities. This provides users with greater control and protection against arbitrary seizure or restriction of their digital assets.

--- a/content/glossary/en/collateral.md
+++ b/content/glossary/en/collateral.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is collateral and how can domains serve as collateral in DeFi?
+description: An asset pledged to secure a loan that the lender can claim on default; a tokenized domain can serve as collateral in NFT-aware lending.
 keywords: ['collateral', 'security', 'lending', 'borrowing', 'domain collateral', 'DeFi']
+level: 1
+sources:
+  - https://www.investopedia.com/terms/c/collateral.asp
 ---
 
 **Collateral** is an asset pledged as security for a loan, which the lender can seize if the borrower defaults. In traditional finance, collateral might be real estate, vehicles, or other valuable assets. In DeFi and [Web3](/en/glossary/web3/), collateral often consists of cryptocurrency or other digital assets locked in [smart contracts](/en/glossary/smart-contract/). Tokenized domains can serve as collateral due to their verifiable ownership, transferability, and often substantial value. A premium domain [NFT](/en/glossary/nft/) like `crypto.com` or `defi.xyz` could be used to secure loans, participate in leveraged trading, or access other financial services—all while maintaining the domain's utility and potential for appreciation.

--- a/content/glossary/en/composability.md
+++ b/content/glossary/en/composability.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is composability and how does it apply to tokenized domains?
+description: The ability to combine independent on-chain components like building blocks, so a tokenized domain can plug into lending, trading, and other protocols.
 keywords: ['composability', 'interoperability', 'building blocks', 'DeFi', 'Web3 integration']
+level: 1
+sources:
+  - https://ethereum.org/en/developers/docs/smart-contracts/
 ---
 
 **Composability** refers to the ability to combine different protocols, applications, or assets like building blocks to create new functionality. In [Web3](/en/glossary/web3/), composable systems can seamlessly integrate with each other without requiring custom partnerships or complex integrations. Tokenized domains on Namefi are inherently composable—they can be used as [collateral](/en/glossary/collateral/) in [lending protocols](/en/glossary/lending-protocol/), integrated into identity systems, combined with other [NFTs](/en/glossary/nft/), or utilized in DeFi applications. This composability unlocks new use cases that weren't possible with traditional domain management, where domains were siloed within [registrar](/en/glossary/registrar/) systems and couldn't easily interact with other digital services.

--- a/content/glossary/en/cross-registrar-transfer.md
+++ b/content/glossary/en/cross-registrar-transfer.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What are cross-registrar transfers and how does tokenization simplify the process?
+description: Moving a domain's registration from one ICANN registrar to another using an auth code, while keeping the same owner and the same name.
 keywords: ['cross-registrar transfer', 'registrar transfer', 'domain migration', 'transfer process', 'tokenization']
+level: 1
+sources:
+  - https://www.icann.org/resources/pages/name-holder-faqs-2017-10-10-en
 ---
 
 **Cross-registrar transfer** is the process of moving a domain from one [registrar](/en/glossary/registrar/) to another, traditionally requiring auth codes, waiting periods, and coordination between [registrars](/en/glossary/registrar/). This process can take days or weeks and may involve fees from both [registrars](/en/glossary/registrar/). With [tokenized](/en/glossary/tokenize/) domains, while the underlying [DNS](/en/glossary/dns/) registration may still require traditional transfer processes, the ownership token can be transferred instantly between [wallets](/en/glossary/wallet/). This separation allows for immediate trading and ownership changes at the token level, while [DNS](/en/glossary/dns/) management can be handled separately. Advanced tokenization models might even automate cross-registrar transfers through [smart contracts](/en/glossary/smart-contract/), significantly reducing the complexity and time required to move domains between different service providers.

--- a/content/glossary/en/cryptographic-security.md
+++ b/content/glossary/en/cryptographic-security.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is cryptographic security and how does it protect tokenized domains?
+description: Protection based on public-key cryptography, where only the holder of a private key can authorize actions, rather than a password a server could leak.
 keywords: ['cryptographic security', 'encryption', 'private keys', 'digital signatures', 'blockchain security']
+level: 1
+sources:
+  - https://ethereum.org/en/developers/docs/accounts/
 ---
 
 **Cryptographic security** refers to protection methods that use mathematical algorithms to secure data and verify authenticity. In blockchain and [tokenized](/en/glossary/tokenize/) domains, cryptographic security includes digital signatures that prove ownership, hash functions that ensure data integrity, and encryption that protects private keys. When you own a [tokenized](/en/glossary/tokenize/) domain, your ownership is secured by cryptographic proofs that are virtually impossible to forge or hack with current technology. This provides stronger security than traditional [domain ownership](/en/glossary/domain-ownership/), which relies on password-protected [registrar](/en/glossary/registrar/) accounts that can be compromised through social engineering, data breaches, or weak authentication systems.

--- a/content/glossary/en/custodial-ownership.md
+++ b/content/glossary/en/custodial-ownership.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is custodial ownership and how does it differ from self-custody?
+description: An arrangement where a third party holds the private keys to your assets for you, so you depend on their security and their permission to transact.
 keywords: ['custodial ownership', 'custody', 'third-party control', 'registrar control', 'centralized storage']
+level: 1
+sources:
+  - https://ethereum.org/en/wallets/
 ---
 
 **Custodial ownership** occurs when a third party holds and manages assets on behalf of the actual owner, who relies on the custodian's policies and systems to access their assets. Traditional domain ownership is largely custodial—[registrars](/en/glossary/registrar/) control the domain records, renewal processes, and transfer mechanisms. Even though you "own" the domain, you depend on the [registrar's](/en/glossary/registrar/) platform and policies to manage it. [Tokenized](/en/glossary/tokenize/) domains shift toward self-custody, where you directly control the ownership token in your own [wallet](/en/glossary/wallet/). While some aspects (like [DNS](/en/glossary/dns/) management) may still involve custodial services, the core ownership becomes self-sovereign and independent of any single service provider's policies or continued operation.

--- a/content/glossary/en/dao.md
+++ b/content/glossary/en/dao.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is a DAO and how can it relate to domain management?
+description: A Decentralized Autonomous Organization run by smart-contract rules and member voting rather than a central executive, often managing a shared treasury.
 keywords: ['DAO', 'decentralized autonomous organization', 'governance', 'collective ownership', 'smart contracts']
+level: 1
+sources:
+  - https://ethereum.org/en/dao/
 ---
 
 A **DAO (Decentralized Autonomous Organization)** is an organization governed by [smart contracts](/en/glossary/smart-contract/) and community voting rather than traditional hierarchical management. DAOs allow members to collectively make decisions about treasury management, protocol upgrades, and strategic direction through token-based voting mechanisms. In the context of domains, DAOs can collectively own and manage valuable domain portfolios, make decisions about domain development or monetization, and govern domain-related protocols. Tokenized domains can be owned by DAOs, enabling communities to collectively invest in, develop, and benefit from high-value digital real estate while maintaining transparent, decentralized governance over these assets.

--- a/content/glossary/en/defi.md
+++ b/content/glossary/en/defi.md
@@ -4,8 +4,11 @@ date: '2026-05-22'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is DeFi and how do tokenized domains plug into it?
+description: Decentralized Finance offers lending, borrowing, and trading through smart contracts on public blockchains, without banks or brokers as intermediaries.
 keywords: ['DeFi', 'decentralized finance', 'lending', 'borrowing', 'collateral', 'DEX', 'money markets', 'on-chain finance']
+level: 1
+sources:
+  - https://ethereum.org/en/defi/
 ---
 
 **DeFi (Decentralized Finance)** is the broad category of financial services — lending, borrowing, trading, derivatives, asset management — built on public blockchains via [smart contracts](/en/glossary/smart-contract/), without traditional intermediaries like banks or brokers. Examples include Aave, Compound, Uniswap, MakerDAO, and many others. DeFi matters to [tokenized domains](/en/blog/what-are-tokenized-domains/) because once a domain is represented as an [NFT](/en/glossary/nft/), it can be used as [collateral](/en/glossary/collateral/) in NFT-aware [lending protocols](/en/glossary/lending-protocol/), traded on decentralized markets, or composed with any other on-chain primitive. The flip side: DeFi positions are public, often non-custodial, and the user is responsible for managing risk — liquidations are automatic. See [Use Cases for Tokenized Domains in 2026](/en/blog/tokenized-domain-use-cases-2026/) for how lending and other DeFi patterns apply specifically to domains. Reference: [Ethereum.org's DeFi explainer](https://ethereum.org/en/defi/).

--- a/content/glossary/en/did.md
+++ b/content/glossary/en/did.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is DID and how do domains play a role in decentralized identity?
+description: A Decentralized Identifier is a globally unique ID controlled by its owner's keys rather than a central registry, used to prove identity across services.
 keywords: ['DID', 'decentralized identity', 'self-sovereign identity', 'blockchain identity', 'Web3 identity']
+level: 1
+sources:
+  - https://www.w3.org/TR/did-core/
 ---
 
 **DID (Decentralized Identity)** refers to identity systems that give individuals control over their digital identity without relying on centralized authorities like governments or corporations. DIDs use blockchain technology to create self-sovereign identities that users can manage directly. Domains play a crucial role in decentralized identity by serving as human-readable identifiers linked to blockchain addresses or identity credentials. A [tokenized](/en/glossary/tokenize/) domain like `alice.eth` or `bob.crypto` can represent someone's decentralized identity, serving as their Web3 username while being cryptographically secured and user-controlled. This creates portable, [censorship-free](/en/glossary/censorship-free/) digital identity that works across different platforms and applications.

--- a/content/glossary/en/dns.md
+++ b/content/glossary/en/dns.md
@@ -4,8 +4,12 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is DNS and how does it relate to domain tokenization?
+description: The Domain Name System translates human-readable names like example.com into the IP addresses computers use to route traffic across the internet.
 keywords: ['DNS', 'domain name system', 'internet infrastructure', 'name resolution', 'traditional domains']
+level: 1
+sources:
+  - https://datatracker.ietf.org/doc/html/rfc1034
+  - https://datatracker.ietf.org/doc/html/rfc1035
 ---
 
 The **DNS (Domain Name System)** is the internet's phonebook—a hierarchical system that translates human-readable domain names like `google.com` into IP addresses that computers use to locate servers. DNS is managed by a global network of servers and governed by [ICANN](/en/glossary/icann/) through registries and [registrars](/en/glossary/registrar/). When Namefi tokenizes a domain, the underlying DNS functionality remains intact, but ownership and management become decentralized. The tokenized domain [NFT](/en/glossary/nft/) represents ownership rights to the DNS name, allowing blockchain-based transfers and management while the domain continues to resolve normally on the internet through traditional DNS infrastructure.

--- a/content/glossary/en/dnssec.md
+++ b/content/glossary/en/dnssec.md
@@ -4,8 +4,11 @@ date: '2026-05-22'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is DNSSEC and why does it matter for tokenized and traditional domains?
+description: Cryptographic signatures on DNS records that let resolvers verify a response is authentic and was not forged or tampered with in transit.
 keywords: ['DNSSEC', 'DNS security', 'domain security', 'DS record', 'chain of trust', 'cryptographic DNS']
+level: 1
+sources:
+  - https://datatracker.ietf.org/doc/html/rfc4033
 ---
 
 **DNSSEC (Domain Name System Security Extensions)** is a set of cryptographic extensions to the [DNS](/en/glossary/dns/) protocol that lets resolvers verify the authenticity and integrity of DNS responses. Without DNSSEC, an attacker can forge or tamper with DNS replies on the path between resolver and authoritative server, redirecting users to malicious infrastructure. With DNSSEC, the records are signed, and a chain of trust runs from the DNS root down through each zone via DS records. DNSSEC is specified in [RFC 4033](https://datatracker.ietf.org/doc/html/rfc4033) and related RFCs. Tokenizing a domain doesn't change DNSSEC at all — the chain of trust still runs through the [registrar](/en/glossary/registrar/) and registry, and DS records are published the same way. Many DNS providers (Cloudflare, Route53) sign zones automatically when DNSSEC is enabled.

--- a/content/glossary/en/domain-bundle.md
+++ b/content/glossary/en/domain-bundle.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is a domain bundle and how does tokenization enable portfolio management?
+description: A group of related domain names sold or managed together as one package, often covering multiple TLDs or spelling variants of a single brand.
 keywords: ['domain bundle', 'portfolio', 'bulk trading', 'domain collection', 'asset management']
+level: 1
+sources:
+  - https://www.namebio.com/
 ---
 
 A **domain bundle** is a collection of related domains packaged together for sale, management, or investment purposes. Traditional domain bundles might include variations of a brand name, different TLD extensions, or thematically related domains. With [tokenization](/en/glossary/tokenize/), domain bundles can be represented as collections of [NFTs](/en/glossary/nft/) or even wrapped into single tokens representing the entire portfolio. This enables bulk trading, simplified portfolio management, and new investment products. For example, a "crypto domains" bundle might include domains like `bitcoin.xyz`, `ethereum.co`, and `defi.io`, allowing investors to gain exposure to the entire cryptocurrency domain sector through a single purchase or investment vehicle.

--- a/content/glossary/en/domain-ownership.md
+++ b/content/glossary/en/domain-ownership.md
@@ -4,8 +4,11 @@ date: '2025-06-29'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What does domain ownership mean when tokenized?
+description: The rights to control, use, and transfer a domain; tokenization records those rights on-chain in a wallet instead of only in a registrar account.
 keywords: ['domain ownership', 'NFT domain', 'registrar', 'custodial', 'wallet ownership']
+level: 1
+sources:
+  - https://www.icann.org/resources/pages/name-holder-faqs-2017-10-10-en
 ---
 
 **Domain ownership** traditionally refers to a registrant holding usage rights through a [registrar](/en/glossary/registrar/), often under restrictive terms. With Namefi, domain ownership means holding an [NFT](/en/glossary/nft/) in your own [wallet](/en/glossary/wallet/) that represents the real-world domain (e.g. `yourname.xyz`). This gives you clearer, cryptographically secured control over transfers, delegation, and integration. Instead of being subject to a registrar’s dashboard or policies, you manage your domain directly [on-chain](/en/glossary/on-chain/). While legal obligations (renewals, trademark rules) still apply, ownership becomes user-first and programmable—unlocking new possibilities in Web3, identity, and digital commerce.

--- a/content/glossary/en/domain-trading.md
+++ b/content/glossary/en/domain-trading.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is domain trading and how does tokenization improve the trading experience?
+description: Buying and selling domain names to profit from price differences, ranging from quick flips to long-term holds in a managed portfolio.
 keywords: ['domain trading', 'domain investing', 'digital real estate', 'secondary market', 'liquidity']
+level: 1
+sources:
+  - https://www.namebio.com/
 ---
 
 **Domain trading** refers to the buying and selling of domain names as investment assets, similar to trading stocks or real estate. Traditional domain trading involves lengthy transfer processes, [escrow](/en/glossary/escrow/) services, and limited liquidity. [Tokenized](/en/glossary/tokenize/) domains transform trading by enabling instant transfers, transparent price history, and access to broader liquidity pools through [NFT](/en/glossary/nft/) [marketplaces](/en/glossary/marketplace/). Traders can now use familiar Web3 tools to manage domain portfolios, execute trades 24/7, and access sophisticated trading features like automated market makers or [fractional ownership](/en/glossary/fractional-ownership/). This creates a more efficient and accessible market for domain investors while providing better price discovery and reduced transaction costs.

--- a/content/glossary/en/ens.md
+++ b/content/glossary/en/ens.md
@@ -4,8 +4,11 @@ date: '2026-05-22'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is ENS and how does it differ from a tokenized ICANN domain?
+description: The Ethereum Name Service maps human-readable names like alice.eth to wallet addresses and records, managed entirely by on-chain smart contracts.
 keywords: ['ENS', 'Ethereum Name Service', '.eth', 'web3 name', 'on-chain naming', 'wallet alias', 'crypto identity']
+level: 1
+sources:
+  - https://docs.ens.domains/
 ---
 
 **ENS (Ethereum Name Service)** is a decentralized naming system that maps human-readable names (like `vitalik.eth`) to Ethereum addresses, content hashes, and other resources. ENS names live entirely on-chain and are managed by [smart contracts](/en/glossary/smart-contract/) on Ethereum. They are not part of the traditional [DNS](/en/glossary/dns/) and do not resolve in standard browsers without a resolver gateway or browser extension. ENS is a sibling category to **tokenized ICANN domains**: ENS optimizes for wallet identity and crypto-native use cases, while [tokenized domains](/en/blog/what-are-tokenized-domains/) keep your real `.com`/`.xyz`/`.io` working everywhere on the internet and add a [wallet](/en/glossary/wallet/)-native ownership layer. Many users hold both — see [Tokenized Domain vs Web3 Domain](/en/blog/tokenized-domain-vs-web3-domain/) for a side-by-side. Official site: [ens.domains](https://ens.domains).

--- a/content/glossary/en/erc-721.md
+++ b/content/glossary/en/erc-721.md
@@ -4,8 +4,11 @@ date: '2026-05-22'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is ERC-721 and why does it matter for tokenized domains?
+description: The Ethereum standard interface for non-fungible tokens that lets wallets and marketplaces handle any unique token, including tokenized domains, alike.
 keywords: ['ERC-721', 'NFT standard', 'Ethereum token standard', 'non-fungible token', 'tokenized domain standard']
+level: 1
+sources:
+  - https://eips.ethereum.org/EIPS/eip-721
 ---
 
 **ERC-721** is the Ethereum standard for non-fungible tokens ([NFTs](/en/glossary/nft/)). It defines a common interface — ownership, transfer, approval — that wallets, marketplaces, and other contracts can rely on. Because [tokenized domains](/en/blog/what-are-tokenized-domains/) are typically implemented as ERC-721 NFTs, they get instant compatibility with the broader NFT ecosystem: OpenSea, Blur, and similar marketplaces can list them; standard wallets like MetaMask, Rabby, and hardware wallets can hold them; NFT-aware lending and rental protocols can plug into them. There is also a related batch standard, ERC-1155, used for fungible/semi-fungible tokens — domains are not usually issued under ERC-1155 because each domain is unique. Reference: [EIP-721 specification](https://eips.ethereum.org/EIPS/eip-721).

--- a/content/glossary/en/escrow.md
+++ b/content/glossary/en/escrow.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is escrow and how do smart contracts provide trustless escrow for domains?
+description: A neutral third party or smart contract that holds funds or assets until both sides meet the agreed terms, then releases them, cutting counterparty risk.
 keywords: ['escrow', 'trusted third party', 'smart contract escrow', 'trustless', 'secure transactions']
+level: 1
+sources:
+  - https://www.investopedia.com/terms/e/escrow.asp
 ---
 
 **Escrow** is a financial arrangement where a neutral third party holds assets during a transaction until all conditions are met, protecting both buyer and seller. Traditional domain escrow services like Escrow.com charge fees and require trust in the service provider. [Smart contract](/en/glossary/smart-contract/)-based escrow for tokenized domains eliminates the need for trusted intermediaries—the blockchain itself acts as the neutral party, automatically releasing funds and transferring domain ownership when conditions are satisfied. This creates trustless, transparent, and often cheaper escrow services that execute automatically according to predetermined rules, reducing counterparty risk in domain transactions.

--- a/content/glossary/en/farcaster.md
+++ b/content/glossary/en/farcaster.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is Farcaster and how do domains relate to decentralized social networks?
+description: A decentralized social network built on Ethereum where accounts, identities, and social graphs live on-chain rather than on one company's servers.
 keywords: ['Farcaster', 'decentralized social', 'Web3 social', 'blockchain identity', 'social protocol']
+level: 1
+sources:
+  - https://docs.farcaster.xyz/
 ---
 
 **Farcaster** is a decentralized social network protocol that allows users to own their social identity and data rather than being dependent on centralized platforms like Twitter or Facebook. Users connect their cryptocurrency [wallets](/en/glossary/wallet/) to create profiles and can move their follower networks and content between different Farcaster-based applications. Domains play an important role in Farcaster and similar protocols as human-readable identifiers that can represent social identities. A [tokenized](/en/glossary/tokenize/) domain like `alice.eth` can serve as both a Web3 identity and a Farcaster username, creating unified digital identity across multiple decentralized platforms while maintaining user ownership and portability.

--- a/content/glossary/en/fractional-ownership.md
+++ b/content/glossary/en/fractional-ownership.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is fractional ownership and how does it apply to valuable domains?
+description: Splitting a single high-value asset into smaller tradable shares so several people can own portions of it, enabled on-chain by token standards.
 keywords: ['fractional ownership', 'shared ownership', 'domain fractionalization', 'accessibility', 'tokenization']
+level: 1
+sources:
+  - https://www.investopedia.com/terms/f/fractionalownership.asp
 ---
 
 **Fractional ownership** allows multiple parties to own shares of a single asset, making expensive assets more accessible to smaller investors. In real estate, this might involve multiple investors owning portions of a property. For domains, fractional ownership enables multiple people to collectively own valuable domains that might be too expensive for individual purchase. A premium domain like `ai.com` could be fractionalized into tokens representing ownership shares, allowing investors to buy portions and share in potential appreciation or [revenue](/en/glossary/revenue-sharing/). This democratizes access to high-value digital real estate while enabling domain owners to partially monetize their assets without selling completely.

--- a/content/glossary/en/gas.md
+++ b/content/glossary/en/gas.md
@@ -4,8 +4,11 @@ date: '2026-05-22'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is gas, and how much does it cost to mint or transfer a tokenized domain?
+description: The fee paid to process a transaction on a blockchain, priced in the network's native asset and rising with congestion; Layer 2s charge far less.
 keywords: ['gas', 'gas fee', 'transaction fee', 'gwei', 'Ethereum gas', 'Base gas', 'L2 fees', 'mint cost']
+level: 1
+sources:
+  - https://ethereum.org/en/developers/docs/gas/
 ---
 
 **Gas** is the unit of computational work required to execute an operation on a blockchain like Ethereum or Base. Users pay a **gas fee** — denominated in the chain's native asset (ETH on Ethereum and Base, MATIC on Polygon, etc.) — to compensate validators for processing the transaction. Gas fees vary with network congestion: minting an [NFT](/en/glossary/nft/) on Ethereum mainnet can cost meaningfully more during busy periods than on quiet days. Layer-2 networks like Base typically charge a small fraction of mainnet gas, which is why many tokenization platforms operate there. For [tokenizing](/en/glossary/tokenize/) or transferring a domain, expect to pay a one-time gas fee per [on-chain](/en/glossary/on-chain/) action (mint, transfer, list, etc.) — usually small relative to the registrar fees. Reference: [Ethereum.org's gas explainer](https://ethereum.org/en/developers/docs/gas/).

--- a/content/glossary/en/hardware-wallet.md
+++ b/content/glossary/en/hardware-wallet.md
@@ -4,8 +4,11 @@ date: '2026-05-22'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is a hardware wallet and why use one to store a tokenized domain?
+description: A dedicated offline device that stores a wallet's private keys and signs transactions on-device, so the keys never touch an internet-connected computer.
 keywords: ['hardware wallet', 'cold wallet', 'Ledger', 'Trezor', 'GridPlus', 'Keystone', 'secure element', 'self-custody']
+level: 1
+sources:
+  - https://ethereum.org/en/wallets/
 ---
 
 A **hardware wallet** is a small dedicated device — typically with a screen and one or two buttons — that stores a [wallet](/en/glossary/wallet/)'s private keys offline and signs transactions on the device itself, so the keys never touch an internet-connected computer. Common examples include Ledger, Trezor, GridPlus Lattice, and Keystone. Because the signing operation happens inside the device's secure element, malware on a connected laptop cannot extract the key; the worst it can do is trick the user into approving a malicious transaction on the device screen — which is why "verify on device" matters. For high-value assets like [tokenized domains](/en/blog/what-are-tokenized-domains/), most owners use a hot wallet (browser extension) for day-to-day interaction and store the [NFT](/en/glossary/nft/) on a hardware wallet for long-term custody. See [Recovering a Tokenized Domain After Wallet Loss](/en/blog/recovering-a-tokenized-domain-after-wallet-loss/) for how this fits into a broader recovery strategy.

--- a/content/glossary/en/icann.md
+++ b/content/glossary/en/icann.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is ICANN and how does it relate to domain tokenization?
+description: The Internet Corporation for Assigned Names and Numbers, the nonprofit that coordinates the global domain name system and accredits registrars.
 keywords: ['ICANN', 'internet governance', 'domain policy', 'DNS oversight', 'domain regulation']
+level: 1
+sources:
+  - https://www.icann.org/resources/pages/what-2012-02-25-en
 ---
 
 **ICANN (Internet Corporation for Assigned Names and Numbers)** is the non-profit organization responsible for coordinating the internet's domain name system, IP address allocation, and protocol identifier assignment globally. ICANN oversees domain policy, accredits [registrars](/en/glossary/registrar/), and manages the root [DNS](/en/glossary/dns/) servers that keep the internet functioning. While tokenized domains operate on blockchain infrastructure, they still interact with ICANN-governed [DNS](/en/glossary/dns/) systems for internet resolution. Domain tokenization doesn't change ICANN's role or domain legal obligations, but it does create new ownership and transfer mechanisms that exist alongside traditional [DNS](/en/glossary/dns/) infrastructure, potentially requiring policy updates as the technology matures.

--- a/content/glossary/en/internet-native-asset.md
+++ b/content/glossary/en/internet-native-asset.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What are internet-native assets and how do domains fit this category?
+description: An asset that originates and lives on the internet itself, like a domain or token, rather than being a digital record of a physical or legal object.
 keywords: ['internet-native asset', 'digital asset', 'blockchain', 'native internet', 'tokenized domains']
+level: 1
+sources:
+  - https://ethereum.org/en/nft/
 ---
 
 An **internet-native asset** is a digital asset that exists primarily or exclusively in online environments and derives its value from internet-based utility or networks. Unlike traditional assets that exist in physical form, internet-native assets are designed for digital environments and often have no physical equivalent. [Tokenized](/en/glossary/tokenize/) domains are prime examples of internet-native assets—they exist as digital tokens, derive value from their online utility, and are managed through internet-based protocols. These assets benefit from properties like instant global transferability, programmable functionality, and integration with other digital systems, making them fundamentally different from traditional assets that were adapted for internet use.

--- a/content/glossary/en/leasing.md
+++ b/content/glossary/en/leasing.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is domain leasing and how does tokenization enable new leasing models?
+description: Renting the use of a domain for a recurring fee while keeping ownership, with smart contracts able to enforce terms and automate the payments.
 keywords: ['leasing', 'domain rental', 'passive income', 'smart contract leasing', 'automated payments']
+level: 1
+sources:
+  - https://www.investopedia.com/terms/l/lease.asp
 ---
 
 **Leasing** in the domain context refers to temporarily granting usage rights to a domain while retaining ownership. Traditional domain leasing involves manual agreements and trust between parties. With tokenized domains, leasing can be automated through [smart contracts](/en/glossary/smart-contract/) that handle payments, term enforcement, and automatic reversion of control. Domain owners can earn passive income by leasing their valuable domains to businesses or projects that need them temporarily. [Smart contract](/en/glossary/smart-contract/)-based leasing eliminates the need for intermediaries, reduces costs, and ensures transparent, automatic execution of lease terms—creating new revenue streams for domain holders while providing flexible access for lessees.

--- a/content/glossary/en/lending-protocol.md
+++ b/content/glossary/en/lending-protocol.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What are lending protocols and how can domains be used in DeFi lending?
+description: A smart-contract platform where users supply assets to earn interest and borrowers take loans against collateral, with no bank as intermediary.
 keywords: ['lending protocol', 'DeFi', 'collateral', 'borrowing', 'domain finance', 'yield']
+level: 1
+sources:
+  - https://ethereum.org/en/defi/
 ---
 
 A **lending protocol** is a decentralized finance (DeFi) platform that allows users to lend and borrow cryptocurrency assets without traditional intermediaries like banks. These protocols use [smart contracts](/en/glossary/smart-contract/) to automate lending terms, interest rates, and [collateral](/en/glossary/collateral/) management. Popular examples include Aave, Compound, and MakerDAO. Tokenized domains can participate in lending protocols as [collateral](/en/glossary/collateral/)—users can lock their valuable domain [NFTs](/en/glossary/nft/) to borrow cryptocurrency, or earn yield by providing liquidity. This creates new financial opportunities for domain holders, allowing them to access capital without selling their domains or generate passive income from their digital real estate holdings.

--- a/content/glossary/en/lens.md
+++ b/content/glossary/en/lens.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is Lens Protocol and how does it use domains for social identity?
+description: Lens Protocol is a decentralized social graph where profiles, follows, and posts are owned by users as on-chain assets they can carry between apps.
 keywords: ['Lens', 'Lens Protocol', 'decentralized social', 'NFT profiles', 'social graph', 'Web3 identity']
+level: 1
+sources:
+  - https://www.lens.xyz/
 ---
 
 **Lens Protocol** is a decentralized social media protocol built on Polygon that allows users to own their social graphs as [NFTs](/en/glossary/nft/). Unlike traditional social media where platforms control user data and connections, Lens gives users ownership of their profiles, followers, and content through blockchain-based assets. Lens profiles use domain-like handles (like `alice.lens`) that function as both usernames and [NFT](/en/glossary/nft/) assets. These handles can be traded, and the social capital built up around them (followers, reputation, content) moves with the owner. This creates a new model where social identity becomes a valuable, portable digital asset that works across different applications built on the Lens ecosystem.

--- a/content/glossary/en/marketplace.md
+++ b/content/glossary/en/marketplace.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What are NFT marketplaces and how do they facilitate domain trading?
+description: An online venue where buyers and sellers trade assets; for NFTs and tokenized domains, examples include OpenSea and Blur.
 keywords: ['marketplace', 'OpenSea', 'Blur', 'NFT trading', 'domain marketplace', 'secondary market']
+level: 1
+sources:
+  - https://ethereum.org/en/nft/
 ---
 
 **Marketplaces** like OpenSea and Blur are platforms where users can buy, sell, and trade [NFTs](/en/glossary/nft/), including tokenized domains. These platforms provide user-friendly interfaces for discovering assets, making offers, and completing transactions while connecting to users' [wallets](/en/glossary/wallet/). Traditional domain marketplaces like Sedo or Afternic require centralized [escrow](/en/glossary/escrow/) and manual transfer processes, while [NFT](/en/glossary/nft/) marketplaces enable instant, trustless trading through [smart contracts](/en/glossary/smart-contract/). When domains are tokenized as [NFTs](/en/glossary/nft/), they gain access to the entire [NFT](/en/glossary/nft/) ecosystem, benefiting from improved liquidity, transparent price history, and integration with broader [Web3](/en/glossary/web3/) infrastructure that serves millions of users globally.

--- a/content/glossary/en/multi-sig.md
+++ b/content/glossary/en/multi-sig.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is multi-sig and how does it enhance domain security?
+description: A wallet that needs several private keys to approve a transaction, such as two of three signers, so one compromised key cannot move funds alone.
 keywords: ['multi-sig', 'multisig', 'multiple signatures', 'enhanced security', 'shared custody']
+level: 1
+sources:
+  - https://docs.safe.global/
 ---
 
 **Multi-sig (multi-signature)** is a security mechanism that requires multiple private keys to authorize a transaction, rather than just one. For example, a 2-of-3 multi-sig setup requires at least 2 out of 3 designated keys to approve any transaction. This is particularly valuable for high-value tokenized domains, where multiple parties might share ownership or where additional security is essential. Multi-sig [wallets](/en/glossary/wallet/) can protect against single points of failure, insider threats, or key loss. Organizations can use multi-sig to ensure that valuable domain transfers require approval from multiple executives, while individuals can use it to protect against theft or accidental loss of their domain assets.

--- a/content/glossary/en/nft.md
+++ b/content/glossary/en/nft.md
@@ -4,8 +4,12 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is an NFT and how does it relate to domain tokenization?
+description: A Non-Fungible Token is a unique, indivisible blockchain token used to represent ownership of a specific item such as a tokenized domain.
 keywords: ['NFT', 'non-fungible token', 'blockchain', 'unique asset', 'domain NFT']
+level: 1
+sources:
+  - https://eips.ethereum.org/EIPS/eip-721
+  - https://ethereum.org/en/nft/
 ---
 
 An **NFT (Non-Fungible Token)** is a unique digital asset that exists on a blockchain, representing ownership of a specific item that cannot be replicated or substituted. Unlike cryptocurrencies which are fungible (one Bitcoin equals another Bitcoin), each NFT has distinct properties and metadata. In Namefi's context, domains are converted into NFTs, making them tradable digital assets with cryptographic proof of ownership. This allows domains to be stored in [wallets](/en/glossary/wallet/), transferred instantly without intermediaries, and integrated with other [Web3](/en/glossary/web3/) protocols while maintaining their uniqueness and verifiable ownership history.

--- a/content/glossary/en/on-chain.md
+++ b/content/glossary/en/on-chain.md
@@ -4,8 +4,11 @@ date: '2025-06-29'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What does "on-chain" mean in the context of domains?
+description: Describes data or actions recorded directly on a blockchain, where they are public, verifiable, and secured by the network rather than a private server.
 keywords: ['on-chain', 'blockchain', 'smart contracts', 'domain NFT', 'decentralization']
+level: 1
+sources:
+  - https://ethereum.org/en/developers/docs/transactions/
 ---
 
 **On-chain** refers to data, assets, or actions that are recorded directly on a public blockchain. When a domain is "on-chain," its ownership and management can be verified and transferred via [smart contracts](/en/glossary/smart-contract/)—without needing approval from a centralized [registrar](/en/glossary/registrar/). Namefi uses on-chain infrastructure to turn domains into [NFTs](/en/glossary/nft/), enabling instant, [permissionless](/en/glossary/permissionless/) transfers and integration with other decentralized protocols. This structure provides greater transparency, programmability, and control to domain holders. While the underlying domain still lives in traditional [DNS](/en/glossary/dns/), its tokenized representation lives on-chain as a secure and interoperable asset.

--- a/content/glossary/en/permissionless.md
+++ b/content/glossary/en/permissionless.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What does permissionless mean in blockchain and domain management?
+description: A system anyone can use or build on without a gatekeeper's approval, because the rules are enforced by open protocols rather than a central authority.
 keywords: ['permissionless', 'decentralized', 'censorship-resistant', 'open access', 'blockchain']
+level: 1
+sources:
+  - https://ethereum.org/en/web3/
 ---
 
 **Permissionless** refers to systems that allow anyone to participate without requiring approval from a central authority. In blockchain contexts, permissionless networks let users transact, build applications, or interact with protocols without gatekeepers. Traditional domain management requires permission from [registrars](/en/glossary/registrar/) and follows their policies, but tokenized domains on Namefi enable permissionless transfers and integrations. Once you own a tokenized domain, you can trade it, use it in DeFi protocols, or build applications around it without seeking approval from intermediaries—as long as the underlying blockchain network is accessible to you.

--- a/content/glossary/en/protocol-asset.md
+++ b/content/glossary/en/protocol-asset.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What are protocol assets and how do tokenized domains function as protocol assets?
+description: An asset whose existence and rules are defined by an open protocol's smart contracts, so it works the same for everyone without a controlling company.
 keywords: ['protocol asset', 'blockchain protocol', 'infrastructure asset', 'network asset', 'utility token']
+level: 1
+sources:
+  - https://ethereum.org/en/developers/docs/smart-contracts/
 ---
 
 A **protocol asset** is a digital asset that serves as a fundamental building block or infrastructure component within a blockchain protocol or decentralized system. These assets often have utility beyond simple value storage, providing functionality that other applications and services can build upon. [Tokenized](/en/glossary/tokenize/) domains function as protocol assets by serving as identity layers, namespace systems, and integration points for Web3 applications. They provide utility to the broader ecosystem while being [composable](/en/glossary/composability/) with other protocols. For example, a [tokenized](/en/glossary/tokenize/) domain might serve as [collateral](/en/glossary/collateral/) in DeFi, identity in social protocols, and naming in [wallet](/en/glossary/wallet/) systems—making it a multi-functional protocol asset.

--- a/content/glossary/en/registrar.md
+++ b/content/glossary/en/registrar.md
@@ -4,7 +4,7 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is a domain registrar and how does it differ from on-chain domain management?
+description: An ICANN-accredited company authorized to register and manage domain names for the public, such as GoDaddy, Namecheap, or Cloudflare.
 keywords: ['registrar', 'domain registration', 'ICANN', 'centralized control', 'domain management']
 level: 1
 sources:

--- a/content/glossary/en/rent-to-own.md
+++ b/content/glossary/en/rent-to-own.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is rent-to-own and how can it apply to domain acquisition?
+description: A purchase arrangement where the buyer pays in installments while using the domain and gains full ownership once the agreed total is paid.
 keywords: ['rent-to-own', 'gradual ownership', 'payment plans', 'domain acquisition', 'smart contracts']
+level: 1
+sources:
+  - https://www.investopedia.com/terms/l/lease-option.asp
 ---
 
 **Rent-to-own** is a financing model where users make regular payments to gradually acquire ownership of an asset, typically used for expensive items like homes or vehicles. For domains, rent-to-own can make premium domains accessible to users who cannot afford the full purchase price upfront. [Smart contracts](/en/glossary/smart-contract/) can automate rent-to-own agreements, handling payment collection, partial ownership tracking, and final transfer when payments are complete. This model could allow startups to gradually acquire valuable domains like `fintech.com` through monthly payments, with the domain automatically transferring to full ownership once the payment schedule is fulfilled, creating new pathways to premium domain ownership.

--- a/content/glossary/en/revenue-sharing.md
+++ b/content/glossary/en/revenue-sharing.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is revenue-sharing and how can it apply to domain monetization?
+description: An arrangement that automatically splits income from an asset among parties by preset percentages, enforceable on-chain by smart contracts.
 keywords: ['revenue-sharing', 'passive income', 'domain monetization', 'profit distribution', 'smart contracts']
+level: 1
+sources:
+  - https://www.investopedia.com/terms/r/revenue-sharing.asp
 ---
 
 **Revenue-sharing** is a business model where profits or income from an asset are distributed among multiple parties according to predetermined terms. In traditional domains, this might involve manual agreements between domain owners and businesses using the domains. With tokenized domains and [smart contracts](/en/glossary/smart-contract/), revenue-sharing can be automated and transparent. For example, a domain used for a successful business could automatically distribute a percentage of profits to the domain owner, investors, or a community. This creates new monetization models where domain ownership becomes a source of ongoing passive income rather than just a one-time sale opportunity.

--- a/content/glossary/en/seed-phrase.md
+++ b/content/glossary/en/seed-phrase.md
@@ -4,8 +4,11 @@ date: '2026-05-22'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is a seed phrase and why is it the single most important thing to back up?
+description: A list of 12 or 24 words that encodes a wallet's master key; anyone holding it controls the wallet, so it is the one thing you must back up.
 keywords: ['seed phrase', 'recovery phrase', 'mnemonic phrase', 'wallet backup', 'BIP39', '12 words', '24 words', 'crypto recovery']
+level: 1
+sources:
+  - https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
 ---
 
 A **seed phrase** — also called a **recovery phrase** or **mnemonic phrase** — is a human-readable list of 12 or 24 words that encodes the master private key for a [wallet](/en/glossary/wallet/). The format is standardized by [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) and is used by most modern wallets (MetaMask, Ledger, Trezor, Rabby, Coinbase Wallet, etc.). With the seed phrase, you can restore the wallet — and any assets in it, including [tokenized domains](/en/blog/what-are-tokenized-domains/) — on any compatible device. Without it, lost device access usually means permanently lost funds, because there is no central authority to issue a "password reset." Best practices: write the seed phrase on paper or a metal backup, store at least two copies in separate physical locations, and **never** type it into any computer, cloud document, password manager that touches the cloud, chat, or AI assistant. See [Recovering a Tokenized Domain After Wallet Loss](/en/blog/recovering-a-tokenized-domain-after-wallet-loss/) for the full operational guide.

--- a/content/glossary/en/seo.md
+++ b/content/glossary/en/seo.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is SEO and how does domain tokenization affect search optimization?
+description: Search Engine Optimization is the practice of improving a site's content and structure so it ranks higher in search results and draws more visitors.
 keywords: ['SEO', 'search engine optimization', 'domain value', 'search rankings', 'digital marketing']
+level: 1
+sources:
+  - https://developers.google.com/search/docs/fundamentals/seo-starter-guide
 ---
 
 **SEO (Search Engine Optimization)** is the practice of improving website visibility in search engine results to increase organic traffic. Domain names play a crucial role in SEO through factors like keyword relevance, brand recognition, and link authority. Premium domains often have inherent SEO advantages due to their memorability and keyword relevance. When domains are [tokenized](/en/glossary/tokenize/), their SEO value becomes part of their digital asset value proposition. Domain investors can now more easily trade domains based on their SEO metrics and potential, while businesses can acquire premium domains with established SEO authority to boost their online presence—all through transparent, blockchain-based transactions.

--- a/content/glossary/en/smart-contract.md
+++ b/content/glossary/en/smart-contract.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What are smart contracts and how do they enable domain tokenization?
+description: A program stored on a blockchain that runs exactly as written when its conditions are met, enabling agreements that execute without an intermediary.
 keywords: ['smart contract', 'blockchain', 'automated execution', 'programmable logic', 'decentralized']
+level: 1
+sources:
+  - https://ethereum.org/en/developers/docs/smart-contracts/
 ---
 
 A **smart contract** is a self-executing program that runs on a blockchain, automatically enforcing agreements and executing transactions when predefined conditions are met. Unlike traditional contracts that require intermediaries, smart contracts operate autonomously through code. Namefi uses smart contracts to tokenize domains, handle transfers, manage ownership records, and enable advanced features like [automated delegation](/en/glossary/automated-delegation/) or [revenue sharing](/en/glossary/revenue-sharing/). These contracts ensure that domain operations are transparent, immutable, and don't require trust in centralized authorities—creating programmable, [internet-native asset](/en/glossary/internet-native-asset/) management that integrates seamlessly with other [Web3](/en/glossary/web3/) protocols.

--- a/content/glossary/en/stablecoin.md
+++ b/content/glossary/en/stablecoin.md
@@ -4,8 +4,11 @@ date: '2026-05-22'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is a stablecoin and why are they often used to pay for tokenized domains?
+description: A cryptocurrency designed to hold a steady value against a reference like the US dollar, used to pay and settle without crypto price volatility.
 keywords: ['stablecoin', 'USDC', 'USDT', 'DAI', 'fiat-pegged', 'crypto payment', 'on-chain dollars']
+level: 1
+sources:
+  - https://ethereum.org/en/stablecoins/
 ---
 
 A **stablecoin** is a cryptocurrency designed to maintain a stable value relative to a reference asset — most commonly the US dollar. Major examples include USDC (Circle), USDT (Tether), and DAI (MakerDAO). Stablecoins are widely used to pay for [tokenized domains](/en/blog/what-are-tokenized-domains/) and to settle [marketplace](/en/glossary/marketplace/) transactions because they remove the price-volatility risk that buying with ETH or BTC introduces between listing and settlement. Different stablecoins use different backing models — fully fiat-reserved (USDC), overcollateralized crypto (DAI), or algorithmic (a category with a troubled history, e.g., the Terra/Luna collapse). Read [What Are Stablecoins?](/en/blog/what-are-stablecoins/) for the deeper dive.

--- a/content/glossary/en/tld.md
+++ b/content/glossary/en/tld.md
@@ -4,8 +4,11 @@ date: '2026-05-22'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is a TLD and how do different TLDs affect a tokenized domain?
+description: The Top-Level Domain is the rightmost part of a name, such as .com, .org, or .io, administered by a registry under ICANN or a country authority.
 keywords: ['TLD', 'top-level domain', 'gTLD', 'ccTLD', 'new gTLD', '.com', '.io', '.xyz', 'TLD registry']
+level: 1
+sources:
+  - https://www.icann.org/resources/pages/tlds-2012-02-25-en
 ---
 
 A **TLD (Top-Level Domain)** is the rightmost part of a domain name — `.com`, `.org`, `.io`, `.xyz`, `.de`, `.uk`, and so on. TLDs are administered by registries operating under [ICANN](/en/glossary/icann/) contract (for gTLDs and new gTLDs) or under country-level authority (for ccTLDs like `.uk` or `.de`). Each TLD has its own rules around eligibility, pricing, renewal, and what a [registrar](/en/glossary/registrar/) can do with names under it. Different TLDs also vary in *how* easily they can be [tokenized](/en/glossary/tokenize/): some TLDs and registries have moved earlier than others toward supporting on-chain ownership layers, others haven't moved at all. The [Choosing a Domain Tokenization Platform](/en/blog/choosing-a-domain-tokenization-platform/) post discusses how to evaluate TLD coverage across platforms. Reference: [ICANN's list of TLDs](https://www.icann.org/resources/pages/tlds-2012-02-25-en).

--- a/content/glossary/en/tokenize.md
+++ b/content/glossary/en/tokenize.md
@@ -4,8 +4,11 @@ date: '2025-06-29'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What does it mean to tokenize a domain or asset?
+description: To represent ownership of an asset like a domain as a transferable token on a blockchain so it can be held in a wallet and traded on-chain.
 keywords: ['tokenize', 'tokenization', 'NFT', 'digital asset', 'on-chain asset']
+level: 1
+sources:
+  - https://ethereum.org/en/nft/
 ---
 
 To **tokenize** something means to convert it into a digital token that exists on a blockchain. In Namefi's case, tokenizing a domain turns a real-world [DNS](/en/glossary/dns/) asset (like `mybrand.xyz`) into a tradable, programmable [NFT](/en/glossary/nft/). This token can be stored in a [wallet](/en/glossary/wallet/), transferred instantly, or integrated with [smart contracts](/en/glossary/smart-contract/). Tokenization gives domains internet-native properties like [composability](/en/glossary/composability/) and automation. It doesn't change the legal status of the domain, but it does upgrade how you can use, trade, and secure it—without relying on intermediaries.

--- a/content/glossary/en/udrp.md
+++ b/content/glossary/en/udrp.md
@@ -4,8 +4,12 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is UDRP and how does it affect tokenized domain ownership?
+description: ICANN's mandatory policy for resolving domain disputes, mainly trademark and cybersquatting claims, as a faster, cheaper alternative to court.
 keywords: ['UDRP', 'domain disputes', 'trademark protection', 'cybersquatting', 'legal framework']
+level: 1
+sources:
+  - https://www.icann.org/resources/pages/udrp-2012-02-25-en
+  - https://www.wipo.int/amc/en/domains/
 ---
 
 **UDRP (Uniform Domain-Name Dispute-Resolution Policy)** is [ICANN](/en/glossary/icann/)'s mandatory policy for resolving disputes over domain name registrations, particularly cases involving trademark infringement or cybersquatting. UDRP provides a faster, cheaper alternative to court litigation for trademark holders to challenge domain registrations they believe infringe their rights. Even when domains are tokenized, UDRP obligations typically remain in effect since the underlying [DNS](/en/glossary/dns/) registration is still subject to [ICANN](/en/glossary/icann/) policies. Domain tokenization doesn't provide immunity from legitimate trademark disputes, and [smart contracts](/en/glossary/smart-contract/) may need to accommodate UDRP decisions that could affect domain ownership or control.

--- a/content/glossary/en/wallet.md
+++ b/content/glossary/en/wallet.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is a crypto wallet and how does it store tokenized domains?
+description: Software or a device that stores the private keys controlling your on-chain assets and signs transactions, such as MetaMask or a hardware wallet.
 keywords: ['wallet', 'crypto wallet', 'private key', 'digital asset storage', 'domain storage']
+level: 1
+sources:
+  - https://ethereum.org/en/wallets/
 ---
 
 A **wallet** in the crypto context is a digital tool that stores private keys and allows users to manage their blockchain-based assets. Unlike traditional wallets that hold physical currency, crypto wallets hold the [cryptographic security](/en/glossary/cryptographic-security/) keys that prove ownership of digital assets like cryptocurrencies and [NFTs](/en/glossary/nft/). When you tokenize a domain with Namefi, the resulting domain [NFT](/en/glossary/nft/) is stored in your wallet, giving you direct [custodial ownership](/en/glossary/custodial-ownership/) and control. Popular wallets include MetaMask, Coinbase Wallet, and hardware wallets like Ledger. Your wallet becomes your portal to manage, transfer, and interact with your tokenized domains without relying on centralized platforms.

--- a/content/glossary/en/web3.md
+++ b/content/glossary/en/web3.md
@@ -4,8 +4,11 @@ date: '2025-06-30'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is Web3 and how do domains fit into the decentralized web?
+description: A vision of the web on public blockchains where users own their assets, identity, and data through their keys rather than through platform accounts.
 keywords: ['Web3', 'decentralized web', 'blockchain internet', 'ownership', 'peer-to-peer']
+level: 1
+sources:
+  - https://ethereum.org/en/web3/
 ---
 
 **Web3** refers to the next evolution of the internet built on blockchain technology, emphasizing decentralization, user ownership, and peer-to-peer interactions rather than reliance on centralized platforms. Unlike Web2 where users create content on platforms they don't own, Web3 enables users to own their data, identity, and digital assets directly. Domains play a crucial role in Web3 as decentralized identifiers that users can own and control without intermediaries. [Tokenized](/en/glossary/tokenize/) domains become building blocks of Web3 infrastructure, serving as gateways to decentralized applications, repositories for identity credentials, and tradable digital assets that work across different blockchain networks and applications.

--- a/content/glossary/en/whois.md
+++ b/content/glossary/en/whois.md
@@ -4,8 +4,12 @@ date: '2026-05-22'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is WHOIS, and how does it relate to tokenized domain ownership?
+description: WHOIS and its successor RDAP are the public lookup services for a domain's registration details, such as its registrar and expiration date.
 keywords: ['WHOIS', 'RDAP', 'domain registration lookup', 'registrant information', 'domain ownership lookup']
+level: 1
+sources:
+  - https://www.icann.org/rdap
+  - https://lookup.icann.org/
 ---
 
 **WHOIS** is the long-standing protocol and public service for looking up registration information about a domain — registrar, registration and expiration dates, and historically the registrant's contact information. Its modern successor is **RDAP (Registration Data Access Protocol)**, which returns structured JSON and is the protocol [ICANN](/en/glossary/icann/) and registries are migrating to. For [tokenized domains](/en/blog/what-are-tokenized-domains/), WHOIS/RDAP records still exist at the [registrar](/en/glossary/registrar/) level because the underlying [DNS](/en/glossary/dns/) registration is real and ICANN-recognized — only the *ownership and transfer mechanics* shift to the [on-chain](/en/glossary/on-chain/) layer. Privacy is increasingly common: many registrars now mask personal contact details by default, in line with privacy laws like GDPR. Reference: [ICANN's WHOIS lookup](https://lookup.icann.org/).

--- a/content/glossary/en/x402.md
+++ b/content/glossary/en/x402.md
@@ -4,8 +4,11 @@ date: '2026-05-22'
 language: en
 tags: ['glossary']
 authors: ['namefiteam']
-description: What is x402 and how does it relate to on-chain payments for tokenized domains?
+description: An open protocol that uses the HTTP 402 Payment Required status to let servers and AI agents request and receive on-chain payments inline with requests.
 keywords: ['x402', 'HTTP 402', 'payment required', 'on-chain payments', 'agent payments', 'crypto payments', 'micropayment']
+level: 1
+sources:
+  - https://www.x402.org/
 ---
 
 **x402** is an open protocol that revives the long-dormant **HTTP 402 "Payment Required"** status code as a structured way for servers, agents, and clients to demand and pay for on-chain payments inline with normal HTTP interactions. When a resource is gated by x402, a `402` response carries the price, the accepted assets (typically [stablecoins](/en/glossary/stablecoin/)), the recipient address, and the facilitator URL; the client pays [on-chain](/en/glossary/on-chain/) and retries the request with proof of payment. x402 matters to [tokenized domains](/en/blog/what-are-tokenized-domains/) because it lets agents and apps using a domain as their identity collect payments cleanly — and because the controlling [wallet](/en/glossary/wallet/) of a tokenized domain doubles as a payment endpoint. See [Route 402](/en/blog/route402-x402-facilitator-router/) for the deeper write-up. Official site: [x402.org](https://www.x402.org/).

--- a/content/termbase.json
+++ b/content/termbase.json
@@ -3,7 +3,8 @@
     "en": "AI Agent",
     "titles": {
       "en": "AI Agent"
-    }
+    },
+    "level": 1
   },
   "atomic-transfer": {
     "en": "Atomic transfer",
@@ -15,7 +16,8 @@
       "zh": "原子传输",
       "ar": "التحويل الذري",
       "hi": "एटॉमिक ट्रांसफर"
-    }
+    },
+    "level": 1
   },
   "auction": {
     "en": "Auction (Dutch, English, dynamic)",
@@ -27,13 +29,15 @@
       "zh": "拍卖（荷兰式、英式、动态）",
       "ar": "المزاد (الهولندي، الإنجليزي، الديناميكي)",
       "hi": "नीलामी (डच, इंग्लिश, डायनामिक)"
-    }
+    },
+    "level": 1
   },
   "auth-code": {
     "en": "Auth Code (EPP Code, Transfer Code)",
     "titles": {
       "en": "Auth Code (EPP Code, Transfer Code)"
-    }
+    },
+    "level": 1
   },
   "automated-delegation": {
     "en": "Automated delegation",
@@ -45,7 +49,8 @@
       "zh": "自动化委托",
       "ar": "التفويض التلقائي",
       "hi": "स्वचालित डेलिगेशन"
-    }
+    },
+    "level": 1
   },
   "censorship-free": {
     "en": "Censorship-free",
@@ -57,7 +62,8 @@
       "zh": "抗审查",
       "ar": "مقاومة للرقابة",
       "hi": "सेंसरशिप-मुक्त"
-    }
+    },
+    "level": 1
   },
   "collateral": {
     "en": "Collateral",
@@ -69,7 +75,8 @@
       "zh": "抵押品",
       "ar": "الضمان",
       "hi": "कोलैटरल (गिरवी)"
-    }
+    },
+    "level": 1
   },
   "composability": {
     "en": "Composability",
@@ -81,7 +88,8 @@
       "zh": "可组合性",
       "ar": "قابلية التركيب",
       "hi": "कम्पोज़िबिलिटी"
-    }
+    },
+    "level": 1
   },
   "cross-registrar-transfer": {
     "en": "Cross-registrar transfer",
@@ -93,7 +101,8 @@
       "zh": "跨注册商转移",
       "ar": "نقل النطاق بين المسجلين",
       "hi": "क्रॉस-रजिस्ट्रार ट्रांसफर"
-    }
+    },
+    "level": 1
   },
   "cryptographic-security": {
     "en": "Cryptographic security",
@@ -105,7 +114,8 @@
       "zh": "加密安全性",
       "ar": "الأمن التشفيري",
       "hi": "क्रिप्टोग्राफिक सुरक्षा"
-    }
+    },
+    "level": 1
   },
   "custodial-ownership": {
     "en": "Custodial ownership",
@@ -117,7 +127,8 @@
       "zh": "托管所有权",
       "ar": "الملكية الحفظية",
       "hi": "कस्टोडियल स्वामित्व"
-    }
+    },
+    "level": 1
   },
   "dao": {
     "en": "DAO (Decentralized Autonomous Organization)",
@@ -129,13 +140,15 @@
       "zh": "DAO（去中心化自治组织）",
       "ar": "DAO (منظمة ذاتية لامركزية)",
       "hi": "DAO (विकेंद्रीकृत स्वायत्त संगठन)"
-    }
+    },
+    "level": 1
   },
   "defi": {
     "en": "DeFi (Decentralized Finance)",
     "titles": {
       "en": "DeFi (Decentralized Finance)"
-    }
+    },
+    "level": 1
   },
   "did": {
     "en": "DID (Decentralized Identity)",
@@ -147,7 +160,8 @@
       "zh": "DID (去中心化身份)",
       "ar": "DID (الهوية اللامركزية)",
       "hi": "डीआईडी (विकेन्द्रीकृत पहचान)"
-    }
+    },
+    "level": 1
   },
   "dns": {
     "en": "DNS (Domain Name System)",
@@ -159,13 +173,15 @@
       "zh": "DNS (域名系统)",
       "ar": "DNS (نظام أسماء النطاقات)",
       "hi": "DNS (डोमेन नेम सिस्टम)"
-    }
+    },
+    "level": 1
   },
   "dnssec": {
     "en": "DNSSEC (Domain Name System Security Extensions)",
     "titles": {
       "en": "DNSSEC (Domain Name System Security Extensions)"
-    }
+    },
+    "level": 1
   },
   "domain-bundle": {
     "en": "Domain bundle",
@@ -177,7 +193,8 @@
       "zh": "域名捆绑包",
       "ar": "حزمة النطاقات",
       "hi": "डोमेन बंडल"
-    }
+    },
+    "level": 1
   },
   "domain-ownership": {
     "en": "Domain ownership",
@@ -189,7 +206,8 @@
       "zh": "域名所有权",
       "ar": "ملكية النطاق",
       "hi": "डोमेन स्वामित्व"
-    }
+    },
+    "level": 1
   },
   "domain-trading": {
     "en": "Domain trading",
@@ -201,19 +219,22 @@
       "zh": "域名交易",
       "ar": "تداول النطاقات",
       "hi": "डोमेन ट्रेडिंग"
-    }
+    },
+    "level": 1
   },
   "ens": {
     "en": "ENS (Ethereum Name Service)",
     "titles": {
       "en": "ENS (Ethereum Name Service)"
-    }
+    },
+    "level": 1
   },
   "erc-721": {
     "en": "ERC-721 (NFT Standard)",
     "titles": {
       "en": "ERC-721 (NFT Standard)"
-    }
+    },
+    "level": 1
   },
   "escrow": {
     "en": "Escrow",
@@ -225,7 +246,8 @@
       "zh": "托管",
       "ar": "الضمان (Escrow)",
       "hi": "एस्क्रो"
-    }
+    },
+    "level": 1
   },
   "farcaster": {
     "en": "Farcaster",
@@ -237,7 +259,8 @@
       "zh": "Farcaster",
       "ar": "Farcaster",
       "hi": "Farcaster"
-    }
+    },
+    "level": 1
   },
   "fractional-ownership": {
     "en": "Fractional ownership",
@@ -249,19 +272,22 @@
       "zh": "部分所有权",
       "ar": "الملكية الجزئية",
       "hi": "आंशिक स्वामित्व"
-    }
+    },
+    "level": 1
   },
   "gas": {
     "en": "Gas (Transaction Fees)",
     "titles": {
       "en": "Gas (Transaction Fees)"
-    }
+    },
+    "level": 1
   },
   "hardware-wallet": {
     "en": "Hardware Wallet",
     "titles": {
       "en": "Hardware Wallet"
-    }
+    },
+    "level": 1
   },
   "icann": {
     "en": "ICANN",
@@ -273,7 +299,8 @@
       "zh": "ICANN",
       "ar": "ICANN",
       "hi": "आईसीएएनएन"
-    }
+    },
+    "level": 1
   },
   "internet-native-asset": {
     "en": "Internet-native asset",
@@ -285,7 +312,8 @@
       "zh": "互联网原生资产",
       "ar": "أصل رقمي أصيل للإنترنت",
       "hi": "इंटरनेट-नेटिव एसेट"
-    }
+    },
+    "level": 1
   },
   "leasing": {
     "en": "Leasing",
@@ -297,7 +325,8 @@
       "zh": "租赁",
       "ar": "تأجير",
       "hi": "लीजिंग"
-    }
+    },
+    "level": 1
   },
   "lending-protocol": {
     "en": "Lending protocol",
@@ -309,7 +338,8 @@
       "zh": "借贷协议",
       "ar": "بروتوكول الإقراض",
       "hi": "लेंडिंग प्रोटोकॉल"
-    }
+    },
+    "level": 1
   },
   "lens": {
     "en": "Lens",
@@ -321,7 +351,8 @@
       "zh": "Lens",
       "ar": "لينس",
       "hi": "लेंस"
-    }
+    },
+    "level": 1
   },
   "marketplace": {
     "en": "Marketplace (e.g., OpenSea, Blur)",
@@ -333,7 +364,8 @@
       "zh": "市场 (例如 OpenSea, Blur)",
       "ar": "السوق (مثل OpenSea، Blur)",
       "hi": "मार्केटप्लेस (जैसे OpenSea, Blur)"
-    }
+    },
+    "level": 1
   },
   "multi-sig": {
     "en": "Multi-sig",
@@ -345,7 +377,8 @@
       "zh": "多重签名",
       "ar": "التوقيع المتعدد (Multi-sig)",
       "hi": "मल्टी-सिग"
-    }
+    },
+    "level": 1
   },
   "nft": {
     "en": "NFT (Non-Fungible Token)",
@@ -357,7 +390,8 @@
       "zh": "NFT（非同质化代币）",
       "ar": "NFT (رمز غير قابل للاستبدال)",
       "hi": "NFT (नॉन-फंजीबल टोकन)"
-    }
+    },
+    "level": 1
   },
   "on-chain": {
     "en": "On-chain",
@@ -369,7 +403,8 @@
       "zh": "链上 (On-chain)",
       "ar": "على السلسلة (On-chain)",
       "hi": "ऑन-चेन"
-    }
+    },
+    "level": 1
   },
   "permissionless": {
     "en": "Permissionless",
@@ -381,7 +416,8 @@
       "zh": "无许可",
       "ar": "بلا تصريح",
       "hi": "अनुमति-रहित"
-    }
+    },
+    "level": 1
   },
   "protocol-asset": {
     "en": "Protocol asset",
@@ -393,7 +429,8 @@
       "zh": "协议资产",
       "ar": "أصل البروتوكول",
       "hi": "प्रोटोकॉल एसेट"
-    }
+    },
+    "level": 1
   },
   "registrar": {
     "en": "Registrar",
@@ -426,7 +463,8 @@
       "zh": "先租后买",
       "ar": "الإيجار المنتهي بالتملك",
       "hi": "रेंट-टू-ओन"
-    }
+    },
+    "level": 1
   },
   "revenue-sharing": {
     "en": "Revenue-sharing",
@@ -438,13 +476,15 @@
       "zh": "收益分享",
       "ar": "مشاركة الإيرادات",
       "hi": "राजस्व-साझाकरण"
-    }
+    },
+    "level": 1
   },
   "seed-phrase": {
     "en": "Seed Phrase (Recovery Phrase, Mnemonic)",
     "titles": {
       "en": "Seed Phrase (Recovery Phrase, Mnemonic)"
-    }
+    },
+    "level": 1
   },
   "seo": {
     "en": "SEO (Search Engine Optimization)",
@@ -456,7 +496,8 @@
       "zh": "SEO（搜索引擎优化）",
       "ar": "تحسين محركات البحث (SEO)",
       "hi": "एसईओ (सर्च इंजन ऑप्टिमाइजेशन)"
-    }
+    },
+    "level": 1
   },
   "smart-contract": {
     "en": "Smart contract",
@@ -468,19 +509,22 @@
       "zh": "智能合约",
       "ar": "عقد ذكي",
       "hi": "स्मार्ट कॉन्ट्रैक्ट"
-    }
+    },
+    "level": 1
   },
   "stablecoin": {
     "en": "Stablecoin",
     "titles": {
       "en": "Stablecoin"
-    }
+    },
+    "level": 1
   },
   "tld": {
     "en": "TLD (Top-Level Domain)",
     "titles": {
       "en": "TLD (Top-Level Domain)"
-    }
+    },
+    "level": 1
   },
   "tokenize": {
     "en": "Tokenize",
@@ -492,7 +536,8 @@
       "zh": "代币化",
       "ar": "ترميز",
       "hi": "टोकनाइज़ करें"
-    }
+    },
+    "level": 1
   },
   "udrp": {
     "en": "UDRP (Uniform Domain-Name Dispute-Resolution Policy)",
@@ -504,7 +549,8 @@
       "zh": "UDRP (统一域名争议解决政策)",
       "ar": "UDRP (السياسة الموحدة لتسوية منازعات أسماء النطاقات)",
       "hi": "UDRP (यूनिफ़ॉर्म डोमेन-नेम विवाद-समाधान नीति)"
-    }
+    },
+    "level": 1
   },
   "wallet": {
     "en": "Wallet",
@@ -516,7 +562,8 @@
       "zh": "钱包",
       "ar": "محفظة",
       "hi": "वॉलेट"
-    }
+    },
+    "level": 1
   },
   "web3": {
     "en": "Web3",
@@ -528,18 +575,21 @@
       "zh": "Web3",
       "ar": "Web3",
       "hi": "वेब3"
-    }
+    },
+    "level": 1
   },
   "whois": {
     "en": "WHOIS (and RDAP)",
     "titles": {
       "en": "WHOIS (and RDAP)"
-    }
+    },
+    "level": 1
   },
   "x402": {
     "en": "x402",
     "titles": {
       "en": "x402"
-    }
+    },
+    "level": 1
   }
 }


### PR DESCRIPTION
## Summary / Solution

Wave 0c of the glossary build-out: **retrofit all 51 existing EN glossary entries to the new L1 bar.** Each entry gets:

1. A **declarative one-liner `description`** (≤155 chars, plain text, period-terminated) replacing the old `What is X…?` question form. This field is dual-purpose — the SEO `<meta>` snippet *and* the hover-tooltip string (Wave T) — so it must define the term standalone, which a question cannot.
2. **`level: 1`** — build-time-only maturity marker that drives L1→L2 promotion.
3. **1–2 canonical `sources`** — primary references (ICANN, IANA/IETF RFCs, ethereum.org, EIPs, W3C, WIPO, etc.), build-time-only.

`level`/`sources` are ignored by astra's glossary frontmatter whitelist (proven in Wave 0a), so they don't reach the renderer or break the build. `content/termbase.json` is regenerated to carry the new `level` values.

Applied by a line-targeted transform (description line swap + insert after `keywords:`) for minimal, reviewable diffs; entries that already carry `level`/`sources` (e.g. `registrar` from Wave 0a) keep them.

**Scope note:** this is EN-only (English-first). The 38 already-translated entries still carry their old question-form translated descriptions; those are refreshed in the translation/reconciliation waves. Source URLs were link-checked (the only non-200s are Investopedia's anti-bot 403s on valid pages — `sources` is build-time-only and unrendered).

## Test plan
- `bun data:validate` → passes (pre-existing warnings only) — declarative descriptions + `level`/`sources` tolerated.
- `bun lint:mdx` → clean.
- `bun termbase:build` then `bun termbase:check` → `termbase.json` up to date with `level` on all 51.
- All 51 EN files re-parse cleanly via gray-matter; descriptions verified ≤155 chars.

## Claude session summary
- **Main prompts (paraphrased):** Execute `GOAL-resources-glossary-buildout.md` autonomously, wave by wave; per batch get Bugbot green, run the PR feedback loop, then admin-merge.
- **This PR (Wave 0c):** rewrote the 51 question-form descriptions into declarative one-liners, added `level:1` + verified canonical sources, regenerated the termbase.
- **Redaction:** no secrets/credentials/PII.

Part of the glossary build-out initiative (Wave 0c). Depends on Wave 0a tooling (#100).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content and generated termbase metadata only; no runtime or auth changes. Risk is limited to SEO/snippet wording if a description is wrong.
> 
> **Overview**
> Wave **0c** brings all **51** English glossary entries up to the new **L1** metadata bar. Each file’s frontmatter now uses a **declarative `description`** (replacing the old “What is…?” form) so the same string can serve SEO meta and future hover tooltips, plus **`level: 1`** and **1–2 canonical `sources`** (ICANN, IETF, ethereum.org, EIPs, etc.). Article bodies are unchanged.
> 
> **`content/termbase.json`** is regenerated so every term carries **`level: 1`**, keeping the termbase in sync with the EN sources. **`level`** and **`sources`** are build-time-only and stay outside the site renderer whitelist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb7d948ef18a83332ad9445bf140c9dc579ee4cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->