### PR TITLE
content(glossary): Wave 1 A+B — 26 new L1 terms (domain anatomy/DNS + lifecycle)

### DIFF
--- a/content/glossary/en/backorder.md
+++ b/content/glossary/en/backorder.md
@@ -1,0 +1,14 @@
+---
+title: Backorder (Drop-Catching)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: A service that tries to register a domain the instant it drops, so you can claim an expiring name.
+keywords: ['backorder', 'drop-catching', 'expired domain', 'pending delete', 'domain acquisition']
+level: 1
+sources:
+  - https://www.namebio.com/
+---
+
+A **backorder** is a request placed with a service to grab a domain the moment it [drops](/en/glossary/pending-delete/) — the instant an unrenewed name is released back to the public. Because many parties may want the same expiring name, **drop-catching** is a speed game: providers fire registration attempts in the milliseconds after release, and when more than one backorder competes for the same domain it often goes to a private [auction](/en/glossary/auction/) among the interested buyers. Backorders are how investors target good names already taken by someone who let them [expire](/en/glossary/domain-expiration/). It is a play on the traditional registration system; once caught, such a name can then be tokenized and held in a [wallet](/en/glossary/wallet/) like any other. *Source: NameBio domain sales data.*

--- a/content/glossary/en/cctld.md
+++ b/content/glossary/en/cctld.md
@@ -1,0 +1,15 @@
+---
+title: ccTLD (Country-Code Top-Level Domain)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: A two-letter top-level domain assigned to a country or territory, such as .uk, .de, or .jp.
+keywords: ['ccTLD', 'country-code TLD', 'country domain', '.uk', '.de', 'ISO 3166']
+level: 1
+sources:
+  - https://www.iana.org/domains/root/db
+  - https://www.iso.org/iso-3166-country-codes.html
+---
+
+A **ccTLD (country-code top-level domain)** is a two-letter [TLD](/en/glossary/tld/) assigned to a country or territory based on the ISO 3166 list — `.uk`, `.de`, `.jp`, `.io` (British Indian Ocean Territory), and so on. Unlike a [gTLD](/en/glossary/gtld/), a ccTLD is administered under the authority of its country rather than directly by [ICANN](/en/glossary/icann/) contract, so each one sets its own eligibility, pricing, and policy rules — some require local presence, others (like `.io` or `.co`) sell globally. Those rules also shape whether and how a ccTLD can support an [on-chain](/en/glossary/on-chain/) ownership layer: a [registry](/en/glossary/registry/) that is open to tokenization makes a domain easier for Namefi to represent as a [wallet](/en/glossary/wallet/)-controlled asset. *Source: IANA root database; ISO 3166 country codes.*

--- a/content/glossary/en/dns-propagation.md
+++ b/content/glossary/en/dns-propagation.md
@@ -1,0 +1,15 @@
+---
+title: DNS Propagation
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: The delay before a DNS change is seen everywhere, as cached old records expire across resolvers.
+keywords: ['DNS propagation', 'DNS update delay', 'TTL', 'DNS cache', 'nameserver change']
+level: 1
+sources:
+  - https://www.cloudflare.com/learning/dns/glossary/time-to-live-ttl/
+  - https://datatracker.ietf.org/doc/html/rfc1035
+---
+
+**DNS propagation** is the lag between making a [DNS](/en/glossary/dns/) change and that change being visible everywhere on the internet. It happens because [resolvers](/en/glossary/dns-resolver/) around the world cache the old answer until its [TTL](/en/glossary/ttl/) expires, so a new [record](/en/glossary/dns-record-types/) or [nameserver](/en/glossary/nameserver/) update rolls out gradually rather than instantly — anywhere from minutes to a couple of days. There is no global "DNS" to update at once; propagation is just caches timing out. The practical fix is to lower the TTL ahead of a planned change. None of this touches a domain's ownership: tokenization changes who controls the name on-chain, not how quickly DNS edits spread. *Sources: Cloudflare TTL glossary; RFC 1035.*

--- a/content/glossary/en/dns-record-types.md
+++ b/content/glossary/en/dns-record-types.md
@@ -1,0 +1,15 @@
+---
+title: DNS Record Types (A, AAAA, CNAME, MX, TXT)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: The entries in a zone that map a domain to addresses and services — A, AAAA, CNAME, MX, TXT, and more.
+keywords: ['DNS records', 'A record', 'AAAA record', 'CNAME', 'MX record', 'TXT record']
+level: 1
+sources:
+  - https://datatracker.ietf.org/doc/html/rfc1035
+  - https://www.cloudflare.com/learning/dns/dns-records/
+---
+
+**DNS record types** are the individual entries in a domain's zone that tell the [DNS](/en/glossary/dns/) where to send different kinds of traffic. The common ones are **A** (maps a name to an IPv4 [IP address](/en/glossary/ip-address/)), **AAAA** (IPv6), **CNAME** (aliases one name to another), **MX** (routes email), and **TXT** (free-form text used for SPF, DKIM, and domain verification). These records are published by the [nameservers](/en/glossary/nameserver/) you delegate a domain to, and they are what actually make a website load or mail deliver. Tokenizing a domain leaves all of this untouched: the records keep resolving normally while ownership and transfer move to a [wallet](/en/glossary/wallet/)-controlled [on-chain](/en/glossary/on-chain/) layer. *Sources: RFC 1035; Cloudflare DNS records.*

--- a/content/glossary/en/dns-resolver.md
+++ b/content/glossary/en/dns-resolver.md
@@ -1,0 +1,15 @@
+---
+title: DNS Resolver (Recursive Resolver)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: The server that takes a domain lookup and walks the DNS hierarchy to return the matching address.
+keywords: ['DNS resolver', 'recursive resolver', 'resolver', '8.8.8.8', '1.1.1.1', 'DNS lookup']
+level: 1
+sources:
+  - https://datatracker.ietf.org/doc/html/rfc1034
+  - https://www.cloudflare.com/learning/dns/what-is-a-dns-resolver/
+---
+
+A **DNS resolver** (or *recursive resolver*) is the server your device asks whenever it needs to turn a domain into an [IP address](/en/glossary/ip-address/). Public resolvers like `1.1.1.1` (Cloudflare) and `8.8.8.8` (Google) do the legwork: starting from the [root zone](/en/glossary/root-zone/), they query down the [DNS](/en/glossary/dns/) hierarchy to the domain's authoritative [nameservers](/en/glossary/nameserver/), then cache the answer for its [TTL](/en/glossary/ttl/). This is the part of DNS that makes "type a name, reach a site" feel instant. Resolvers read public DNS data only — they have no view of who *owns* a domain, which is why a tokenized domain's [wallet](/en/glossary/wallet/)-based ownership layer is invisible to resolution and changes nothing about how names resolve. *Sources: RFC 1034; Cloudflare DNS resolver.*

--- a/content/glossary/en/domain-expiration.md
+++ b/content/glossary/en/domain-expiration.md
@@ -1,0 +1,14 @@
+---
+title: Domain Expiration
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: The date a domain's registration ends; if not renewed, it begins a lapse process toward deletion.
+keywords: ['domain expiration', 'expired domain', 'renewal', 'grace period', 'redemption']
+level: 1
+sources:
+  - https://www.icann.org/resources/pages/name-holder-faqs-2017-10-10-en
+---
+
+**Domain expiration** is the date a domain's registration term ends. Missing it does not instantly free the name: most [TLDs](/en/glossary/tld/) run a defined lapse sequence — a [grace period](/en/glossary/grace-period/) where you can still [renew](/en/glossary/domain-renewal/) at normal price, then a [redemption period](/en/glossary/redemption-period/) with a recovery fee, and finally [pending delete](/en/glossary/pending-delete/) before the name drops. [Registrars](/en/glossary/registrar/) send reminders, but the responsibility to renew is the registrant's. For a tokenized domain, expiration of the underlying registration is what matters operationally — the [wallet](/en/glossary/wallet/)-held ownership token tracks the asset, but the name itself must still be kept renewed at the [registry](/en/glossary/registry/) level. *Source: ICANN registrant FAQs.*

--- a/content/glossary/en/domain-renewal.md
+++ b/content/glossary/en/domain-renewal.md
@@ -1,0 +1,14 @@
+---
+title: Domain Renewal (Auto-Renew)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: Paying to extend a domain's registration before it expires, often automatically each term.
+keywords: ['domain renewal', 'auto-renew', 'registration term', 'expiration', 'renewal fee']
+level: 1
+sources:
+  - https://www.icann.org/resources/pages/name-holder-faqs-2017-10-10-en
+---
+
+**Domain renewal** is paying to extend a domain's registration for another term — typically one year — before it lapses. Most [registrars](/en/glossary/registrar/) offer **auto-renew**, which charges your payment method automatically so the domain never reaches [expiration](/en/glossary/domain-expiration/); it is the simplest insurance against losing a name to an oversight. Renewal pricing is set by the [registry](/en/glossary/registry/) (plus the registrar's markup) and varies sharply by [TLD](/en/glossary/tld/). Renewal keeps the *registration* alive in the traditional system; for a tokenized domain, the on-chain ownership record and the registry renewal are complementary — you still renew the underlying name while holding its ownership in your [wallet](/en/glossary/wallet/). *Source: ICANN registrant FAQs.*

--- a/content/glossary/en/domain-tasting.md
+++ b/content/glossary/en/domain-tasting.md
@@ -1,0 +1,14 @@
+---
+title: Domain Tasting (AGP)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: A largely defunct tactic of registering domains then cancelling within the free add-grace period.
+keywords: ['domain tasting', 'AGP', 'add grace period', 'domain kiting', 'ICANN policy']
+level: 1
+sources:
+  - https://www.icann.org/resources/pages/agp-policy-2008-06-25-en
+---
+
+**Domain tasting** was the practice of registering large batches of domains and then cancelling them within the **add grace period (AGP)** — a few-day window after registration in which a [registrar](/en/glossary/registrar/) could get a full refund — to "taste" each name's type-in traffic and keep only the profitable ones for free. ICANN curbed it in 2008 by making registries charge a non-refundable fee on excessive AGP deletions, and the tactic largely collapsed. It is mostly history now, but it explains why the [registry](/en/glossary/registry/) lifecycle has the safeguards it does. Domain tasting is a quirk of the traditional registration economics and has no bearing on tokenized ownership. *Source: ICANN AGP Limits Policy.*

--- a/content/glossary/en/grace-period.md
+++ b/content/glossary/en/grace-period.md
@@ -1,0 +1,14 @@
+---
+title: Grace Period
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: A short window right after a domain expires when you can still renew it at the normal price.
+keywords: ['grace period', 'auto-renew grace period', 'domain expiration', 'renewal', 'RGP']
+level: 1
+sources:
+  - https://www.icann.org/resources/pages/errp-2013-02-28-en
+---
+
+The **grace period** is the short window — often around 30–45 days, set per [TLD](/en/glossary/tld/) — immediately after a domain [expires](/en/glossary/domain-expiration/) during which the [registrant](/en/glossary/registrant/) can still [renew](/en/glossary/domain-renewal/) it at the ordinary price, no penalty. It is the first and cheapest of the post-expiration safety nets; miss it and the name falls into the far costlier [redemption period](/en/glossary/redemption-period/). Exact lengths and whether the site stays up during grace vary by [registrar](/en/glossary/registrar/) and registry, so they should never be relied on as a renewal strategy. The grace period governs the underlying registration only — it is separate from whatever ownership layer, including a tokenized [wallet](/en/glossary/wallet/) record, sits on top of the name. *Source: ICANN Expired Registration Recovery Policy.*

--- a/content/glossary/en/gtld.md
+++ b/content/glossary/en/gtld.md
@@ -1,0 +1,15 @@
+---
+title: gTLD (Generic Top-Level Domain)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: A top-level domain not tied to a country, such as .com, .org, or .xyz, run under ICANN contract.
+keywords: ['gTLD', 'generic TLD', '.com', '.org', '.xyz', 'ICANN']
+level: 1
+sources:
+  - https://www.icann.org/resources/pages/tlds-2012-02-25-en
+  - https://www.iana.org/domains/root/db
+---
+
+A **gTLD (generic top-level domain)** is a [TLD](/en/glossary/tld/) that is not tied to a country — the classic ones are `.com`, `.org`, `.net`, and `.info`, joined since 2012 by hundreds of [new gTLDs](/en/glossary/new-gtld/) like `.xyz`, `.app`, and `.shop`. Every gTLD is operated by a [registry](/en/glossary/registry/) under contract with [ICANN](/en/glossary/icann/), which sets the baseline policy that all accredited [registrars](/en/glossary/registrar/) must follow — distinct from a [ccTLD](/en/glossary/cctld/), which answers to a country instead. Because gTLD policy is comparatively uniform, gTLDs are often the first place a tokenization platform like Namefi can add a [wallet](/en/glossary/wallet/)-controlled ownership layer. *Sources: ICANN TLD listings; IANA root database.*

--- a/content/glossary/en/iana.md
+++ b/content/glossary/en/iana.md
@@ -1,0 +1,15 @@
+---
+title: IANA (Internet Assigned Numbers Authority)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: The function that maintains the DNS root zone and allocates IP address blocks and protocol numbers.
+keywords: ['IANA', 'root zone', 'IP allocation', 'protocol numbers', 'ICANN']
+level: 1
+sources:
+  - https://www.iana.org/
+  - https://www.iana.org/domains/root/db
+---
+
+**IANA (Internet Assigned Numbers Authority)** is the function — operated under [ICANN](/en/glossary/icann/) — that maintains the global pools the internet depends on: the [DNS](/en/glossary/dns/) [root zone](/en/glossary/root-zone/), the allocation of [IP address](/en/glossary/ip-address/) blocks to regional registries, and the registry of protocol numbers. When a new [TLD](/en/glossary/tld/) is delegated, it is IANA that records which [registry](/en/glossary/registry/) operates it in the root database. IANA sits above the day-to-day domain market — it doesn't sell names — but everything a [registrar](/en/glossary/registrar/) or registrant does ultimately resolves through the root data IANA publishes, the same authoritative layer a tokenized domain keeps using unchanged. *Sources: IANA; IANA root database.*

--- a/content/glossary/en/idn.md
+++ b/content/glossary/en/idn.md
@@ -1,0 +1,15 @@
+---
+title: IDN (Internationalized Domain Name) / Punycode
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: A domain using non-ASCII characters, encoded for DNS as ASCII Punycode beginning with xn--.
+keywords: ['IDN', 'internationalized domain name', 'Punycode', 'xn--', 'Unicode domain', 'homograph']
+level: 1
+sources:
+  - https://datatracker.ietf.org/doc/html/rfc5890
+  - https://www.icann.org/resources/pages/idn-2012-02-25-en
+---
+
+An **IDN (internationalized domain name)** is a domain that uses non-ASCII characters — `münchen.de`, `中国.cn`, or an emoji domain — so names can be written in scripts beyond basic Latin. Because the [DNS](/en/glossary/dns/) itself only handles ASCII, an IDN is encoded into a compatible ASCII string called **Punycode**, which always begins with the `xn--` prefix (so `münchen` becomes `xn--mnchen-3ya`). [Registries](/en/glossary/registry/) and [registrars](/en/glossary/registrar/) support IDNs at the [TLD](/en/glossary/tld/) level, though they carry a known risk: visually similar characters enable *homograph* lookalikes used in phishing. An IDN is still an ordinary registered name underneath, so it can be tokenized and held in a [wallet](/en/glossary/wallet/) like any other domain. *Sources: RFC 5890; ICANN IDN resources.*

--- a/content/glossary/en/ip-address.md
+++ b/content/glossary/en/ip-address.md
@@ -1,0 +1,15 @@
+---
+title: IP Address (IPv4 / IPv6)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: The numeric address that identifies a device on a network, which DNS maps a domain name to.
+keywords: ['IP address', 'IPv4', 'IPv6', 'A record', 'AAAA record', 'networking']
+level: 1
+sources:
+  - https://datatracker.ietf.org/doc/html/rfc791
+  - https://www.cloudflare.com/learning/dns/glossary/what-is-my-ip-address/
+---
+
+An **IP address** is the numeric label that identifies a device on a network — `93.184.216.34` in the older **IPv4** format, or a longer hexadecimal string like `2606:2800:220:1:248:1893:25c8:1946` in **IPv6**, which exists because the world ran out of IPv4 space. The whole point of the [DNS](/en/glossary/dns/) is to map a human-friendly domain to one of these addresses: an **A** [record](/en/glossary/dns-record-types/) points a name at an IPv4 address, an **AAAA** record at IPv6. Blocks of addresses are allocated through [IANA](/en/glossary/iana/) to regional registries. Domain tokenization operates a layer above all this — it changes who *owns* the name, not the addresses the name resolves to. *Sources: RFC 791; Cloudflare IP address glossary.*

--- a/content/glossary/en/nameserver.md
+++ b/content/glossary/en/nameserver.md
@@ -1,0 +1,15 @@
+---
+title: Nameserver (NS Record)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: A server that answers DNS queries for a domain; its NS records name the authoritative servers.
+keywords: ['nameserver', 'NS record', 'authoritative server', 'DNS delegation', 'DNS hosting']
+level: 1
+sources:
+  - https://datatracker.ietf.org/doc/html/rfc1034
+  - https://www.cloudflare.com/learning/dns/dns-server-types/
+---
+
+A **nameserver** is a server that answers [DNS](/en/glossary/dns/) queries for a domain, and the **NS records** at a domain's [registry](/en/glossary/registry/) declare which nameservers are authoritative for it. When you point a domain at a DNS host (Cloudflare, Route 53, your [registrar](/en/glossary/registrar/)'s own DNS), you are setting its nameservers; those servers then publish the [record types](/en/glossary/dns-record-types/) — A, MX, TXT, and the rest — that route traffic and mail. Tokenizing a domain does not change this layer: the nameservers and their records keep working exactly as before, while ownership and transfer move to a [wallet](/en/glossary/wallet/)-controlled [on-chain](/en/glossary/on-chain/) layer on top. *Sources: RFC 1034; Cloudflare DNS server types.*

--- a/content/glossary/en/new-gtld.md
+++ b/content/glossary/en/new-gtld.md
@@ -1,0 +1,15 @@
+---
+title: New gTLD
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: A generic top-level domain introduced by ICANN's expansion program, such as .app, .xyz, or .shop.
+keywords: ['new gTLD', 'ICANN expansion', '.app', '.xyz', '.shop', 'domain extension']
+level: 1
+sources:
+  - https://newgtlds.icann.org/en/
+  - https://www.icann.org/resources/pages/tlds-2012-02-25-en
+---
+
+A **new gTLD** is one of the hundreds of [generic top-level domains](/en/glossary/gtld/) that [ICANN](/en/glossary/icann/) introduced through its expansion program, which began delegating strings like `.app`, `.xyz`, `.io`, `.dev`, and `.shop` from 2013 onward. The program opened the right-of-the-dot namespace beyond the original handful, letting brands and communities run their own [registry](/en/glossary/registry/) and giving registrants far more naming choice. New gTLDs vary widely in price and adoption, and — like any [TLD](/en/glossary/tld/) — in how readily they support an [on-chain](/en/glossary/on-chain/) ownership layer; the newer, more web-native extensions are often the most open to Namefi tokenization. *Sources: ICANN new gTLD program; ICANN TLD listings.*

--- a/content/glossary/en/pending-delete.md
+++ b/content/glossary/en/pending-delete.md
@@ -1,0 +1,14 @@
+---
+title: Pending Delete (Drop)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: The final status before an unrenewed domain is released back to the public for registration.
+keywords: ['pending delete', 'domain drop', 'drop catching', 'expired domain', 'release']
+level: 1
+sources:
+  - https://www.icann.org/resources/pages/epp-status-codes-2014-06-16-en
+---
+
+**Pending delete** is the last status in a lapsed domain's lifecycle: after the [redemption period](/en/glossary/redemption-period/) ends without recovery, the [registry](/en/glossary/registry/) marks the name `pendingDelete` for about five days, during which it cannot be renewed or transferred. At the end of that window the domain **drops** — it is purged and released back to the public, available to register again first-come-first-served. This moment is what [backorder](/en/glossary/backorder/) and drop-catching services race to capture for desirable names. Pending delete is purely a [registry](/en/glossary/registry/)-level state in the traditional [DNS](/en/glossary/dns/) system; it has no analog in the on-chain ownership layer, which is why keeping a tokenized domain's underlying registration renewed still matters. *Source: ICANN EPP status codes.*

--- a/content/glossary/en/premium-domain.md
+++ b/content/glossary/en/premium-domain.md
@@ -1,0 +1,14 @@
+---
+title: Premium Domain
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: A high-value domain priced above standard rates for its memorability, brevity, or keyword strength.
+keywords: ['premium domain', 'premium name', 'registry premium', 'aftermarket', 'domain value']
+level: 1
+sources:
+  - https://www.namebio.com/
+---
+
+A **premium domain** is a name considered especially valuable — short, memorable, brandable, or built on a strong keyword — and therefore priced well above standard registration rates. "Premium" comes in two flavors: **registry premiums**, where the [registry](/en/glossary/registry/) itself sets an elevated price (and often an elevated [renewal](/en/glossary/domain-renewal/)) on a name within its [TLD](/en/glossary/tld/), and **aftermarket premiums**, where an owner resells a name through [domain trading](/en/glossary/domain-trading/) for far more than they paid. Premium status is about market demand, not technical difference — the name resolves like any other. Premium domains are prime candidates for tokenization, since putting a high-value asset's ownership in a [wallet](/en/glossary/wallet/) makes it easier to trade, collateralize, or transfer. *Source: NameBio domain sales data.*

--- a/content/glossary/en/redemption-period.md
+++ b/content/glossary/en/redemption-period.md
@@ -1,0 +1,14 @@
+---
+title: Redemption Period (RGP)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: A post-expiration window where a lapsed domain can be recovered, usually for a steep redemption fee.
+keywords: ['redemption period', 'RGP', 'redemption grace period', 'expired domain recovery', 'redemption fee']
+level: 1
+sources:
+  - https://www.icann.org/resources/pages/errp-2013-02-28-en
+---
+
+The **redemption period** (formally the Redemption Grace Period, RGP) is a roughly 30-day window after a domain has fully lapsed — past its [grace period](/en/glossary/grace-period/) — during which the original [registrant](/en/glossary/registrant/) can still recover it, but only by paying a steep **redemption fee** on top of the [renewal](/en/glossary/domain-renewal/) cost. During RGP the name is removed from the zone (the site goes dark) but not yet released. If it is not redeemed, the domain moves to [pending delete](/en/glossary/pending-delete/) and then drops. The redemption period is a [registry](/en/glossary/registry/)-level safety net in the traditional system; the lesson for any valuable name — tokenized or not — is to renew well before [expiration](/en/glossary/domain-expiration/). *Source: ICANN Expired Registration Recovery Policy.*

--- a/content/glossary/en/registrant.md
+++ b/content/glossary/en/registrant.md
@@ -1,0 +1,14 @@
+---
+title: Registrant
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: The person or organization that holds the rights to a registered domain name — the owner of record.
+keywords: ['registrant', 'domain owner', 'registered name holder', 'RNH', 'domain ownership']
+level: 1
+sources:
+  - https://www.icann.org/resources/pages/name-holder-faqs-2017-10-10-en
+---
+
+A **registrant** is the person or organization that holds the rights to a registered domain — the *registered name holder* on record. The registrant contracts with a [registrar](/en/glossary/registrar/), which in turn works with the [registry](/en/glossary/registry/) under [ICANN](/en/glossary/icann/) rules; the registrant is the closest thing the traditional system has to an "owner," though those rights live in a registrar account rather than something you hold directly. This is exactly what tokenization changes: when a domain is tokenized, control moves into a [wallet](/en/glossary/wallet/) as an [on-chain](/en/glossary/on-chain/) ownership layer, so the registrant's rights become a transferable asset you custody yourself rather than a row in a registrar's database. *Source: ICANN registered name holder FAQs.*

--- a/content/glossary/en/registry.md
+++ b/content/glossary/en/registry.md
@@ -1,0 +1,15 @@
+---
+title: Registry (Registry Operator)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: The organization that runs the master database for one or more TLDs and sets their wholesale pricing.
+keywords: ['registry', 'registry operator', 'TLD', 'ICANN', 'registrar', 'wholesale pricing']
+level: 1
+sources:
+  - https://www.icann.org/resources/pages/registries
+  - https://www.iana.org/domains/root/db
+---
+
+A **registry** (or *registry operator*) is the organization that runs the master database for one or more [TLDs](/en/glossary/tld/) — e.g. Verisign for `.com`, the Public Interest Registry for `.org`. It sets wholesale prices and policies and delegates retail sales to [registrars](/en/glossary/registrar/), which is why you buy a `.com` from GoDaddy or Namecheap, not from Verisign directly. The registry, its registrars, and the [registrant](/en/glossary/registrant/) form the three-tier system that [ICANN](/en/glossary/icann/) coordinates. When Namefi tokenizes a domain, the registry's authoritative [DNS](/en/glossary/dns/) record is unchanged — tokenization adds a [wallet](/en/glossary/wallet/)-controlled ownership layer on top. *Sources: ICANN registry listings; IANA root database.*

--- a/content/glossary/en/reserved-names.md
+++ b/content/glossary/en/reserved-names.md
@@ -1,0 +1,14 @@
+---
+title: Reserved Names (Blocked Names)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: Domains a registry withholds from open registration, such as premium, policy, or protected labels.
+keywords: ['reserved names', 'blocked names', 'registry reserved', 'premium reserved', 'collision list']
+level: 1
+sources:
+  - https://www.icann.org/resources/pages/tlds-2012-02-25-en
+---
+
+**Reserved names** are labels a [registry](/en/glossary/registry/) holds back from open registration. The reasons vary: some are **premium** names set aside to sell at a higher price, some are blocked for policy or legal reasons (geographic terms, registrar names, ICANN-mandated strings), and some sit on a collision-avoidance list to prevent clashes with internal network names. The reserved list is specific to each [TLD](/en/glossary/tld/) and set by its operator under [ICANN](/en/glossary/icann/) rules, which is why a name can be available in one TLD but unregisterable in another. Reservation happens entirely at the registry layer of the traditional system, before a name ever becomes a [registrant](/en/glossary/registrant/)'s — and so before it could be tokenized. *Source: ICANN TLD listings.*

--- a/content/glossary/en/root-zone.md
+++ b/content/glossary/en/root-zone.md
@@ -1,0 +1,15 @@
+---
+title: Root Zone (Root Servers)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: The top of the DNS hierarchy, listing every TLD and the servers authoritative for it.
+keywords: ['root zone', 'root servers', 'DNS hierarchy', 'TLD delegation', 'IANA']
+level: 1
+sources:
+  - https://www.iana.org/domains/root
+  - https://www.iana.org/domains/root/servers
+---
+
+The **root zone** is the very top of the [DNS](/en/glossary/dns/) hierarchy — the master list of every [TLD](/en/glossary/tld/) and which [registry](/en/glossary/registry/) servers are authoritative for it. It is served by the **root servers**, a globally distributed set of systems reached at thirteen named addresses, and the zone's contents are maintained through [IANA](/en/glossary/iana/). Every domain lookup that isn't already cached starts here: a [resolver](/en/glossary/dns-resolver/) asks the root where to find `.com`, then follows the chain down. The root zone is the internet's naming anchor — and it is untouched by tokenization, which adds a [wallet](/en/glossary/wallet/)-controlled ownership layer above the existing DNS rather than replacing the root. *Sources: IANA root zone; IANA root servers.*

--- a/content/glossary/en/second-level-domain.md
+++ b/content/glossary/en/second-level-domain.md
@@ -1,0 +1,15 @@
+---
+title: Second-Level Domain (SLD)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: The label directly left of the TLD — the "example" in example.com — the part you actually register.
+keywords: ['second-level domain', 'SLD', 'root domain', 'apex domain', 'registrable name']
+level: 1
+sources:
+  - https://datatracker.ietf.org/doc/html/rfc1034
+  - https://www.icann.org/resources/pages/tlds-2012-02-25-en
+---
+
+A **second-level domain (SLD)** is the label immediately to the left of the [TLD](/en/glossary/tld/) — the `example` in `example.com`. It is the part you actually register through a [registrar](/en/glossary/registrar/), and combined with the TLD it forms the registrable name that the [registry](/en/glossary/registry/) records against a [registrant](/en/glossary/registrant/). Everything to the left of the SLD — `www`, `blog`, `app` — is a [subdomain](/en/glossary/subdomain/) you control yourself; everything to the right is the public suffix. Because the SLD+TLD pair is the unit of ownership, it is exactly what Namefi tokenizes: the registrable name becomes a [wallet](/en/glossary/wallet/)-controlled asset, while subdomains remain configuration beneath it. *Sources: RFC 1034; ICANN TLD listings.*

--- a/content/glossary/en/subdomain.md
+++ b/content/glossary/en/subdomain.md
@@ -1,0 +1,15 @@
+---
+title: Subdomain
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: A prefix added to a domain to create a separate address, such as blog.example.com or app.example.com.
+keywords: ['subdomain', 'host', 'blog.example.com', 'DNS', 'second-level domain']
+level: 1
+sources:
+  - https://datatracker.ietf.org/doc/html/rfc1034
+  - https://www.cloudflare.com/learning/dns/glossary/what-is-a-subdomain/
+---
+
+A **subdomain** is a prefix added to your domain to create a distinct address under it — `blog.example.com`, `app.example.com`, or `mail.example.com` are all subdomains of `example.com`. You create one by adding a [DNS record](/en/glossary/dns-record-types/) (usually an A or CNAME) at the [nameservers](/en/glossary/nameserver/) for the parent domain, with no extra registration or fee. Subdomains let one registered name host many services, which is why they are a building block for sites, apps, and APIs. In the tokenized world, ownership lives at the [registered](/en/glossary/registrant/) [second-level domain](/en/glossary/second-level-domain/); subdomains are configuration under it and follow whoever controls the parent's [wallet](/en/glossary/wallet/). *Sources: RFC 1034; Cloudflare subdomain glossary.*

--- a/content/glossary/en/ttl.md
+++ b/content/glossary/en/ttl.md
@@ -1,0 +1,15 @@
+---
+title: TTL (Time to Live)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: How long, in seconds, a DNS record may be cached by resolvers before it must be looked up again.
+keywords: ['TTL', 'time to live', 'DNS cache', 'DNS propagation', 'record caching']
+level: 1
+sources:
+  - https://datatracker.ietf.org/doc/html/rfc1035
+  - https://www.cloudflare.com/learning/dns/glossary/time-to-live-ttl/
+---
+
+**TTL (time to live)** is a value, in seconds, attached to every [DNS record](/en/glossary/dns-record-types/) that tells [resolvers](/en/glossary/dns-resolver/) how long they may cache the answer before checking again. A short TTL (say 300 seconds) means changes take effect quickly but generates more lookups; a long TTL (86,400 seconds = one day) is efficient but means an update lingers in caches. Lowering the TTL a day before you plan a change is the standard trick for fast [DNS propagation](/en/glossary/dns-propagation/). TTL governs DNS caching only — it is unrelated to a domain's registration term or to the [on-chain](/en/glossary/on-chain/) ownership layer a tokenized domain adds. *Sources: RFC 1035; Cloudflare TTL glossary.*

--- a/content/glossary/en/zone-file.md
+++ b/content/glossary/en/zone-file.md
@@ -1,0 +1,15 @@
+---
+title: Zone File (Glue Record)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: The text file holding all the DNS records for a domain, including glue records for its nameservers.
+keywords: ['zone file', 'glue record', 'DNS zone', 'authoritative records', 'nameserver']
+level: 1
+sources:
+  - https://datatracker.ietf.org/doc/html/rfc1035
+  - https://www.cloudflare.com/learning/dns/glossary/dns-zone/
+---
+
+A **zone file** is the text file on a domain's authoritative [nameservers](/en/glossary/nameserver/) that holds all of its [DNS records](/en/glossary/dns-record-types/) — the A, MX, TXT, and other entries that define how the domain behaves. A **glue record** is a special case: when a domain's nameservers live *under that same domain* (e.g. `ns1.example.com` serving `example.com`), the parent [registry](/en/glossary/registry/) must publish the nameserver's [IP address](/en/glossary/ip-address/) directly in the parent zone to avoid a chicken-and-egg lookup. Editing the zone file is how you configure a domain's [DNS](/en/glossary/dns/). It is operational data, separate from ownership — which is exactly what a tokenized domain moves to a [wallet](/en/glossary/wallet/)-controlled layer. *Sources: RFC 1035; Cloudflare DNS zone glossary.*

--- a/content/termbase.json
+++ b/content/termbase.json
@@ -64,6 +64,20 @@
     },
     "level": 1
   },
+  "backorder": {
+    "en": "Backorder (Drop-Catching)",
+    "titles": {
+      "en": "Backorder (Drop-Catching)"
+    },
+    "level": 1
+  },
+  "cctld": {
+    "en": "ccTLD (Country-Code Top-Level Domain)",
+    "titles": {
+      "en": "ccTLD (Country-Code Top-Level Domain)"
+    },
+    "level": 1
+  },
   "censorship-free": {
     "en": "Censorship-free",
     "titles": {
@@ -194,6 +208,27 @@
     },
     "level": 1
   },
+  "dns-propagation": {
+    "en": "DNS Propagation",
+    "titles": {
+      "en": "DNS Propagation"
+    },
+    "level": 1
+  },
+  "dns-record-types": {
+    "en": "DNS Record Types (A, AAAA, CNAME, MX, TXT)",
+    "titles": {
+      "en": "DNS Record Types (A, AAAA, CNAME, MX, TXT)"
+    },
+    "level": 1
+  },
+  "dns-resolver": {
+    "en": "DNS Resolver (Recursive Resolver)",
+    "titles": {
+      "en": "DNS Resolver (Recursive Resolver)"
+    },
+    "level": 1
+  },
   "dnssec": {
     "en": "DNSSEC (Domain Name System Security Extensions)",
     "titles": {
@@ -220,6 +255,13 @@
     },
     "level": 1
   },
+  "domain-expiration": {
+    "en": "Domain Expiration",
+    "titles": {
+      "en": "Domain Expiration"
+    },
+    "level": 1
+  },
   "domain-ownership": {
     "en": "Domain ownership",
     "titles": {
@@ -230,6 +272,20 @@
       "zh": "域名所有权",
       "ar": "ملكية النطاق",
       "hi": "डोमेन स्वामित्व"
+    },
+    "level": 1
+  },
+  "domain-renewal": {
+    "en": "Domain Renewal (Auto-Renew)",
+    "titles": {
+      "en": "Domain Renewal (Auto-Renew)"
+    },
+    "level": 1
+  },
+  "domain-tasting": {
+    "en": "Domain Tasting (AGP)",
+    "titles": {
+      "en": "Domain Tasting (AGP)"
     },
     "level": 1
   },
@@ -324,6 +380,20 @@
     },
     "level": 1
   },
+  "grace-period": {
+    "en": "Grace Period",
+    "titles": {
+      "en": "Grace Period"
+    },
+    "level": 1
+  },
+  "gtld": {
+    "en": "gTLD (Generic Top-Level Domain)",
+    "titles": {
+      "en": "gTLD (Generic Top-Level Domain)"
+    },
+    "level": 1
+  },
   "hardware-wallet": {
     "en": "Hardware Wallet",
     "titles": {
@@ -334,6 +404,13 @@
       "zh": "硬件钱包",
       "ar": "محفظة الأجهزة",
       "hi": "हार्डवेयर वॉलेट"
+    },
+    "level": 1
+  },
+  "iana": {
+    "en": "IANA (Internet Assigned Numbers Authority)",
+    "titles": {
+      "en": "IANA (Internet Assigned Numbers Authority)"
     },
     "level": 1
   },
@@ -350,6 +427,13 @@
     },
     "level": 1
   },
+  "idn": {
+    "en": "IDN (Internationalized Domain Name) / Punycode",
+    "titles": {
+      "en": "IDN (Internationalized Domain Name) / Punycode"
+    },
+    "level": 1
+  },
   "internet-native-asset": {
     "en": "Internet-native asset",
     "titles": {
@@ -360,6 +444,13 @@
       "zh": "互联网原生资产",
       "ar": "أصل رقمي أصيل للإنترنت",
       "hi": "इंटरनेट-नेटिव एसेट"
+    },
+    "level": 1
+  },
+  "ip-address": {
+    "en": "IP Address (IPv4 / IPv6)",
+    "titles": {
+      "en": "IP Address (IPv4 / IPv6)"
     },
     "level": 1
   },
@@ -428,6 +519,20 @@
     },
     "level": 1
   },
+  "nameserver": {
+    "en": "Nameserver (NS Record)",
+    "titles": {
+      "en": "Nameserver (NS Record)"
+    },
+    "level": 1
+  },
+  "new-gtld": {
+    "en": "New gTLD",
+    "titles": {
+      "en": "New gTLD"
+    },
+    "level": 1
+  },
   "nft": {
     "en": "NFT (Non-Fungible Token)",
     "titles": {
@@ -454,6 +559,13 @@
     },
     "level": 1
   },
+  "pending-delete": {
+    "en": "Pending Delete (Drop)",
+    "titles": {
+      "en": "Pending Delete (Drop)"
+    },
+    "level": 1
+  },
   "permissionless": {
     "en": "Permissionless",
     "titles": {
@@ -467,6 +579,13 @@
     },
     "level": 1
   },
+  "premium-domain": {
+    "en": "Premium Domain",
+    "titles": {
+      "en": "Premium Domain"
+    },
+    "level": 1
+  },
   "protocol-asset": {
     "en": "Protocol asset",
     "titles": {
@@ -477,6 +596,20 @@
       "zh": "协议资产",
       "ar": "أصل البروتوكول",
       "hi": "प्रोटोकॉल एसेट"
+    },
+    "level": 1
+  },
+  "redemption-period": {
+    "en": "Redemption Period (RGP)",
+    "titles": {
+      "en": "Redemption Period (RGP)"
+    },
+    "level": 1
+  },
+  "registrant": {
+    "en": "Registrant",
+    "titles": {
+      "en": "Registrant"
     },
     "level": 1
   },
@@ -501,6 +634,13 @@
       ]
     }
   },
+  "registry": {
+    "en": "Registry (Registry Operator)",
+    "titles": {
+      "en": "Registry (Registry Operator)"
+    },
+    "level": 1
+  },
   "rent-to-own": {
     "en": "Rent-to-own",
     "titles": {
@@ -514,6 +654,13 @@
     },
     "level": 1
   },
+  "reserved-names": {
+    "en": "Reserved Names (Blocked Names)",
+    "titles": {
+      "en": "Reserved Names (Blocked Names)"
+    },
+    "level": 1
+  },
   "revenue-sharing": {
     "en": "Revenue-sharing",
     "titles": {
@@ -524,6 +671,20 @@
       "zh": "收益分享",
       "ar": "مشاركة الإيرادات",
       "hi": "राजस्व-साझाकरण"
+    },
+    "level": 1
+  },
+  "root-zone": {
+    "en": "Root Zone (Root Servers)",
+    "titles": {
+      "en": "Root Zone (Root Servers)"
+    },
+    "level": 1
+  },
+  "second-level-domain": {
+    "en": "Second-Level Domain (SLD)",
+    "titles": {
+      "en": "Second-Level Domain (SLD)"
     },
     "level": 1
   },
@@ -579,6 +740,13 @@
     },
     "level": 1
   },
+  "subdomain": {
+    "en": "Subdomain",
+    "titles": {
+      "en": "Subdomain"
+    },
+    "level": 1
+  },
   "tld": {
     "en": "TLD (Top-Level Domain)",
     "titles": {
@@ -602,6 +770,13 @@
       "zh": "代币化",
       "ar": "ترميز",
       "hi": "टोकनाइज़ करें"
+    },
+    "level": 1
+  },
+  "ttl": {
+    "en": "TTL (Time to Live)",
+    "titles": {
+      "en": "TTL (Time to Live)"
     },
     "level": 1
   },
@@ -667,6 +842,13 @@
       "zh": "x402",
       "ar": "x402",
       "hi": "x402"
+    },
+    "level": 1
+  },
+  "zone-file": {
+    "en": "Zone File (Glue Record)",
+    "titles": {
+      "en": "Zone File (Glue Record)"
     },
     "level": 1
   }


### PR DESCRIPTION
## Summary / Solution

Wave 1 of the glossary build-out: the first **26 new L1 glossary entries** (English-first), covering the two highest-priority categories — **A · Domain anatomy & DNS** and **B · Registration & lifecycle**. These fill the biggest gap behind the build-out: the corpus is ~70% traditional-domain content, but the glossary was ~70% web3, so cornerstone posts had nothing to link to for `registry`, `registrant`, `gtld/cctld`, `domain-renewal`, etc.

**Batch A (17):** registry, registrant, cctld, gtld, new-gtld, nameserver, dns-record-types, subdomain, second-level-domain, iana, ip-address, ttl, dns-resolver, dns-propagation, root-zone, zone-file, idn.

**Batch B (9):** domain-renewal, domain-expiration, redemption-period, grace-period, pending-delete, backorder, domain-tasting, premium-domain, reserved-names.

Each entry meets the L1 bar: declarative `description` (≤155 chars, tooltip + SEO meta), `level:1`, 1–2 canonical `sources` (ICANN, IANA/IETF RFCs, NameBio, etc.), a short house-voice paragraph with **2–4 glossary cross-links** and the Namefi-tokenization angle. `content/termbase.json` regenerated → 77 concepts (en=77). Translations follow in Wave 1T.

## Test plan
- `bun data:validate` → passes (19 pre-existing warnings, none new).
- `bun lint:mdx` → clean.
- Cross-link audit across all 26 entries → **0 broken** (every link resolves to an existing glossary slug, in-batch or among the 51).
- `bun termbase:build` → 77 concepts.
- Descriptions verified ≤155 chars; `level:1` on all.

## Claude session summary
- **Main prompts (paraphrased):** Execute `GOAL-resources-glossary-buildout.md` autonomously; per batch, Bugbot green → feedback loop → admin-merge.
- **This PR (Wave 1 A+B):** authored 26 new L1 EN entries to the locked template, audited cross-links, regenerated the termbase.
- **Redaction:** no secrets/credentials/PII.

Part of the glossary build-out initiative (Wave 1, batches A+B). Builds on Wave 0 (#100, #101, #102). Remaining categories C–I follow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only content and termbase metadata; no application logic, auth, or data-handling changes.
> 
> **Overview**
> Wave 1 **A+B** expands the English glossary with **26 new L1 entries**, aimed at traditional domain/DNS topics that posts can link to (registry, registrant, TLD types, renewal/expiration, etc.).
> 
> **Domain anatomy & DNS (17):** e.g. `registry`, `registrant`, `gtld`/`cctld`/`new-gtld`, `nameserver`, `dns-record-types`, `subdomain`, `second-level-domain`, `iana`, `ip-address`, `ttl`, `dns-resolver`, `dns-propagation`, `root-zone`, `zone-file`, `idn`.
> 
> **Registration & lifecycle (9):** e.g. `domain-renewal`, `domain-expiration`, `grace-period`, `redemption-period`, `pending-delete`, `backorder`, `domain-tasting`, `premium-domain`, `reserved-names`.
> 
> Each new page follows the L1 template (`description`, `level: 1`, sources, short body with glossary cross-links and a tokenization angle). **`content/termbase.json`** is updated with matching slugs (English titles only for these terms until Wave 1T translations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae8ae1296ba001c4bc87f34ad522fb3cfcd375bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->