### PR TITLE
ci: add translate-glossary workflow (Wave 1T)

### DIFF
--- a/.github/workflows/translate-glossary.yml
+++ b/.github/workflows/translate-glossary.yml
@@ -1,0 +1,66 @@
+name: Translate Glossary Entries
+
+# Manual-only: glossary translations run on demand (Actions → Run workflow),
+# not on every English-content merge. English-first is the workflow; translate a
+# batch deliberately after the English entries are reviewed. Mirrors
+# translate-blog.yml but runs the glossary-specific translator (path/batch mode,
+# fills missing locales, termbase-aware prompt). translate-blog.ts is blog-only.
+on:
+  workflow_dispatch:
+    inputs:
+      slugs:
+        description: 'Optional space-separated glossary slugs to translate (default: all missing).'
+        required: false
+        default: ''
+      locales:
+        description: 'Optional comma-separated target locales (default: all).'
+        required: false
+        default: ''
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  translate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run glossary translation
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GEMINI_MODEL: ${{ vars.GEMINI_MODEL || 'gemini-3.1-pro-preview' }}
+        run: |
+          ARGS=""
+          if [ -n "${{ github.event.inputs.locales }}" ]; then ARGS="$ARGS --locales=${{ github.event.inputs.locales }}"; fi
+          if [ -n "${{ github.event.inputs.slugs }}" ]; then ARGS="$ARGS ${{ github.event.inputs.slugs }}"; fi
+          bun scripts/translate-glossary.ts $ARGS
+
+      - name: Rebuild termbase
+        run: bun scripts/build-termbase.ts
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'content(glossary): auto-translate missing locales (Wave 1T)'
+          branch: 'auto-translate-glossary'
+          delete-branch: true
+          title: 'content(glossary): auto-translate missing glossary locales'
+          body: |
+            Adds missing per-locale translations for glossary entries detected in
+            `content/glossary/en`, generated with the termbase-aware glossary
+            translator, and regenerates `content/termbase.json`.
+
+            Review the per-locale **titles** (the canonical termbase terms) before
+            merging — zh and ar (Egyptian register) especially.
+          base: main


### PR DESCRIPTION
## Summary

Adds `.github/workflows/translate-glossary.yml` — a manual-dispatch workflow that runs the Wave-0a glossary translator (`scripts/translate-glossary.ts`) with the existing `GEMINI_API_KEY` secret, regenerates `content/termbase.json`, and opens an auto-PR with the new per-locale files. Mirrors the existing `translate-blog.yml` pattern; `translate-blog.ts` is blog-only and cannot translate glossary entries.

Needed to translate the 87 new Wave-1 English glossary entries into the 6 other locales (Wave 1T) at scale. Supports optional `slugs`/`locales` dispatch inputs for scoped runs.

## Test plan
- Workflow file only (no content change); `data:validate`/`lint:mdx` unaffected.
- The translator + termbase scripts it calls were shipped and hardened in #100.

## Claude session summary
- **Main prompts (paraphrased):** Execute the glossary build-out GOAL autonomously; Bugbot green → feedback loop → admin-merge per batch.
- **This PR:** add the CI workflow that drives Wave 1T translation.
- **Redaction:** no secrets in the diff (uses the repo's existing GEMINI_API_KEY secret reference).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition with no runtime app changes; uses existing secrets and writes content via a PR for human review.
> 
> **Overview**
> Adds **`.github/workflows/translate-glossary.yml`**, a **manual-only** (`workflow_dispatch`) CI job to run glossary localization at scale after English entries are reviewed.
> 
> The workflow checks out the repo, runs **`bun scripts/translate-glossary.ts`** with optional **`slugs`** and **`locales`** inputs, uses **`GEMINI_API_KEY`** (and optional **`GEMINI_MODEL`**), then **`bun scripts/build-termbase.ts`** and opens an auto-PR via **`peter-evans/create-pull-request`** on branch `auto-translate-glossary`. It follows the same pattern as **`translate-blog.yml`** but targets glossary content and termbase regeneration instead of blog posts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 298a1dd5534599ffca09bf873c46281d5886c205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated glossary translation workflow that can be manually triggered to translate glossary entries into specified locales with optional filtering by entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->