### PR TITLE
content(glossary): Wave 1 batch E — 17 aftermarket & investing terms

### DIFF
--- a/content/glossary/en/aftermarket.md
+++ b/content/glossary/en/aftermarket.md
@@ -1,0 +1,14 @@
+---
+title: Aftermarket (Secondary Market)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: The resale market for already-registered domains, where names are bought and sold between owners.
+keywords: ['aftermarket', 'secondary market', 'domain resale', 'domain investing', 'domain sales']
+level: 1
+sources:
+  - https://www.namebio.com/
+---
+
+The **aftermarket** (or *secondary market*) is where already-registered domains are bought and sold between owners, as opposed to the *primary market* of registering a brand-new name from a [registrar](/en/glossary/registrar/). Most memorable, short, or keyword-rich names were claimed long ago, so the aftermarket is where they actually change hands — through marketplaces, a [domain broker](/en/glossary/domain-broker/), [auctions](/en/glossary/auction/), or private deals, often settled via [escrow](/en/glossary/escrow/). Prices range from a few dollars to eight figures for a [premium domain](/en/glossary/premium-domain/). Tokenization is a natural fit for the aftermarket: representing a name as a [wallet](/en/glossary/wallet/)-held asset makes ownership transfer instant and trustless, removing much of the friction that slows traditional aftermarket sales. *Source: NameBio domain sales data.*

--- a/content/glossary/en/brandable-domain.md
+++ b/content/glossary/en/brandable-domain.md
@@ -1,0 +1,14 @@
+---
+title: Brandable Domain
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: A short, catchy, often invented name that works as a memorable brand, like a made-up word.
+keywords: ['brandable domain', 'brand domain', 'invented domain', 'made-up word domain', 'memorable domain']
+level: 1
+sources:
+  - https://www.namebio.com/
+---
+
+A **brandable domain** is a name chosen for its memorability, sound, and visual appeal rather than for literal keyword meaning — think invented words like Zoom, Spotify, or Canva, which carry no dictionary definition but are instantly distinctive. Unlike an [exact-match domain](/en/glossary/exact-match-domain/), a brandable name does not try to rank for a search query by matching it verbatim; instead it creates a fresh identity that a company can grow into and own exclusively. Brandable domains tend to be short (one or two syllables), easy to spell after hearing them once, and free of hyphens and numbers. Investors in this category rely heavily on [domain appraisal](/en/glossary/domain-appraisal/) services and marketplaces like Brandpa or Squadhelp, which curate names based on linguistic and aesthetic criteria. Because brandable names derive value from imagination rather than data, they can be harder to price than keyword assets, but when they land with the right buyer they often command [premium domain](/en/glossary/premium-domain/) prices. Namefi's on-chain ownership record ensures that a brandable name's clean chain of title is verifiable before an end user commits to a high-price purchase. *Source: NameBio domain sales data.*

--- a/content/glossary/en/buy-now-vs-make-offer.md
+++ b/content/glossary/en/buy-now-vs-make-offer.md
@@ -1,0 +1,14 @@
+---
+title: Buy-Now (BIN) vs Make-Offer
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: Two ways to price a listing — a fixed instant price, or inviting buyers to negotiate an offer.
+keywords: ['buy now', 'BIN', 'make offer', 'domain listing', 'domain pricing strategy', 'negotiated sale']
+level: 1
+sources:
+  - https://www.namebio.com/
+---
+
+**Buy-Now (BIN) vs Make-Offer** describes the two primary pricing strategies a seller can use when listing a domain on the [aftermarket](/en/glossary/aftermarket/). A Buy-Now price is a fixed, instant-purchase amount — a buyer who meets it completes the transaction immediately without negotiation. A Make-Offer listing invites prospective buyers to submit bids, which the seller can accept, counter, or decline, making it more suitable for names where the seller is uncertain of optimal price or expects that an end-user buyer will surface willing to pay more than an investor floor. Some [marketplace](/en/glossary/marketplace/) platforms combine both options: a BIN is listed for certainty, while a Make-Offer flow is also open for buyers who want to try below asking. Sellers use a [reserve price](/en/glossary/reserve-price/) in Make-Offer flows to define the private floor below which they will not engage. A [domain broker](/en/glossary/domain-broker/) advising on strategy typically recommends BIN for commodity assets and Make-Offer for unique or high-value names with a defined target buyer profile. Namefi can encode BIN logic directly on-chain — a buyer transferring the exact token price triggers automatic settlement — while Make-Offer flows are handled through the platform's negotiation interface. *Source: NameBio domain sales data.*

--- a/content/glossary/en/comparable-sales.md
+++ b/content/glossary/en/comparable-sales.md
@@ -1,0 +1,14 @@
+---
+title: Comparable Sales (Comps)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: Past sales of similar domains used as benchmarks to estimate what a name is worth.
+keywords: ['comparable sales', 'comps', 'domain sales data', 'domain benchmarks', 'domain pricing history']
+level: 1
+sources:
+  - https://www.namebio.com/
+---
+
+**Comparable sales** — or *comps* — are the historical sale prices of domains that closely resemble the name being valued, and they are the single most reliable input in any [domain appraisal](/en/glossary/domain-appraisal/). A comp is most useful when it matches on TLD, length, word count, keyword category, and approximate age of the sale; a three-letter .com that sold for $80,000 last year is a far stronger signal for a similar three-letter .com than a five-year-old sale of a four-word .net. Databases like NameBio aggregate hundreds of thousands of disclosed aftermarket transactions, and platforms such as DNJournal publish weekly sale reports, making the [aftermarket](/en/glossary/aftermarket/) increasingly transparent. Because not all domain sales are disclosed, comps always represent a floor sample rather than a complete market picture. Namefi's on-chain transaction history has the potential to create a new layer of verifiable, tamper-proof comp data — every tokenized transfer carries a public price record that any appraisal tool can query without relying on voluntary disclosure. *Source: NameBio domain sales data.*

--- a/content/glossary/en/domain-appraisal.md
+++ b/content/glossary/en/domain-appraisal.md
@@ -1,0 +1,14 @@
+---
+title: Domain Appraisal (Valuation)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: Estimating a domain's market value from comparable sales, keyword demand, length, and extension.
+keywords: ['domain appraisal', 'domain valuation', 'domain worth', 'domain pricing', 'comparable sales']
+level: 1
+sources:
+  - https://www.namebio.com/
+---
+
+**Domain appraisal** (or *domain valuation*) is the process of estimating what a domain name would fetch on the open market. Appraisers weigh [comparable sales](/en/glossary/comparable-sales/) of similar names, keyword search volume and commercial intent, character count and pronounceability, TLD strength (.com commands a significant premium over most alternatives), and current buyer demand in the [aftermarket](/en/glossary/aftermarket/). Automated tools like Estibot and GoDaddy's appraisal engine produce algorithmic estimates, but experienced brokers and investors often rely heavily on hand-curated comps and market feel. A strong [premium domain](/en/glossary/premium-domain/) backed by solid comps can justify a five- or six-figure ask, while a [brandable domain](/en/glossary/brandable-domain/) with no close comparables requires more subjective judgment. On Namefi, tokenizing a domain creates an immutable provenance record that can support transparent, on-chain pricing history — giving future appraisers a richer data set to work from. *Source: NameBio domain sales data.*

--- a/content/glossary/en/domain-broker.md
+++ b/content/glossary/en/domain-broker.md
@@ -1,0 +1,14 @@
+---
+title: Domain Broker (Brokerage)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: An intermediary who negotiates a domain sale between buyer and seller, usually for a commission.
+keywords: ['domain broker', 'domain brokerage', 'domain negotiation', 'domain intermediary', 'domain commission']
+level: 1
+sources:
+  - https://www.namebio.com/
+---
+
+A **domain broker** is a professional intermediary who facilitates the sale of a domain name between a seller and a buyer, typically earning a commission — commonly 10–20% of the final sale price — in exchange for prospecting buyers, conducting outreach, negotiating price, and coordinating the transaction through [escrow](/en/glossary/escrow/). Brokers are especially valuable for high-value assets where direct outreach to an unknown seller would feel adversarial, or when a buyer wants a name that isn't publicly listed for sale. Both inbound brokerage (selling a name a client owns) and acquisition brokerage (finding a name a client wants to buy) are common services. Reputable brokerage firms include Sedo, Media Options, and GoDaddy's brokerage team, all of which leverage large databases of recent [aftermarket](/en/glossary/aftermarket/) transactions. Because a broker's outreach often involves identifying the [end user](/en/glossary/end-user/) willing to pay retail, brokered [domain trading](/en/glossary/domain-trading/) frequently achieves the highest prices in the market. On Namefi, tokenized ownership can simplify the settlement leg of a brokered deal — the broker coordinates the deal, and the token transfer handles the conveyance atomically. *Source: NameBio domain sales data.*

--- a/content/glossary/en/domain-liquidity.md
+++ b/content/glossary/en/domain-liquidity.md
@@ -1,0 +1,14 @@
+---
+title: Liquidity
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: How quickly a domain can be sold near its estimated value — high for great names, low for niche ones.
+keywords: ['domain liquidity', 'liquidity', 'domain marketability', 'domain sell speed', 'domain market depth']
+level: 1
+sources:
+  - https://www.investopedia.com/terms/l/liquidity.asp
+---
+
+**Liquidity** in domain investing describes how readily a name can be converted to cash at or near its appraised value. A short, generic .com with broad commercial appeal is highly liquid — a motivated seller can reasonably expect a buyer within weeks or months. A long, niche, or obscure name may sit unsold for years despite a fair asking price, making it illiquid regardless of its theoretical worth. [Sell-through rate](/en/glossary/sell-through-rate/) across a portfolio is the most direct measure of aggregate liquidity. The [aftermarket](/en/glossary/aftermarket/)'s liquidity is structurally lower than stock or forex markets because each domain is a unique asset with no standard lot size or continuous two-sided quote, and because most buyers are end users with infrequent, specific purchase needs rather than market makers. [Domain appraisal](/en/glossary/domain-appraisal/) estimates the value at which a name *could* sell, but liquidity determines how long the seller must wait to realize it. Namefi improves domain liquidity by making tokenized names discoverable and tradable by on-chain market participants globally, expanding the buyer pool beyond those familiar with traditional domain registrar transfer workflows. *Source: Investopedia, Liquidity.*

--- a/content/glossary/en/domain-portfolio.md
+++ b/content/glossary/en/domain-portfolio.md
@@ -1,0 +1,14 @@
+---
+title: Domain Portfolio
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: A collection of domains held by one owner, managed as an investment with renewals, sales, and valuation.
+keywords: ['domain portfolio', 'domain investing', 'domain management', 'domain valuation', 'domain assets']
+level: 1
+sources:
+  - https://www.namebio.com/
+---
+
+A **domain portfolio** is a curated collection of domain names held by a single owner or entity, managed with the same discipline as any investment portfolio — tracking renewal dates, monitoring [holding costs](/en/glossary/holding-cost/), pursuing sales through the [aftermarket](/en/glossary/domain-trading/), and periodically appraising each name's value via [domain appraisal](/en/glossary/domain-appraisal/). Portfolios range from a handful of hand-registered names to thousands of [premium domains](/en/glossary/premium-domain/) assembled over years of active buying. Investors must balance the carrying cost of annual renewals against the expected sale price of each name, pruning weak assets before renewal fees exceed realistic return. On Namefi, each domain in a portfolio is represented as an on-chain NFT token, so the entire collection lives in a single wallet with a transparent, auditable ownership record — making portfolio valuation, transfer, and collateralization far more tractable than in the traditional registrar model. *Source: NameBio domain sales data.*

--- a/content/glossary/en/domaining.md
+++ b/content/glossary/en/domaining.md
@@ -1,0 +1,14 @@
+---
+title: Domaining (Domainer)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: The practice of investing in domain names — registering, buying, and selling them for profit.
+keywords: ['domaining', 'domainer', 'domain investing', 'domain flipping', 'domain speculation']
+level: 1
+sources:
+  - https://www.namebio.com/
+---
+
+**Domaining** is the practice of acquiring domain names as investment assets — hand-registering expiring names, buying from the [aftermarket](/en/glossary/aftermarket/), and eventually selling for profit through [domain trading](/en/glossary/domain-trading/). Practitioners, called *domainers*, treat domain names as digital real estate: a name's value derives from keyword relevance, memorability, extension strength, and market timing rather than any intrinsic physical property. Serious domainers build and manage a structured [domain portfolio](/en/glossary/domain-portfolio/), tracking renewal deadlines, outbound sales efforts, and market comps to maximize returns. The craft spans everything from drop-catching expiring .com names at auction to acquiring entire portfolios from retiring investors. Namefi extends domaining into the on-chain era — tokens representing domain ownership can be listed, transferred, or used as collateral without relying on a single registrar's interface, giving domainers a more liquid and programmable asset layer. *Source: NameBio domain sales data.*

--- a/content/glossary/en/end-user.md
+++ b/content/glossary/en/end-user.md
@@ -1,0 +1,14 @@
+---
+title: End User
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: A buyer who wants a domain to actually use for a business or project, not to resell it.
+keywords: ['end user', 'domain buyer', 'domain end use', 'business domain', 'domain deployment']
+level: 1
+sources:
+  - https://www.namebio.com/
+---
+
+An **end user** is a buyer who intends to actively deploy a domain — building a website, launching a brand, or anchoring a business identity on it — rather than flipping it on the [aftermarket](/en/glossary/aftermarket/). Because end users derive direct business value from a great name, they are typically willing to pay retail prices that far exceed what one domainer would pay another; a startup needing a clean, memorable .com for its product launch may pay ten times what an investor-to-investor deal would clear. This pricing gap is why [domain brokers](/en/glossary/domain-broker/) focus on finding end-user buyers rather than selling within the investor community. End users often seek [brandable domains](/en/glossary/brandable-domain/) — short, distinctive names with no incumbent brand baggage — or category-defining keyword names that immediately convey their business. Namefi's tokenization layer makes end-user acquisition faster and more transparent: once price is agreed, settlement is a single on-chain transfer rather than a multi-day registrar push with manual verification. *Source: NameBio domain sales data.*

--- a/content/glossary/en/exact-match-domain.md
+++ b/content/glossary/en/exact-match-domain.md
@@ -1,0 +1,14 @@
+---
+title: Exact-Match Domain (EMD)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: A domain that exactly matches a search keyword, like besthotels.com, once highly prized for SEO.
+keywords: ['exact-match domain', 'EMD', 'keyword match domain', 'SEO domain', 'search ranking domain']
+level: 1
+sources:
+  - https://developers.google.com/search/docs/fundamentals/seo-starter-guide
+---
+
+An **exact-match domain** (EMD) is a domain name that precisely replicates a search query — for example, besthotels.com matching the phrase "best hotels." During the early 2000s, EMDs conveyed a meaningful [SEO](/en/glossary/seo/) advantage because search engines used domain text as a ranking signal, making thin sites on exact-match names rank well with minimal content. Google's 2012 "EMD update" and subsequent quality algorithm changes substantially reduced that effect, so an EMD today provides little or no inherent ranking boost over a strong [brandable domain](/en/glossary/brandable-domain/) with high-quality content. However, [keyword domains](/en/glossary/keyword-domain/) that happen to be exact matches still carry value for pay-per-click landing pages, lead-generation verticals, and markets where the domain immediately communicates the business category to visitors. Investors should weigh current algorithmic reality against any seller claim that an EMD commands a premium solely for SEO reasons. Namefi's tokenized title records give buyers full historical context on an EMD's use before committing to a purchase. *Source: Google Search Central SEO Starter Guide.*

--- a/content/glossary/en/holding-cost.md
+++ b/content/glossary/en/holding-cost.md
@@ -1,0 +1,14 @@
+---
+title: Holding / Carrying Cost
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: The ongoing renewal fees an investor pays to keep a domain until it sells.
+keywords: ['holding cost', 'carrying cost', 'domain renewal cost', 'domain investment cost', 'annual renewal fee']
+level: 1
+sources:
+  - https://www.namebio.com/
+---
+
+**Holding cost** (or *carrying cost*) is the sum of recurring fees an investor pays simply to retain ownership of a domain while waiting for a sale — most directly the annual [domain renewal](/en/glossary/domain-renewal/) fee charged by the registrar, which for a standard .com runs roughly $10–15 per year per name. For a large [domain portfolio](/en/glossary/domain-portfolio/) of thousands of names, holding costs compound into a significant annual expense that erodes returns if names do not sell. The economics of domaining therefore demand that an investor honestly assess whether a name's realistic sale price — and its probability of selling within a reasonable horizon — justifies continued renewal. Weak names with low [sell-through rate](/en/glossary/sell-through-rate/) potential should be dropped rather than renewed indefinitely. Premium names with higher renewal costs (some ccTLD or premium registry labels charge hundreds of dollars annually) require even stricter return analysis. On Namefi, a tokenized domain still incurs the underlying registrar renewal, but the on-chain representation can be freely transferred or listed without additional intermediary fees, keeping the cost structure lean for active traders. *Source: NameBio domain sales data.*

--- a/content/glossary/en/keyword-domain.md
+++ b/content/glossary/en/keyword-domain.md
@@ -1,0 +1,14 @@
+---
+title: Keyword Domain
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: A domain built around a valuable search keyword or phrase, valued for descriptive clarity.
+keywords: ['keyword domain', 'keyword-rich domain', 'descriptive domain', 'search keyword domain', 'SEO domain name']
+level: 1
+sources:
+  - https://www.namebio.com/
+---
+
+A **keyword domain** is a domain name built around one or more search keywords that describe a category, product, or service — think loans.com, insurance.com, or car.com — valued primarily for descriptive clarity and the commercial intent those words signal to visitors. Unlike [exact-match domains](/en/glossary/exact-match-domain/), keyword domains need not match a single query string precisely; they may combine two or three related terms. The [SEO](/en/glossary/seo/) benefit of keyword-rich names has diminished since Google's algorithm matured, but keyword domains still convert well in direct navigation, pay-per-click campaigns, and lead-generation niches where the domain itself pre-qualifies visitor intent. Pricing is assessed via [domain appraisal](/en/glossary/domain-appraisal/) using search volume data, cost-per-click rates, and [comparable sales](/en/glossary/comparable-sales/) of similar keyword names. The category's most valuable names — generic one-word .coms representing billion-dollar industries — have sold for record prices (insurance.com sold for $35.6M in 2010). Namefi's on-chain ownership layer makes high-value keyword assets easier to collateralize or fractionally hold as programmable tokens. *Source: NameBio domain sales data.*

--- a/content/glossary/en/reserve-price.md
+++ b/content/glossary/en/reserve-price.md
@@ -1,0 +1,14 @@
+---
+title: Reserve Price (Minimum Offer)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: The lowest price a seller will accept, often hidden, below which an offer or auction bid is rejected.
+keywords: ['reserve price', 'minimum offer', 'reserve bid', 'floor price', 'domain auction reserve']
+level: 1
+sources:
+  - https://www.investopedia.com/terms/r/reserveprice.asp
+---
+
+A **reserve price** is the confidential minimum sale price set by a domain seller, below which no [auction](/en/glossary/auction/) bid or negotiated offer will result in a completed transaction. In a domain auction, if bidding closes below the reserve, the name is not awarded to the highest bidder — it simply goes unsold. Most major auction platforms (GoDaddy Auctions, Sedo, NameJet) allow sellers to set a hidden reserve, so bidders see the current bid but not whether it has met the floor. A reserve that is set too high relative to market value leads to repeated no-sales and erodes credibility; a reserve set too low risks leaving money on the table. In private [buy-now-vs-make-offer](/en/glossary/buy-now-vs-make-offer/) listings, the reserve functions as the seller's internal walk-away number during negotiation, often communicated to a [domain broker](/en/glossary/domain-broker/) but not disclosed to the buyer. Namefi's smart-contract auction infrastructure can encode a reserve price directly in the contract, enforcing it automatically and transparently without requiring the seller to manually decline bids below threshold. *Source: Investopedia, Reserve Price.*

--- a/content/glossary/en/sell-through-rate.md
+++ b/content/glossary/en/sell-through-rate.md
@@ -1,0 +1,14 @@
+---
+title: Sell-Through Rate (STR)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: The share of a domain portfolio that sells in a given period — a key liquidity metric for investors.
+keywords: ['sell-through rate', 'STR', 'domain liquidity', 'portfolio performance', 'domain sales velocity']
+level: 1
+sources:
+  - https://www.namebio.com/
+---
+
+**Sell-through rate** (STR) is the percentage of names in a [domain portfolio](/en/glossary/domain-portfolio/) that actually sell within a defined period — typically a calendar year — and it serves as a practical measure of [domain liquidity](/en/glossary/domain-liquidity/) for an investor's overall book. Even large, reputable portfolios rarely achieve an STR above a few percent annually; a 2–3% sell-through on a well-curated .com portfolio is considered healthy, meaning most names must be carried for years before finding a buyer. A low STR relative to holding costs signals that a portfolio needs pruning — dropping marginal names before their renewal fees erase returns. Tracking STR alongside average sale price and holding period gives investors a clearer picture of their real return on capital deployed in the [aftermarket](/en/glossary/aftermarket/). Namefi's tokenized domain model can improve STR by opening domain assets to a broader, global pool of on-chain buyers who can acquire names without navigating traditional registrar transfer workflows. *Source: NameBio domain sales data.*

--- a/content/glossary/en/short-domain.md
+++ b/content/glossary/en/short-domain.md
@@ -1,0 +1,14 @@
+---
+title: Short / Numeric Domain (LLLL, NNNN)
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: Very short domains — three to four letters or all-digits — prized for brevity, especially in some markets.
+keywords: ['short domain', 'numeric domain', 'LLLL domain', 'NNNN domain', 'three-letter domain', 'four-letter domain']
+level: 1
+sources:
+  - https://www.namebio.com/
+---
+
+**Short domains** — particularly three-letter (LLL) and four-letter (LLLL) combinations, plus three-digit (NNN) and four-digit (NNNN) all-numeric names — are among the most consistently valued assets in domain investing, prized purely for their brevity and the ease with which they can be typed, remembered, and branded. All three-character .com combinations were registered years ago, making them available only on the [aftermarket](/en/glossary/aftermarket/), often at [premium domain](/en/glossary/premium-domain/) prices. The NNNN and NNN .com categories attract particular demand from Chinese buyers, where numeric sequences carry cultural and phonetic significance, creating a distinct sub-market with its own [domain appraisal](/en/glossary/domain-appraisal/) dynamics. While a short string offers no built-in keyword meaning, its memorability and flexibility as a [brandable domain](/en/glossary/brandable-domain/) foundation make it appealing to startups and large enterprises alike — companies like Zoom (zoom.com) and Box (box.com) built global brands on short names. Namefi tokenizes these high-value short and numeric names as on-chain NFTs, enabling atomic settlement without multi-day registrar push delays. *Source: NameBio domain sales data.*

--- a/content/glossary/en/wholesale-vs-retail.md
+++ b/content/glossary/en/wholesale-vs-retail.md
@@ -1,0 +1,14 @@
+---
+title: Wholesale vs Retail Pricing
+date: '2026-06-22'
+language: en
+tags: ['glossary']
+authors: ['namefiteam']
+description: The gap between the low price investors pay each other and the higher price an end user pays.
+keywords: ['wholesale pricing', 'retail pricing', 'domain wholesale', 'domain retail', 'investor pricing', 'end user pricing']
+level: 1
+sources:
+  - https://www.namebio.com/
+---
+
+**Wholesale vs retail pricing** captures the fundamental spread in domain investing between what one investor will pay another investor for a name and what an [end user](/en/glossary/end-user/) — a business or individual who intends to actually deploy the domain — will pay. Wholesale is the investor-to-investor floor: a domainer selling a name quickly to liquidate capital typically accepts 20–40% of what a retail end-user buyer might pay, because the buyer is pricing in their own resale risk and required return. Retail is what the name is worth to someone who needs it for a specific business purpose and has no plan to resell. The spread exists because end users derive direct economic value from the name — brand recognition, category authority, traffic — while investors only capture upside on resale. This gap is why [domain brokers](/en/glossary/domain-broker/) who reach end users generate the highest sale prices in the [aftermarket](/en/glossary/aftermarket/), and why selling into the investor community through a [registry](/en/glossary/registry/)-adjacent channel or bulk portfolio sale is a faster but lower-yield strategy. Namefi's global on-chain marketplace expands seller reach beyond the wholesale investor base toward a broader pool of potential end-user buyers. *Source: NameBio domain sales data.*

--- a/content/termbase.json
+++ b/content/termbase.json
@@ -1,4 +1,11 @@
 {
+  "aftermarket": {
+    "en": "Aftermarket (Secondary Market)",
+    "titles": {
+      "en": "Aftermarket (Secondary Market)"
+    },
+    "level": 1
+  },
   "ai-agent": {
     "en": "AI Agent",
     "titles": {
@@ -71,6 +78,20 @@
     },
     "level": 1
   },
+  "brandable-domain": {
+    "en": "Brandable Domain",
+    "titles": {
+      "en": "Brandable Domain"
+    },
+    "level": 1
+  },
+  "buy-now-vs-make-offer": {
+    "en": "Buy-Now (BIN) vs Make-Offer",
+    "titles": {
+      "en": "Buy-Now (BIN) vs Make-Offer"
+    },
+    "level": 1
+  },
   "cctld": {
     "en": "ccTLD (Country-Code Top-Level Domain)",
     "titles": {
@@ -101,6 +122,13 @@
       "zh": "抵押品",
       "ar": "الضمان",
       "hi": "कोलैटरल (गिरवी)"
+    },
+    "level": 1
+  },
+  "comparable-sales": {
+    "en": "Comparable Sales (Comps)",
+    "titles": {
+      "en": "Comparable Sales (Comps)"
     },
     "level": 1
   },
@@ -242,6 +270,20 @@
     },
     "level": 1
   },
+  "domain-appraisal": {
+    "en": "Domain Appraisal (Valuation)",
+    "titles": {
+      "en": "Domain Appraisal (Valuation)"
+    },
+    "level": 1
+  },
+  "domain-broker": {
+    "en": "Domain Broker (Brokerage)",
+    "titles": {
+      "en": "Domain Broker (Brokerage)"
+    },
+    "level": 1
+  },
   "domain-bundle": {
     "en": "Domain bundle",
     "titles": {
@@ -262,6 +304,13 @@
     },
     "level": 1
   },
+  "domain-liquidity": {
+    "en": "Liquidity",
+    "titles": {
+      "en": "Liquidity"
+    },
+    "level": 1
+  },
   "domain-ownership": {
     "en": "Domain ownership",
     "titles": {
@@ -272,6 +321,13 @@
       "zh": "域名所有权",
       "ar": "ملكية النطاق",
       "hi": "डोमेन स्वामित्व"
+    },
+    "level": 1
+  },
+  "domain-portfolio": {
+    "en": "Domain Portfolio",
+    "titles": {
+      "en": "Domain Portfolio"
     },
     "level": 1
   },
@@ -299,6 +355,20 @@
       "zh": "域名交易",
       "ar": "تداول النطاقات",
       "hi": "डोमेन ट्रेडिंग"
+    },
+    "level": 1
+  },
+  "domaining": {
+    "en": "Domaining (Domainer)",
+    "titles": {
+      "en": "Domaining (Domainer)"
+    },
+    "level": 1
+  },
+  "end-user": {
+    "en": "End User",
+    "titles": {
+      "en": "End User"
     },
     "level": 1
   },
@@ -338,6 +408,13 @@
       "zh": "托管",
       "ar": "الضمان (Escrow)",
       "hi": "एस्क्रो"
+    },
+    "level": 1
+  },
+  "exact-match-domain": {
+    "en": "Exact-Match Domain (EMD)",
+    "titles": {
+      "en": "Exact-Match Domain (EMD)"
     },
     "level": 1
   },
@@ -407,6 +484,13 @@
     },
     "level": 1
   },
+  "holding-cost": {
+    "en": "Holding / Carrying Cost",
+    "titles": {
+      "en": "Holding / Carrying Cost"
+    },
+    "level": 1
+  },
   "iana": {
     "en": "IANA (Internet Assigned Numbers Authority)",
     "titles": {
@@ -451,6 +535,13 @@
     "en": "IP Address (IPv4 / IPv6)",
     "titles": {
       "en": "IP Address (IPv4 / IPv6)"
+    },
+    "level": 1
+  },
+  "keyword-domain": {
+    "en": "Keyword Domain",
+    "titles": {
+      "en": "Keyword Domain"
     },
     "level": 1
   },
@@ -654,6 +745,13 @@
     },
     "level": 1
   },
+  "reserve-price": {
+    "en": "Reserve Price (Minimum Offer)",
+    "titles": {
+      "en": "Reserve Price (Minimum Offer)"
+    },
+    "level": 1
+  },
   "reserved-names": {
     "en": "Reserved Names (Blocked Names)",
     "titles": {
@@ -701,6 +799,13 @@
     },
     "level": 1
   },
+  "sell-through-rate": {
+    "en": "Sell-Through Rate (STR)",
+    "titles": {
+      "en": "Sell-Through Rate (STR)"
+    },
+    "level": 1
+  },
   "seo": {
     "en": "SEO (Search Engine Optimization)",
     "titles": {
@@ -711,6 +816,13 @@
       "zh": "SEO（搜索引擎优化）",
       "ar": "تحسين محركات البحث (SEO)",
       "hi": "एसईओ (सर्च इंजन ऑप्टिमाइजेशन)"
+    },
+    "level": 1
+  },
+  "short-domain": {
+    "en": "Short / Numeric Domain (LLLL, NNNN)",
+    "titles": {
+      "en": "Short / Numeric Domain (LLLL, NNNN)"
     },
     "level": 1
   },
@@ -829,6 +941,13 @@
       "zh": "WHOIS（与 RDAP）",
       "ar": "WHOIS (و RDAP)",
       "hi": "WHOIS (और RDAP)"
+    },
+    "level": 1
+  },
+  "wholesale-vs-retail": {
+    "en": "Wholesale vs Retail Pricing",
+    "titles": {
+      "en": "Wholesale vs Retail Pricing"
     },
     "level": 1
   },


### PR DESCRIPTION
## Summary / Solution

Wave 1 batch **E · Aftermarket / investing / valuation** — 17 new L1 glossary entries, the third priority category (A+B+E first). These give the investing-heavy blog corpus real definitions to link to: `aftermarket` (25 mentions), `domain-portfolio` (43), `domain-appraisal` (30), `comparable-sales` (23), `domain-broker` (23), `brandable-domain` (30), etc.

Entries: aftermarket, domain-portfolio, domaining, domain-appraisal, comparable-sales, sell-through-rate, domain-broker, end-user, brandable-domain, exact-match-domain, keyword-domain, short-domain, domain-liquidity, holding-cost, reserve-price, buy-now-vs-make-offer, wholesale-vs-retail.

Each meets the L1 bar: declarative `description` (≤155), `level:1`, canonical `sources` (NameBio for sales data, Investopedia for finance terms, Google SEO docs), house-voice paragraph with 2–4 cross-links + Namefi-tokenization angle. `termbase.json` → 94 concepts.

## Test plan
- `bun data:validate` → passes (19 pre-existing warnings, none new).
- `bun lint:mdx` → clean.
- Cross-link audit across all 17 → **0 broken** (links resolve to the 51 + Wave-1 A/B + in-batch slugs only).
- Descriptions verified ≤155; `level:1` on all.

## Claude session summary
- **Main prompts (paraphrased):** Execute `GOAL-resources-glossary-buildout.md` autonomously; per batch Bugbot green → feedback loop → admin-merge.
- **This PR (Wave 1 batch E):** authored 17 aftermarket/investing L1 entries to the locked template, audited cross-links, regenerated the termbase.
- **Redaction:** no secrets/credentials/PII.

Part of the glossary build-out (Wave 1 batch E). Builds on Wave 0 + Wave 1 A+B (#103).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only content under `content/glossary` and termbase metadata; no application or auth logic changes.
> 
> **Overview**
> Adds **17 English L1 glossary entries** for aftermarket and domain investing (e.g. `aftermarket`, `domain-portfolio`, `domain-appraisal`, `comparable-sales`, `domaining`, `brandable-domain`, `wholesale-vs-retail`), using the same frontmatter pattern as prior waves: short `description`, `level: 1`, cited `sources`, and body copy with cross-links plus a Namefi tokenization angle.
> 
> **`content/termbase.json`** is updated with matching slugs and English titles so the site termbase and link tooling can resolve these concepts (94 concepts total per the PR description).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 523278ba4dda18a7c79bbae76568355dce0e1e52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added 17 new glossary entries to provide comprehensive coverage of domain trading and investment concepts, including aftermarket dynamics, domain appraisal and valuation methods, brokerage services, liquidity factors, portfolio management strategies, pricing models (wholesale vs. retail, buy-now vs. make-offer), domain characteristics (exact-match, keyword, brandable, short/numeric), and distinctions between end-users and investors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->