### PR TITLE
[codex] Add domain holding cost guide

### DIFF
--- a/content/blog/en/how-much-is-a-domain-understanding-holding-cost.md
+++ b/content/blog/en/how-much-is-a-domain-understanding-holding-cost.md
@@ -1,0 +1,156 @@
+---
+title: "How Much Is a Domain? Understanding the Holding Cost"
+date: '2026-06-29'
+language: en
+tags: ['domains', 'domain-investing', 'domain-pricing', 'guide']
+authors: ['namefiteam']
+draft: false
+cluster: domain-investing
+series: domain-flipping-skills
+seriesOrder: 41
+format: guide
+description: "A practical guide to domain holding cost: first-year price, renewal, transfer, restore fees, privacy, taxes, payment methods, and registrar pricing models."
+keywords: ['how much is a domain', 'domain holding cost', 'domain renewal cost', 'domain registration price', 'domain transfer fee', 'domain restore fee', 'domain privacy cost', 'registrar pricing', 'first year domain price', 'domain renewal price', 'domain redemption fee', 'domain pricing model', 'domain total cost', 'domain ownership cost', 'domain carrying cost']
+relatedArticles:
+  - /en/blog/domain-renewal-costs-and-sell-through-rate/
+  - /en/blog/domain-portfolio-management/
+  - /en/blog/when-to-drop-a-domain/
+  - /en/blog/domain-flipping/
+  - /en/blog/taxes-and-accounting-for-domain-investors/
+relatedTopics:
+  - /en/topics/domain-investing/
+  - /en/topics/domain-basics/
+relatedSeries:
+  - /en/series/domain-flipping-skills/
+  - /en/series/domain-investor-field-guide/
+relatedGlossary:
+  - /en/glossary/holding-cost/
+  - /en/glossary/domain-renewal/
+  - /en/glossary/registrar/
+  - /en/glossary/registry/
+  - /en/glossary/retail-pricing/
+---
+
+The cheapest domain is rarely the cheapest domain to *hold*.
+
+That is the first thing to understand before you register a name. The checkout price is only one line in the ledger. A domain has a first-year registration price, a renewal price, a transfer price, possible restore or redemption fees, privacy settings, taxes, payment-method costs, and sometimes surrounding product fees for DNS, email, hosting, or account services.
+
+That is why a $1 first-year domain can be perfectly legitimate and still become a $30, $60, or $80 annual commitment later. The first-year price gets you in the door. The renewal price is what decides the long-term [holding cost](/en/glossary/holding-cost/).
+
+## The number you see first is not the cost
+
+Most people ask "how much is a domain?" and expect one answer. A better question is: "What will this name cost if I keep it for three years and something goes wrong once?"
+
+Here is the cost stack.
+
+| Cost | What it means | Why it matters |
+| --- | --- | --- |
+| First-year registration | The price to register an available name for the first term | This is where promotions usually appear |
+| Renewal | The recurring price to keep the domain after the first term | This is the real long-term cost |
+| Transfer | The price to move the name to another registrar | It may differ from renewal and may extend the term |
+| Restore / redemption | The fee to recover a name after it has expired and entered a recovery window | This can be many times the annual renewal |
+| WHOIS privacy | Contact-data privacy or proxy service | It may be included, paid, unavailable, or handled differently by TLD |
+| Taxes and regulatory fees | Sales tax, VAT, GST, local fees, ICANN fees, or other checkout additions | These depend on jurisdiction, currency, and registrar |
+| Payment costs | Card foreign-exchange spread, wire costs, crypto network fees, delayed payment methods, refund friction | The registrar price may not be the exact amount that leaves your account |
+| DNS / product fees | Hosted-zone, query, email, forwarding, SSL, or bundled service costs | A domain can be cheap while the surrounding account is not |
+
+The line that trips people most often is renewal. ICANN's Expired Registration Recovery Policy requires registrars to make [renewal, post-expiration renewal, and redemption/restore fees reasonably available](https://www.icann.org/resources/pages/errp-2013-02-28-en#Notice), but the buyer still has to compare them before checkout. A low first-year number is not misleading by itself. It becomes a problem when the buyer treats it as the annual cost.
+
+## Why a $1 domain can renew at $30 to $80
+
+Introductory pricing is common because the first year and the renewal year are different economic events.
+
+The first year may be discounted because the registry or registrar wants adoption, because a promotion is running, or because the registrar expects many customers to keep the domain for multiple years. The renewal year has a different job. It has to support the ongoing registry fee, registrar margin, payment processing, fraud controls, support, compliance, renewal notifications, and whatever product layer is bundled around the name.
+
+This is normal across many industries: acquisition pricing is often lower than retention pricing. The domain-specific risk is that renewals are not optional if the name matters. If your website, email, brand, app, or portfolio depends on a domain, the renewal bill is the cost of keeping control.
+
+The practical habit is simple: before you register, write down both numbers. If the first-year price is $1 and the renewal is $40, think of the domain as a $40-per-year asset with a discounted first year, not as a $1 asset.
+
+## Registration, renewal, transfer, restore
+
+The four domain operations to compare are registration, renewal, transfer, and restore.
+
+**Registration** is the first term. It is the number marketing pages emphasize because it is the easiest one to understand. A discounted first year can be useful if you are testing an idea, but it is not the right number for long-term planning.
+
+**Renewal** is the cost of continuing control. If you are registering one domain for a side project, the difference between $15 and $30 may be tolerable. If you are holding 200 names, a $15 renewal difference becomes $3,000 per year. This is why domain investors obsess over [renewal cost and sell-through rate](/en/blog/domain-renewal-costs-and-sell-through-rate/).
+
+**Transfer** is what you pay to move the domain to another registrar. A transfer may include a one-year term extension, but that is not a universal shortcut you should assume without checking. Also watch transfer locks, recent-registration limits, authorization-code handling, and whether the transfer changes your DNS or privacy settings.
+
+**Restore or redemption** is the expensive panic button. ICANN's recovery policy says gTLD registries generally must offer a [30-day Redemption Grace Period](https://www.icann.org/resources/pages/errp-2013-02-28-en#Redemption) after deletion, during which the deleted registration may be restored through the deleting registrar. During that period, recovery can cost much more than a normal renewal. The lesson is simple: auto-renew is cheaper than rescue.
+
+## Privacy, taxes, and payment method costs
+
+WHOIS privacy belongs in the cost comparison because it changes the practical value of the package. Some domains include privacy by default. Some make it optional. Some TLDs or registrant types may handle public contact data differently. If privacy matters to you, compare it as part of the domain cost rather than as an afterthought.
+
+Taxes and regulatory fees are less tidy. Sales tax, VAT, GST, and local rules depend on where you are, where the registrar sells from, and how the service is classified. A checkout total may differ from the advertised base price, especially across currencies or jurisdictions.
+
+Payment method can also change the real cost. A card may add foreign-exchange spread. A bank wire may carry bank fees or minimums. A local bank transfer may delay activation. A crypto payment may involve network fees, confirmation time, and refund limitations. If you are buying one inexpensive name, this may be minor. If you are buying or renewing a portfolio, payment rails become part of the operating model.
+
+## Registrar pricing models
+
+Registrars sell the same general object, but not the same experience. Comparing them only on one TLD's first-year price misses the business model.
+
+### Cost-pass-through style
+
+Some registrars position themselves around minimal markup. The appeal is obvious: if the registrar can pass through the underlying registry cost with little extra margin, the buyer may get a lower renewal price. This model tends to work best for buyers who already know what they need and do not require much support or bundling.
+
+The tradeoff is that lower markup is not the only variable. You still care about supported TLDs, account recovery, DNSSEC, bulk controls, billing controls, transfer workflows, support responsiveness, and how well the registrar fits your security model.
+
+### Infrastructure-first registrar
+
+Some registrars are attached to a broader cloud or infrastructure platform. In that model, the domain is one part of a larger system that may include hosted DNS, query charges, access controls, audit logs, infrastructure automation, health checks, and other operational services.
+
+This can be attractive for technical teams that want domains close to infrastructure and billing. It may be overkill for a casual buyer who only wants a simple domain and renewal reminder. The domain price can look reasonable while the surrounding product costs make the total bill harder to compare.
+
+### Investor-focused registrar
+
+Some registrars are optimized for domain investors and active traders. The features that matter there are bulk search, bulk renewals, portfolio exports, clear renewal columns, transfer tooling, aftermarket access, expiry controls, and account-level reporting.
+
+For investors, a small renewal difference compounds quickly. A portfolio of names renews every year whether the names sell or not. That makes the registrar's renewal table, restore fees, bulk tooling, and payment workflow more important than a pleasant one-name checkout.
+
+### Consumer retail registrar
+
+Consumer retail registrars optimize for a broader buyer: small businesses, creators, local services, side projects, first-time domain owners, and teams that want support and adjacent products. The value may be a simpler search flow, reminders, customer support, privacy handling, email or hosting integrations, website tools, or easier account recovery.
+
+Retail pricing is not automatically bad. The fair comparison is not "who has the lowest first-year price on one TLD?" It is "what will this registrar cost me over the life of the domain, and does the service layer justify the difference?"
+
+### Marketplace and productized registrar experience
+
+Some registrar experiences are built around domains as assets, not just domains as checkout items. That can include listings, transfers, ownership verification, financing, portfolio views, tokenized ownership, marketplace settlement, or domain handoff workflows.
+
+The product layer can be useful, but it does not replace the basic cost check. A productized experience still has first-year pricing, renewal pricing, transfer rules, restore risk, privacy settings, taxes, and payment flows. The extra features are valuable only if the total holding cost still makes sense for the name.
+
+## What to compare before choosing a registrar
+
+Use this checklist before registering a name you intend to keep.
+
+1. What is the first-year price?
+2. What is the renewal price after the first term?
+3. Is the name standard-price or premium-price?
+4. Is WHOIS privacy included, optional, or unavailable?
+5. What is the transfer-in price and does it extend the term?
+6. What is the restore or redemption fee if the domain expires?
+7. What happens after expiration: notices, grace period, DNS interruption, auction, redemption, pending delete?
+8. Are taxes or local regulatory fees added at checkout?
+9. Which payment methods are supported, and do they create extra cost, delay, or refund friction?
+10. Are DNS, hosted zones, email, forwarding, SSL, or security products separate costs?
+11. How easy is it to export, transfer, recover, or hand off the domain?
+12. If you hold many domains, can you bulk renew, tag, filter, export, and forecast the portfolio?
+
+For one personal project, the answer may be "pick the registrar you trust and keep auto-renew on." For a brand, the answer may be "pay more for better support and account security." For an investor, the answer may be "optimize renewal cost ruthlessly because the portfolio renews whether it sells or not."
+
+## The practical answer
+
+So, how much is a domain?
+
+For a common TLD, it may be roughly the price of lunch for the first year. For a promoted new gTLD, it may be $1 today and $30 to $80 next year. For a high-priced ccTLD or premium registry tier, it may be much more. If you miss the renewal and have to restore it, the bill can jump into the hundreds.
+
+The practical answer is not the first-year price. It is:
+
+> **Domain holding cost = registration + renewals + transfers + restore risk + privacy + taxes + payment costs + surrounding product fees.**
+
+That is the number to compare. A domain is not expensive because the first year costs $60, and it is not cheap because the first year costs $1. It is cheap or expensive based on the cost of keeping control for as long as the name matters.
+
+## Sources and further reading
+
+- ICANN — [Expired Registration Recovery Policy](https://www.icann.org/resources/pages/errp-2013-02-28-en)


### PR DESCRIPTION
## Summary / Solution

Adds a new English Namefi Resources blog draft, `How Much Is a Domain? Understanding the Holding Cost`, explaining domain holding cost across first-year registration, renewal, transfer, restore/redemption, privacy, taxes, payment-method costs, and surrounding product fees.

The article now avoids mentioning individual registrars or brand-specific pricing sources. It explains registrar pricing models generically: cost-pass-through style, infrastructure-first registrar, investor-focused registrar, consumer retail registrar, and marketplace/productized registrar experiences. The piece stays neutral and conceptual, with ICANN lifecycle policy used for the restore/redemption citation.

## Test plan

- `bun run data:validate` passed with 29 pre-existing keyword warnings
- `bun run lint:mdx` passed
- `bun .agents/skills/cross-link/link-audit.ts content/blog/en/how-much-is-a-domain-understanding-holding-cost.md` passed with `0 broken, 0 locale-mismatch, 0 missing-translation, 0 cross-locale fallback`
- Brand/source scan for named registrars and prior pricing-artifact terms returned no matches
- Pre-push hook reran `data_validate` and `lint_mdx` successfully

## Claude session summary

Authored by Codex. Synced `namefi-resources/main`, created fresh worktree `namefi-resources/.worktrees/domain-holding-cost` from `origin/main`, read only the provided Astra pricing artifacts for background context, drafted one new English blog post, revised it to remove named registrar mentions, validated the content, committed, and pushed branch `codex/domain-holding-cost`. No deploy or Astra edits performed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only addition with no application or infrastructure changes; editorial risk is limited to factual/policy claims, which are anchored to ICANN sources and neutral registrar framing.
> 
> **Overview**
> Adds a new English blog post, **How Much Is a Domain? Understanding the Holding Cost**, as `seriesOrder: 41` in the `domain-flipping-skills` series (`domain-investing` cluster).
> 
> The guide reframes “domain price” around **holding cost**: first-year vs renewal pricing, transfer and restore/redemption, privacy, taxes, payment friction, and bundled DNS/product fees, with ICANN ERRP citations for disclosure and redemption windows. It explains why promo first-year pricing can diverge sharply from renewals, and walks through **generic registrar pricing models** (cost-pass-through, infrastructure-first, investor-focused, consumer retail, marketplace/productized) without naming specific brands.
> 
> Front matter wires the piece to related articles (e.g. renewal/sell-through, portfolio management), topics, series, and glossary entries (`holding-cost`, `domain-renewal`, `registrar`, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7d89ffaa269b916efaf3a11afd63a940db0e49c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->