### PR TITLE
[codex] Clarify prod release workflow convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,15 @@ translation, cross-linking, validation, publishing). Read it before changing
 content. Drafting and translation playbooks live in the skills under
 [`.agents/skills/`](.agents/skills/).
 
+## Production releases
+
+When the user asks you to "do a prod release", "prod promotion", or similar,
+assume they mean to use the existing release/deploy GitHub Actions workflow
+checked into `.github/workflows/` for this repo or its publishing path. It is
+fine to use `gh workflow run` or `gh run watch` only to dispatch and observe that
+checked-in workflow; do not replace the workflow with ad hoc local or `gh`
+commandline release steps unless the user explicitly asks for that.
+
 ## Images — always use the `namefi-resource-images` skill
 
 **Whenever you are asked to generate or revise a cover image (OpenGraph/Twitter


### PR DESCRIPTION
## Summary

- Add an AGENTS.md production release convention for agent behavior.
- Clarify that prod release or prod promotion requests should use the existing checked-in GitHub Actions workflow for this repo or its publishing path.
- Note that gh should only be used to dispatch or observe that workflow unless explicitly requested otherwise.

## Validation

- Docs-only change; no package tests run.
- Verified the worktree is clean after commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent guidance; no runtime, deployment, or application code affected.
> 
> **Overview**
> Adds a **Production releases** section to `AGENTS.md` so coding agents handle “prod release” / “prod promotion” requests consistently.
> 
> Agents should run the existing release/deploy workflow under `.github/workflows/` (or its publishing path), and may use `gh workflow run` / `gh run watch` only to trigger and monitor that workflow—not ad hoc local or CLI release steps unless the user explicitly asks otherwise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3b8d628c6900113408ba78599b490dc9d16e0bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->