### PR TITLE
docs(skills): add content-authoring skill (writing + translation playbook + lessons)

### DIFF
--- a/.agents/skills/content-authoring/SKILL.md
+++ b/.agents/skills/content-authoring/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: content-authoring
+description: Write (draft) and translate Namefi resources content — blog posts, glossary terms, TLD pages — in namefi-resources. Use this whenever drafting new English content OR translating English content into the other locales (especially bulk batches), and before publishing. Covers the model/scale choices, the en-first drafting playbook, the per-locale translation rules, a hard-won translation error catalog (Arabic-heavy), the post-translation QA + verification workflow, and the dev-vs-prod publish cadence. Complements the authoritative rules in `.claude/rules/content.md`, the `cross-link` skill, and the `namefi-resource-images` skill.
+---
+
+# content-authoring
+
+The playbook for **drafting and translating** Namefi resources content. This is the *how-to + lessons*;
+the **authoritative rules live in [`.claude/rules/content.md`](../../../.claude/rules/content.md)** (and
+`.claude/rules/glossary.md` for glossary). When they conflict, the rules file wins — update it, then this skill.
+
+Related skills: **`cross-link`** (internal link graph), **`namefi-resource-images`** (illustrations).
+
+## Golden rules (don't relearn these the hard way)
+
+- **English is the source of truth.** Author in `en` first; translate *from English*, never language→language.
+- **Draft AND translate with Claude — never Gemini.** The Gemini tooling was deleted (`translate-blog.ts`/
+  `generate-blog.ts`, the `@google/generative-ai` dep, `translate-blog.yml`). There is no batch translate script;
+  translation is one focused Claude pass per locale.
+- **Locales are repo-defined and growing** (`en ar de es fr hi zh`, and `ta`/others are being added). Don't hardcode
+  the list — derive it from the content tree / `content.md`.
+- **Only act on Cursor Bugbot** in review; ignore CodeRabbit. Never force-push a shared branch without approval.
+
+## Model & scale (learned 2026-06-26, the expensive way)
+
+- **Use the latest Claude Sonnet (`claude-sonnet-4-6`) for drafting and translation agents — NOT Opus.** In a workflow,
+  pass `agent(prompt, { model: 'sonnet', ... })`. Sonnet is more than enough for content/translation and far cheaper.
+  A large Opus fan-out (177 translation agents) burned the Claude **session/usage limit** mid-run ("session limit ·
+  resets 1pm PT") and had to be split across the reset. Reserve Opus for orchestration/judgement, not bulk content.
+  (Codified in `content.md` → Translations § "Model:".)
+- **Throttle concurrency.** ~16 concurrent agents trips Anthropic 429s; ~7 is usually safe; the user may ask for **2**
+  to be safe. Run in sequential batches (`await parallel(pair)` per chunk) + a 3-pass retry loop for stragglers
+  (429s, "connection closed", session-limit). Expect transient failures and re-run only the failed (slug, locale) pairs.
+- **A truncated agent leaves artifacts.** A run killed mid-write can leave a partial file ending in `</content>` /
+  `</invoke>` / tool tags. Always scan after (see QA below); the body is often complete — strip the trailing tag lines
+  rather than re-translating.
+
+## Drafting (English-first)
+
+1. One Claude writer per post. Read `domain-flipping.md` (or a sibling) first for house voice.
+2. **Verify every citation** by fetching a public 200 page; use inline `#:~:text=` fragments + a
+   `## Sources and further reading`. Never ship unverified domainer claims (drop-cycle days, UDRP test, fees).
+3. Frontmatter: `title`, `date`, `language: en`, `tags`, `authors: ['namefiteam']`, `description` (≤155),
+   `keywords` (10–15), `ogImage`, + taxonomy `cluster`/`series`/`seriesOrder`/`format`.
+   **`seriesOrder` must be a positive integer (1-based)** — astra's build rejects `0`; standalone `data:validate`
+   does NOT catch it (build-only failure). Keep series order contiguous.
+4. Internal links per the `cross-link` skill. Illustrations per `namefi-resource-images`.
+
+## Translation (one Claude pass per locale)
+
+Per `content.md`. Translate FRESH from the EN source — don't read/copy the old locale file (re-translations):
+
+- Set `language: <locale>`. **Translate** `title`, `description`, `keywords`. Keep **verbatim**: `date`, `tags`,
+  `authors`, `draft`, `cluster`, `series`, `seriesOrder`, `format`, `ogImage` (image path).
+- **`ar` = modern Egyptian Arabic register** (not MSA). **`zh` titles are maintainer-reviewed** — pick the canonical
+  term deliberately from `content/termbase.json`.
+- **Internal links:** rewrite the prefix `/en/…` → `/<locale>/…`, **never change the slug**. Anchor text = the linked
+  term's canonical title in that locale (use `termbase.json`).
+- **Keep verbatim:** citation URLs (incl. `#:~:text=` fragments), code, brand/protocol/standard names (UDRP, ACPA,
+  ICANN, ENS, NFT, ERC-721, OpenSea, Seaport, Afternic, Sedo, GoDaddy, NameBio, SEO), domain names, figures/numbers/dates.
+- YAML: double an apostrophe inside single-quoted scalars (`''`), never backslash. First line must be `---`. No code
+  fences, no `<content>`/tool tags anywhere.
+
+### Translation error catalog — what actually goes wrong
+
+These are real defects caught in shipped batches. **The error rate concentrates in Arabic** (the Egyptian register is
+the hardest target); EN-derived `de/es/fr/hi/zh` came out structurally clean. So: **always run a dedicated Arabic
+accuracy QA pass after any bulk translation** (one Sonnet agent per `ar` file, diffing against the EN, fixing only clear
+errors — no restyling). Check for these classes:
+
+- **Untranslated keywords** — the `keywords:` array left byte-identical to English. Detect: compare each locale's
+  `keywords:` line to the EN line; identical ⇒ not translated. Fix: translate the human phrases, keep brand/standard
+  names. (One batch left 17 files like this; Bugbot flagged 1, a sibling scan found the other 16.)
+- **Wrong-sense word choices** (translator picked a literal but wrong meaning):
+  - "invented/fake personas" → `المخترعين` (inventors) ✗ → `الوهميين` (fictitious) ✓
+  - "squatting *profile*" (risk posture) → `ملف` (a file/document) ✗ → `وضع` (posture) ✓
+  - "domain *reseller*" → `بيع بالجملة` (wholesale) ✗ → `إعادة بيع` (reselling) ✓
+  - "end-user *premium*" → `عمولة` (commission) ✗ → `علاوة سعر` (price premium) ✓
+  - "retired" (e.g. a product) → `قاعدت` (sat) ✗ → `أوقفت` (discontinued) ✓
+- **Registrant vs registrar** — the meaning-critical pair. `registrant` = the owner (`صاحب الدومين` / `المسجَّل`, *fatha*);
+  `registrar` = the accredited company (`المسجِّل`, *kasra*). Easy to flip; check every occurrence.
+- **Meaning-inverting errors** — a negation or comparative rendered as its opposite. Highest-severity:
+  - "thinner/thinnest chance/premium" rendered `أرفع` (higher/highest) ✗ → `أضعف` (weaker/thinnest) ✓
+  - garbled "never": `تعمر ما تتصرف` (reads like the verb "you build") ✗ → `عمرك ما تتصرف` (you never act) ✓
+- **Hallucinated additions** — examples/brands invented and injected that aren't in the EN source, e.g. adding
+  "(مثل OpenSea، Blur)" to a *domain* marketplace link (OpenSea/Blur are NFT marketplaces, not domain aftermarkets).
+  Translate only what's there; never add specifics the source didn't name.
+
+## QA & verification (run after any batch, before merge)
+
+1. **Artifact scan** all touched files: first line is `---`; frontmatter parses; NO ``` fences; NO `</content>` /
+   `</invoke>` / `<parameter` / tool tags (especially the *last* lines — truncation marker); every `](/en/` rewritten
+   to `](/<locale>/`; `language:` correct; not truncated (length sanity).
+2. `TMPDIR=/private/tmp bun run data:validate` (pass + ~19 pre-existing warnings) and `bun run lint:mdx`.
+   (Fresh worktree? run `bun install` first or eslint can't resolve `@eslint/eslintrc`.)
+3. `bun .agents/skills/cross-link/link-audit.ts <paths>` → **0 broken, 0 locale-mismatch** (1 `missing-translation`
+   warning is OK — app serves the en fallback).
+4. **Dedicated Arabic accuracy QA pass** (see error catalog) — non-negotiable for bulk batches.
+5. **Bugbot handling:** it reviews a *sample/diff*, so **one flag often means several siblings** — when it flags an
+   issue, grep the rest of the corpus for the same pattern and fix them all. Reply to each thread in a human voice and
+   **resolve threads one-by-one as you fix them — never bulk-auto-resolve** (a bulk resolver once closed a thread before
+   the fix, hiding a real finding; caught only via the comment-count delta).
+
+### Verification false-positive trap (cost ~2h once — don't repeat)
+
+When verifying a **re-translation** is live (content of an existing page changed, slug unchanged), a naive
+`curl … | grep "<translated phrase>"` gives **false positives**: the *old* version (e.g. Gemini's) often shares the
+phrase, so the marker matches stale content and you wrongly conclude "deployed."
+- Derive a marker that is **provably in the new version AND absent from the prior commit**:
+  `git show <oldsha>:content/blog/<L>/<slug>.md | grep -c "<phrase>"` must be **0**, and `git show <newsha>:…` ≥ 1.
+- Cross-check `x-vercel-cache` / `age` headers and the prod release tag's submodule pin. A stale page = an old release,
+  not a failed build.
+
+## Publish & prod cadence (so "merged" ≠ "live on prod")
+
+namefi.io/r serves the `apps/resources/data` **submodule pin** in namefi-astra — see
+`[[namefi-resources-publish-pipeline]]`. Merging in namefi-resources only auto-deploys **dev**:
+- Every bump → astra `main` → `deploy-resources.yml` (push to main) deploys **dev** (`namefi.dev/r`).
+- **PROD (`namefi.io/r`) only deploys on an `astra-resources/v*` release tag** — created by the daily `0 11 * * *`
+  cron (gated by repo var `AUTO_DEPLOY_RESOURCES`) or a manual run. So an overnight merge sits on dev until ~11:00 UTC.
+- To ship prod now (a deliberate action; get explicit OK):
+  `gh workflow run release-resources.yml --repo d3servelabs/namefi-astra --ref main -f forceRelease=true`
+  → tags a release → prod deploy (~13 min end-to-end). Verify with a provably-unique marker (above).
+
+## PR & review
+
+PR body per `.rulesync` standards (Summary/Solution + Test plan + redacted Claude session summary, ISO-8601 UTC).
+Drive **Bugbot** to green (act on it, ignore CodeRabbit), then merge per repo policy. The pre-push hook can fail on a
+TTY error in non-interactive shells — run the validators by hand and `git push --no-verify`.

--- a/.claude/rules/content.md
+++ b/.claude/rules/content.md
@@ -14,6 +14,12 @@ older plan/GOAL doc, **this file wins** — update the plan, not the rule.
 > product promotion; one concept per entry; single canonical titles;
 > `also_known_as` for strict synonyms only; ≥2 specific sources.)
 
+> **Writing or translating?** The step-by-step playbook + hard-won lessons (model/scale choices, the
+> en-first drafting flow, per-locale translation rules, a translation **error catalog** [Arabic-heavy],
+> the post-batch QA + verification workflow, and the dev-vs-prod publish cadence) live in the
+> [`content-authoring`](../../.agents/skills/content-authoring/SKILL.md) skill. This file is the rules;
+> that skill is the how-to.
+
 ---
 
 ## Golden rules


### PR DESCRIPTION
## Summary / Solution

Adds a repo-specific **`content-authoring`** skill — the step-by-step playbook for **drafting and translating** Namefi resources content, with the hard-won lessons from the domain-flipping cluster re-translation baked in so they aren't relearned the hard way.

- **`.agents/skills/content-authoring/SKILL.md`** (new) — covers:
  - **Model & scale:** use latest **Sonnet (`claude-sonnet-4-6`), not Opus**, for bulk drafting/translation (a large Opus fan-out exhausted the session/usage limit mid-run); throttle concurrency + 3-pass retry for 429/limit stragglers.
  - **En-first drafting** (verify citations, frontmatter, the `seriesOrder` build-only gotcha).
  - **Per-locale translation rules** (links `/en/`→`/<locale>/`, verbatim citations/brands, `ar` = Egyptian Arabic, `termbase.json`).
  - **Translation error catalog** (the actual defects caught, Arabic-heavy): untranslated `keywords`, wrong-sense words (`المخترعين`/`ملف`/`بالجملة`), **registrant vs registrar** (`المسجِّل`/`المسجَّل`), **meaning-inverting** negations/comparatives, and **hallucinated link additions**.
  - **Post-batch QA:** artifact scan → `data:validate`/`lint:mdx` → `link-audit` → a **dedicated Arabic accuracy QA pass**; Bugbot handling (scan for siblings; reply+resolve per fix, never bulk auto-resolve).
  - **Verification false-positive trap:** verify re-translations with markers **provably unique vs the prior commit**, not naive greps.
  - **dev-vs-prod publish cadence** (dev on every bump; prod only on an `astra-resources/v*` release tag).
- **`.claude/rules/content.md`** — adds a pointer to the new skill ("this file is the rules; that skill is the how-to").

This is documentation only — no content or tooling changes.

## Test plan
- `bun run data:validate` → pass (skill/rules live outside `content/`, unaffected; only pre-existing warnings)
- `bun run lint:mdx` → clean (globs `content/**`, so `.agents/`/`.claude/` are out of scope)
- Markdown links in the skill + the content.md pointer resolve to real paths

## Claude session summary (redacted)
- **Prompt (paraphrased):** capture the translation mistakes in a skill, and start maintaining a writing + translation skill specific to namefi-resources.
- **Change:** added the `content-authoring` skill (writing + translation playbook + lessons) and cross-linked it from `content.md`.
- **Timestamp (UTC):** 2026-06-26.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes under `.agents/` and `.claude/`; no runtime, content, or tooling behavior changes.
> 
> **Overview**
> Adds a new **`content-authoring`** agent skill that documents the end-to-end playbook for drafting and translating Namefi resources content, with operational lessons from bulk re-translation work (Sonnet vs Opus, concurrency limits, truncation artifacts).
> 
> The skill spells out **en-first drafting**, per-locale translation rules, an **Arabic-heavy error catalog** (untranslated keywords, wrong-sense terms, registrant/registrar, meaning inversions, hallucinated examples), and a **post-batch QA** flow (`data:validate`, `lint:mdx`, `link-audit`, dedicated Arabic pass, Bugbot sibling scans). It also documents **prod verification** (commit-unique markers vs naive greps) and **dev vs prod** publish cadence via namefi-astra.
> 
> **`.claude/rules/content.md`** gains a short callout that this file stays authoritative for rules while the skill is the how-to.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e43b0e9a1f3d776d3a28401f993d3444d583852f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new content-authoring guide with step-by-step instructions for drafting, translating, reviewing, and publishing resource content.
  * Clarified writing vs. translating guidance so contributors know where to find the full workflow and locale-specific rules.
  * Included quality checks, link handling, formatting expectations, and release timing notes to support more consistent content updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->