### PR TITLE
docs(translation): add locale-convention + authoritative-terminology principle

### DIFF
--- a/.agents/skills/article-translation/SKILL.md
+++ b/.agents/skills/article-translation/SKILL.md
@@ -83,6 +83,20 @@ consistency checks don't false-flag legitimate word forms. Set a style profile: 
 address style, brand posture, and a **local SEO posture (natural target-language search phrases over literal
 English)**.
 
+**Establish the locale's borrowing convention** before drafting: for each foreign term decide between (a) a
+native translation, (b) transliteration into the **native script**, or (c) keeping it verbatim in the source
+script. Locales differ in how aggressively they nativise, and product-UI register differs from casual/social
+text. The default that matches well-localized major apps (Apple / Google / Meta): translate ordinary words that
+have a native term, transliterate entrenched borrowings into the native script (don't leave a common word in the
+source script mid-sentence), and keep verbatim only brand/product names and global standard acronyms/tickers/codes
+(the locale's analog of how those apps keep `Wi-Fi`/`USB`/`Bluetooth` while translating everything around them).
+**Ground specific renderings in an authoritative, locale-maintained terminology source** — the **Microsoft
+Language Portal** (publicly searchable per-language terminology) first, then Apple/Google style guides, CLDR, and
+the product's own already-localized strings — checking the language generally, the term's class, and the exact
+term. Use these as guidance, not gospel (coverage thins for low-resource languages; the source carries its own
+product flavour); reconcile with the product's register, and let native-LQA be the final arbiter. Persist the
+resolved choices in the working glossary / `termbase.json` so each term is decided once and reused.
+
 ### 5. Segmentation & mapping
 Assign stable IDs to source units (frontmatter fields, headings, paragraphs, list items, table rows/cells,
 FAQ Q/A, image alt text, blockquotes, source blocks, MDX visible text). Segment IDs are a **review and

--- a/.claude/rules/content.md
+++ b/.claude/rules/content.md
@@ -58,6 +58,20 @@ older plan/GOAL doc, **this file wins** — update the plan, not the rule.
   when a native reviewer validates a term correction, record it as a forbidden →
   preferred entry in the [`article-translation`](../../.agents/skills/article-translation/SKILL.md)
   skill's per-locale error catalog so it is enforced site-wide, not re-litigated.
+- **Establish the locale's borrowing convention first, and ground terms in
+  authoritative precedent.** Each foreign term is resolved one of three ways —
+  translate to a native word, transliterate into the **native script**, or keep it
+  verbatim in the source script — and locales differ in how far they nativise (and
+  product-UI register differs from casual/social text). Default: translate ordinary
+  words that have a native term, transliterate entrenched borrowings into the native
+  script (don't leave them in the source script), and keep verbatim only brand/product
+  names and global standard acronyms/tickers/codes. Resolve specific terms against an
+  **authoritative, locale-maintained terminology source** — the **Microsoft Language
+  Portal** (publicly searchable per-language terminology) first, plus Apple/Google
+  style guides, CLDR, and the product's own existing localized strings — checking the
+  language generally, the term's class, and the exact term. Use as guidance, not
+  gospel (coverage thins for low-resource languages); reconcile with the product's
+  register, and native-LQA stays the final arbiter.
 - Rewrite internal links `/en/…` → `/<locale>/…`; **never change the slug**. A
   link's anchor text = the linked term's canonical title in that locale.
 - Keep verbatim: citation URLs (incl. `#:~:text=` fragments), code, brand names,


### PR DESCRIPTION
## Summary / Solution

Generalizes the next translation lesson (from the Tamil register discussion) into the shared guidance — **fully locale-agnostic**, building on the principles merged in #157.

Two additions:
1. **Establish the locale's borrowing convention first.** Every foreign term is resolved one of three ways — (a) translate to a native word, (b) transliterate into the **native script**, or (c) keep verbatim in the source script. Locales differ in how aggressively they nativise, and product-UI register differs from casual text. Default mirrors well-localized major apps (Apple/Google/Meta): translate ordinary words with a native term, native-script the entrenched borrowings, keep verbatim only brand/product names + global standard acronyms/tickers/codes (their `Wi-Fi`/`USB` pattern).
2. **Ground specific terms in an authoritative, locale-maintained terminology source** — the **Microsoft Language Portal** first, plus Apple/Google style guides, CLDR, and the product's own existing strings — checking the language generally, the term's class, and the exact term. Used as *guidance, not gospel* (coverage thins for low-resource languages); native-LQA stays the final arbiter. Resolved choices persist in the working glossary/termbase so each term is decided once and reused.

Placement mirrors #157: `content.md` (Translations §) gets the concise rule; the `article-translation` skill (workflow step 4, Glossary & style setup) gets the fuller method. **No specific locale named.**

## Test plan
Docs-only (rules + skill markdown). No content/code touched.

## Claude session summary
- Prompt (paraphrased): is 'establish the locale's transliterate/native/Latin convention + consult Microsoft Language Portal' a good general translation principle? Yes — refined and encoded it, general (not locale-specific).
- No secrets/PII.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to translation rules and skill markdown; no runtime code or content files.
> 
> **Overview**
> Adds **locale-agnostic** translation guidance in two places (same split as #157): a concise rule in `.claude/rules/content.md` **Translations** and the fuller workflow text in the `article-translation` skill at **step 4 (Glossary & style setup)**.
> 
> Translators must **set the locale’s borrowing convention before drafting**: each foreign term is either a native translation, **transliteration in the native script**, or verbatim in the source script, with a default aligned to major localized apps (native ordinary words, native-script entrenched borrowings, verbatim only brands and global acronyms/tickers/codes).
> 
> **Specific renderings** should be checked against authoritative locale terminology (**Microsoft Language Portal** first, then Apple/Google guides, CLDR, and existing product strings), treated as guidance not gospel, with native LQA final and decisions **persisted in the working glossary / `termbase.json`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bdd78a7db206615d5c118abba93ba81e04c9dee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->