### PR TITLE
fix(content): strip trailing agent-tool markup from 6 published pages

### DIFF
--- a/content/blog/en/avoiding-domain-sale-scams.md
+++ b/content/blog/en/avoiding-domain-sale-scams.md
@@ -114,5 +114,3 @@ Most of this guide is about defending the moment of handover — proving payment
 - Wikipedia — [Chargeback (definition and how a chargeback reverses a payment)](https://en.wikipedia.org/wiki/Chargeback#:~:text=A%20chargeback%20is%20a%20return%20of%20money%20to%20a%20payer)
 - Wikipedia — [Domain name transfer (EPP auth code, ~5-day transfer, 30-day lock)](https://en.wikipedia.org/wiki/Domain_name_transfer#:~:text=obtains%20the%20authentication%20code%20%28EPP%20transfer%20code%29)
 - Namefi resources — [Domain escrow explained](/en/blog/domain-escrow-explained/) · [How to sell a domain name you own](/en/blog/how-to-sell-a-domain-name-you-own/) · [How domain hijacking actually happens](/en/blog/how-domain-hijacking-actually-happens/)
-</content>
-</invoke>

--- a/content/blog/en/domain-parking-and-monetization.md
+++ b/content/blog/en/domain-parking-and-monetization.md
@@ -99,5 +99,3 @@ This is the gap [Namefi](https://namefi.io) is built to narrow. Tokenized owners
 - Wikipedia — [Domain name speculation (PPC revenue from parked domains; registrar parking systems)](https://en.wikipedia.org/wiki/Domain_name_speculation#:~:text=The%20ease%20with%20which%20PPC%20revenue%20could%20be%20derived%20from%20parked%20domains)
 - Wikipedia — [Domain name registrar (10-year max gTLD term; retail `.com` renewal pricing)](https://en.wikipedia.org/wiki/Domain_name_registrar#:~:text=The%20maximum%20period%20of%20registration%20for%20a%20gTLD%20domain%20name%20is%2010%20years)
 - SIDN — [Voice.com sold for USD 30 million (Block.one, 2019)](https://www.sidn.nl/en/news-and-blogs/voice-com-sold-for-usd-30-million#:~:text=blockchain%20provider%20Block.one%20paid%2030%20million%20US%20dollars%20for%20the%20domain%20name%20voice.com)
-</content>
-</invoke>

--- a/content/blog/en/domain-renewal-costs-and-sell-through-rate.md
+++ b/content/blog/en/domain-renewal-costs-and-sell-through-rate.md
@@ -110,5 +110,3 @@ The economics above decide *whether* to hold a name. The other half of every fli
 - Wikipedia — [Domain drop catching (redemption window of ~30–90 days; 5-day pending-delete phase)](https://en.wikipedia.org/wiki/Domain_drop_catching#:~:text=usually%20around%2030%20to%2090%20days)
 - Domain Name Wire — [Verisign .com wholesale price increase to $10.26 (7% annual cap under the registry contract)](https://domainnamewire.com/2024/02/08/verisign-announces-com-price-hike-to-10-26/#:~:text=charges%20registrars%20%249.59%20per%20year%20for%20.com%20registrations.%20That%20will%20increase%20to%20%2410.26)
 - Wikipedia — [Domain name speculation (parking and PPC revenue share on unused domains)](https://en.wikipedia.org/wiki/Domain_name_speculation#:~:text=allow%20unused%20domains%20to%20be%20parked%20with%20the%20registrant%20receiving%20a%20share%20of%20the%20PPC%20revenue)
-</content>
-</invoke>

--- a/content/blog/en/how-to-read-comparable-domain-sales.md
+++ b/content/blog/en/how-to-read-comparable-domain-sales.md
@@ -115,5 +115,3 @@ This is the gap [Namefi](https://namefi.io) is built to narrow. Tokenizing a rea
 - GoDaddy — [Domain Name Value & Appraisal tool](https://www.godaddy.com/resources/skills/godaddy-domain-name-value-appraisal-tool#:~:text=algorithm%20uses%20proprietary%20machine%20learning%20and%20real%20market%20sales%20data%20to%20estimate%20domain%20values) (machine learning + real market sales data; provides comparable sales)
 - GlobeNewswire — [QuinStreet Announces Acquisition of CarInsurance.com, Inc.](https://www.globenewswire.com/news-release/2010/11/08/433738/12254/en/QuinStreet-Announces-Acquisition-of-CarInsurance-com-Inc.html#:~:text=for%20%2449.7%20million%20in%20cash) ($49.7M cash, 2010)
 - Domain Name Wire — [QuinStreet Bought CarInsurance.com for the Organic Traffic](https://domainnamewire.com/2010/11/09/quinstreet-bought-carinsurance-com-for-the-organic-traffic/#:~:text=the%20value%20comes%20primarily%20from%20the%20organic%20traffic)
-</content>
-</invoke>

--- a/content/blog/en/inbound-vs-outbound-domain-sales.md
+++ b/content/blog/en/inbound-vs-outbound-domain-sales.md
@@ -122,5 +122,3 @@ This is the gap [Namefi](https://namefi.io) is built to narrow. Tokenized owners
 - Wikipedia — [Domain name speculation (definition of domaining)](https://en.wikipedia.org/wiki/Domain_name_speculation#:~:text=is%20the%20practice%20of%20identifying%20and%20registering%20or%20acquiring%20generic%20Internet%20domain%20names%20as%20an%20investment)
 - Wikipedia — [Uniform Domain-Name Dispute-Resolution Policy (the three elements of a UDRP claim)](https://en.wikipedia.org/wiki/Uniform_Domain-Name_Dispute-Resolution_Policy#:~:text=identical%20or%20confusingly%20similar%20to%20a%20trademark%20or%20service%20mark)
 - Wikipedia — [Cybersquatting (definition)](https://en.wikipedia.org/wiki/Cybersquatting#:~:text=is%20the%20practice%20of%20registering%2C%20trafficking%20in%2C%20or%20using%20an%20Internet%20domain%20name%2C%20with%20a%20bad%20faith%20intent)
-</content>
-</invoke>

--- a/content/tld/en/realtor.md
+++ b/content/tld/en/realtor.md
@@ -185,5 +185,3 @@ The `.realtor` registry is operated by Real Estate Domains LLC, which is also th
 - [What is a domain?](/en/blog/what-is-domain) — the fundamentals, if you are new to domains.
 - [Domain terminology guide](/en/blog/domain-terminology-guide) — a glossary of the terms used above.
 - [ICANN](/en/glossary/icann), [registrar](/en/glossary/registrar), [DNS](/en/glossary/dns), and [DNSSEC](/en/glossary/dnssec) glossary entries.
-</content>
-</invoke>


### PR DESCRIPTION
## Summary

Six published EN pages ended with leaked agent-tool markup (`</content>` / `</invoke>`) — the truncation artifact described in `.agents/skills/content-authoring/SKILL.md` ("a killed agent can leave a file ending in `</content>` / tool tags — strip the trailing lines"). This markup was rendering (or at risk of rendering) on the live pages.

Affected files:
- `content/blog/en/avoiding-domain-sale-scams.md`
- `content/blog/en/domain-parking-and-monetization.md`
- `content/blog/en/domain-renewal-costs-and-sell-through-rate.md`
- `content/blog/en/how-to-read-comparable-domain-sales.md`
- `content/blog/en/inbound-vs-outbound-domain-sales.md`
- `content/tld/en/realtor.md` (found during the sweep, beyond the five originally reported blog posts)

## Solution

Removed only the two trailing artifact lines from each file (12 deletions total, no other changes). Each file still ends with its legitimate final content — a Sources section or related-links list.

Swept the **entire** `content/` tree — all locales (en, zh-CN, ja, ko, ar, hi, …) and all collections (blog, tld, glossary, partners) — with `grep -rn '</content>\|</invoke>\|<parameter\|antml' content/`. Only these six EN files carried the artifact; translated copies are clean.

## Test plan

- [x] `grep -rn '</content>\|</invoke>\|<parameter\|antml' content/` → no matches after the fix
- [x] Verified each file's tail: ends with legitimate content (Sources / related links), no dangling blank markup
- [x] `TMPDIR=/private/tmp bun run data:validate` → passed (29 pre-existing keyword-SEO warnings, unrelated to this change)
- [x] `bun run lint:mdx` → clean

## Session summary (redacted)

- 2026-07-10T21:31Z — Created fresh worktree `fix/strip-truncation-artifacts` off `origin/main` (fadf522d2)
- 2026-07-10T21:31Z — Swept all of `content/` for tool-markup patterns; found 6 files (5 reported blog posts + `tld/en/realtor.md`), all locales/collections otherwise clean
- 2026-07-10T21:32Z — Confirmed the artifact is exactly the trailing `</content>` + `</invoke>` lines in each file, preceded by legitimate Sources content; stripped them
- 2026-07-10T21:33Z — `bun install --frozen-lockfile`; `data:validate` passed (pre-existing warnings only); `lint:mdx` clean
- 2026-07-10T21:34Z — Committed (cb94f3e5c) and pushed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only deletions of erroneous trailing markup with no logic, routing, or data pipeline changes.
> 
> **Overview**
> Six published English pages (five blog posts and `content/tld/en/realtor.md`) had **two trailing artifact lines** left from interrupted content authoring — `</content>` and `</invoke>` — after their normal Sources or Related resources sections.
> 
> This change **deletes only those lines** (12 lines total across the six files). Article body, front matter, and legitimate closing sections are unchanged; each file still ends on its real final bullet list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb94f3e5c50174f407f677b51581b5722833a32b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->