### PR TITLE
docs(content): add translation completeness LQA rules

### DIFF
--- a/.agents/skills/content-authoring/SKILL.md
+++ b/.agents/skills/content-authoring/SKILL.md
@@ -58,6 +58,13 @@ Per `content.md`. Translate FRESH from the EN source — don't read/copy the old
   term's canonical title in that locale (use `termbase.json`).
 - **Keep verbatim:** citation URLs (incl. `#:~:text=` fragments), code, brand/protocol/standard names (UDRP, ACPA,
   ICANN, ENS, NFT, ERC-721, OpenSea, Seaport, Afternic, Sedo, GoDaddy, NameBio, SEO), domain names, figures/numbers/dates.
+- **Do not ship link-only localization.** A file with `language: <locale>` and localized `/en/` links but English body
+  copy is still untranslated. Translate all human-facing content: body prose, headings, image alt text, table/list
+  labels, FAQ questions/answers, disclaimers, source notes, `title`, `description`, and `keywords`.
+- **Do not collapse full English entries into short locale stubs unless the task explicitly asks for stubs.** Preserve
+  the source meaning, examples, caveats, citations, and protocol/domain details. Glossary translations must retain the
+  definition's important examples and distinctions (for example EPP status code names and registrar-vs-registry
+  differences), not just a generic one-sentence summary.
 - YAML: double an apostrophe inside single-quoted scalars (`''`), never backslash. First line must be `---`. No code
   fences, no `<content>`/tool tags anywhere.
 
@@ -91,12 +98,22 @@ errors — no restyling). Check for these classes:
 1. **Artifact scan** all touched files: first line is `---`; frontmatter parses; NO ``` fences; NO `</content>` /
    `</invoke>` / `<parameter` / tool tags (especially the *last* lines — truncation marker); every `](/en/` rewritten
    to `](/<locale>/`; `language:` correct; not truncated (length sanity).
-2. `TMPDIR=/private/tmp bun run data:validate` (pass + ~19 pre-existing warnings) and `bun run lint:mdx`.
+2. **Translation-completeness LQA** for every locale batch:
+   - Compare a deterministic ~1% sample against the English source, stratified across touched collections (`blog`,
+     `glossary`, `tld`, `partners`, `authors`). Check meaning, frontmatter, FAQ, links, images/alt text, tables, and
+     whether prose is natural in the target language.
+   - Scan for exact body copies after normalizing `/<locale>/` links back to `/en/`. Exact copies are release-blocking.
+   - Scan for high English-word ratios in non-English files; allow brand/protocol/domain names, but investigate whole
+     English sentences, English FAQ/frontmatter, or copied TLD sections.
+   - For glossary, compare body length/detail against English. Large shrinkage can mean the entry became a stub and
+     lost examples, caveats, or protocol-specific details. If a sample catches one, audit sibling entries.
+   - If one sampled file has a pattern, search the rest of the same collection/locale for that pattern before shipping.
+3. `TMPDIR=/private/tmp bun run data:validate` (pass + ~19 pre-existing warnings) and `bun run lint:mdx`.
    (Fresh worktree? run `bun install` first or eslint can't resolve `@eslint/eslintrc`.)
-3. `bun .agents/skills/cross-link/link-audit.ts <paths>` → **0 broken, 0 locale-mismatch** (1 `missing-translation`
+4. `bun .agents/skills/cross-link/link-audit.ts <paths>` → **0 broken, 0 locale-mismatch** (1 `missing-translation`
    warning is OK — app serves the en fallback).
-4. **Dedicated Arabic accuracy QA pass** (see error catalog) — non-negotiable for bulk batches.
-5. **Bugbot handling:** it reviews a *sample/diff*, so **one flag often means several siblings** — when it flags an
+5. **Dedicated Arabic accuracy QA pass** (see error catalog) — non-negotiable for bulk batches.
+6. **Bugbot handling:** it reviews a *sample/diff*, so **one flag often means several siblings** — when it flags an
    issue, grep the rest of the corpus for the same pattern and fix them all. Reply to each thread in a human voice and
    **resolve threads one-by-one as you fix them — never bulk-auto-resolve** (a bulk resolver once closed a thread before
    the fix, hiding a real finding; caught only via the comment-count delta).

--- a/.claude/rules/content.md
+++ b/.claude/rules/content.md
@@ -50,6 +50,22 @@ older plan/GOAL doc, **this file wins** — update the plan, not the rule.
   link's anchor text = the linked term's canonical title in that locale.
 - Keep verbatim: citation URLs (incl. `#:~:text=` fragments), code, brand names,
   domain names, and figures (`GoDaddy`, `ICANN`, `.com`, `$30`, `BIP-39`, …).
+- **Link-localized English is not a translation.** A translated file must localize
+  the human-facing frontmatter and body copy, not only `language:` and `/en/`
+  links. This includes `title`, `description`, `keywords`, FAQ questions/answers,
+  image alt text, headings, tables, list labels, disclaimers, and source notes.
+- **Do not compress full entries into stubs unless the task explicitly asks for
+  stubs.** Translations should preserve the source's meaning, examples,
+  caveats, citations, and domain/protocol details. Glossary entries especially
+  must not drop important protocol examples or term distinctions just because the
+  prose is shorter.
+- **Run a translation-completeness LQA before calling a locale batch done.** At
+  minimum: compare a deterministic ~1% sample against English across every
+  touched collection; scan for exact body copies after normalizing locale links;
+  scan for unusually high English-word ratio in non-English files; and compare
+  glossary body length against English to catch accidental stubs. Any sampled
+  exact-copy or stub issue means search the sibling collection for the same
+  pattern before shipping.
 
 ## Cross-linking & SEO
 


### PR DESCRIPTION
## Summary
- Add explicit translation rules that link-localized English is not acceptable localized content.
- Require translated frontmatter/body/FAQ/alt text/table/list/source-note content, not just language codes and internal link prefixes.
- Add translation-completeness LQA checks to the content-authoring skill: deterministic ~1% sample, exact-copy scan, high-English-ratio scan, and glossary shrinkage/stub audit.

## Test plan
- Pre-push hook ran `bun data:validate` successfully with existing SEO keyword warnings only.
- Pre-push hook ran `bun lint:mdx` successfully.

## Notes
- This PR intentionally changes only translation rules/playbook docs. It does not include ja/ta localized content changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to translation playbooks; no runtime, auth, or content file changes in this PR.
> 
> **Overview**
> Tightens **translation quality** rules in `content.md` and the **content-authoring** skill so locale batches cannot pass with link-only or stubbed English.
> 
> **New requirements:** localized files must translate frontmatter, body, FAQ, alt text, tables/lists, and source notes—not just `language:` and `/en/` → `/<locale>/` links. Full entries must not be compressed into short stubs unless explicitly requested; glossary entries must keep protocol examples and distinctions.
> 
> **New pre-merge LQA:** a deterministic ~1% sample vs English across touched collections, scans for exact English body copies (after normalizing links), high English-word ratios, and glossary length shrinkage; pattern hits trigger sibling audits. The skill’s QA checklist is renumbered to insert this step before `data:validate` / link-audit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d406833b24690b901e83d51fb1f4082962ac5acf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->