### PR TITLE
chore(cross-link): audit the Tamil (ta) locale

### DIFF
--- a/.agents/skills/cross-link/link-audit.ts
+++ b/.agents/skills/cross-link/link-audit.ts
@@ -58,7 +58,10 @@
 import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
-const LOCALES = ['en', 'es', 'de', 'fr', 'zh', 'ar', 'hi', 'ko', 'ja'] as const;
+// Must mirror `i18n.locales` in apps/resources/src/i18n-config.ts (the astra
+// renderer): a locale the renderer serves but this list omits is silently
+// skipped by the audit (its files never checked, and links into it invisible).
+const LOCALES = ['en', 'es', 'de', 'fr', 'zh', 'ar', 'hi', 'ko', 'ja', 'ta'] as const;
 // Mirrors i18n.defaultLocale in apps/resources: the locale every other locale
 // falls back to at runtime when it lacks a slug. A link the default locale can
 // satisfy is never a hard 404.


### PR DESCRIPTION
## Summary

The cross-link link auditor didn't know about the **Tamil (`ta`)** locale. `link-audit.ts` hard-codes `const LOCALES = ['en','es','de','fr','zh','ar','hi','ko','ja']` — `ta` was missing, even though [PR #154](https://github.com/d3servelabs/namefi-resources/pull/154) started Tamil content (`content/{glossary,tld,blog}/ta/`).

Consequences of the gap:
- **`ta` files were skipped entirely** — `localeOfFile()` returns `'ta'`, which isn't in `LOCALES`, so the per-file loop hit `continue` and never audited them.
- **Links pointing to `/ta/...` from any locale were invisible** — `LINK_RE` is built from `LOCALES`, so a `/ta/...` href didn't even match.

Since [PR #152](https://github.com/d3servelabs/namefi-resources/pull/152) wired `bun links:audit` into CI (`.github/workflows/validate.yml`) **and** the pre-push hook, that was a real, silent coverage gap for the in-progress Tamil batch.

## Solution

Add `'ta'` to `LOCALES` so Tamil is audited like every other locale, plus a comment pinning `LOCALES` to the renderer's `i18n-config` to stop this drift recurring.

### Is this consistent with the renderer?
Yes. The astra resources renderer at `apps/resources/src/i18n-config.ts` (on `d3servelabs/namefi-astra@origin/main`) **already lists `ta`**:
```ts
locales: ['en', 'es', 'de', 'fr', 'zh', 'ar', 'hi', 'ko', 'ja', 'ta'],
```
…with full `localeDirections`/`localeLabels`/`localeDateLocales` entries (`ta: 'ltr' / 'தமிழ்' / 'ta-IN'`). So the renderer serves `ta` pages today; the auditor was the only place still behind. This change brings the two back in sync.

### Does adding `ta` turn CI red on the partial Tamil content?
**No.** Full-repo audit with `ta` added:
```
Audited 3374 file(s): 0 broken, 0 missing-locale, 0 locale-mismatch,
107 missing-translation, 125 cross-locale fallback.   (exit 0)
```
Only `BROKEN` and `MISSING_LOCALE` fail the run (exit 1). The 107 new `ta` findings are all `MISSING_TRANSLATION` (warnings): `ta` pages linking to not-yet-translated `ta` targets, which the app renders via the `en` fallback (a 200, not a 404). These never affect the exit code, so adding `ta` is safe **now** and does **not** block the in-progress Tamil translation. The warnings will clear naturally as the Tamil batch completes.

Because there's no red CI to weigh against the partial batch, no hold-off / maintainer fork-in-the-road was needed (option (a) vs (b) in the task): we simply add `ta`.

## Test plan

All run from the repo root:
- `bun test ./.agents/skills/cross-link/link-audit.test.ts` → **7 pass, 0 fail** (the `--fix`/prefix-collision regression suite uses its own scaffolded `en`/`zh` tree, unaffected by the `LOCALES` change).
- `bun links:audit` (full repo) → **exit 0** (0 broken, 0 missing-locale, 0 locale-mismatch).
- `bun data:validate` → **exit 0** (29 pre-existing "empty keywords" SEO warnings only).
- `bun lint:mdx` → **exit 0** (clean; pre-push hook also re-ran it green).

## Claude session summary

- `2026-06-28T00:00Z` — Created worktree `chore/cross-link-add-ta` off freshly-fetched `origin/main`.
- Confirmed the gap: `ta` content footprint = glossary 143, tld 19, blog 3 files; `ta` absent from `LOCALES`.
- Verified astra `apps/resources/src/i18n-config.ts@origin/main` already lists `ta` in `i18n.locales` → renderer is ahead of the auditor.
- Added `'ta'` to `LOCALES` (+ invariant comment), ran the full-repo audit: exit 0, only `MISSING_TRANSLATION`/`CROSS_LOCALE` warnings for `ta` → CI stays green.
- Validated with the unit tests + `data:validate` + `lint:mdx`; all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant and comment in the audit script; no runtime or auth changes, and full-repo audit remains exit 0 per the PR test plan.
> 
> **Overview**
> **Adds Tamil (`ta`) to the cross-link auditor’s `LOCALES` list** so CI/pre-push `bun links:audit` covers the same locales the resources renderer serves.
> 
> Without `ta`, Tamil markdown under `content/*/ta/` was skipped in the per-file loop, and `](/ta/...)` hrefs did not match `LINK_RE`, so Tamil was a silent audit gap.
> 
> A short comment documents that **`LOCALES` must stay aligned with `i18n.locales` in `apps/resources/src/i18n-config.ts`** to avoid future drift. Existing `MISSING_TRANSLATION` warnings for partial Tamil content still do not fail the run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44c6d5c463250c40e37ab6bfaa7f17730b71fefc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->