### PR TITLE
docs(translation): fix dead terminology-source reference (Language Portal → Microsoft Terminology)

### DIFF
--- a/.agents/skills/article-translation/SKILL.md
+++ b/.agents/skills/article-translation/SKILL.md
@@ -90,8 +90,9 @@ text. The default that matches well-localized major apps (Apple / Google / Meta)
 have a native term, transliterate entrenched borrowings into the native script (don't leave a common word in the
 source script mid-sentence), and keep verbatim only brand/product names and global standard acronyms/tickers/codes
 (the locale's analog of how those apps keep `Wi-Fi`/`USB`/`Bluetooth` while translating everything around them).
-**Ground specific renderings in an authoritative, locale-maintained terminology source** — the **Microsoft
-Language Portal** (publicly searchable per-language terminology) first, then Apple/Google style guides, CLDR, and
+**Ground specific renderings in an authoritative, locale-maintained terminology source** — **Microsoft
+Terminology** (a Terminology Search + downloadable `.tbx` on Microsoft Learn; the former *Language Portal* is
+retired) first, then Apple/Google style guides, CLDR, and
 the product's own already-localized strings — checking the language generally, the term's class, and the exact
 term. Use these as guidance, not gospel (coverage thins for low-resource languages; the source carries its own
 product flavour); reconcile with the product's register, and let native-LQA be the final arbiter. Persist the

--- a/.claude/rules/content.md
+++ b/.claude/rules/content.md
@@ -66,8 +66,9 @@ older plan/GOAL doc, **this file wins** — update the plan, not the rule.
   words that have a native term, transliterate entrenched borrowings into the native
   script (don't leave them in the source script), and keep verbatim only brand/product
   names and global standard acronyms/tickers/codes. Resolve specific terms against an
-  **authoritative, locale-maintained terminology source** — the **Microsoft Language
-  Portal** (publicly searchable per-language terminology) first, plus Apple/Google
+  **authoritative, locale-maintained terminology source** — **Microsoft Terminology**
+  (a Terminology Search + downloadable `.tbx` on Microsoft Learn; the former *Language
+  Portal* is retired) first, plus Apple/Google
   style guides, CLDR, and the product's own existing localized strings — checking the
   language generally, the term's class, and the exact term. Use as guidance, not
   gospel (coverage thins for low-resource languages); reconcile with the product's


### PR DESCRIPTION
## Summary / Solution

Follow-up to #158. The **Microsoft Language Portal was retired (~2023)**; its terminology now lives as **Microsoft Terminology** on Microsoft Learn — a [Terminology Search](https://learn.microsoft.com/en-us/globalization/reference/microsoft-terminology) plus a downloadable `.tbx` collection. This updates the reference (added in #158) in both `.claude/rules/content.md` and the `article-translation` skill so translators are pointed at a live resource.

Surfaced by *exercising* the principle — looking up `beta`/`registrar` for Tamil hit the dead portal. Docs-only.

## Test plan
Docs-only (rules + skill markdown). No content/code touched.

## Claude session summary
- Prompt (paraphrased): exercise the new principle (look up borderline terms on the Microsoft Language Portal) — discovered the portal is retired, so patch the guideline's reference.
- No secrets/PII.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only guidance updates with no runtime, content, or security impact.
> 
> **Overview**
> Replaces the retired **Microsoft Language Portal** with **Microsoft Terminology** on Microsoft Learn as the first authoritative terminology source in translation guidance.
> 
> The same wording is applied in `.claude/rules/content.md` and `.agents/skills/article-translation/SKILL.md`: Terminology Search plus a downloadable `.tbx`, with an explicit note that the old portal is retired. No workflow or borrowing rules change—only where translators are told to look up terms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26d68075cd92ab573f7b21f3dabe1e4b95d1bdc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->