### PR TITLE
content(fr): translate all missing English blog articles

### DIFF
--- a/content/blog/fr/blockchain-consensus-mechanisms.md
+++ b/content/blog/fr/blockchain-consensus-mechanisms.md
@@ -1,0 +1,136 @@
+---
+title: "Les principaux mécanismes de consensus des blockchains : preuve de travail, preuve d’enjeu et au-delà"
+date: '2026-07-02'
+language: fr
+tags: ['guide']
+authors: ['namefiteam']
+draft: false
+cluster: web3-foundations
+series: blockchain-concepts
+seriesOrder: 20
+format: roundup
+description: "Un guide clair des mécanismes de consensus des blockchains : preuve de travail, preuve d’enjeu, preuve d’enjeu déléguée, consensus BFT et rôle de chacun dans la sécurisation d’un réseau."
+ogImage: ../../assets/blockchain-consensus-mechanisms-og.jpg
+keywords: ["mécanismes de consensus blockchain", "mécanisme de consensus", "preuve de travail", "preuve d’enjeu", "preuve d’enjeu déléguée", "tolérance aux pannes byzantines", "Tendermint", "CometBFT", "preuve d’histoire", "preuve d’autorité", "preuve d’espace", "problème de la double dépense", "finalité de la blockchain", "The Merge d’Ethereum", "minage de Bitcoin", "validateur", "staking", "résistance Sybil", "Namefi"]
+relatedArticles:
+  - /fr/blog/blockchain-virtual-machines/
+  - /fr/blog/blockchain-scaling-approaches/
+  - /fr/blog/blockchain-cryptographic-primitives/
+  - /fr/blog/blockchain-privacy-technologies/
+  - /fr/blog/what-are-tokenized-domains/
+relatedGlossary:
+  - /fr/glossary/consensus-mechanism/
+  - /fr/glossary/proof-of-work/
+  - /fr/glossary/proof-of-stake/
+  - /fr/glossary/blockchain/
+  - /fr/glossary/ethereum/
+relatedTopics:
+  - /fr/topics/web3-foundations/
+  - /fr/topics/domain-tokenization/
+relatedSeries:
+  - /fr/series/tokenize-your-com/
+  - /fr/series/domain-flipping-skills/
+---
+
+Toute [Blockchain](/fr/glossary/blockchain/) doit répondre à une question avant qu’on puisse lui confier l’argent de quiconque : qui décide de ce qui s’est passé, et dans quel ordre ? Il n’y a ni banque, ni notaire, ni serveur central pour trancher. Un **mécanisme de consensus** est l’ensemble des règles que les participants d’un réseau suivent pour s’accorder sur un historique unique et partagé des transactions, sans tiers central et sans permettre à quiconque de dépenser deux fois la même pièce.
+
+Ce guide présente les principaux mécanismes de consensus utilisés aujourd’hui, la manière dont chacun choisit réellement le bloc suivant, ainsi que leurs compromis.
+
+---
+
+## Ce que résout réellement le consensus
+
+Deux problèmes rendent difficile l’accord décentralisé.
+
+**Le problème de la double dépense.** Dans un système numérique, une unité de valeur n’est que de la donnée, et la donnée peut être copiée. Sans arbitre, rien n’empêche quelqu’un de diffuser deux transactions contradictoires qui dépensent toutes deux la même pièce. Le livre blanc de Bitcoin formule directement l’objectif : le réseau a besoin « d’un système permettant aux participants de s’accorder sur un historique unique de l’ordre dans lequel les transactions ont été reçues », afin que le destinataire puisse être certain qu’un paiement antérieur ne soit pas annulé par un paiement ultérieur contradictoire ([livre blanc de Bitcoin](https://bitcoin.org/bitcoin.pdf)).
+
+**L’accord sans tiers central.** Dans une base de données ordinaire, la parole d’un opérateur est définitive. Dans un réseau public sans autorisation, chacun peut exécuter un nœud, proposer des transactions et tenter d’ajouter le bloc suivant, y compris des participants susceptibles de mentir, de censurer ou de réécrire l’historique. Un mécanisme de consensus doit rendre l’attaque du registre excessivement coûteuse ou autrement dissuasive, tout en restant suffisamment peu coûteux pour que les participants honnêtes puissent faire fonctionner le réseau.
+
+Chaque mécanisme ci-dessous apporte une réponse différente à la question : « qui propose le bloc suivant, et comment savoir qu’on peut lui faire confiance ? » Les deux axes les plus importants pour les comparer sont la **[résistance Sybil](/fr/glossary/consensus-mechanism/)** — ce qui empêche un attaquant de créer un nombre illimité de fausses identités afin de surpasser tous les autres au vote — et la **finalité** — la rapidité et le caractère définitif avec lesquels une transaction devient irréversible.
+
+---
+
+## Preuve de travail
+
+![Plusieurs mineurs s’affrontent pour résoudre la même énigme de hachage, l’un d’eux brandissant un bloc portant la mention « trouvé ! », tandis que des éclairs illustrent le coût énergétique élevé du minage](../../assets/blockchain-consensus-mechanisms-01-proof-of-work.jpg)
+
+La [preuve de travail](/fr/glossary/proof-of-work/) (Proof of Work, PoW) est le mécanisme introduit par Bitcoin en 2009 et celui auquel la plupart des gens pensent lorsqu’ils entendent le mot « blockchain ». Les mineurs rivalisent pour résoudre une énigme cryptographique : ils hachent à répétition les données d’un bloc candidat avec un nonce jusqu’à ce que le hachage obtenu soit inférieur à une valeur cible. La documentation pour développeurs d’Ethereum décrit simplement cette course : un mineur fait passer « de façon répétée un ensemble de données… dans une fonction mathématique » afin de trouver une solution valide avant les autres ([ethereum.org : preuve de travail](https://ethereum.org/en/developers/docs/consensus-mechanisms/pow/#:~:text=When%20racing%20to%20create%20a%20block%2C%20a%20miner%20repeatedly%20put%20a%20dataset)). Celui qui trouve en premier un hachage valide peut proposer le bloc suivant et percevoir la récompense de bloc ainsi que les frais de transaction.
+
+La **résistance Sybil** provient de l’énigme elle-même : calculer des hachages consomme de l’électricité et du matériel réels ; multiplier les identités fictives ne confère donc aucun avantage, seule la puissance de calcul brute compte. **La finalité est probabiliste.** Le livre blanc de Bitcoin indique que les nœuds étendent toujours « la chaîne la plus longue comme étant la bonne » ([livre blanc de Bitcoin](https://bitcoin.org/bitcoin.pdf)), et un destinataire gagne en confiance dans le règlement d’une transaction en attendant que des blocs supplémentaires soient minés au-dessus d’elle : chaque nouveau bloc rend la réécriture de l’historique exponentiellement plus coûteuse, mais aucun bloc isolé n’est instantanément et mathématiquement définitif.
+
+Le compromis est l’énergie. Sécuriser le réseau par des calculs ancrés dans le monde réel implique une consommation d’électricité réelle ; c’est pourquoi le minage de Bitcoin se mesure en térawattheures par an. **Exemples de chaînes :** Bitcoin, Litecoin, Dogecoin et Ethereum avant 2022.
+
+---
+
+## Preuve d’enjeu
+
+![Un validateur verrouille une pile de pièces dans un coffre comme dépôt mis en jeu, puis une roue de loterie le sélectionne pour proposer le bloc suivant, avec une étiquette d’avertissement sur la pénalisation attachée au coffre](../../assets/blockchain-consensus-mechanisms-02-proof-of-stake.jpg)
+
+La [preuve d’enjeu](/fr/glossary/proof-of-stake/) (Proof of Stake, PoS) remplace le travail de calcul par une garantie économique. Au lieu de miner, les participants font du **staking** — ils verrouillent l’actif natif du réseau — et le protocole sélectionne de manière pseudo-aléatoire un participant ayant misé des actifs pour proposer chaque bloc. Le rôle de validateur d’Ethereum fournit une bonne référence : un validateur dépose 32 ETH et exécute un logiciel client ; le protocole sélectionne ensuite aléatoirement « un validateur… pour être le proposeur de bloc à chaque créneau », tandis qu’un comité choisi au hasard parmi les autres validateurs atteste la validité de ce bloc ([ethereum.org : preuve d’enjeu](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/#:~:text=One%20validator%20is%20randomly%20selected%20to%20be%20a%20block%20proposer%20in%20every%20slot)).
+
+La **résistance Sybil** vient de l’enjeu lui-même : créer de nombreux faux validateurs revient simplement à répartir le même capital entre davantage d’identités, ce qui n’apporte aucune influence supplémentaire. Les comportements malhonnêtes, comme proposer des blocs contradictoires ou des attestations incompatibles, sont sanctionnés par le **slashing** : le protocole détruit une partie de l’enjeu du validateur fautif ([ethereum.org : preuve d’enjeu](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/#:~:text=Two%20primary%20behaviors%20can%20be%20considered%20dishonest)). Ethereum finalise les blocs par époques à l’aide d’un mécanisme de points de contrôle (Casper FFG combiné à la règle de choix de fourche LMD-GHOST), offrant des garanties de finalité plus fortes que la preuve de travail pure sans exiger un vote unique de type BFT.
+
+Le compromis principal par rapport à la preuve de travail concerne l’énergie : le staking ne requiert aucun matériel spécialisé rivalisant pour résoudre des énigmes ; ainsi, comme l’indique ethereum.org, « il n’est pas nécessaire d’utiliser beaucoup d’énergie pour des calculs de preuve de travail » ([ethereum.org : preuve d’enjeu](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/#:~:text=there%20is%20no%20need%20to%20use%20lots%20of%20energy%20on%20proof)). L’ampleur de cette économie est bien documentée : une analyse indépendante (CCRI) a conclu que la transition d’Ethereum de la PoW à la PoS en septembre 2022 — « The Merge » — avait réduit de plus de 99.988% la consommation annuelle d’électricité du réseau ([ethereum.org : consommation d’énergie](https://ethereum.org/en/energy-consumption/#:~:text=CCRI%20estimates%20that%20The%20Merge%20reduced%20Ethereum%27s%20annualized%20electricity%20consumption%20by%20more%20than%2099.988%25)). **Exemples de chaînes :** Ethereum, Cardano, Solana (qui utilise la PoS pour la sécurité économique en complément de la preuve d’histoire) et Polkadot.
+
+---
+
+## Preuve d’enjeu déléguée
+
+La preuve d’enjeu déléguée (Delegated Proof of Stake, DPoS) conserve le modèle du staking, mais y ajoute une couche électorale. Au lieu de permettre à chaque participant ayant misé des actifs de proposer individuellement des blocs, les détenteurs de jetons affectent leur enjeu par vote à un petit ensemble de **délégués** (également appelés témoins ou producteurs de blocs), et seul cet ensemble élu produit effectivement les blocs. Le poids de vote évolue avec les jetons détenus ; le secteur résume bien le mécanisme central : « le pouvoir de vote de chaque détenteur de jetons est proportionnel au nombre de jetons qu’il détient », et les élections sont continues, de sorte que les détenteurs peuvent réaffecter leurs votes ou évincer à tout moment les délégués peu performants ([Binance Academy : explication de la preuve d’enjeu déléguée](https://www.binance.com/en/academy/articles/delegated-proof-of-stake-explained)).
+
+La **résistance Sybil** repose toujours sur l’enjeu — les votes sont pondérés par les jetons détenus, et non par le nombre de comptes — mais la *production* des blocs est concentrée dans un petit comité élu plutôt qu’ouverte à tous les participants ayant misé des actifs. Cette concentration est précisément l’objectif : parce que l’ensemble actif des validateurs est restreint et connu à l’avance, les réseaux DPoS « peuvent atteindre des temps de bloc rapides, souvent bien inférieurs à trois secondes » ([Binance Academy : explication de la preuve d’enjeu déléguée](https://www.binance.com/en/academy/articles/delegated-proof-of-stake-explained)). Le compromis porte sur la décentralisation : la plupart des réseaux DPoS fonctionnent avec environ « 21 à 101 validateurs actifs », un ensemble bien plus réduit que les centaines ou milliers de validateurs habituels des réseaux PoS ouverts, et l’apathie des votants peut permettre aux mêmes délégués de s’installer durablement ([Binance Academy : explication de la preuve d’enjeu déléguée](https://www.binance.com/en/academy/articles/delegated-proof-of-stake-explained)). **Exemples de chaînes :** EOS, TRON et, sous une forme modifiée, de nombreuses premières chaînes applicatives fondées sur le Cosmos SDK.
+
+---
+
+## Consensus de type BFT (Tendermint / CometBFT, PBFT)
+
+![Un conseil de validateurs réuni autour d’une table, où plus des deux tiers lèvent des palettes vertes avec une coche pour valider instantanément un bloc affiché avec une icône de cadenas](../../assets/blockchain-consensus-mechanisms-03-bft.jpg)
+
+Le consensus tolérant aux fautes byzantines (Byzantine Fault Tolerant, BFT) adopte une approche entièrement différente : au lieu de faire la course ou de sélectionner aléatoirement un proposeur par bloc, un ensemble connu de validateurs exécute des tours de vote explicites et ne valide un bloc qu’une fois qu’une supermajorité — généralement plus des deux tiers du pouvoir de vote — l’a approuvé lors de ce même tour. **CometBFT** (le successeur de Tendermint Core, le moteur de consensus qui sous-tend le Cosmos SDK) se décrit comme réalisant la « réplication byzantine tolérante aux fautes (BFT) de machines à états (SMR) pour des machines à états finies, déterministes et arbitraires » ([documentation Cosmos : CometBFT](https://docs.cosmos.network/cometbft)) ; autrement dit, il transforme un ensemble de nœuds exploités indépendamment en un registre cohérent et répliqué, même si certains sont défaillants ou malveillants.
+
+Dans les chaînes de type Tendermint, la **résistance Sybil** est généralement apportée par-dessus le protocole au moyen du staking (les validateurs sont pondérés selon leur enjeu, comme en PoS), tandis que le protocole de vote BFT fournit la **finalité** : dès qu’un bloc recueille la supermajorité requise de signatures de validateurs dans un tour, il est validé et n’est plus susceptible d’être réorganisé comme peut l’être un bloc PoW. Cela permet un règlement rapide et concret : le Cosmos Network met en avant un règlement des transactions en moins d’une seconde entre les chaînes fondées sur CometBFT ([Cosmos Network](https://cosmos.network/#:~:text=%3C1%20second%20transaction%20settlement)), contrairement au modèle PoW où la confirmation exige d’attendre. Le compromis est que les protocoles BFT exigent que l’ensemble des validateurs soit connu et de taille limitée (la charge de communication augmente avec le nombre de validateurs), ce qui plafonne le nombre de validateurs pouvant participer directement. **Exemples de chaînes :** Cosmos Hub et d’autres chaînes Cosmos SDK (CometBFT), Binance Chain et les registres avec autorisation ou d’entreprise fondés sur le modèle original de tolérance aux fautes byzantines pratique (PBFT).
+
+---
+
+## Au-delà : preuve d’histoire, preuve d’autorité, preuve d’espace
+
+Quelques autres mécanismes complètent le paysage ; chacun résout un problème plus circonscrit plutôt que de remplacer la question centrale de la résistance Sybil.
+
+La **preuve d’histoire** (Proof of History, PoH), utilisée par Solana avec la PoS, n’est pas un mécanisme de consensus autonome, mais une horloge cryptographique. Elle insère des horodatages vérifiables directement dans la chaîne en hachant à répétition « les données des états générés précédemment », créant une séquence qui prouve le temps écoulé entre les événements sans que les validateurs aient besoin de communiquer au sujet du temps ([Solana : preuve d’histoire](https://solana.com/news/proof-of-history#:~:text=inserting%20data%20into%20the%20sequence%20by%20appending%20the%20hash%20of%20the%20data%20of%20the%20previously%20generated%20states)). En rendant le temps lui-même vérifiable, elle permet aux validateurs de traiter et de vérifier les transactions en parallèle, ce qui réduit la charge de communication qui ralentit habituellement le consensus.
+
+La **preuve d’autorité** (Proof of Authority, PoA) abandonne entièrement le coût économique et de calcul au profit de la réputation. Un ensemble fixe de validateurs connus et identifiés — des « entreprises bien connues » ou des personnes contrôlées — est chargé de produire les blocs, et les comportements fautifs sont dissuadés par la responsabilité juridique et réputationnelle plutôt que par la destruction de l’enjeu ou le gaspillage de calculs ([ethereum.org : preuve d’autorité](https://ethereum.org/en/developers/docs/consensus-mechanisms/poa/#:~:text=The%20reputation%20in%20this%20context%20is%20not%20a%20quantified%20thing)). Ce modèle échange de la décentralisation contre de la rapidité et un faible coût ; il est donc surtout utilisé sur des chaînes privées, des réseaux de test et des réseaux de développement locaux plutôt que sur des réseaux publics adversariaux.
+
+La **preuve d’espace** (et son proche parent, la preuve d’espace-temps) substitue l’espace de stockage sur disque alloué à la puissance de calcul ou à l’enjeu : les participants prouvent qu’ils ont réservé de l’espace inutilisé sur un disque dur, et le protocole leur demande périodiquement de démontrer qu’ils le détiennent toujours. Elle fournit une résistance Sybil comparable à celle de la PoW avec une empreinte énergétique beaucoup plus faible, au prix d’un besoin important en matériel de stockage. Chia en est l’exemple le plus connu.
+
+---
+
+## Comparaison des mécanismes
+
+| Mécanisme | Base de la résistance Sybil | Finalité | Coût énergétique | Décentralisation | Exemples de chaînes |
+|---|---|---|---|---|---|
+| Preuve de travail | Coût de calcul (hachage) | Probabiliste (confirmations) | Très élevé | Élevée (minage sans autorisation) | Bitcoin, Litecoin, Dogecoin |
+| Preuve d’enjeu | Enjeu économique exposé au risque | Par points de contrôle / quasi définitive au sein des époques | Très faible | Élevée (centaines de milliers de validateurs) | Ethereum, Cardano, Polkadot |
+| Preuve d’enjeu déléguée | Vote pondéré par l’enjeu pour les délégués | Rapide, quasi instantanée par producteur élu | Très faible | Plus faible (petit ensemble élu de validateurs) | EOS, TRON |
+| Type BFT (Tendermint/CometBFT, PBFT) | Enjeu ou identité autorisée + vote à supermajorité | Instantanée/déterministe une fois validée | Faible | Modérée (ensemble de validateurs limité) | Cosmos Hub, Binance Chain |
+| Preuve d’autorité | Identité/réputation contrôlée | Rapide, quasi instantanée | Très faible | Faible (petit ensemble de validateurs de confiance) | Chaînes privées/d’entreprise, réseaux de test |
+| Preuve d’espace | Capacité de stockage allouée | Probabiliste (par blocs) | Faible | Modérée (dépend du matériel de stockage) | Chia |
+
+---
+
+## Le lien avec les domaines tokenisés
+
+Les mécanismes de consensus constituent la fondation invisible de chaque [domaine tokenisé](/fr/blog/what-are-tokenized-domains/). Lorsqu’un domaine `.com`, `.ai` ou `.io` est frappé sous forme de [NFT (Jeton Non Fongible)](/fr/glossary/nft/), le registre indiquant qui possède ce jeton — ainsi que chacun de ses transferts, ventes ou renouvellements ultérieurs — n’est digne de confiance qu’à la mesure du mécanisme de consensus qui sécurise la chaîne sur laquelle il existe. Un NFT de domaine frappé sur [Ethereum](/fr/glossary/ethereum/) hérite de la finalité rapide et peu coûteuse de la PoS ainsi que d’un ensemble de validateurs comptant des centaines de milliers de membres ; le même actif sur une chaîne PoW hériterait d’une finalité probabiliste et de coûts de transaction bien plus élevés. Comprendre le mécanisme qui sous-tend une chaîne — et ce que signifient réellement ses garanties de résistance Sybil et de finalité — fait partie de l’évaluation de tout actif on-chain, y compris les domaines tokenisés.
+
+---
+
+## Sources et lectures complémentaires
+
+- [Bitcoin : un système de monnaie électronique pair à pair (livre blanc de Nakamoto)](https://bitcoin.org/bitcoin.pdf)
+- [ethereum.org — preuve de travail](https://ethereum.org/en/developers/docs/consensus-mechanisms/pow/)
+- [ethereum.org — preuve d’enjeu](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/)
+- [ethereum.org — preuve d’autorité](https://ethereum.org/en/developers/docs/consensus-mechanisms/poa/)
+- [ethereum.org — consommation d’énergie](https://ethereum.org/en/energy-consumption/)
+- [Documentation Cosmos — CometBFT](https://docs.cosmos.network/cometbft)
+- [Cosmos Network](https://cosmos.network/)
+- [Binance Academy — explication de la preuve d’enjeu déléguée](https://www.binance.com/en/academy/articles/delegated-proof-of-stake-explained)
+- [Solana — preuve d’histoire](https://solana.com/news/proof-of-history)

--- a/content/blog/fr/blockchain-cryptographic-primitives.md
+++ b/content/blog/fr/blockchain-cryptographic-primitives.md
@@ -1,0 +1,128 @@
+---
+title: "Principales primitives cryptographiques derrière chaque blockchain"
+date: '2026-07-02'
+language: fr
+tags: ['guide']
+authors: ['namefiteam']
+draft: false
+cluster: web3-foundations
+series: blockchain-concepts
+seriesOrder: 10
+format: roundup
+description: "Guide des primitives cryptographiques fondamentales qui font fonctionner les blockchains : fonctions de hachage, signatures numériques, arbres de Merkle, cryptographie sur courbes elliptiques et engagements."
+ogImage: ../../assets/blockchain-cryptographic-primitives-og.jpg
+keywords: ['cryptographie blockchain', 'primitives cryptographiques', 'fonction de hachage', 'SHA-256', 'Keccak-256', 'signature numérique', 'ECDSA', 'EdDSA', 'signature BLS', 'arbre de Merkle', 'cryptographie sur courbes elliptiques', 'secp256k1', 'schéma d’engagement', 'cryptographie post-quantique', 'cryptographie à clé publique', 'sécurité blockchain']
+relatedArticles:
+  - /fr/blog/blockchain-privacy-technologies/
+  - /fr/blog/blockchain-consensus-mechanisms/
+  - /fr/blog/blockchain-virtual-machines/
+  - /fr/blog/blockchain-scaling-approaches/
+  - /fr/blog/perfect-vs-computational-zero-knowledge/
+relatedGlossary:
+  - /fr/glossary/hash-function/
+  - /fr/glossary/digital-signature/
+  - /fr/glossary/merkle-tree/
+  - /fr/glossary/public-key/
+  - /fr/glossary/private-key/
+relatedTopics:
+  - /fr/topics/web3-foundations/
+  - /fr/topics/domain-tokenization/
+relatedSeries:
+  - /fr/series/tokenize-your-com/
+  - /fr/series/domain-flipping-skills/
+---
+
+Chaque affirmation portée par une blockchain — « cette transaction est définitive », « cette adresse possède cet actif », « cet historique n’a pas été modifié » — se ramène en définitive à une poignée de primitives cryptographiques qui effectuent des tâches étroites et clairement définies. Aucune n’est une invention des blockchains. Les fonctions de hachage, les signatures numériques et les arbres de Merkle existaient des décennies avant Bitcoin. Les blockchains les ont simplement combinés dans un système où aucune partie unique n’a besoin d’être digne de confiance pour que ces affirmations tiennent.
+
+Ce guide examine les primitives qui portent réellement cette charge : les [fonctions de hachage](/fr/glossary/hash-function/) qui servent d’empreinte aux données, les [signatures numériques](/fr/glossary/digital-signature/) qui autorisent les transactions, les [arbres de Merkle](/fr/glossary/merkle-tree/) qui rendent de très grands jeux de données vérifiables par morceaux, les mathématiques des courbes elliptiques sur lesquelles reposent ces signatures, et les schémas d’engagement — la brique qui mène aux [preuves à divulgation nulle de connaissance](/fr/glossary/zero-knowledge-proof/). Comprendre chacune d’elles est la manière la plus rapide de saisir ce qu’une blockchain fait réellement en coulisses.
+
+---
+
+## Fonctions de hachage cryptographiques (SHA-256, Keccak)
+
+![Un document introduit dans une machine de hachage produit une empreinte de taille fixe, et la modification d’une seule lettre de l’entrée produit une empreinte entièrement différente, illustrant l’effet d’avalanche](../../assets/blockchain-cryptographic-primitives-01-hash-function.jpg)
+
+Une [fonction de hachage](/fr/glossary/hash-function/) prend une entrée de taille quelconque et produit de façon déterministe une sortie de taille fixe — une « empreinte » — de sorte qu’inverser un seul bit de l’entrée bouleverse entièrement la sortie, et qu’il est infaisable en pratique de trouver deux entrées différentes qui donnent la même sortie de hachage. Cette propriété, la résistance aux collisions, permet d’utiliser un hachage comme empreinte compacte et révélatrice de toute altération, même pour des données arbitrairement volumineuses.
+
+Bitcoin utilise SHA-256 partout : les en-têtes de blocs sont chaînés en intégrant le hachage SHA256(SHA256()) de l’en-tête précédent dans chaque nouvel en-tête ; modifier un bloc passé change donc son hachage et invalide chaque en-tête qui le suit ([Bitcoin Developer Guide](https://developer.bitcoin.org/devguide/block_chain.html#:~:text=Each%20block%20also%20stores%20the%20hash%20of%20the%20previous%20block%27s%20header%2C%20chaining%20the%20blocks%20together)). Cette même construction à double SHA-256 hache les transactions dans l’[arbre de Merkle](/fr/glossary/merkle-tree/) du bloc ([référence Bitcoin.org](https://developer.bitcoin.org/reference/block_chain.html#:~:text=A%20SHA256%28SHA256%28%29%29%20hash%20in%20internal%20byte%20order)).
+
+Ethereum standardise plutôt Keccak-256 (la soumission Keccak d’origine, distincte de la norme SHA-3 du NIST publiée plus tard) comme fonction de hachage généraliste. Chaque adresse de compte est dérivée en prenant les 20 derniers octets du hachage Keccak-256 de la [Clé Publique](/fr/glossary/public-key/) du compte ([ethereum.org](https://ethereum.org/en/developers/docs/accounts/#:~:text=You%20get%20a%20public%20address%20for%20your%20account%20by%20taking%20the%20last%2020%20bytes%20of%20the%20Keccak-256%20hash%20of%20the%20public%20key)), et cette même fonction sous-tend l’adressage par contenu clé/valeur utilisé dans le [Merkle Patricia Trie](https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/#:~:text=key%20%3D%3D%20keccak256%28rlp%28value%29%29) qui stocke l’état d’Ethereum.
+
+Le hachage transforme aussi les en-têtes de blocs en une véritable chaîne plutôt qu’en une simple collection d’enregistrements : le hachage de chaque en-tête dépend de celui de l’en-tête précédent. Réécrire l’historique impose donc de refaire chaque bloc après le point que l’on veut modifier, et de dépasser le travail continu du réseau honnête. Cette propriété de « chaînage » est la raison littérale pour laquelle cette structure de données s’appelle une **blockchain**.
+
+---
+
+## Cryptographie à clé publique et signatures numériques (ECDSA, EdDSA, BLS)
+
+![Une clé privée signe une transaction pour produire une signature numérique ; la clé publique correspondante la vérifie avec une coche verte, tandis qu’une clé publique non correspondante la rejette avec une croix rouge](../../assets/blockchain-cryptographic-primitives-02-signatures.jpg)
+
+Une blockchain n’a pas de formulaire de connexion ; elle a donc besoin d’un autre moyen de prouver que « cette transaction provient bien du propriétaire de ce compte ». La [cryptographie à clé publique](/fr/glossary/public-key/) résout ce problème avec une paire de clés : une [Clé Privée](/fr/glossary/private-key/) tenue secrète et une clé publique qui peut être librement partagée. Signer une transaction avec la clé privée produit une [signature numérique](/fr/glossary/digital-signature/) que n’importe qui peut vérifier par rapport à la clé publique : l’autorisation est ainsi prouvée sans jamais révéler la clé privée elle-même.
+
+Les comptes Ethereum dérivent leur clé publique de la clé privée au moyen de l’algorithme de signature numérique à courbe elliptique, ECDSA, sur la courbe secp256k1 — la même courbe que Bitcoin utilise ([documentation ethereum.org sur les comptes](https://ethereum.org/en/developers/docs/accounts/#:~:text=The%20public%20key%20is%20generated%20from%20the%20private%20key%20using%20the%20Elliptic%20Curve%20Digital%20Signature%20Algorithm); [EIP-2, correctif de malléabilité des signatures secp256k1](https://eips.ethereum.org/EIPS/eip-2#:~:text=secp256k1n%2F2)). ECDSA est rapide à vérifier et a été scruté pendant des décennies, mais présente une faiblesse opérationnelle pertinente pour les conceptions plus récentes : les signatures ECDSA individuelles ne s’agrègent pas efficacement ; en vérifier des milliers revient donc à effectuer des milliers de vérifications séparées.
+
+C’est précisément ce que comblent les signatures EdDSA et BLS. EdDSA (employé par des chaînes comme Solana et Stellar) utilise une construction de courbe différente, déterministe et résistante à certains écueils d’implémentation qui ont historiquement provoqué des bogues de réutilisation de nonce avec ECDSA. Les signatures BLS vont plus loin : grâce à la propriété mathématique d’appariement des courbes qu’elles utilisent, de nombreuses signatures BLS peuvent être réunies en une signature agrégée unique qui les vérifie toutes en une seule fois. La couche de consensus par preuve d’enjeu d’Ethereum repose exactement sur ce mécanisme : les validateurs signent des attestations avec des clés BLS afin que la beacon chain puisse agréger les votes de centaines de milliers de validateurs en signatures assez compactes pour être vérifiées rapidement. C’est ce qui rend la preuve d’enjeu à grande échelle praticable ([ethereum.org, *The Beacon Chain*](https://eth2book.info/capella/part2/building_blocks/signatures/#:~:text=BLS%20signatures%20can%20be%20aggregated%20together%2C%20making%20them%20efficient%20to%20verify%20at%20large%20scale)). Ethereum expose aussi des opérations sur la courbe BLS12-381 sous forme de précompilations EVM, précisément pour prendre en charge la vérification de signatures BLS dans les smart contracts ([EIP-2537](https://eips.ethereum.org/EIPS/eip-2537#:~:text=Add%20functionality%20to%20efficiently%20perform%20operations%20over%20the%20BLS12-381%20curve%2C%20including%20those%20for%20BLS%20signature%20verification)).
+
+---
+
+## Arbres de Merkle
+
+![Une pyramide de nœuds de hachage d’un arbre de Merkle se combine par paires jusqu’à une racine unique ; un chemin de preuve allant d’une feuille à la racine est surligné en orange pour montrer une preuve de Merkle de client léger](../../assets/blockchain-cryptographic-primitives-03-merkle-tree.jpg)
+
+Un [arbre de Merkle](/fr/glossary/merkle-tree/) permet à une blockchain de résumer des milliers de transactions dans un unique hachage de 32 octets sans obliger chaque participant à stocker chaque transaction. Les feuilles sont les hachages d’éléments de données individuels (transactions, états de compte) ; chaque paire de hachages est concaténée puis hachée de nouveau, jusqu’à ce qu’il ne reste qu’un hachage — la racine ([Bitcoin Developer Guide](https://developer.bitcoin.org/devguide/block_chain.html#:~:text=Copies%20of%20each%20transaction%20are%20hashed%2C%20and%20the%20hashes%20are%20then%20paired%2C%20hashed%2C%20paired%20again%2C%20and%20hashed%20again%20until%20a%20single%20hash%20remains%2C%20the%20merkle%20root%20of%20a%20merkle%20tree)). Cette racine est stockée directement dans l’en-tête du bloc, ce qui permet à un nœud complet de prendre un engagement cryptographique sur l’intégralité du contenu d’un bloc avec presque aucun espace supplémentaire.
+
+Le gain est la taille de la preuve. Pour démontrer qu’une transaction est incluse dans un bloc, le bloc entier n’est pas nécessaire : il suffit de la transaction et d’une « branche de Merkle », c’est-à-dire les hachages frères le long du chemin de cette feuille à la racine, soit en général de l’ordre de log₂(n) hachages pour n transactions. C’est le fondement de la vérification de paiement simplifiée (SPV) : un client léger qui ne possède que les en-têtes de blocs peut encore vérifier qu’une transaction précise a eu lieu en comparant sa branche de Merkle à la racine de l’en-tête, sans télécharger l’intégralité de la blockchain ([Bitcoin Developer Guide](https://developer.bitcoin.org/devguide/operating_modes.html#:~:text=the%20merkle%20root%20in%20the%20block%20header%20along%20with%20a%20merkle%20branch%20can%20prove%20to%20the%20SPV%20client%20that%20the%20transaction%20in%20question%20is%20embedded%20in%20a%20block%20in%20the%20block%20chain)).
+
+Ethereum étend cette idée avec le Merkle Patricia Trie, un hybride d’arbre de Merkle et de trie de préfixes (radix) utilisé pour stocker l’état complet des comptes, et non une simple liste de transactions. Chaque en-tête de bloc contient trois racines de trie distinctes — `stateRoot`, `transactionsRoot` et `receiptsRoot` — chacune pouvant être prouvée indépendamment ([ethereum.org](https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/#:~:text=From%20a%20block%20header%20there%20are%203%20roots%20from%203%20of%20these%20tries)). C’est ce qui permet à un smart contract ou à un client léger de vérifier le solde d’un compte ou un emplacement de stockage donné sans rejouer toute la chaîne.
+
+---
+
+## Cryptographie sur courbes elliptiques
+
+La cryptographie sur courbes elliptiques (ECC) est le fondement mathématique sur lequel reposent ECDSA, EdDSA et BLS. Au lieu de s’appuyer sur la difficulté de factoriser de grands nombres (comme le RSA classique), l’ECC repose sur la difficulté du problème du logarithme discret sur courbe elliptique : étant donné un point de la courbe obtenu en ajoutant un point de base à lui-même de très nombreuses fois, il est infaisable en pratique de retrouver le nombre d’additions — alors que calculer ce point dans le sens direct est facile. Cette asymétrie (facile dans un sens, difficile à inverser) est précisément ce qui permet d’utiliser une clé privée pour signer tout en publiant sans risque la clé publique qui en est dérivée.
+
+La courbe précise importe. Bitcoin et Ethereum utilisent tous deux secp256k1, une courbe de Koblitz normalisée par le Standards for Efficient Cryptography Group avec des paramètres de 256 bits bien étudiés ([SEC 2: Recommended Elliptic Curve Domain Parameters](https://www.secg.org/sec2-v2.pdf)). D’autres écosystèmes emploient des courbes différentes selon les compromis recherchés : Ed25519 (la courbe derrière EdDSA dans Solana et Stellar) privilégie la sûreté d’implémentation et la vitesse, tandis que BLS12-381 est choisie spécifiquement parce qu’elle prend en charge les opérations d’appariement nécessaires à l’agrégation. Toutes offrent, par bit de clé, à peu près le même niveau de sécurité pratique tout en produisant des clés et des signatures beaucoup plus courtes que le RSA équivalent ; c’est pourquoi l’ECC, et non RSA, est devenue la norme pour les comptes blockchain.
+
+---
+
+## Schémas d’engagement (un pont vers la divulgation nulle)
+
+Un schéma d’engagement permet de « verrouiller » une valeur — publier un élément qui vous lie à une donnée précise — sans révéler cette donnée, puis d’« ouvrir » l’engagement plus tard pour prouver de quelle valeur il s’agissait. L’analogie courante est l’enveloppe scellée : vous pouvez remettre aujourd’hui une enveloppe fermée à quelqu’un comme preuve que vous avez déjà choisi une réponse, sans qu’il la voie avant que vous décidiez de l’ouvrir, et une fois l’enveloppe scellée, vous ne pouvez pas échanger la réponse qu’elle contient.
+
+Cette primitive paraît modeste, mais elle soutient la plupart des systèmes de preuve à divulgation nulle. La conception de disponibilité des données d’Ethereum fondée sur les blobs utilise par exemple des engagements KZG — un schéma d’engagement polynomial — pour réduire un grand blob de données de rollup à un unique petit engagement cryptographique que les prouveurs et vérificateurs peuvent contrôler sans traiter le blob en entier ([ethereum.org, Danksharding](https://ethereum.org/en/roadmap/danksharding/#:~:text=KZG%20stands%20for%20Kate-Zaverucha-Goldberg)). Une racine de Merkle est d’ailleurs elle-même un schéma d’engagement simple : elle engage un jeu de données entier au moyen de son hachage racine, et une branche de Merkle est l’« ouverture » qui révèle l’un de ses éléments. Les ZK-rollups s’appuient sur des schémas d’engagement plus avancés (engagements polynomiaux et vectoriels) pour compresser l’exécution d’un lot entier de transactions dans une preuve peu coûteuse à vérifier onchain — un sujet traité en profondeur dans [Preuve à divulgation nulle parfaite vs computationnelle](/fr/blog/perfect-vs-computational-zero-knowledge/).
+
+---
+
+## Comparaison : primitives cryptographiques blockchain
+
+| Primitive | Propriété apportée | Utilisation onchain | Risque classique ou post-quantique |
+|---|---|---|---|
+| Fonctions de hachage (SHA-256, Keccak-256) | Empreinte résistante aux collisions ; chaînage des blocs | Hachage des blocs, dérivation d’adresses, racines de Merkle | Solides avec les tailles de sortie actuelles dans le cadre classique ; les schémas fondés sur le hachage sont généralement considérés comme plus résistants aux attaques quantiques que les signatures actuelles sur courbe elliptique |
+| Signatures numériques — ECDSA | Autorisation de transaction au moyen d’une paire de clés privée/publique | Signatures des comptes Bitcoin et Ethereum | Sûres dans le cadre classique ; un ordinateur quantique à grande échelle suffisamment capable devrait casser les schémas fondés sur les courbes elliptiques, raison pour laquelle le NIST a normalisé des alternatives post-quantiques ([NIST, 2024](https://www.nist.gov/news-events/news/2024/08/nist-releases-first-3-finalized-post-quantum-encryption-standards#:~:text=A%20sufficiently%20capable%20quantum%20computer%2C%20though%2C%20would%20be%20able%20to%20sift%20through%20a%20vast%20number%20of%20potential%20solutions%20to%20these%20problems%20very%20quickly%2C%20thereby%20defeating%20current%20encryption)) |
+| Signatures numériques — EdDSA / BLS | Signature déterministe (EdDSA) ; agrégation efficace de signatures (BLS) | Signatures Solana/Stellar (EdDSA) ; attestations des validateurs Ethereum (BLS) | Même hypothèse sous-jacente de courbe elliptique qu’ECDSA — donc même exposition quantique à long terme |
+| Arbres de Merkle | Engagement compact envers un grand jeu de données ; petites preuves d’inclusion | En-têtes de blocs, vérification par client léger (SPV), tries d’état/de transactions/de reçus d’Ethereum | Dépend uniquement de la résistance aux collisions de la fonction de hachage sous-jacente ; hérite donc de son profil quantique sans ajouter de nouvelle exposition |
+| Cryptographie sur courbes elliptiques | Base mathématique de clés et de signatures compactes | secp256k1 (Bitcoin, Ethereum), Ed25519, BLS12-381 | Vulnérable de la même manière qu’ECDSA/EdDSA/BLS à un futur ordinateur quantique à grande échelle ; c’est le moteur principal de la recherche sur la migration post-quantique |
+| Schémas d’engagement | S’engager maintenant sur une valeur, la révéler ou la prouver plus tard sans l’exposer d’emblée | Engagements KZG pour la disponibilité des données Ethereum ; racines de Merkle comme engagements simples ; brique des ZK-rollups | La sécurité dépend de l’hypothèse de hachage ou de courbe elliptique utilisée pour construire le schéma |
+
+---
+
+## Lien avec les domaines tokenisés
+
+Chacune de ces primitives intervient directement lorsque vous [tokenisez](/fr/glossary/tokenize/) un domaine. Le [NFT](/fr/glossary/nft/) qui représente la propriété est sécurisé par les mêmes signatures ECDSA que tout autre actif blockchain : qui contrôle la clé privée contrôle le jeton de domaine, sans exception. C’est pourquoi les [portefeuilles matériels](/fr/glossary/hardware-wallet/) et la conservation rigoureuse de la [phrase de récupération](/fr/glossary/seed-phrase/) comptent autant pour un `.com` tokenisé que pour tout autre actif on-chain. L’enregistrement de propriété du domaine se trouve dans le même état dont l’engagement cryptographique est assuré par une racine de Merkle, qui sécurise chaque autre solde de compte et chaque [Smart contract](/fr/glossary/smart-contract/) de la chaîne. C’est exactement ce qui confère à un domaine tokenisé la même résistance à l’altération que tout autre actif on-chain : il est transférable, vérifiable et sa propriété est démontrable sans que la base de données d’un bureau d’enregistrement soit l’unique source de vérité.
+
+Comprendre ces primitives clarifie aussi ce que la tokenisation change, et ce qu’elle ne change pas : l’enregistrement DNS et le statut au registre du domaine suivent toujours les règles de l’ICANN, mais la preuve de propriété s’appuie désormais sur la cryptographie décrite ci-dessus plutôt que sur un compte de [bureau d’enregistrement](/fr/glossary/registrar/) protégé par des identifiants de connexion. Découvrez le tableau d’ensemble dans [Mécanismes de consensus blockchain](/fr/blog/blockchain-consensus-mechanisms/) et [Approches de mise à l’échelle des blockchains](/fr/blog/blockchain-scaling-approaches/), ou commencez à tokeniser sur [namefi.io](https://namefi.io).
+
+---
+
+## Sources et lectures complémentaires
+
+- Bitcoin Developer Guide — [Block Chain](https://developer.bitcoin.org/devguide/block_chain.html), chaînage via SHA256(SHA256()) de l’en-tête précédent
+- Bitcoin Developer Reference — [Block Chain](https://developer.bitcoin.org/reference/block_chain.html), construction de la racine de Merkle
+- Bitcoin Developer Guide — [Operating Modes](https://developer.bitcoin.org/devguide/operating_modes.html), SPV et branches de Merkle
+- ethereum.org — [Ethereum Accounts](https://ethereum.org/en/developers/docs/accounts/), ECDSA et dérivation d’adresse Keccak-256
+- ethereum.org — [Merkle Patricia Trie](https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/), racines d’état/de transactions/de reçus
+- ethereum.org — [Danksharding](https://ethereum.org/en/roadmap/danksharding/), engagements polynomiaux KZG
+- EIP-2 — [Homestead Hard-fork Changes](https://eips.ethereum.org/EIPS/eip-2), contraintes de signature secp256k1
+- EIP-2537 — [Precompile for BLS12-381 curve operations](https://eips.ethereum.org/EIPS/eip-2537)
+- SEC 2: Recommended Elliptic Curve Domain Parameters — [secg.org](https://www.secg.org/sec2-v2.pdf)
+- *The Eth2 Book* — [Signatures and BLS aggregation](https://eth2book.info/capella/part2/building_blocks/signatures/)
+- NIST — [NIST Releases First 3 Finalized Post-Quantum Encryption Standards](https://www.nist.gov/news-events/news/2024/08/nist-releases-first-3-finalized-post-quantum-encryption-standards)

--- a/content/blog/fr/blockchain-privacy-technologies.md
+++ b/content/blog/fr/blockchain-privacy-technologies.md
@@ -1,0 +1,152 @@
+---
+title: "Les principales technologies de confidentialité des blockchains : preuves à divulgation nulle, FHE, MPC, TEE et signatures en anneau"
+date: '2026-07-02'
+language: fr
+tags: ['guide']
+authors: ['namefiteam']
+draft: false
+cluster: web3-foundations
+series: blockchain-concepts
+seriesOrder: 50
+format: roundup
+description: "Un guide clair des cinq principales technologies de confidentialité des blockchains — preuves à divulgation nulle, FHE, MPC, TEE et signatures en anneau — comparées côte à côte."
+ogImage: ../../assets/blockchain-privacy-technologies-og.jpg
+keywords: ["confidentialité blockchain", "preuve à divulgation nulle", "ZKP", "chiffrement entièrement homomorphe", "FHE", "calcul multipartite sécurisé", "MPC", "environnement d’exécution de confiance", "TEE", "signatures en anneau", "adresses furtives", "Monero", "Zcash", "zkSync", "Starknet", "technologie de confidentialité", "informatique confidentielle", "confidentialité on-chain", "cryptographie blockchain", "cryptomonnaies confidentielles"]
+relatedArticles:
+  - /fr/blog/blockchain-cryptographic-primitives/
+  - /fr/blog/blockchain-scaling-approaches/
+  - /fr/blog/blockchain-virtual-machines/
+  - /fr/blog/blockchain-consensus-mechanisms/
+  - /fr/blog/perfect-vs-computational-zero-knowledge/
+relatedGlossary:
+  - /fr/glossary/zero-knowledge-proof/
+  - /fr/glossary/fully-homomorphic-encryption/
+  - /fr/glossary/secure-multiparty-computation/
+  - /fr/glossary/trusted-execution-environment/
+  - /fr/glossary/cryptographic-security/
+relatedTopics:
+  - /fr/topics/web3-foundations/
+  - /fr/topics/domain-tokenization/
+relatedSeries:
+  - /fr/series/tokenize-your-com/
+  - /fr/series/domain-flipping-skills/
+---
+
+Chaque transaction sur une [Blockchain](/fr/glossary/blockchain/) publique est, par défaut, visible par quiconque la consulte. Les soldes, les montants transférés et les contreparties demeurent à jamais dans le registre public. Cette transparence est à l’origine des garanties de confiance d’une blockchain, mais elle constitue aussi un handicap : aucune banque ne publie les soldes de ses clients, et aucune entreprise ne souhaite que ses paiements à ses fournisseurs ou ses versements de salaires soient lisibles par ses concurrents.
+
+Les technologies de confidentialité des blockchains cherchent à combler cet écart sans abandonner les propriétés qui rendent les chaînes utiles au départ : la vérifiabilité, la décentralisation et la possibilité pour des inconnus de réaliser des transactions sans intermédiaire de confiance. Cinq techniques dominent le paysage actuel : les [preuves à divulgation nulle](/fr/glossary/zero-knowledge-proof/), le [chiffrement entièrement homomorphe](/fr/glossary/fully-homomorphic-encryption/) (FHE), le [calcul multipartite sécurisé](/fr/glossary/secure-multiparty-computation/) (MPC), les [environnements d’exécution de confiance](/fr/glossary/trusted-execution-environment/) (TEE) et les signatures en anneau avec adresses furtives. Chacune masque une partie différente du problème, repose sur une hypothèse de confiance différente et exige une quantité de calcul différente. Ce guide détaille les cinq, les compare côte à côte et explique pourquoi ce choix compte pour toute personne qui construit sur le [Web3](/fr/glossary/web3/) ou cherche simplement à le comprendre.
+
+---
+
+## Preuves à divulgation nulle
+
+![Un prouveur remet à un vérificateur un badge lumineux de preuve valide tout en gardant un document verrouillé derrière son dos, illustrant comment une preuve à divulgation nulle convainc sans révéler l’énoncé sous-jacent](../../assets/blockchain-privacy-technologies-01-zero-knowledge.jpg)
+
+Une [preuve à divulgation nulle](/fr/glossary/zero-knowledge-proof/) (zero-knowledge proof, ZKP) permet à une partie — le *prouveur* — de convaincre une autre partie — le *vérificateur* — qu’une affirmation est vraie sans rien révéler d’autre à son sujet. La documentation destinée aux développeurs d’Ethereum le formule simplement : « une preuve à divulgation nulle permet de prouver la validité d’une affirmation sans révéler l’affirmation elle-même » ; « le “prouveur” est la partie qui cherche à démontrer une allégation, tandis que le “vérificateur” est chargé de valider cette allégation » ([ethereum.org](https://ethereum.org/en/zero-knowledge-proofs/#:~:text=A%20zero%2Dknowledge%20proof%20is,without%20revealing%20the%20statement%20itself)).
+
+Pour qu’un système de preuve soit un véritable protocole à divulgation nulle, il doit satisfaire trois propriétés : la complétude (« si l’entrée est valide, le protocole à divulgation nulle renvoie toujours “vrai” »), la solidité (« si l’entrée est invalide, il est théoriquement impossible de tromper le protocole à divulgation nulle pour qu’il renvoie “vrai” ») et la divulgation nulle elle-même, c’est-à-dire que « le vérificateur n’apprend rien d’une affirmation au-delà de sa validité ou de sa fausseté » ([ethereum.org](https://ethereum.org/en/zero-knowledge-proofs/)). Concrètement, une preuve se compose d’un témoin (le secret connu du prouveur), d’un défi (une question posée par le vérificateur) et d’une réponse qui permet au vérificateur de contrôler la connaissance du prouveur sans jamais voir le témoin lui-même.
+
+**Ce qu’elle masque :** les données ou le calcul sous-jacent ; seule la preuve qu’une affirmation est vraie est révélée.
+
+**Utilisation actuelle :** les rollups ZK constituent le principal usage des ZKP en production pour le passage à l’échelle des blockchains. Ils « regroupent (ou “roll up”) les transactions en lots exécutés hors chaîne », puis génèrent une unique preuve de validité qu’Ethereum vérifie avant de finaliser les changements d’état du lot ([ethereum.org](https://ethereum.org/en/developers/docs/scaling/zk-rollups/#:~:text=ZK%2Drollups%20bundle%20)). zkSync Era, créé par Matter Labs, est « un ZK Rollup compatible EVM… alimenté par sa propre zkEVM » ([ethereum.org](https://ethereum.org/en/developers/docs/scaling/zk-rollups/)), tandis que Starknet, créé par StarkWare, est un rollup de validité qui exécute sa propre machine virtuelle Cairo plutôt que l’EVM (les contrats Solidity y sont reliés séparément). L2BEAT répertorie les deux comme des rollups sécurisés par des preuves de validité plutôt que par la fenêtre de contestation par preuve de fraude utilisée par les rollups optimistes ([l2beat.com](https://l2beat.com/scaling/summary)). Côté confidentialité, [Zcash](https://z.cash/technology/) a été pionnier des zk-SNARK (Zero-Knowledge Succinct Non-Interactive Arguments of Knowledge) pour les transactions protégées, où « les adresses des utilisateurs, le montant de leurs transactions » et d’autres détails restent chiffrés, tandis que le réseau confirme toujours la validité de la transaction ([z.cash](https://z.cash/technology/)).
+
+**Le compromis :** générer une preuve ZK est coûteux en calcul — les circuits de preuve parcourent chaque transaction d’un lot et en réexécutent les vérifications — de sorte que le temps de génération et le coût du matériel constituent de véritables contraintes, même si la vérification on-chain est bon marché et rapide. La confiance dans le système revient à faire confiance aux mathématiques et, pour certains systèmes de preuve, à une cérémonie unique de configuration de confiance.
+
+---
+
+## Chiffrement entièrement homomorphe (FHE)
+
+![Une boîte verrouillée traverse une machine mathématique opérée par un serveur cloud sans clé et en ressort toujours verrouillée, mais contenant un résultat calculé, illustrant un calcul effectué directement sur des données chiffrées](../../assets/blockchain-privacy-technologies-02-fhe.jpg)
+
+Le [chiffrement entièrement homomorphe](/fr/glossary/fully-homomorphic-encryption/) adopte une approche différente : au lieu de prouver un fait au sujet de données cachées, il permet de *calculer directement sur des données chiffrées* et d’obtenir un résultat chiffré qui se déchiffre pour donner la même réponse que si le calcul avait été effectué sur des données en clair. Zama, l’une des principales entreprises de recherche et d’infrastructure FHE, le décrit ainsi : « le FHE permet de traiter des données sans les déchiffrer : les entreprises fournissent des services sans accéder aux données des utilisateurs, tandis que les utilisateurs conservent les mêmes fonctionnalités » ([zama.org](https://www.zama.org/introduction-to-homomorphic-encryption)).
+
+**Ce qu’il masque :** les entrées brutes, l’état intermédiaire et les sorties d’un calcul ; toute personne autre que le détenteur de la clé ne voit que le texte chiffré, y compris la partie qui effectue le calcul.
+
+**Fonctionnement, à haut niveau :** les schémas FHE encodent des valeurs en clair dans des textes chiffrés fondés sur des mathématiques de réseaux euclidiens, puis définissent des équivalents chiffrés de l’addition et de la multiplication afin que des circuits arbitraires puissent s’exécuter sur ces textes chiffrés. Appliqué à une blockchain, cela signifie qu’un smart contract peut déplacer des jetons ou évaluer une logique sans jamais voir les montants concernés ; comme le formule l’exemple de Zama, « la blockchain a vérifié qu’Alice disposait de fonds suffisants sans jamais voir les montants réels » ([zama.org](https://www.zama.org/introduction-to-homomorphic-encryption#:~:text=The%20blockchain%20verified%20Alice%20has%20sufficient%20funds%20without%20ever%20seeing%20the%20actual%20amounts)). Zama note également que les schémas FHE fondés sur les réseaux sont « intrinsèquement résistants aux attaques quantiques », ce qui importe pour toute personne qui réfléchit au risque cryptographique à long terme ([zama.org](https://www.zama.org/introduction-to-homomorphic-encryption)).
+
+**Exemples de projets :** [Zama](https://www.zama.org/) développe les bibliothèques FHE open source (TFHE-rs, Concrete) et la fhEVM utilisée pour ajouter l’exécution confidentielle de smart contracts aux chaînes EVM. [Fhenix](https://cofhe-docs.fhenix.zone/) est une blockchain conçue spécifiquement pour permettre aux « développeurs de construire des smart contracts respectueux de la confidentialité en utilisant le chiffrement entièrement homomorphe », afin que « les données sensibles restent chiffrées pendant tout le calcul » ; elle propose une bibliothèque JavaScript (Cofhejs) pour le chiffrement côté client et une bibliothèque Solidity FHE pour les opérations chiffrées on-chain ([cofhe-docs.fhenix.zone](https://cofhe-docs.fhenix.zone/)).
+
+**Le compromis :** le FHE offre la garantie de confidentialité la plus forte de cette liste — rien n’est jamais déchiffré, même pendant le calcul — mais il est aussi de très loin le plus coûteux en calcul par rapport à une exécution sur données en clair. C’est pourquoi les chaînes fondées sur le FHE exécutent aujourd’hui la logique critique pour la confidentialité plutôt que chaque transaction, et pourquoi l’accélération matérielle du FHE fait l’objet d’une course active de recherche.
+
+---
+
+## Calcul multipartite sécurisé (MPC)
+
+![Trois personnes tiennent chacune un fragment de clé en forme de pièce de puzzle, reliés par des lignes pointillées à une même transaction signée, illustrant comment le calcul multipartite sécurisé produit un résultat commun sans qu’aucune partie ne voie le secret complet](../../assets/blockchain-privacy-technologies-03-mpc.jpg)
+
+Le [calcul multipartite sécurisé](/fr/glossary/secure-multiparty-computation/) résout un problème proche, mais distinct : au lieu qu’une partie calcule sur des données chiffrées, *plusieurs* parties qui détiennent chacune une portion privée de l’entrée calculent conjointement une fonction sans révéler leurs entrées individuelles les unes aux autres. Selon la définition formelle, le MPC est « un sous-domaine de la cryptographie dont l’objectif est de créer des méthodes permettant à des parties de calculer conjointement une fonction sur leurs entrées tout en gardant ces entrées privées » ; ainsi, pour trois participants, « Alice, Bob et Charlie peuvent toujours apprendre F(x, y, z) sans révéler qui produit quoi » ([Wikipedia](https://en.wikipedia.org/wiki/Secure_multi-party_computation#:~:text=Secure%20multi%2Dparty%20computation%20)).
+
+**Ce qu’il masque :** l’entrée individuelle de chaque partie pour toutes les autres ; seule la sortie convenue est révélée, et aucun participant ne voit jamais le secret complet.
+
+**Hypothèse de confiance :** la sécurité dépend du nombre de participants qui peuvent être malhonnêtes avant que le schéma ne cède. Les constructions classiques de partage de secret offrent une sécurité informationnelle tant que moins d’un tiers des parties sont activement malveillantes, ou que moins de la moitié sont seulement curieuses ([Wikipedia](https://en.wikipedia.org/wiki/Secure_multi-party_computation)). En d’autres termes, le MPC remplace « faire confiance à un seul dépositaire » par « faire confiance au fait qu’un nombre insuffisant de ces N parties collabore ».
+
+**Utilisation actuelle — la conservation par signature à seuil :** l’application blockchain la plus visible du MPC consiste à répartir une clé privée entre des parties indépendantes, de sorte qu’aucun appareil ou individu ne détienne jamais la clé complète. Le fournisseur d’infrastructure de conservation Fireblocks le décrit directement : « le calcul multipartite (MPC) est une méthode cryptographique qui divise une clé privée en parts distinctes réparties entre plusieurs parties indépendantes » et, surtout, « la clé complète n’est jamais assemblée en un seul endroit, à aucun moment » ([fireblocks.com](https://www.fireblocks.com/what-is-mpc#:~:text=Multi%2Dparty%20computation%20)). Lorsqu’une transaction doit être signée, un quorum de points de terminaison valide chacun la transaction et apporte une signature partielle ; « à aucun moment la clé privée n’est assemblée », de sorte que « même si un point de terminaison est compromis… les parts de clé détenues ailleurs sont inutiles isolément » ([fireblocks.com](https://www.fireblocks.com/what-is-mpc)). Ce modèle de signature à seuil sous-tend désormais l’essentiel de la conservation institutionnelle de cryptoactifs et de nombreux portefeuilles à signatures multiples.
+
+**Le compromis :** le MPC évite le point de défaillance unique d’une clé privée stockée sur un seul appareil, mais il ajoute des tours de communication entre les parties (de la latence) et exige une conception de protocole rigoureuse. La garantie de sécurité d’un schéma MPC ne vaut que ce que vaut son seuil supposé de majorité honnête ; il s’agit d’une hypothèse sociale et opérationnelle, et non seulement mathématique.
+
+---
+
+## Environnements d’exécution de confiance (TEE)
+
+Un [environnement d’exécution de confiance](/fr/glossary/trusted-execution-environment/) emprunte une autre voie : plutôt que de chiffrer les données pendant tout le calcul, il isole le calcul dans une région d’une puce protégée par le matériel — une *enclave sécurisée* — que même le système d’exploitation de la machine ne peut pas inspecter. SGX (Software Guard Extensions) d’Intel, l’implémentation la plus connue, est décrit sur Wikipedia comme « un ensemble de codes d’instruction mettant en œuvre un environnement d’exécution de confiance, intégré à certaines unités centrales de traitement (CPU) Intel » ([Wikipedia](https://en.wikipedia.org/wiki/Software_Guard_Extensions#:~:text=Intel%20Software%20Guard%20Extensions)). Mécaniquement, « SGX implique le chiffrement par le CPU d’une portion de mémoire (l’enclave) » ; « les données et le code provenant de l’enclave sont déchiffrés à la volée au sein du CPU, ce qui les protège contre l’examen ou la lecture par d’autres codes », notamment « du code exécuté à des niveaux de privilège supérieurs, tels que le système d’exploitation et les hyperviseurs sous-jacents » ([Wikipedia](https://en.wikipedia.org/wiki/Software_Guard_Extensions)).
+
+**Ce qu’il masque :** les données et le code contenus dans l’enclave pour tous les autres processus de la même machine, y compris un système d’exploitation compromis ; c’est utile lorsqu’il faut faire confiance à l’exécution d’un morceau de code précis sans faire confiance à l’opérateur du serveur.
+
+**Hypothèse de confiance :** contrairement aux ZKP, au FHE ou au MPC, qui reposent uniquement sur les mathématiques, un TEE vous demande de faire confiance au matériel et au firmware du fabricant de la puce. Cette confiance a été mise à l’épreuve : SGX « ne protège pas contre les attaques par canal auxiliaire », et les chercheurs ont démontré à plusieurs reprises des compromissions concrètes, depuis l’extraction de « clés RSA d’enclaves SGX exécutées sur le même système en cinq minutes » (2017) jusqu’à l’attaque Foreshadow, qui « combine l’exécution spéculative et le dépassement de tampon pour contourner SGX » (2018), en passant par des vulnérabilités plus récentes, dont Plundervolt, LVI, SGAxe et ÆPIC Leak ([Wikipedia](https://en.wikipedia.org/wiki/Software_Guard_Extensions#:~:text=While%20this%20can%20mitigate%20many%20kinds%20of%20attacks%2C%20it%20does%20not%20protect%20against%20side%2Dchannel%20attacks)). Cet historique explique pourquoi les TEE sont généralement présentés comme un compromis pragmatique et plus rapide plutôt que comme une garantie cryptographiquement étanche.
+
+**Exemples de projets :** le réseau Sapphire d’[Oasis Protocol](https://oasis.net/technology) exécute des smart contracts à l’intérieur d’enclaves matérielles afin que les utilisateurs puissent « exécuter du code dans des enclaves sécurisées par le matériel », où « les données restent chiffrées même pour les opérateurs de serveurs », tandis que « chaque exécution produit une preuve cryptographique que les utilisateurs peuvent vérifier sans confiance aveugle ». Il fournit ainsi des « smart contracts confidentiels » qui préservent « la compatibilité et la composabilité EVM » ([oasis.net](https://oasis.net/technology)). Secret Network et plusieurs produits de confidentialité liés au restaking reposent aussi sur des TEE, souvent associés à d’autres techniques pour une défense en profondeur.
+
+**Le compromis :** les TEE s’exécutent à une vitesse proche de la vitesse native — bien plus vite que le FHE ou la génération lourde de preuves ZK — ce qui les rend attrayants pour les applications sensibles à la latence. Cette vitesse provient toutefois de la confiance accordée à un matériel qui présente un historique réel et documenté de compromissions par canal auxiliaire ; dans les hypothèses de confiance les plus défavorables, les systèmes fondés sur des TEE sont donc généralement plus faibles que les approches purement cryptographiques.
+
+---
+
+## Signatures en anneau et adresses furtives
+
+La dernière paire de techniques protège une cible plus limitée, mais très concrète : masquer *qui* a envoyé une transaction et *qui* l’a reçue, même si la transaction elle-même est visible on-chain. [Monero](https://www.getmonero.org/) en est le principal exemple en production pour les deux.
+
+Les **signatures en anneau** masquent l’expéditeur. La documentation de Monero explique qu’« une signature en anneau est un type de signature numérique qui peut être produite par n’importe quel membre d’un groupe d’utilisateurs possédant chacun des clés » et qu’« il doit être impossible, du point de vue du calcul, de déterminer laquelle des clés des membres du groupe a servi à produire la signature » ([getmonero.org](https://www.getmonero.org/resources/moneropedia/ring-signatures.html#:~:text=a%20ring%20signature%20is%20a%20type%20of%20digital%20signature)). En pratique, une transaction Monero mélange la clé du véritable dépensier avec des clés publiques leurres « extraites de la blockchain au moyen d’une méthode de distribution gamma », de sorte que, dans un « anneau » de signataires possibles, tous les membres de l’anneau sont égaux et valides, et « aucun observateur extérieur ne peut déterminer lequel des signataires possibles d’un groupe de signatures appartient à votre compte » ([getmonero.org](https://www.getmonero.org/resources/moneropedia/ring-signatures.html)).
+
+Les **adresses furtives** masquent le destinataire. Au lieu de réutiliser une adresse publique, « l’expéditeur [crée] des adresses aléatoires à usage unique pour chaque transaction au nom du destinataire », de sorte que les paiements entrants « sont envoyés vers des adresses uniques sur la blockchain, où ils ne peuvent être reliés ni à l’adresse publiée du destinataire ni aux adresses d’aucune autre transaction » ([getmonero.org](https://www.getmonero.org/resources/moneropedia/stealthaddress.html#:~:text=They%20allow%20and%20require%20the%20sender%20to%20create%20random%20one%2Dtime%20addresses)). Un destinataire utilise une clé de visualisation privée pour parcourir la chaîne à la recherche de paiements et une clé de dépense privée pour les déplacer ; ainsi, « seuls l’expéditeur et le destinataire peuvent déterminer où un paiement a été envoyé » ([getmonero.org](https://www.getmonero.org/resources/moneropedia/stealthaddress.html)).
+
+**Ce qu’elles masquent :** l’identité de l’expéditeur (signatures en anneau) et celle du destinataire (adresses furtives) ; les *montants* des transactions sont masqués par un mécanisme distinct (Confidential Transactions / RingCT), qui n’est pas couvert par ces deux techniques seules.
+
+**Le compromis :** les deux techniques s’exécutent efficacement sur du matériel ordinaire, sans surcharge de génération de preuve ni dépendance à une enclave, ce qui les rend bien adaptées à un réseau de paiements actif. Leur modèle de confiance repose toutefois sur l’impossibilité statistique de distinguer les ensembles de leurres du véritable signataire : une mauvaise sélection des leurres ou des heuristiques d’analyse de blockchain ont, par le passé, réduit les ensembles d’anonymat dans les premiers déploiements de signatures en anneau. Les choix de paramètres (taille de l’anneau, distribution des leurres) comptent donc autant que la primitive sous-jacente.
+
+---
+
+## Comparaison des cinq approches
+
+| Technologie | Ce qu’elle masque | Hypothèse de confiance | Coût de performance | Maturité actuelle | Exemples de projets |
+|---|---|---|---|---|---|
+| Preuves à divulgation nulle | Données/calcul sous-jacent ; seule la validité de la preuve est révélée | Mathématiques cryptographiques (+ configuration de confiance pour certains systèmes) | Coût élevé pour générer les preuves ; faible coût de vérification | En production à grande échelle (rollups, paiements protégés) | zkSync, Starknet, Zcash |
+| Chiffrement entièrement homomorphe | Toutes les données pendant le calcul, y compris pour le fournisseur de calcul | Mathématiques cryptographiques (fondées sur les réseaux) | Surcharge de calcul très élevée | Production précoce ; recherche active sur l’accélération matérielle | Zama, Fhenix |
+| Calcul multipartite sécurisé | L’entrée individuelle de chaque partie | Majorité honnête/seuil parmi les participants | Modéré ; tours de communication supplémentaires | Mature et largement déployé pour la conservation | Fireblocks et autres dépositaires par signature à seuil |
+| Environnements d’exécution de confiance | Données/code vis-à-vis de tous les autres processus, y compris le système d’exploitation | Fournisseur du matériel/firmware (fabricant de puces) | Vitesse proche de la vitesse native | En production, mais avec un historique documenté d’attaques par canal auxiliaire | Intel SGX, Oasis Sapphire |
+| Signatures en anneau et adresses furtives | Identité de l’expéditeur et du destinataire | Indistinguabilité statistique des ensembles de leurres | Faible ; efficace sur matériel courant | Mature, en fonctionnement depuis plus de dix ans | Monero |
+
+Aucune technologie ne l’emporte sur tous les axes ; c’est pourquoi la recherche actuelle les combine de plus en plus, par exemple des preuves ZK qui vérifient la correction d’un calcul MPC, ou des TEE utilisés avec le FHE pour une défense en profondeur.
+
+---
+
+## Le lien avec les domaines tokenisés
+
+Les domaines [tokenisés](/fr/glossary/tokenize/) héritent de la même transparence par défaut que tout autre actif on-chain : les transferts de propriété, les enchères et les mises à jour de métadonnées sont lisibles publiquement. C’est surtout une fonctionnalité — la provenance et l’historique de propriété sont précisément ce qui rend un [domaine tokenisé](/fr/blog/what-are-tokenized-domains/) digne de confiance en tant qu’actif négociable — mais cela signifie aussi que les avoirs et les prix de vente d’un portefeuille de domaines sont visibles par toute personne qui observe la chaîne.
+
+Les technologies de confidentialité décrites ici indiquent la direction que pourrait prendre l’infrastructure de domaines sous forme de NFT : la conservation à seuil fondée sur le MPC sécurise déjà les [portefeuilles](/fr/glossary/wallet/) institutionnels qui détiennent des NFT de domaine de la même manière qu’elle sécurise d’autres actifs numériques ; les preuves ZK pourraient un jour permettre à un enchérisseur de prouver qu’il peut financer une offre sans révéler l’intégralité de son solde ; et les techniques de calcul confidentiel pourraient permettre à un bureau d’enregistrement ou à une place de marché de vérifier des règles d’éligibilité sans exposer l’identité complète d’un acheteur. Rien de cela n’est déployé aujourd’hui dans la tokenisation de domaine, mais les primitives sous-jacentes sont les mêmes que celles qui sécurisent actuellement des milliards de dollars dans l’infrastructure DeFi et de conservation.
+
+---
+
+## Sources et lectures complémentaires
+
+- [Preuves à divulgation nulle — ethereum.org](https://ethereum.org/en/zero-knowledge-proofs/)
+- [Rollups ZK — ethereum.org](https://ethereum.org/en/developers/docs/scaling/zk-rollups/)
+- [Résumé du passage à l’échelle L2BEAT](https://l2beat.com/scaling/summary)
+- [Présentation de la technologie Zcash](https://z.cash/technology/)
+- [Introduction au chiffrement homomorphe — Zama](https://www.zama.org/introduction-to-homomorphic-encryption)
+- [Documentation cofhe de Fhenix](https://cofhe-docs.fhenix.zone/)
+- [Calcul multipartite sécurisé — Wikipedia](https://en.wikipedia.org/wiki/Secure_multi-party_computation)
+- [Qu’est-ce que le MPC ? — Fireblocks](https://www.fireblocks.com/what-is-mpc)
+- [Software Guard Extensions (SGX) — Wikipedia](https://en.wikipedia.org/wiki/Software_Guard_Extensions)
+- [Technologie Oasis Protocol](https://oasis.net/technology)
+- [Signatures en anneau — Moneropedia de Monero](https://www.getmonero.org/resources/moneropedia/ring-signatures.html)
+- [Adresses furtives — Moneropedia de Monero](https://www.getmonero.org/resources/moneropedia/stealthaddress.html)

--- a/content/blog/fr/blockchain-scaling-approaches.md
+++ b/content/blog/fr/blockchain-scaling-approaches.md
@@ -1,0 +1,121 @@
+---
+title: "Principales approches de mise à l’échelle blockchain : rollups, sidechains, canaux et sharding"
+date: '2026-07-02'
+language: fr
+tags: ['guide']
+authors: ['namefiteam']
+draft: false
+cluster: web3-foundations
+series: blockchain-concepts
+seriesOrder: 40
+format: roundup
+description: "Guide pour comprendre la mise à l’échelle des blockchains : rollups optimistes, ZK rollups, sidechains, canaux de paiement, sharding et couches de disponibilité des données, comparés."
+ogImage: ../../assets/blockchain-scaling-approaches-og.jpg
+keywords: ['mise à l’échelle blockchain', 'solutions de mise à l’échelle blockchain', 'mise à l’échelle layer 2', 'rollups', 'rollup optimiste', 'zk rollup', 'sidechains', 'canaux de paiement', 'canaux d’état', 'sharding', 'disponibilité des données', 'trilemme de la scalabilité', 'Arbitrum', 'Optimism', 'zkSync', 'Starknet', 'Celestia', 'EigenDA', 'Polygon PoS', 'Lightning Network']
+relatedArticles:
+  - /fr/blog/blockchain-virtual-machines/
+  - /fr/blog/blockchain-consensus-mechanisms/
+  - /fr/blog/blockchain-privacy-technologies/
+  - /fr/blog/blockchain-cryptographic-primitives/
+  - /fr/blog/premium-web3-tlds/
+relatedGlossary:
+  - /fr/glossary/rollup/
+  - /fr/glossary/optimistic-rollup/
+  - /fr/glossary/zk-rollup/
+  - /fr/glossary/data-availability/
+  - /fr/glossary/layer-2/
+relatedTopics:
+  - /fr/topics/web3-foundations/
+  - /fr/topics/domain-tokenization/
+relatedSeries:
+  - /fr/series/tokenize-your-com/
+  - /fr/series/domain-flipping-skills/
+---
+
+Le réseau principal Ethereum traite environ 15 transactions par seconde. Un réseau de paiement comme Visa en traite des dizaines de milliers. Cet écart explique pourquoi les blockchains doivent passer à l’échelle : il faut pouvoir effectuer davantage de travail sans demander à chaque participant de vérifier chaque transaction sur la chaîne de base. Ces dernières années, le secteur a convergé vers quelques approches distinctes — les [rollups](/fr/glossary/rollup/), les sidechains, les canaux de paiement et le sharding — qui arbitrent chacune différemment entre sécurité, décentralisation et coût.
+
+Ce guide présente les principales approches de mise à l’échelle, explique le mécanisme de chacune et les compare côte à côte afin que la différence soit claire la prochaine fois qu’elles apparaîtront dans la documentation d’un projet.
+
+---
+
+## Le trilemme de la scalabilité
+
+La formulation par Vitalik Buterin du **trilemme de la scalabilité** est le modèle mental sur lequel repose l’essentiel de ce domaine. Une blockchain recherche simultanément trois propriétés : « scalability: the chain can process more transactions than a single regular node... can verify », « decentralization: the chain can run without any trust dependencies on a small group of large centralized actors » et « security: the chain can resist a large percentage of participating nodes trying to attack it ». Or les conceptions traditionnelles n’en atteignent que deux sur trois ([vitalik.eth.limo](https://vitalik.eth.limo/general/2021/04/07/sharding.html#:~:text=Scalability%3A%20the%20chain%20can%20process%20more%20transactions%20than%20a%20single%20regular%20node)). Bitcoin et le premier Ethereum ont privilégié décentralisation et sécurité plutôt que débit ; les chaînes à TPS élevé qui reposent sur un petit ensemble de validateurs puissants obtiennent la scalabilité et la sécurité mais sacrifient la décentralisation ; les conceptions naïves à chaînes multiples peuvent passer à l’échelle tout en restant décentralisées, mais deviennent peu sûres si un attaquant n’a besoin de compromettre qu’une seule chaîne.
+
+Chaque approche ci-dessous répond en réalité à la même question : comment augmenter le débit sans abandonner les deux autres sommets du triangle ?
+
+## Rollups : exécuter hors chaîne, régler sur chaîne
+
+![Schéma vectoriel plat montrant de nombreux petits tickets de transaction converger vers un compacteur intitulé « Rollup Compressor », qui les comprime dans un cube de lots avant de le publier sur une chaîne de blocs liée de couche de base](../../assets/blockchain-scaling-approaches-01-rollup-batching.jpg)
+
+Un **[rollup](/fr/glossary/rollup/)** exécute des transactions en dehors de la couche 1 (L1), puis publie un résumé compact — ainsi que les données de transaction sous-jacentes — sur la chaîne de base. L2BEAT, le principal outil de suivi de ces systèmes, définit les rollups comme des « L2s that periodically post state commitments to Ethereum », des engagements « validated by either Validity Proofs or... accepted optimistically and can be challenged via [a] Fraud Proof mechanism within a certain fraud proof window » ([l2beat.com](https://l2beat.com/scaling/summary)). Comme les données et l’engagement arrivent tous deux sur L1, n’importe qui peut reconstruire l’état du rollup à partir d’Ethereum seul. C’est ce qui permet à un rollup d’hériter de la sécurité de L1 sans demander aux utilisateurs de faire confiance à un nouvel ensemble de validateurs. C’est la technologie qui se trouve derrière les réseaux de [layer 2](/fr/glossary/layer-2/) avec lesquels la plupart des gens interagissent aujourd’hui : Base, Arbitrum, Optimism, zkSync et Starknet sont tous des rollups.
+
+Les rollups se divisent en deux familles selon la manière dont ils prouvent la correction de leur exécution hors chaîne.
+
+### Rollups optimistes
+
+![Illustration vectorielle plate de deux portes côte à côte : une porte orange « Optimistic » avec une horloge de 7 jours et un drapeau représentant la fenêtre de preuve de fraude, et une porte verte « ZK » avec une coche verte instantanée de preuve de validité](../../assets/blockchain-scaling-approaches-02-optimistic-vs-zk.jpg)
+
+Un [rollup optimiste](/fr/glossary/optimistic-rollup/) « assume[s] offchain transactions are valid and don't publish proofs of validity for batches of transactions » ([ethereum.org](https://ethereum.org/en/developers/docs/scaling/optimistic-rollups/#:~:text=Optimistic%20rollups%20assume%20offchain%20transactions%20are%20valid%20and%20don%27t%20publish%20proofs%20of%20validity)). Les opérateurs regroupent les transactions, les exécutent hors chaîne et publient les données compressées sur Ethereum. Une fenêtre de contestation s’ouvre alors, pendant laquelle toute personne exécutant un nœud complet peut contester le lot avec une preuve de fraude ; le retrait de fonds de L2 vers L1 doit attendre que « the challenge period—lasting roughly seven days—elapses » ([ethereum.org](https://ethereum.org/en/developers/docs/scaling/optimistic-rollups/#:~:text=the%20challenge%20period%E2%80%94lasting%20roughly%20seven%20days%E2%80%94elapses)). Cette fenêtre d’une semaine explique pourquoi un retrait direct depuis un rollup optimiste prend environ une semaine, sauf si un fournisseur de liquidité tiers est utilisé pour une sortie plus rapide, moyennant des frais.
+
+Les rollups optimistes n’ont besoin que d’un système de preuve de fraude, et non d’une chaîne complète de génération de preuves cryptographiques. Historiquement, cela a facilité la prise en charge de smart contracts généralistes. **Arbitrum**, **Optimism** et **Base** — le rollup de Coinbase, décrit par ethereum.org comme « an Optimistic Rollup built with the OP Stack » ([ethereum.org](https://ethereum.org/en/layer-2/#:~:text=Base%20is%20an%20Optimistic%20Rollup%20built%20with%20the%20OP%20Stack)) — sont aujourd’hui les plus grands rollups optimistes en termes d’usage.
+
+### ZK rollups
+
+Un [ZK rollup](/fr/glossary/zk-rollup/) adopte l’approche opposée : au lieu de présumer la validité et d’autoriser une période de contestation, il soumet avec chaque lot une preuve de validité — une preuve cryptographique que la transition d’état du lot est correcte. Comme Ethereum vérifie cette preuve onchain, « there are no delays when moving funds from a ZK-rollup to Ethereum... because exit transactions are executed once the ZK-rollup contract verifies the validity proof » ([ethereum.org](https://ethereum.org/en/developers/docs/scaling/zk-rollups/#:~:text=There%20are%20no%20delays%20when%20moving%20funds%20from%20a%20ZK%2Drollup%20to%20Ethereum)). Les ZK rollups « can process thousands of transactions in a batch and then only post some minimal summary data to Mainnet » ([ethereum.org](https://ethereum.org/en/developers/docs/scaling/zk-rollups/#:~:text=ZK%2Drollups%20can%20process%20thousands%20of%20transactions%20in%20a%20batch)), avec des systèmes de preuve comme les zk-SNARK (preuves courtes, vérification rapide) ou les zk-STARK (transparents, sans configuration de confiance requise). **zkSync Era**, **Starknet** — « a general purpose ZK Rollup based on STARKs and the Cairo VM » ([ethereum.org](https://ethereum.org/en/layer-2/#:~:text=Starknet%20is%20a%20general%20purpose%20ZK%20Rollup%20based%20on%20STARKs%20and%20the%20Cairo%20VM)) — et **Linea** sont des ZK rollups importants ; Polygon zkEVM et Scroll mettent également en œuvre une zkEVM afin d’exécuter des smart contracts Ethereum existants dans un environnement prouvable par ZK.
+
+Le compromis : la génération de preuves de validité est coûteuse en calcul et, pour une équivalence EVM complète, techniquement plus difficile à construire qu’un système de preuve de fraude. C’est en partie pourquoi les rollups optimistes ont atteint l’adoption grand public en premier, même si les ZK rollups offrent une finalité plus rapide.
+
+## Sidechains
+
+Une **sidechain** est « a separate blockchain that runs independent of Ethereum and is connected to Ethereum Mainnet by a two-way bridge » et, contrairement à un rollup, « a sidechain uses a separate consensus mechanism and doesn't benefit from Ethereum's security guarantees » ([ethereum.org](https://ethereum.org/en/developers/docs/scaling/sidechains/#:~:text=A%20sidechain%20uses%20a%20separate%20consensus%20mechanism%20and%20doesn%27t%20benefit%20from%20Ethereum%27s%20security%20guarantees)). Voilà la différence fondamentale avec une layer 2 : une sidechain échange la sécurité héritée contre une liberté de conception indépendante et, en général, des frais plus faibles et des blocs plus rapides, car elle dépend de son propre ensemble de validateurs plutôt que d’Ethereum.
+
+**Polygon PoS** en est l’exemple le plus connu. Sa propre page produit le décrit comme « Ethereum's most-used sidechain—battle-tested with billions in value secured, near-instant transactions, and sub-cent fees » ([polygon.technology](https://polygon.technology/polygon-pos)), protégé par son propre ensemble de validateurs en preuve d’enjeu plutôt que par celui d’Ethereum. **Gnosis Chain** (anciennement xDai) est une autre sidechain largement utilisée, avec Skale et Metis Andromeda. Comme vous faites confiance à un ensemble de validateurs différent, généralement plus petit, la sécurité d’une sidechain n’est jamais plus forte que cet ensemble. Il s’agit d’une garantie sensiblement différente de celle d’un rollup, où les états invalides peuvent en principe être détectés et annulés au moyen de données ancrées sur L1.
+
+## Canaux d’état et de paiement
+
+Un **canal d’état** permet à deux parties ou plus de traiter hors chaîne en verrouillant des fonds dans un contrat partagé et en échangeant directement des mises à jour signées. Ainsi, « channel peers can conduct an arbitrary number of offchain transactions while only submitting two onchain transactions to open and close the channel » ([ethereum.org](https://ethereum.org/en/developers/docs/scaling/state-channels/#:~:text=Channel%20peers%20can%20conduct%20an%20arbitrary%20number%20of%20offchain%20transactions%20while%20only%20submitting%20two%20onchain%20transactions)). Un canal de paiement en est la spécialisation pour les simples transferts de solde et « is best described as a 'two-way ledger' collectively maintained by two users » ([ethereum.org](https://ethereum.org/en/developers/docs/scaling/state-channels/#:~:text=A%20payment%20channel%20is%20best%20described%20as%20a%20%E2%80%9Ctwo%2Dway%20ledger%E2%80%9D%20collectively%20maintained%20by%20two%20users)). Les participants peuvent traiter entre eux autant de fois qu’ils le souhaitent, hors chaîne et instantanément, en touchant la chaîne de base uniquement pour ouvrir le canal (verrouiller une garantie) et le fermer (régler le solde final).
+
+L’implémentation la plus connue est le **Lightning Network** de Bitcoin, décrit sur son propre site comme « a decentralized network using smart contract functionality in the blockchain to enable instant payments across a network of participants », construit à partir de « bidirectional payment channels » qui acheminent les paiements comme les paquets de données sur Internet ([lightning.network](https://lightning.network/)). Le revers : les canaux ne font passer à l’échelle que les transactions *entre des parties reliées par un chemin de canaux ouverts*, les fonds doivent être engagés à l’avance pour ouvrir un canal, et les réseaux de canaux nécessitent un routage de liquidité pour bien fonctionner à grande échelle. Rien de cela ne s’applique à un rollup généraliste capable d’exécuter des smart contracts arbitraires pour n’importe qui.
+
+## Sharding et couches de disponibilité des données
+
+![Schéma vectoriel plat de transactions réparties entre quatre voies de shards parallèles (Shard 1 à Shard 4), chacune traitant indépendamment sa propre chaîne de blocs, toutes alimentant une bande de couche de disponibilité des données en dessous](../../assets/blockchain-scaling-approaches-03-sharding.jpg)
+
+Le **sharding** répartit le travail de validation d’une blockchain entre plusieurs sous-ensembles parallèles (« shards ») de nœuds, afin qu’aucun nœud unique n’ait à traiter la charge transactionnelle de l’ensemble du réseau. Vitalik Buterin affirme que « sharding is a technique that gets you all three » sommets du trilemme à la fois ([vitalik.eth.limo](https://vitalik.eth.limo/general/2021/04/07/sharding.html#:~:text=Sharding%20is%20a%20technique%20that%20gets%20you%20all%20three)), en utilisant des comités de validateurs échantillonnés aléatoirement pour vérifier différents shards en parallèle. La technologie qui rend le sharding sûr sans forcer chaque nœud à télécharger l’intégralité des données de chaque shard est l’échantillonnage de [disponibilité des données](/fr/glossary/data-availability/) (DAS) — « a way for the network to check that data is available without putting too much strain on any individual node » ([ethereum.org](https://ethereum.org/en/developers/docs/data-availability/#:~:text=Data%20availability%20sampling%20is%20a%20way%20for%20the%20network%20to%20check%20that%20data%20is%20available%20without%20putting%20too%20much%20strain%20on%20any%20individual%20node)). Un nœud léger ne télécharge que de petits fragments choisis aléatoirement parmi les données d’un bloc et peut néanmoins, grâce au codage à effacement, acquérir la certitude que les données complètes ont été publiées.
+
+Ce même problème de disponibilité des données concerne directement les rollups, d’où l’émergence des couches dédiées de disponibilité des données comme catégorie d’infrastructure à part entière. **Celestia** est une blockchain modulaire conçue spécifiquement pour que « rollups and L2s use Celestia as a network for publishing and making transaction data available for anyone to download » ([celestia.org](https://celestia.org/what-is-celestia/#:~:text=Rollups%20and%20L2s%20use%20Celestia%20as%20a%20network%20for%20publishing%20and%20making%20transaction%20data%20available%20for%20anyone%20to%20download)), ce qui permet à un rollup de publier ses données sur une couche DA dédiée, moins coûteuse, plutôt que sur le réseau principal Ethereum. **EigenDA**, construit sur l’infrastructure de restaking d’EigenLayer, propose un service comparable, sécurisé par des stakers Ethereum qui choisissent également de sécuriser la couche DA. Les rollups qui publient leurs données sur une couche DA externe plutôt que sur Ethereum L1 sont parfois appelés *validiums* ou *optimiums* plutôt que des rollups « purs », car L2BEAT les suit comme une catégorie distincte à côté des rollups et d’autres solutions L2 ([l2beat.com](https://l2beat.com/scaling/summary)). Ils échangent une partie de cette garantie de sécurité ancrée dans L1 contre des coûts de publication des données plus faibles.
+
+## Comparaison des approches
+
+| Approche | Lieu d’exécution du calcul | Hérite de la sécurité de L1 ? | Disponibilité des données | Principal compromis | Exemples |
+|---|---|---|---|---|---|
+| Rollup optimiste | Hors chaîne (L2) | Oui — données + preuve de fraude sur L1 | Données complètes publiées sur L1 | Fenêtre de contestation du retrait d’environ 7 jours | Arbitrum, Optimism, Base |
+| ZK rollup | Hors chaîne (L2) | Oui — données + preuve de validité sur L1 | Données complètes publiées sur L1 | Génération de preuves coûteuse ; équivalence EVM complète plus difficile | zkSync, Starknet, Linea |
+| Sidechain | Chaîne indépendante | Non — consensus/validateurs propres | Chaîne propre, non publiée sur L1 | Sécurité seulement aussi forte que son propre ensemble de validateurs | Polygon PoS, Gnosis Chain |
+| Canal d’état/de paiement | Hors chaîne, entre participants | Indirectement — fonds verrouillés sur L1 | Non publiée ; seul l’état final est onchain | Ne fait passer à l’échelle que les transactions entre parties reliées par canaux ; fonds à pré-verrouiller | Lightning Network |
+| Sharding / couche DA | Shards parallèles ou réseau DA séparé | Variable — le sharding L1 en hérite ; les couches DA externes ajoutent une nouvelle hypothèse de confiance | Vérifiée par échantillonnage de disponibilité des données | Une DA externe réduit le coût mais ajoute une dépendance hors de L1 | Feuille de route de sharding d’Ethereum, Celestia, EigenDA |
+
+Aucune approche ne gagne sur tous les axes ; c’est pourquoi les systèmes de production les combinent de plus en plus. Un ZK rollup qui publie par exemple ses données sur Celestia plutôt que sur Ethereum emprunte la sécurité de preuve de validité à une couche et une disponibilité des données moins coûteuse à une autre.
+
+---
+
+## Lien avec les domaines tokenisés
+
+Les choix de mise à l’échelle comptent pour les [domaines tokenisés](/fr/glossary/tokenized-domain/), car chaque frappe, transfert, mise à jour DNS ou action de garantie est une transaction onchain dont le coût et le délai de finalité dépendent de la couche où elle se règle. Le transfert d’un `.com` tokenisé confirmé sur un rollup optimiste est peu coûteux et rapide pour l’utilisateur, mais n’est pas entièrement définitif face à L1 pendant environ une semaine, sauf si un bridge de sortie rapide est utilisé. Le même transfert sur un ZK rollup devient définitif face à L1 dès que la preuve de validité est publiée. Les sidechains peuvent être encore moins coûteuses, mais un NFT de domaine vivant uniquement sur une sidechain hérite de la sécurité de l’ensemble de validateurs plus restreint de cette sidechain plutôt que de celle d’Ethereum. Comprendre ces compromis aide à comprendre ce que l’on possède réellement lorsqu’un domaine est représenté onchain — la même habitude de diligence raisonnable qui importe, de façon générale, dans les [fondations du Web3](/fr/topics/web3-foundations/).
+
+---
+
+## Sources et lectures complémentaires
+
+- [The Limits to Blockchain Scalability — Vitalik Buterin](https://vitalik.eth.limo/general/2021/04/07/sharding.html)
+- [Layer 2 — ethereum.org](https://ethereum.org/en/layer-2/)
+- [Optimistic Rollups — ethereum.org](https://ethereum.org/en/developers/docs/scaling/optimistic-rollups/)
+- [ZK-Rollups — ethereum.org](https://ethereum.org/en/developers/docs/scaling/zk-rollups/)
+- [Sidechains — ethereum.org](https://ethereum.org/en/developers/docs/scaling/sidechains/)
+- [State Channels — ethereum.org](https://ethereum.org/en/developers/docs/scaling/state-channels/)
+- [Data Availability — ethereum.org](https://ethereum.org/en/developers/docs/data-availability/)
+- [L2BEAT Scaling Summary](https://l2beat.com/scaling/summary)
+- [What Is Celestia? — celestia.org](https://celestia.org/what-is-celestia/)
+- [Lightning Network](https://lightning.network/)
+- [Polygon PoS — polygon.technology](https://polygon.technology/polygon-pos)

--- a/content/blog/fr/blockchain-virtual-machines.md
+++ b/content/blog/fr/blockchain-virtual-machines.md
@@ -1,0 +1,151 @@
+---
+title: "Principales machines virtuelles blockchain : EVM, SVM, MoveVM, WASM et CairoVM"
+date: '2026-07-02'
+language: fr
+tags: ['guide']
+authors: ['namefiteam']
+draft: false
+cluster: web3-foundations
+series: blockchain-concepts
+seriesOrder: 30
+format: roundup
+description: "Guide des principales machines virtuelles blockchain — EVM, SVM, MoveVM, VM fondées sur WASM et CairoVM — comparant langages, modèles d’exécution et écosystèmes."
+ogImage: ../../assets/blockchain-virtual-machines-og.jpg
+keywords: ['machine virtuelle blockchain', 'machines virtuelles blockchain', 'evm', 'ethereum virtual machine', 'svm', 'solana virtual machine', 'sealevel', 'movevm', 'langage move', 'blockchain wasm', 'cosmwasm', 'polkavm', 'cairovm', 'langage cairo', 'starknet', 'langage de smart contract', 'exécution parallèle blockchain', 'compatible evm', 'environnement d’exécution blockchain', 'machine à états blockchain']
+relatedArticles:
+  - /fr/blog/blockchain-consensus-mechanisms/
+  - /fr/blog/blockchain-scaling-approaches/
+  - /fr/blog/blockchain-cryptographic-primitives/
+  - /fr/blog/blockchain-privacy-technologies/
+  - /fr/blog/what-are-tokenized-domains/
+relatedTopics:
+  - /fr/topics/web3-foundations/
+  - /fr/topics/domain-tokenization/
+relatedSeries:
+  - /fr/series/tokenize-your-com/
+  - /fr/series/domain-flipping-skills/
+relatedGlossary:
+  - /fr/glossary/ethereum-virtual-machine/
+  - /fr/glossary/webassembly/
+  - /fr/glossary/smart-contract/
+  - /fr/glossary/ethereum/
+  - /fr/glossary/gas/
+---
+
+Chaque [smart contract](/fr/glossary/smart-contract/) doit s’exécuter quelque part. Ce « quelque part » est une machine virtuelle (VM) blockchain : le programme isolé que chaque nœud du réseau exécute de manière identique, afin que la même entrée produise toujours la même sortie, quel que soit celui qui l’exécute. La VM sur laquelle vous construisez façonne presque tout dans une chaîne : les langages que vous pouvez utiliser, la possibilité d’exécuter les transactions simultanément ou seulement les unes après les autres, et la part de l’écosystème de développeurs existant que vous pouvez exploiter dès le premier jour.
+
+Ce guide présente cinq conceptions de VM qui, à elles seules, propulsent aujourd’hui l’essentiel de l’activité de smart contracts dans le [Web3](/fr/glossary/web3/) : l’[Ethereum Virtual Machine](/fr/glossary/ethereum-virtual-machine/) (EVM), la SVM de Solana, la MoveVM employée par Aptos et Sui, les VM fondées sur [WebAssembly](/fr/glossary/webassembly/) (WASM), comme CosmWasm et PolkaVM, et la CairoVM de Starknet.
+
+---
+
+## Qu’est-ce qu’une machine virtuelle blockchain, et pourquoi est-ce important ?
+
+Une VM blockchain est un environnement d’exécution déterministe et isolé : chaque nœud complet télécharge les mêmes transactions, les exécute avec la même VM et aboutit au même état [onchain](/fr/glossary/on-chain/). La documentation d’Ethereum décrit l’EVM comme « a decentralized virtual environment that executes code consistently and securely across all Ethereum nodes » ([ethereum.org](https://ethereum.org/en/developers/docs/evm/#:~:text=The%20EVM%20is%20a%20decentralized,mechanics%20of%20how%20they%20work)), une description qui se généralise à toutes les VM de ce guide.
+
+Deux propriétés définissent les arbitrages de conception d’une VM :
+
+- **Langage et chaîne d’outils.** Dans quels langages les développeurs peuvent-ils écrire des contrats, et quelle est la taille de la bibliothèque existante de code audité, des outils et du vivier de recrutement qui les maîtrise déjà ?
+- **Modèle d’exécution.** La VM traite-t-elle les transactions strictement une à la fois (exécution séquentielle), ou des transactions indépendantes peuvent-elles s’exécuter simultanément sur plusieurs cœurs de processeur (exécution parallèle) ? L’exécution séquentielle est plus simple à raisonner ; l’exécution parallèle augmente le débit théorique mais ajoute de la complexité d’ordonnancement.
+
+Ces choix se répercutent sur les coûts de gas, le comportement en cas de congestion et la capacité des contrats et outils existants à être portés sans réécriture. C’est pourquoi la question de la VM est l’une des premières auxquelles doit répondre toute nouvelle chaîne, ou tout actif [tokenisé](/fr/glossary/tokenize/) construit dessus.
+
+---
+
+## EVM (Ethereum Virtual Machine)
+
+![Schéma vectoriel plat de l’EVM comme machine à pile à voie unique, avec un pointeur d’instruction qui empile et dépile des valeurs sur une pile verticale, et un compteur de gas qui suit le coût d’exécution](../../assets/blockchain-virtual-machines-01-evm-stack.jpg)
+
+L’EVM est la VM de smart contracts la plus ancienne et la plus largement déployée, introduite avec [Ethereum](/fr/glossary/ethereum/) en 2015. C’est une machine **à pile** : la documentation Ethereum précise qu’elle fonctionne comme « a stack machine with a depth of 1024 items », chaque élément étant un mot de 256 bits ([ethereum.org](https://ethereum.org/en/developers/docs/evm/#:~:text=The%20EVM%20executes%20as%20a,256%2Dbit%20word)). L’état des contrats réside dans un trie Merkle Patricia associé à chaque compte, et l’état global de la chaîne est lui aussi organisé comme un trie Merkle Patricia modifié qui relie tous les comptes par hachage ([ethereum.org](https://ethereum.org/en/developers/docs/evm/#:~:text=Ethereum%20uses%20a%20modified%20Merkle,linked%20by%20hashes)).
+
+**Langage.** Les contrats sont presque toujours écrits en **Solidity**, décrit dans la documentation Ethereum comme un « object-oriented, high-level language for implementing smart contracts », fortement influencé par la syntaxe C++ ([ethereum.org](https://ethereum.org/en/developers/docs/smart-contracts/languages/#:~:text=Solidity)). **Vyper**, un langage « Pythonic » qui réduit délibérément ses fonctionnalités pour rendre les contrats plus faciles à auditer, en est la principale alternative ([ethereum.org](https://ethereum.org/en/developers/docs/smart-contracts/languages/#:~:text=Vyper)).
+
+**Modèle d’exécution.** L’EVM traite les transactions d’un bloc de façon **séquentielle**, l’une après l’autre dans un ordre déterminé. Cela maintient une logique de transition d’état simple et facile à auditer, mais limite le débit de la couche de base.
+
+**Gas.** Chaque opération coûte du [gas](/fr/glossary/gas/), l’unité Ethereum qui mesure « the computational effort required for operations ». Il tarifie l’exécution et protège le réseau contre le spam ou les boucles infinies ([ethereum.org](https://ethereum.org/en/developers/docs/evm/#:~:text=Since%20each%20transaction%20is%20broadcast,uses%20gas)).
+
+**Atout distinctif et portée.** Le véritable fossé défensif de l’EVM est son écosystème : c’est la VM la plus implémentée dans les cryptomonnaies, et des dizaines de Layer 2 et de chaînes indépendantes (Arbitrum, Optimism, Base, Polygon, BNB Chain, Avalanche C-Chain) proposent des environnements **compatibles EVM** ou **équivalents EVM**, afin que les contrats Solidity, portefeuilles et outils existants puissent être déployés avec peu ou pas de modification.
+
+---
+
+## SVM (Solana / Sealevel)
+
+![Schéma vectoriel plat opposant une autoroute à plusieurs voies où des voitures-transactions roulent en parallèle à une route à voie unique avec des voitures en file, illustrant l’exécution parallèle de Sealevel sur Solana par rapport à l’exécution séquentielle](../../assets/blockchain-virtual-machines-02-parallel-execution.jpg)
+
+Le runtime de Solana, **Sealevel**, repose sur une hypothèse précise : la plupart des transactions touchent des parties distinctes de l’état et peuvent donc s’exécuter simultanément plutôt qu’une par une. L’annonce de Solana décrit Sealevel comme « Solana's parallel smart contracts runtime », capable de « processing thousands of contracts in parallel, using as many cores as are available to the Validator » ([solana.com](https://solana.com/news/sealevel---parallel-processing-thousands-of-smart-contracts#:~:text=Sealevel%E2%80%94Parallel%20Smart%20Contracts%20Runtime)).
+
+**Fonctionnement du parallélisme.** Les transactions Solana doivent déclarer à l’avance chaque compte qu’elles liront ou écriront. Cette déclaration rend l’ordonnancement possible : le runtime peut « sort millions of pending transactions » et « schedule all the non-overlapping transactions in parallel », tout en laissant s’exécuter simultanément plusieurs transactions qui ne font que *lire* le même compte ([solana.com](https://solana.com/news/sealevel---parallel-processing-thousands-of-smart-contracts#:~:text=Sort%20millions%20of%20pending%20transactions)). Deux transactions ne sont sérialisées que lorsqu’elles écrivent toutes deux dans le même compte.
+
+**Langage et fonctionnement interne de la VM.** Les programmes Solana (le terme employé pour les smart contracts) sont compilés vers une variante de bytecode Berkeley Packet Filter. Solana Labs indique avoir choisi « a variant of the Berkeley Packet Filter (BPF) bytecode » pour la VM onchain ([solana.com](https://solana.com/news/sealevel---parallel-processing-thousands-of-smart-contracts#:~:text=Berkeley%20Packet%20Filter)). Les programmes sont le plus souvent écrits en **Rust**, tandis que C et C++ sont également pris en charge.
+
+**Atout distinctif.** Comme le parallélisme au niveau des comptes est une propriété du runtime plutôt qu’un mécanisme que chaque auteur de contrat doit mettre en œuvre, Solana peut soutenir un débit élevé sans déplacer l’exécution hors chaîne. En contrepartie, son modèle de déclaration stricte des comptes change la façon dont les contrats sont écrits par rapport au stockage libre de l’EVM.
+
+---
+
+## MoveVM (Aptos et Sui)
+
+![Schéma vectoriel plat d’une pièce traitée comme une ressource physique passée de main en main entre deux boîtes de compte, avec les badges de garde « cannot copy » et « cannot lose » illustrant le modèle de ressources de Move](../../assets/blockchain-virtual-machines-03-move-resource.jpg)
+
+**Move** est un langage de smart contracts initialement créé pour le projet Diem de Meta, et désormais la couche de base d’**Aptos** et de **Sui**, qui exécutent chacun leur propre variante de MoveVM. La documentation d’Aptos décrit Move comme « a safe and secure programming language for Web3 that emphasizes scarcity and access control » ([aptos.dev](https://aptos.dev/en/network/blockchain/move#:~:text=Move%20is%20a%20safe%20and,scarcity%20and%20access%20control)).
+
+**Le modèle de ressources.** L’idée déterminante de Move est de traiter les actifs numériques comme des **ressources**, des types de structures particuliers que le système de types du langage garantit qu’ils « cannot be accidentally duplicated or dropped » ([aptos.dev](https://aptos.dev/en/network/blockchain/move#:~:text=Resources%20cannot%20be%20copied%2C%20they,structs%20cannot%20be%20accidentally%20duplicated)). Un jeton ou NFT modélisé comme une ressource Move ne peut matériellement pas être copié par un contrat bogué comme un entier naïf représentant un solde de compte pourrait être doublement dépensé : le compilateur rejette le programme. Seules les structures explicitement marquées comme copiables ou supprimables peuvent être dupliquées ou écartées.
+
+**Exécution parallèle.** Aptos exécute les contrats Move avec **Block-STM**, que la documentation décrit comme permettant « concurrent execution of transactions without any input from the user ». Le runtime déduit quelles transactions sont indépendantes au moment de l’exécution, plutôt que d’exiger les listes de comptes déclarées que Solana utilise ([aptos.dev](https://aptos.dev/en/network/blockchain/move#:~:text=Parallelism%20via%20Block,input%20from%20the%20user)).
+
+**Le modèle objet de Sui.** Sui pousse l’idée de ressource de Move plus loin grâce à une couche de stockage centrée sur les objets : « An object is a fundamental unit of storage on the network. Every resource, asset, or piece of data on-chain is an object », adressable par un identifiant unique plutôt que stocké dans le magasin clé-valeur d’un compte ([docs.sui.io](https://docs.sui.io/concepts/object-model#:~:text=An%20object%20is%20a%20fundamental,piece%20of%20data%20onchain%20is%20an%20object)). Les objets sont soit à propriétaire unique (**owned objects**, qui peuvent s’exécuter en parallèle sans ordre de consensus puisqu’aucune autre transaction ne peut y accéder), soit des **shared objects**, auxquels plusieurs parties peuvent accéder et qui exigent une séquence de consensus.
+
+**Atout distinctif.** Les types de ressources de Move rendent des catégories entières de bogues d’actifs — doubles dépenses, destructions accidentelles — impossibles à représenter à la compilation. Aptos et Sui associent tous deux ce modèle de sûreté à une exécution parallèle pensée dès le départ plutôt qu’ajoutée a posteriori.
+
+---
+
+## VM fondées sur WASM (CosmWasm, PolkaVM)
+
+Plutôt que de définir un format de bytecode sur mesure, une seconde famille de chaînes exécute les smart contracts via **WebAssembly**, un format binaire généraliste conçu à l’origine pour le navigateur. La norme WebAssembly décrit Wasm comme « a binary instruction format for a stack-based virtual machine », conçu comme « a portable compilation target for programming languages » et visant à « execute at native speed » ([webassembly.org](https://webassembly.org/#:~:text=WebAssembly%20(abbreviated%20Wasm)%20is%20a,wide%20range%20of%20platforms)). Employer Wasm comme VM de contrat signifie que tout langage ayant une cible de compilation Wasm — Rust, C, C++, Go — peut, en principe, produire un contrat déployable.
+
+**CosmWasm.** Principale plateforme de smart contracts fondée sur Wasm dans l’écosystème Cosmos, CosmWasm se décrit comme une « secure, performant, interoperable smart contract platform for the multi-chain world » ([cosmwasm.com](https://www.cosmwasm.com/#:~:text=Secure%2C%20performant%2C%20interoperable%20smart%20contract,platform%20for%20the%20multi%2Dchain%20world)). Les contrats sont écrits en **Rust** et s’exécutent sur « a highly optimized Web Assembly runtime » ([cosmwasm.com](https://www.cosmwasm.com/#:~:text=highly%20optimized%20Web%20Assembly%20runtime)). CosmWasm est déployé sur des dizaines de chaînes Cosmos SDK, notamment Osmosis, Neutron, Injective, Secret Network et Terra, et hérite de la messagerie interchaîne IBC native de Cosmos.
+
+**PolkaVM.** La nouvelle VM de smart contracts de Polkadot a choisi une autre voie : au lieu d’exécuter du Wasm brut, Parity a créé PolkaVM, décrite dans son propre dépôt comme « a general purpose user-level RISC-V based virtual machine » ([github.com/paritytech/polkavm](https://github.com/paritytech/polkavm#:~:text=PolkaVM%20is%20a%20general%20purpose,level%20RISC%2DV%20based%20virtual%20machine)). La justification, selon la documentation de smart contracts ink!, est la performance : l’exécution RISC-V « correlates with transaction throughput and transaction costs », procurant une exécution plus rapide et moins coûteuse que l’interpréteur Wasm qu’ink! utilisait auparavant ([use.ink](https://use.ink/docs/v6/background/why-riscv-and-polkavm-for-smart-contracts/#:~:text=performance%20correlates%20with%20transaction%20throughput)). Fait notable, la pile PolkaVM de Polkadot (sous la marque « Revive ») propose aussi une couche d’interpréteur EVM, qui permet aux contrats Solidity de s’exécuter sur le même backend RISC-V.
+
+**Atout distinctif.** Les VM fondées sur WASM échangent un bytecode conçu sur mesure contre une cible de compilation mature et très largement implémentée. Rust, en particulier, apporte de solides garanties de sûreté mémoire au code de contrat, et les runtimes Wasm/RISC-V sous-jacents profitent d’outils conçus pour des usages non blockchain bien plus étendus.
+
+---
+
+## CairoVM (Starknet)
+
+**Cairo** est le langage de smart contracts et la VM conçus spécifiquement pour générer des preuves à divulgation nulle, qui sous-tendent **Starknet**, une [Layer 2](/fr/glossary/layer-2/) Ethereum. La documentation de Starknet est explicite quant à l’objectif de conception : « Cairo is a STARK-friendly Von Neumann architecture capable of generating validity proofs for arbitrary computations » ([starknet.io](https://www.starknet.io/cairo-book/ch201-architecture.html#:~:text=Cairo%20is%20a%20STARK,for%20arbitrary%20computations)). Le fait d’être « STARK-friendly » signifie que l’ensemble d’instructions est « optimized for the STARK proof system, while remaining compatible with other proof system backends » ([starknet.io](https://www.starknet.io/cairo-book/ch201-architecture.html#:~:text=Being%20STARK,other%20proof%20system%20backends)). C’est la priorité inverse de l’EVM ou de la SVM, qui ont été conçues d’abord pour l’exécution et auxquelles des systèmes de preuve n’ont été ajoutés que plus tard pour la mise à l’échelle.
+
+**Modèle d’exécution.** Cairo est compilé vers un ensemble d’instructions Turing-complet (la « machine Cairo »), défini comme un ensemble de représentations intermédiaires algébriques. La trace d’exécution de tout programme Cairo peut ainsi être transformée en une preuve STARK concise vérifiable sur Ethereum L1 ([starknet.io](https://www.starknet.io/cairo-book/ch201-architecture.html#:~:text=At%20its%20core%2C%20Cairo%20is,arbitrary%20code%29%20through%20the%20Cairo%20machine)). Starknet peut donc regrouper des milliers de transactions hors chaîne et publier une preuve compacte de correction sur Ethereum, au lieu de rejouer chaque transaction.
+
+**Atout distinctif.** Puisque la facilité de génération de preuves a été la contrainte de conception initiale, et non un ajout tardif, les programmes Cairo coûtent moins cher à prouver qu’un calcul équivalent exécuté dans une VM généraliste adaptée ensuite à un zk-prover (une « zkEVM »). Le compromis est un écosystème de langage plus récent et plus petit, ainsi qu’une courbe d’apprentissage plus abrupte que Solidity pour les développeurs venant d’Ethereum.
+
+---
+
+## Tableau comparatif
+
+| VM | Langage(s) de contrat | Modèle d’exécution / d’état | Exécution parallèle | Taille de l’écosystème | Compatible EVM |
+|---|---|---|---|---|---|
+| **EVM** | Solidity, Vyper | Machine à pile ; état des comptes/du stockage dans un trie Merkle Patricia | Non — séquentielle dans un bloc | Le plus grand ; cible par défaut des L2 et des chaînes applicatives | Native |
+| **SVM (Solana)** | Rust, C, C++ | Bytecode dérivé de BPF ; état fondé sur les comptes avec ensembles lecture/écriture déclarés | Oui — Sealevel ordonne simultanément les transactions qui ne se chevauchent pas | Grand, en croissance rapide, principalement natif de Solana | Non (écosystème distinct) |
+| **MoveVM (Aptos/Sui)** | Move | Objets typés comme ressources ; Aptos utilise Block-STM, Sui un modèle d’objets détenus/partagés | Oui — déduit au runtime (Aptos) ou via la propriété des objets (Sui) | Plus petit, en croissance ; deux écosystèmes Move indépendants | Non |
+| **Fondées sur WASM (CosmWasm, PolkaVM)** | Rust (CosmWasm) ; chaînes d’outils Rust/C/RISC-V (PolkaVM) | Bytecode Wasm (CosmWasm) ou RISC-V (PolkaVM) | Dépend de la chaîne ; ce n’est pas une propriété universelle de l’exécution Wasm | Moyen ; réparti entre de nombreuses chaînes Cosmos et l’ensemble de parachains Polkadot | PolkaVM/Revive ajoute une couche d’interpréteur EVM ; CosmWasm n’est pas compatible EVM |
+| **CairoVM (Starknet)** | Cairo | Machine Turing-complète fondée sur AIR, conçue pour les preuves STARK | Ce n’est pas l’objectif principal — optimisée pour la prouvabilité, non pour la concurrence | La plus petite des cinq, mais grandit avec l’activité L2 de Starknet | Non (les projets zkEVM font entrer les contrats Solidity séparément) |
+
+---
+
+## Lien avec les domaines tokenisés
+
+La VM d’une chaîne importe directement pour l’infrastructure des [domaines tokenisés](/fr/glossary/tokenized-domain/). Un domaine représenté par un [NFT](/fr/glossary/nft/) est, au fond, un smart contract qui impose qui possède un jeton et ce qu’il peut en faire. C’est le même type de logique que le modèle de ressources de Move a été conçu pour rendre manifestement sûr, et que les outils matures de l’EVM rendent facile à auditer et à intégrer aux portefeuilles et places de marché existants. Le modèle de tokenisation de Namefi vise délibérément l’écosystème EVM : la compatibilité EVM signifie que le NFT de propriété d’un domaine `.com` ou `.ai` tokenisé fonctionne immédiatement avec l’univers existant de portefeuilles, places de marché et protocoles DeFi EVM, sans exiger une intégration sur mesure pour chaque nouvelle VM. Découvrez les domaines tokenisés sur [namefi.io](https://namefi.io).
+
+---
+
+## Sources et lectures complémentaires
+
+- [The Ethereum Virtual Machine (EVM) — ethereum.org](https://ethereum.org/en/developers/docs/evm/)
+- [Smart Contract Languages — ethereum.org](https://ethereum.org/en/developers/docs/smart-contracts/languages/)
+- [Sealevel — Parallel Processing Thousands of Smart Contracts — Solana](https://solana.com/news/sealevel---parallel-processing-thousands-of-smart-contracts)
+- [Move — Documentation Aptos](https://aptos.dev/en/network/blockchain/move)
+- [Object Model — Documentation Sui](https://docs.sui.io/concepts/object-model)
+- [CosmWasm](https://www.cosmwasm.com/)
+- [PolkaVM — GitHub (paritytech)](https://github.com/paritytech/polkavm)
+- [Why RISC-V and PolkaVM for Smart Contracts — documentation ink!](https://use.ink/docs/v6/background/why-riscv-and-polkavm-for-smart-contracts/)
+- [Cairo Architecture — The Cairo Programming Language / Starknet](https://www.starknet.io/cairo-book/ch201-architecture.html)
+- [WebAssembly](https://webassembly.org/)

--- a/content/blog/fr/how-much-is-a-domain-understanding-holding-cost.md
+++ b/content/blog/fr/how-much-is-a-domain-understanding-holding-cost.md
@@ -1,0 +1,156 @@
+---
+title: "Combien coûte un domaine ? Comprendre le coût de détention"
+date: '2026-06-29'
+language: fr
+tags: ['domains', 'domain-investing', 'domain-pricing', 'guide']
+authors: ['namefiteam']
+draft: false
+cluster: domain-investing
+series: domain-flipping-skills
+seriesOrder: 41
+format: guide
+description: "Guide pratique du coût de détention d’un domaine : prix de première année, renouvellement, transfert, restauration, confidentialité, taxes, moyens de paiement et modèles de tarification des registrars."
+keywords: ['combien coûte un domaine', 'coût de détention de domaine', 'coût de renouvellement de domaine', 'prix d’enregistrement de domaine', 'frais de transfert de domaine', 'frais de restauration de domaine', 'coût de confidentialité de domaine', 'tarification des registrars', 'prix de domaine la première année', 'prix de renouvellement de domaine', 'frais de rédemption de domaine', 'modèle de tarification de domaine', 'coût total de domaine', 'coût de propriété de domaine', 'coût de portage de domaine']
+relatedArticles:
+  - /fr/blog/domain-renewal-costs-and-sell-through-rate/
+  - /fr/blog/domain-portfolio-management/
+  - /fr/blog/when-to-drop-a-domain/
+  - /fr/blog/domain-flipping/
+  - /fr/blog/taxes-and-accounting-for-domain-investors/
+relatedTopics:
+  - /fr/topics/domain-investing/
+  - /fr/topics/domain-basics/
+relatedSeries:
+  - /fr/series/domain-flipping-skills/
+  - /fr/series/domain-investor-field-guide/
+relatedGlossary:
+  - /fr/glossary/holding-cost/
+  - /fr/glossary/domain-renewal/
+  - /fr/glossary/registrar/
+  - /fr/glossary/registry/
+  - /fr/glossary/retail-pricing/
+---
+
+Le domaine le moins cher est rarement celui qui coûte le moins cher à *détenir*.
+
+C’est la première chose à comprendre avant d’enregistrer un nom. Le prix affiché au paiement n’est qu’une ligne du grand livre. Un domaine a un prix d’enregistrement la première année, un prix de renouvellement, un prix de transfert, d’éventuels frais de restauration ou de rédemption, des réglages de confidentialité, des taxes, des coûts liés au moyen de paiement et parfois des frais de produit périphériques pour le DNS, l’e-mail, l’hébergement ou les services de compte.
+
+C’est pourquoi un domaine à $1 la première année peut être parfaitement légitime et devenir tout de même un engagement annuel de $30, $60 ou $80 par la suite. Le prix de la première année vous ouvre la porte. Le prix de renouvellement détermine le [coût de détention](/fr/glossary/holding-cost/) à long terme.
+
+## Le premier chiffre affiché n’est pas le coût
+
+La plupart des gens demandent « combien coûte un domaine ? » et attendent une seule réponse. Une meilleure question est : « Combien ce nom me coûtera-t-il si je le garde trois ans et qu’un problème survient une fois ? »
+
+Voici les composantes du coût.
+
+| Coût | Ce qu’il signifie | Pourquoi il compte |
+| --- | --- | --- |
+| Enregistrement la première année | Le prix pour enregistrer un nom disponible pendant la première période | C’est là que les promotions apparaissent généralement |
+| Renouvellement | Le prix récurrent pour conserver le domaine après la première période | C’est le véritable coût à long terme |
+| Transfert | Le prix pour déplacer le nom vers un autre registrar | Il peut différer du renouvellement et prolonger la période |
+| Restauration / rédemption | Les frais pour récupérer un nom après son expiration et son entrée dans une fenêtre de récupération | Ils peuvent dépasser de nombreuses fois le renouvellement annuel |
+| Confidentialité WHOIS | Service de confidentialité ou de mandataire pour les données de contact | Il peut être inclus, payant, indisponible ou traité différemment selon le TLD |
+| Taxes et frais réglementaires | Taxe sur les ventes, TVA, GST, frais locaux, frais ICANN ou autres ajouts au paiement | Ils dépendent de la juridiction, de la devise et du registrar |
+| Coûts de paiement | Marge de change de carte, frais de virement, frais de réseau crypto, moyens de paiement différés, friction sur les remboursements | Le prix du registrar peut ne pas être exactement le montant qui sort de votre compte |
+| Frais DNS / produits | Coûts des zones hébergées, des requêtes, de l’e-mail, de la redirection, du SSL ou de services groupés | Un domaine peut être bon marché alors que le compte environnant ne l’est pas |
+
+La ligne qui surprend le plus souvent est le renouvellement. La politique ICANN de récupération des enregistrements expirés impose aux registrars de rendre les [frais de renouvellement, de renouvellement après expiration et de rédemption/restauration raisonnablement disponibles](https://www.icann.org/resources/pages/errp-2013-02-28-en#Notice), mais l’acheteur doit tout de même les comparer avant le paiement. Un petit prix la première année n’est pas trompeur en soi. Il devient un problème lorsque l’acheteur le traite comme un coût annuel.
+
+## Pourquoi un domaine à $1 peut se renouveler à $30 à $80
+
+La tarification d’introduction est courante, car la première année et l’année de renouvellement sont deux événements économiques distincts.
+
+La première année peut être remisée parce que le registre ou le registrar cherche à favoriser l’adoption, parce qu’une promotion est en cours, ou parce que le registrar prévoit que de nombreux clients garderont le domaine plusieurs années. L’année de renouvellement a une fonction différente. Elle doit financer les frais récurrents du registre, la marge du registrar, le traitement des paiements, les contrôles contre la fraude, le support, la conformité, les notifications de renouvellement et toute couche de produit regroupée autour du nom.
+
+C’est normal dans de nombreux secteurs : le prix d’acquisition est souvent inférieur au prix de rétention. Le risque propre aux domaines est que les renouvellements ne sont pas facultatifs si le nom compte. Si votre site web, votre e-mail, votre marque, votre application ou votre portefeuille dépend d’un domaine, la facture de renouvellement est le coût du maintien du contrôle.
+
+L’habitude pratique est simple : avant d’enregistrer, notez les deux chiffres. Si le prix de la première année est de $1 et que le renouvellement coûte $40, considérez le domaine comme un actif à $40 par an avec une première année remisée, et non comme un actif à $1.
+
+## Enregistrement, renouvellement, transfert, restauration
+
+Les quatre opérations de domaine à comparer sont l’enregistrement, le renouvellement, le transfert et la restauration.
+
+L’**enregistrement** est la première période. C’est le chiffre mis en avant par les pages marketing, car c’est le plus facile à comprendre. Une première année remisée peut être utile pour tester une idée, mais ce n’est pas le bon chiffre pour planifier à long terme.
+
+Le **renouvellement** est le coût de la poursuite du contrôle. Si vous enregistrez un seul domaine pour un projet parallèle, l’écart entre $15 et $30 peut être tolérable. Si vous détenez 200 noms, un écart de renouvellement de $15 devient $3,000 par an. C’est pourquoi les investisseurs en domaines se préoccupent tant du [coût de renouvellement et du taux de vente](/fr/blog/domain-renewal-costs-and-sell-through-rate/).
+
+Le **transfert** est ce que vous payez pour déplacer le domaine vers un autre registrar. Un transfert peut inclure une prolongation d’un an, mais ce n’est pas un raccourci universel qu’il faut présumer sans vérification. Surveillez également les verrous de transfert, les limites liées à un enregistrement récent, la gestion du code d’autorisation et la question de savoir si le transfert modifie vos réglages DNS ou de confidentialité.
+
+La **restauration ou rédemption** est le coûteux bouton de panique. La politique de récupération de l’ICANN indique que les registres de gTLD doivent généralement proposer une [période de grâce de rédemption de 30 jours](https://www.icann.org/resources/pages/errp-2013-02-28-en#Redemption) après la suppression, durant laquelle l’enregistrement supprimé peut être restauré par l’intermédiaire du registrar qui l’a supprimé. Pendant cette période, la récupération peut coûter bien plus qu’un renouvellement normal. La leçon est simple : le renouvellement automatique coûte moins cher que le sauvetage.
+
+## Coûts de confidentialité, de taxes et de moyens de paiement
+
+La confidentialité WHOIS doit figurer dans la comparaison de coût, car elle modifie la valeur pratique de l’offre. Certains domaines incluent la confidentialité par défaut. D’autres la rendent facultative. Certains TLD ou types de titulaires peuvent traiter les données de contact publiques différemment. Si la confidentialité vous importe, comparez-la comme un élément du coût du domaine plutôt que comme une idée après coup.
+
+Les taxes et frais réglementaires sont moins ordonnés. La taxe sur les ventes, la TVA, la GST et les règles locales dépendent de votre lieu de résidence, du lieu de vente du registrar et de la classification du service. Le total au paiement peut différer du prix de base annoncé, surtout entre devises ou juridictions.
+
+Le moyen de paiement peut également modifier le coût réel. Une carte peut ajouter une marge de change. Un virement bancaire peut comporter des frais bancaires ou des minimums. Un virement bancaire local peut retarder l’activation. Un paiement crypto peut impliquer des frais de réseau, un délai de confirmation et des limites de remboursement. Si vous achetez un seul nom peu coûteux, cela peut être secondaire. Si vous achetez ou renouvelez un portefeuille, les rails de paiement deviennent une partie du modèle opérationnel.
+
+## Modèles de tarification des registrars
+
+Les registrars vendent le même objet général, mais pas la même expérience. Les comparer uniquement sur le prix de première année d’un TLD manque le modèle économique.
+
+### Modèle de répercussion des coûts
+
+Certains registrars se positionnent autour d’une marge minimale. L’attrait est évident : si le registrar peut répercuter le coût sous-jacent du registre avec peu de marge supplémentaire, l’acheteur peut obtenir un prix de renouvellement plus bas. Ce modèle convient généralement mieux aux acheteurs qui savent déjà ce dont ils ont besoin et ne réclament ni beaucoup de support ni de services groupés.
+
+Le compromis est qu’une marge plus faible n’est pas la seule variable. Vous devez toujours vous soucier des TLD pris en charge, de la récupération de compte, de DNSSEC, des contrôles en masse, des contrôles de facturation, des flux de transfert, de la réactivité du support et de l’adéquation du registrar à votre modèle de sécurité.
+
+### Registrar centré sur l’infrastructure
+
+Certains registrars sont rattachés à une plateforme cloud ou d’infrastructure plus vaste. Dans ce modèle, le domaine fait partie d’un système plus large pouvant inclure le DNS hébergé, la facturation des requêtes, les contrôles d’accès, les journaux d’audit, l’automatisation d’infrastructure, les contrôles de santé et d’autres services opérationnels.
+
+Cela peut séduire les équipes techniques qui souhaitent garder les domaines proches de l’infrastructure et de la facturation. Cela peut être excessif pour un acheteur occasionnel qui souhaite seulement un domaine simple et un rappel de renouvellement. Le prix du domaine peut paraître raisonnable alors que les coûts du produit environnant rendent la facture totale plus difficile à comparer.
+
+### Registrar orienté investisseurs
+
+Certains registrars sont optimisés pour les investisseurs en domaines et les traders actifs. Les fonctions qui comptent sont alors la recherche en masse, les renouvellements en masse, les exports de portefeuille, des colonnes de renouvellement claires, les outils de transfert, l’accès au marché secondaire, les contrôles d’expiration et les rapports au niveau du compte.
+
+Pour les investisseurs, un petit écart de renouvellement se cumule rapidement. Un portefeuille de noms se renouvelle chaque année, qu’ils se vendent ou non. Le tableau de renouvellement du registrar, les frais de restauration, les outils en masse et le flux de paiement comptent donc davantage qu’un agréable paiement pour un seul nom.
+
+### Registrar de détail pour consommateurs
+
+Les registrars de détail pour consommateurs s’adressent à un éventail d’acheteurs plus large : petites entreprises, créateurs, services locaux, projets parallèles, premiers propriétaires de domaines et équipes qui veulent du support et des produits adjacents. Leur valeur peut résider dans une recherche plus simple, des rappels, le support client, la gestion de la confidentialité, les intégrations d’e-mail ou d’hébergement, les outils de site web ou une récupération de compte plus facile.
+
+La tarification de détail n’est pas automatiquement mauvaise. La comparaison juste n’est pas « qui affiche le prix de première année le plus bas pour un TLD ? », mais « combien ce registrar me coûtera-t-il sur la durée de vie du domaine, et la couche de service justifie-t-elle l’écart ? »
+
+### Expérience de registrar orientée marketplace et produits
+
+Certaines expériences de registrar sont conçues autour des domaines comme actifs, et non comme simples éléments de paiement. Elles peuvent inclure des annonces, des transferts, la vérification de propriété, le financement, des vues de portefeuille, une propriété tokenisée, le règlement de marketplace ou des flux de remise de domaine.
+
+La couche produit peut être utile, mais elle ne remplace pas la vérification des coûts de base. Une expérience enrichie conserve des prix de première année, des prix de renouvellement, des règles de transfert, un risque de restauration, des réglages de confidentialité, des taxes et des flux de paiement. Les fonctions supplémentaires n’ont de valeur que si le coût de détention total reste pertinent pour le nom.
+
+## Ce qu’il faut comparer avant de choisir un registrar
+
+Utilisez cette liste de contrôle avant d’enregistrer un nom que vous comptez conserver.
+
+1. Quel est le prix de la première année ?
+2. Quel est le prix de renouvellement après la première période ?
+3. Le nom est-il à prix standard ou à prix premium ?
+4. La confidentialité WHOIS est-elle incluse, facultative ou indisponible ?
+5. Quel est le prix du transfert entrant et prolonge-t-il la période ?
+6. Quels sont les frais de restauration ou de rédemption si le domaine expire ?
+7. Que se passe-t-il après l’expiration : notifications, période de grâce, interruption DNS, enchère, rédemption, suppression en attente ?
+8. Des taxes ou frais réglementaires locaux sont-ils ajoutés au paiement ?
+9. Quels moyens de paiement sont acceptés et créent-ils un coût supplémentaire, un délai ou une friction de remboursement ?
+10. Le DNS, les zones hébergées, l’e-mail, la redirection, le SSL ou les produits de sécurité sont-ils des coûts distincts ?
+11. Est-il facile d’exporter, de transférer, de récupérer ou de remettre le domaine ?
+12. Si vous détenez de nombreux domaines, pouvez-vous renouveler, étiqueter, filtrer, exporter et prévoir le portefeuille en masse ?
+
+Pour un projet personnel, la réponse peut être : « choisissez le registrar auquel vous faites confiance et activez le renouvellement automatique ». Pour une marque, elle peut être : « payez davantage pour un meilleur support et une meilleure sécurité de compte ». Pour un investisseur, elle peut être : « optimisez sans relâche le coût de renouvellement, car le portefeuille se renouvelle qu’il se vende ou non ».
+
+## La réponse pratique
+
+Alors, combien coûte un domaine ?
+
+Pour un TLD courant, il peut coûter environ le prix d’un déjeuner la première année. Pour un nouveau gTLD en promotion, il peut coûter $1 aujourd’hui et $30 à $80 l’année prochaine. Pour un ccTLD onéreux ou un niveau premium de registre, il peut coûter bien davantage. Si vous manquez le renouvellement et devez le restaurer, la facture peut atteindre plusieurs centaines de dollars.
+
+La réponse pratique n’est pas le prix de première année. C’est :
+
+> **Coût de détention d’un domaine = enregistrement + renouvellements + transferts + risque de restauration + confidentialité + taxes + coûts de paiement + frais des produits périphériques.**
+
+C’est le chiffre à comparer. Un domaine n’est pas cher parce que sa première année coûte $60, et il n’est pas bon marché parce que sa première année coûte $1. Il est bon marché ou cher selon le coût du maintien du contrôle aussi longtemps que le nom importe.
+
+## Sources et lectures complémentaires
+
+- ICANN — [Expired Registration Recovery Policy](https://www.icann.org/resources/pages/errp-2013-02-28-en)

--- a/content/blog/fr/why-a-dao-should-control-the-main-domain.md
+++ b/content/blog/fr/why-a-dao-should-control-the-main-domain.md
@@ -1,0 +1,141 @@
+---
+title: "Pourquoi une DAO devrait contrôler le domaine principal"
+date: '2026-06-23'
+language: fr
+tags: ['governance', 'dao', 'web3', 'namefi space']
+authors: ['namefiteam']
+draft: false
+format: opinion
+description: "Chaque pays et chaque mouvement finit par connaître un moment de crise constitutionnelle : qui est légitime, qui fait autorité, qui s’exprime au centre de la scène ? Pour un mouvement en ligne, cette question se concentre sur un actif : le domaine principal. Voici pourquoi il devrait appartenir à la DAO."
+ogImage: ../../assets/why-a-dao-should-control-the-main-domain-og.jpg
+keywords: ['gouvernance dao', 'domaine principal', 'crise constitutionnelle', 'qui parle pour la dao', 'ens dao', 'aave labs', 'gouvernance wikipedia', 'ethereum classic', 'bitcoin.org', 'domaines tokenisés', 'souveraineté numérique', 'contrôle de marque', 'gouvernance décentralisée', 'propriété de domaine', 'namefi']
+relatedArticles:
+  - /fr/blog/from-mona-co-to-crypto-com/
+  - /fr/blog/from-bufferapp-com-to-buffer-com/
+  - /fr/blog/from-del-icio-us-to-delicious-com/
+  - /fr/blog/from-discordapp-com-to-discord-com/
+  - /fr/blog/from-ctrip-com-to-trip-com/
+relatedTopics:
+  - /fr/topics/domain-investing/
+  - /fr/topics/domain-basics/
+relatedSeries:
+  - /fr/series/name-change-game-change/
+  - /fr/series/domain-apocalypse/
+relatedGlossary:
+  - /fr/glossary/registrar/
+  - /fr/glossary/icann/
+  - /fr/glossary/dns/
+  - /fr/glossary/web3/
+  - /fr/glossary/tld/
+---
+
+Par l’équipe Namefi — juin 2026
+
+La plupart du temps, personne ne demande qui est aux commandes. Le travail avance, le site reste en ligne, les votes passent, et la question de l’autorité ultime demeure poliment évitée. Puis quelque chose se brise — une décision contestée, un litige financier, une scission — et soudain, la seule question qui compte est celle que personne ne voulait formuler à voix haute : *qui parle réellement au nom de cette chose ?*
+
+C’est un moment de crise constitutionnelle. Et pour tout mouvement en ligne, l’endroit où cette crise se règle n’est presque jamais un tribunal ni une charte. C’est un nom de domaine.
+
+## Le moment de crise constitutionnelle
+
+Une constitution est le document que personne n’a besoin de lire par temps calme. On peut diriger un pays, une entreprise ou une communauté pendant des années sans jamais le consulter. Son rôle est de rester là, ennuyeux et ignoré, jusqu’au jour où les règles habituelles ne suffisent plus — une élection disputée, une succession contestée, un dirigeant qui refuse de partir — et où tout le monde s’y réfère à la fois pour répondre à une seule question : lorsque nous ne sommes pas d’accord sur qui décide, qui décide ?
+
+La crise ne porte jamais vraiment sur le conflit immédiat. Elle porte sur la *légitimité* : qui fait autorité, qui est reconnu, qui peut se tenir au centre de la scène et dire « je parle pour nous » pendant que tous les autres l’acceptent. Les pays répondent à cette question par des constitutions, des tribunaux et des élections. La réponse est rarement nette, mais le mécanisme existe.
+
+Les mouvements qui ne sont pas des pays n’ont aucun mécanisme de ce type par défaut. Ils l’improvisent, et l’improvisation échoue généralement au pire moment.
+
+![Un document usé semblable à une constitution repose fermé sur un pupitre au centre d’une scène vide ; un unique projecteur éclaire l’endroit où la légitimité est revendiquée](../../assets/why-a-dao-should-control-the-main-domain-01-crisis-moment.jpg)
+
+## Les entités qui ne sont pas des pays connaissent aussi des crises constitutionnelles
+
+Il ne faut ni drapeau ni frontière pour connaître une crise de succession. Il suffit d’assez de personnes, d’assez de valeur, et d’un moment où deux parties se croient chacune la voix légitime.
+
+Wikipédia — une encyclopédie bénévole, une institution aussi éloignée que possible d’un État-nation — en a connu plusieurs. La première est arrivée tôt. En février 2002, la communauté hispanophone, partant d’une [attente perçue selon laquelle Wikipédia allait bientôt diffuser des publicités](https://en.wikipedia.org/wiki/Enciclopedia_Libre_Universal_en_Espa%C3%B1ol#:~:text=soon%20start%20hosting%20advertisements), est simplement partie. [Menée par Edgar Enyedy, elle a quitté Wikipédia le 26 février 2002 et créé le nouveau site web](https://en.wikipedia.org/wiki/Enciclopedia_Libre_Universal_en_Espa%C3%B1ol#:~:text=Led%20by%20Edgar%20Enyedy) Enciclopedia Libre. Le contenu de l’encyclopédie pouvait être copié librement ; ce qui ne pouvait pas être copié était la réponse à la question de savoir quel projet était la *véritable* Wikipédia en espagnol.
+
+Une décennie plus tard, le conflit s’est inversé : la communauté contre la fondation. En 2014, la Wikimedia Foundation a créé un nouveau pouvoir administratif appelé « superprotect » et l’a utilisé pour [imposer l’installation d’une nouvelle fonctionnalité logicielle sur Wikipédia en allemand contre la volonté de la communauté Wikimedia](https://en.wikipedia.org/wiki/Superprotect#:~:text=force%20the%20installation%20of%20a%20new%20software%20feature). [Ce conflit était sans précédent](https://en.wikipedia.org/wiki/Superprotect#:~:text=This%20conflict%20was%20unprecedented) : pour la première fois, la Fondation qui exploitait les serveurs l’emportait par la force technique sur les bénévoles qui rédigeaient l’encyclopédie. La leçon durable de cet épisode fut que [la Wikimedia Foundation était incapable de contrôler la communauté Wikimedia à l’aide de fonctionnalités techniques](https://en.wikipedia.org/wiki/Superprotect#:~:text=unable%20to%20control%20the%20Wikimedia%20community) ; superprotect a fini par être retiré.
+
+Puis vint 2019. Lorsque l’équipe Trust & Safety de la Fondation a banni de Wikipédia en anglais un contributeur établi connu sous le nom de Fram, l’objection de la communauté ne concernait pas vraiment Fram. Elle portait sur la compétence. Comme l’a formulé un administrateur, [banning from en.wiki only seems like something ArbCom gets to do, not WMF](https://en.wikipedia.org/wiki/Wikipedia:Fram#:~:text=something%20ArbCom%20gets%20to%20do%2C%20not%20WMF), une affirmation directe selon laquelle la Fondation avait outrepassé son autorité et pénétré un terrain gouverné par la communauté. Le litige a absorbé le projet pendant des mois.
+
+Trois conflits différents, une question récurrente : lorsque ceux qui *font fonctionner l’infrastructure* et ceux qui *forment la communauté* ne sont pas d’accord sur l’autorité finale, qui l’emporte ? C’est une crise constitutionnelle, drapeau ou non.
+
+![Une scène éditoriale scindée opposant la pile de serveurs d’une fondation d’un côté et une foule de contributeurs bénévoles de l’autre, avec un sceau contesté flottant entre les deux](../../assets/why-a-dao-should-control-the-main-domain-02-wikipedia.jpg)
+
+## Le domaine est l’endroit où la crise se concentre
+
+Voici ce qu’il est facile de manquer tant qu’on ne l’a pas vécu : une DAO n’est ni un bâtiment que l’on peut occuper ni une place publique sur laquelle on peut se tenir. Presque tout ce qu’elle fait se déroule en ligne — les propositions, les débats, les votes, les annonces. Les questions qui déterminent réellement qui détient le pouvoir ne sont donc jamais territoriales. Elles concernent les canaux : *Quel compte est l’« officiel » ? Où la communauté se réunit-elle réellement pour discuter ? Qui peut se connecter et publier sous le nom du projet ?* Quiconque peut répondre à ces trois questions à son avantage **est** le projet en pratique, quelle que soit l’issue d’un vote.
+
+Et les trois questions se résolvent autour du même actif racine : le domaine principal. Le `.com`, le `.org`, le `.eth` que les gens saisissent de mémoire, que les portefeuilles résolvent, que Google classe en premier : c’est le centre de la scène rendu concret. Celui qui le contrôle n’a pas besoin de *gagner* l’argument de la légitimité ; il devient légitime par défaut, car c’est l’adresse en laquelle tout le monde a déjà confiance. La branche dissidente peut avoir la meilleure revendication, la plus grande communauté, les contributeurs d’origine, et pourtant perdre, parce que le public continue d’emprunter la porte qu’il connaît déjà.
+
+Le domaine n’est pas seulement le site web. Il est aussi la racine de tout ce qui en découle. L’e-mail « officiel » s’exécute sur lui, et cet e-mail réinitialise le mot de passe du compte X, du Discord, du forum de gouvernance, de la liste de diffusion. Contrôler le domaine, c’est contrôler la boîte de réception ; contrôler la boîte de réception, c’est contrôler chaque canal officiel qui en dépend. Voilà pourquoi, dans une scission, les deux camps cherchent d’abord à le saisir. C’est le seul actif où les questions souples de légitimité se réduisent à une question dure de contrôle d’accès : qui détient l’identifiant, qui peut modifier les serveurs de noms, quelle signature déplace l’actif. La constitution qui fonctionne réellement est celle de la personne capable d’orienter le domaine.
+
+C’est aussi ce qui transforme un beau principe en exigence ferme. Une DAO qui ne peut pas détenir son propre domaine ne peut pas *faire appliquer* ses propres décisions. La gouvernance peut voter pour changer de direction, écarter un contributeur ou désavouer une interface malveillante, mais si le domaine et les comptes qu’il ouvre restent aux mains d’une autre personne, ce vote est un communiqué de presse, pas une instruction. L’application des décisions réside là où réside le domaine. Si vous voulez que la parole de la DAO soit définitive, la DAO doit détenir la porte d’entrée.
+
+![Une unique porte éclairée au centre d’une place publique, vers laquelle afflue une foule ; de petites portes latérales restent sombres et ignorées](../../assets/why-a-dao-should-control-the-main-domain-03-front-door.jpg)
+
+## La version crypto : lequel est le vrai ?
+
+La crypto a mené cette expérience au grand jour, avec de l’argent en jeu.
+
+En 2016, après le vol de fonds de « The DAO », Ethereum a exécuté un hard fork pour l’annuler. Tout le monde n’était pas d’accord. La chaîne s’est scindée et [l’historique modifié a été nommé [Ethereum](/fr/glossary/ethereum/) (ETH), tandis que l’historique non modifié a été nommé Ethereum Classic (ETC)](https://en.wikipedia.org/wiki/Ethereum_Classic#:~:text=the%20altered%20history%20was%20named%20Ethereum). Toute la revendication du camp Classic était une revendication de légitimité : celle d’être, plutôt que la branche majoritaire, [le détenteur de l’historique originel et non modifié du réseau Ethereum](https://en.wikipedia.org/wiki/Ethereum_Classic#:~:text=unaltered%20history%20of%20the%20Ethereum%20network). Les deux chaînes étaient techniquement réelles. Une seule a pu conserver le nom « Ethereum » dans l’esprit du public : celle vers laquelle pointaient les portes d’entrée de l’écosystème — les exchanges, les portefeuilles, le site principal.
+
+La version qui sert d’avertissement est `bitcoin.org`, porte d’entrée canonique enregistrée à l’origine à l’époque de Satoshi. En 2020, son contrôle effectif reposait sur un unique propriétaire pseudonyme, « Cobra », qui a évincé le mainteneur historique du site dans un conflit de propriété unilatéral. Le récit du mainteneur était sans détour : [Cobra has removed my access and seized control of the site and accompanying code repositories](https://decrypt.co/33703/bitcoin-orgs-secret-owner-kicks-out-the-sites-maintainer#:~:text=seized%20control%20of%20the%20site). Une personne anonyme, détenant les clés de l’adresse la plus célèbre d’un mouvement, sans rendre de comptes à personne. C’est la forme la plus pure de cette défaillance : le domaine le plus important de la pièce gouverné par quiconque contrôle le compte du [registrar](/fr/glossary/registrar/).
+
+![Deux vitrines presque identiques côte à côte, l’une éclairée et animée, l’autre sombre, avec un unique panneau indicateur qui pointe seulement vers la première](../../assets/why-a-dao-should-control-the-main-domain-04-which-is-real.jpg)
+
+## La crise d’identité d’Aave : « Labs » parle-t-il pour la DAO ?
+
+Le cas récent le plus clair est Aave, et il est presque trop évident : une DAO qui affirme publiquement qu’elle, et non l’entreprise qui développe le logiciel, devrait contrôler son propre domaine principal et sa marque.
+
+Fin 2025, une proposition de gouvernance demandait aux détenteurs de jetons Aave de faire entrer dans la DAO la marque, les droits de dénomination, les domaines web et les comptes sociaux du protocole, après un différend autour d’un accord qui dirigeait les frais vers Aave Labs plutôt que vers la DAO. Remarquez ce qui était regroupé : *les domaines web et les comptes sociaux*, parce que dans le monde réel ils voyagent comme un même paquet : l’entité qui détient le domaine détient les clés des canaux. Le débat portait sur l’identité du véritable propriétaire de la porte d’entrée. Comme le formulait la proposition, [we should not have to fear that the implicit steward of the brand may at any point leverage that brand for their own benefit](https://www.dlnews.com/articles/defi/aave-dao-proposal-to-take-control-of-brand-from-aave-labs-gains-traction/#:~:text=implicit%20steward%20of%20the%20brand) sans le consentement de la DAO. L’expression importante est *implicit steward* : personne n’avait jamais voté pour faire de Labs la voix d’Aave ; Labs l’était simplement parce qu’elle détenait les actifs.
+
+Et les actifs incluaient le site web. La défense de Labs rendait ce contrôle explicite : elle soutenait avoir besoin de la nouvelle source de revenus pour couvrir le coût de fonctionnement du site du protocole, [which it controls](https://www.dlnews.com/articles/defi/aave-dao-proposal-to-take-control-of-brand-from-aave-labs-gains-traction/#:~:text=which%20it%20controls). Les commentateurs qui cherchaient la bonne métaphore ont retenu précisément celle sur laquelle repose cet article : la DAO est le moteur qui livre les mises à jour et génère les revenus, tandis que les [actifs de marque servent de vitrine](https://www.coindesk.com/tech/2025/12/23/most-important-tokenholder-rights-debate-aave-faces-identity-crisis#:~:text=brand%20assets%20function%20as%20the%20storefront). Ils ont appelé cela [le plus important débat actuel sur les droits des détenteurs de jetons](https://www.coindesk.com/tech/2025/12/23/most-important-tokenholder-rights-debate-aave-faces-identity-crisis#:~:text=the%20most%20important%20live%20debate). Un protocole de plusieurs milliards de dollars a découvert, au milieu d’un conflit sur les frais, qu’il n’avait jamais réellement décidé qui possédait sa propre porte d’entrée.
+
+![Diagramme éditorial d’un protocole : un bloc moteur étiqueté d’un côté qui génère de la valeur, une vitrine lumineuse séparée de l’autre, et une corde de tir à la corde entre un bureau d’entreprise et une assemblée de détenteurs de jetons](../../assets/why-a-dao-should-control-the-main-domain-05-aave.jpg)
+
+## La réponse d’ENS : écrire qui fait autorité
+
+Aave montre une crise qui arrive sans prévenir. ENS montre un mouvement qui tente de répondre à la question *avant* la crise — et c’est tout l’enjeu.
+
+ENS sépare déjà clairement les rôles. [La DAO ENS gouverne le protocole et la trésorerie ENS](https://docs.ens.domains/dao#:~:text=governs%20the%20ENS%20protocol%20and%20treasury), tandis qu’[ENS Labs est une organisation à but non lucratif responsable du développement du logiciel central d’ENS](https://basics.ensdao.org/ens-labs#:~:text=responsible%20for%20the%20core%20software%20development%20of%20ENS). Labs construit ; la DAO gouverne. Mais une consultation préliminaire de 2024 sur la « prochaine ère » de la gouvernance ENS allait plus loin et tentait d’écrire explicitement la carte des autorités. Dans la structure proposée, [le contrôle du protocole, comme les mises à niveau de smart contracts, la tarification ENS et les structures de frais, le contrôle de la clé racine et du registre, ainsi que les amendements constitutionnels, restent exclusivement entre les mains des détenteurs de jetons](https://discuss.ens.domains/t/temp-check-next-era-of-ens-dao-empowering-the-ens-foundation/22175#:~:text=remain%20exclusively%20with%20tokenholders), tandis qu’une Fondation sous charte, et non l’entreprise d’exploitation, détient les marques et les actifs de marque et [les concède sous licence à Labs](https://discuss.ens.domains/t/temp-check-next-era-of-ens-dao-empowering-the-ens-foundation/22175#:~:text=licenses%20them%20to%20Labs).
+
+Lisez cela attentivement. L’actif le plus contesté en temps de crise — la marque, le nom, l’identité pour laquelle tout le monde se bat — est placé sous l’autorité d’une entité sous charte redevable aux détenteurs de jetons, et simplement *concédé sous licence* à l’entreprise qui assure le travail quotidien. C’est un mouvement qui décide par temps calme qui se tient au centre de la scène, afin que personne n’ait à l’improviser sous le feu.
+
+![Une charte reliée ouverte sur une table, avec un organigramme clair qui sépare une assemblée de détenteurs de jetons, une fondation qui détient un sceau de marque et une équipe de travail détentrice d’une licence sous elles](../../assets/why-a-dao-should-control-the-main-domain-06-ens.jpg)
+
+## Pourquoi la DAO, précisément
+
+Admettons que *quelqu’un* doive détenir délibérément le domaine principal plutôt que par accident : pourquoi la DAO, et non le fondateur, l’entreprise Labs ou un multisig de proches de confiance ?
+
+Parce que la DAO est le seul candidat dont l’autorité est à la fois explicite, vérifiable et durable.
+
+- **Explicite.** Un vote des détenteurs de jetons est ce qui se rapproche le plus, pour un mouvement décentralisé, d’une constitution écrite assortie d’une élection. Personne n’est l’« intendant implicite ». L’autorité est un résultat enregistré, pas un défaut hérité.
+- **Vérifiable.** Qui peut déplacer l’actif et à quel seuil est visible [onchain](/fr/glossary/on-chain/). Il n’est pas nécessaire de croire que les bonnes personnes détiennent le mot de passe du registrar : vous pouvez lire la règle.
+- **Durable.** Les fondateurs partent, changent d’avis ou, comme l’a montré `bitcoin.org`, se révèlent être un pseudonyme ne rendant de comptes à personne. Les entreprises développent des intérêts qui divergent de leur communauté, comme Aave l’a découvert. La légitimité d’une DAO ne s’évapore pas lorsqu’une personne s’en va, car elle n’a jamais résidé dans une seule personne.
+
+Placez le domaine principal n’importe où ailleurs et vous réintroduisez exactement le point unique de captation que le mouvement était censé éliminer. Le domaine devient l’actif centralisé qui soutient un récit décentralisé : supportable jusqu’à la crise, décisif pendant elle. Le placer sous la DAO signifie que la réponse à « qui parle au centre de la scène ? » est produite par le même mécanisme de légitimité qui gouverne tout le reste, plutôt que par quiconque détient l’identifiant.
+
+Il existe une objection honnête : historiquement, une DAO ne *pouvait* tout simplement pas détenir un `.com`. Les domaines vivent chez des registrars Web2, derrière un identifiant, un mot de passe et une carte de crédit. Le mieux qu’une DAO pouvait faire était de faire confiance à un humain — ou à une entreprise Labs — pour se connecter en son nom. C’est précisément cette lacune qui crée d’abord l’« intendant implicite ».
+
+Les domaines tokenisés comblent cette lacune. Lorsqu’un domaine est un actif onchain, un contrat de gouvernance ou un multisig contrôlé par la DAO peut le détenir et le transférer par vote, selon les mêmes règles et les mêmes seuils que la trésorerie. La porte d’entrée cesse d’être un mot de passe dans le coffre personnel de quelqu’un et devient un actif gouvernable selon la véritable constitution du mouvement. C’est le problème que [Namefi](https://namefi.io) existe pour résoudre : placer les domaines réels onchain afin que l’entité qui gouverne le protocole puisse aussi détenir, de façon vérifiable, sa porte d’entrée.
+
+![Un nom de domaine représenté comme une carte d’actif onchain, placée dans un coffre multisig transparent, avec des signatures de gouvernance autour d’elle et tenue par une assemblée plutôt que par une seule main](../../assets/why-a-dao-should-control-the-main-domain-07-dao-vault.jpg)
+
+## Décider avant la crise
+
+Le problème avec une crise constitutionnelle est que c’est un terrible moment pour rédiger une constitution. Tout le monde se bat déjà, chaque choix paraît partisan, et celui qui détient l’actif lorsque la musique s’arrête tend à le conserver.
+
+Décidez donc maintenant, tant qu’il fait calme et que personne ne se bat à ce sujet : qui contrôle le domaine principal ? Si la réponse honnête est « le compte registrar du fondateur » ou « l’entreprise Labs qui gère le site », alors le mouvement a un intendant implicite et une constitution non écrite — et il découvrira les deux au pire moment.
+
+Confiez la porte d’entrée à l’entité censée parler pour l’ensemble du mouvement. Rendez cela explicite, vérifiable, capable de survivre à toute personne. Une DAO qui détient son propre domaine peut faire appliquer ses décisions ; une DAO qui ne le détient pas ne peut que demander gentiment et espérer que celui qui a l’identifiant accepte. Placez le domaine principal sous la DAO avant d’en avoir besoin.
+
+## Sources et lectures complémentaires
+
+- Wikipédia — [Enciclopedia Libre Universal en Español](https://en.wikipedia.org/wiki/Enciclopedia_Libre_Universal_en_Espa%C3%B1ol#:~:text=soon%20start%20hosting%20advertisements) (la scission de Wikipédia en espagnol de 2002)
+- Wikipédia — [Superprotect](https://en.wikipedia.org/wiki/Superprotect#:~:text=This%20conflict%20was%20unprecedented) (la remise en cause Fondation-communauté de 2014)
+- Wikipédia — [Wikipedia:Fram](https://en.wikipedia.org/wiki/Wikipedia:Fram#:~:text=something%20ArbCom%20gets%20to%20do%2C%20not%20WMF) (le litige de compétence « Framgate » de 2019)
+- Wikipédia — [Ethereum Classic](https://en.wikipedia.org/wiki/Ethereum_Classic#:~:text=the%20altered%20history%20was%20named%20Ethereum) (la scission de 2016 : « quelle chaîne est le véritable Ethereum ? »)
+- Decrypt — [Bitcoin.org's Secret Owner Kicks Out the Site's Maintainer](https://decrypt.co/33703/bitcoin-orgs-secret-owner-kicks-out-the-sites-maintainer#:~:text=seized%20control%20of%20the%20site) (le conflit de contrôle de `bitcoin.org` en 2020)
+- DLNews — [Aave DAO proposal to take control of brand from Aave Labs gains traction](https://www.dlnews.com/articles/defi/aave-dao-proposal-to-take-control-of-brand-from-aave-labs-gains-traction/#:~:text=implicit%20steward%20of%20the%20brand)
+- CoinDesk — [The most important tokenholder-rights debate: Aave faces an identity crisis](https://www.coindesk.com/tech/2025/12/23/most-important-tokenholder-rights-debate-aave-faces-identity-crisis#:~:text=brand%20assets%20function%20as%20the%20storefront)
+- Forum de gouvernance Aave — [Temp Check: The Aave Interface Transparency Act](https://governance.aave.com/t/temp-check-the-aave-interface-transparency-act/23647)
+- ENS — [Temp Check: Next era of ENS DAO — Empowering the ENS Foundation](https://discuss.ens.domains/t/temp-check-next-era-of-ens-dao-empowering-the-ens-foundation/22175#:~:text=remain%20exclusively%20with%20tokenholders)
+- Documentation ENS — [The ENS DAO](https://docs.ens.domains/dao#:~:text=governs%20the%20ENS%20protocol%20and%20treasury) · ENS DAO Basics — [ENS Labs](https://basics.ensdao.org/ens-labs#:~:text=responsible%20for%20the%20core%20software%20development%20of%20ENS)


### PR DESCRIPTION
## Summary / Solution

- Adds the seven English blog articles that were missing their French counterparts, bringing `content/blog/fr` to the same 130-article coverage as `en`.
- Each translation is fresh from the English source and includes French frontmatter, body copy, headings, image alt text, tables, and source labels while preserving dates, figures, code, image paths, brand/protocol names, citation URLs, and slugs.
- Internal content routes use the same `/fr/<collection>/<slug>/` route as the containing French article. `relatedArticles` and `relatedGlossary` preserve the English source order and slugs, changing only the locale prefix.
- The 26 remaining `MISSING-TR` notices are intentional `/fr/` routes whose English source is served by the runtime fallback; there are no broken, bare, cross-locale, or relationship-mismatched routes.
- The privacy article is translated fresh on current `main`; draft #171 was not reused or changed.

## Access control

No endpoint, runtime page, privileged action, or data access surface changes. This is public editorial content only; no additional access control is required.

## Test plan

- [x] `TMPDIR=/private/tmp bun run data:validate` — passes with 29 pre-existing empty-keyword warnings; 0 locale/relationship mismatches across 3,521 content files.
- [x] `TMPDIR=/private/tmp bun run lint:mdx` — passes.
- [x] `TMPDIR=/private/tmp bun run check:termbase` — 0 deviations.
- [x] Focused `link-audit.ts` for all seven files — 0 broken, 0 missing-locale, 0 locale mismatch, 0 relationship mismatch; 26 intentional French runtime-fallback notices.
- [x] Deterministic EN/FR parity — external URLs, image paths, numeric tokens, heading counts, language frontmatter, no untranslated `/en/` internal hrefs, artifact scan, and non-stub length sanity.
- [x] Independent bilingual + monolingual French LQA sample: `blockchain-cryptographic-primitives` (1 of 7, rounded up from the 1/10 batch policy) — no S0/S1; five concrete S2 fluency/precision repairs applied. Two terminology suggestions were declined because the repository's canonical French termbase requires `Smart contract` and `On-chain`.
- [x] `git diff --check`.

## Redacted agent-session summary

`2026-07-14T04:22:27Z` — Seven isolated EN→FR article tasks wrote separate files in one shared worktree; independent LQA sampled one article and the author applied its accepted repairs. No secrets or personal data included. The agent interface exposes no model or reasoning-effort metadata. No native-human review or rendered preview was performed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only locale content with no runtime or security surface changes; main risk is translation/link accuracy, which the PR description says was validated.
> 
> **Overview**
> Adds **seven new French blog posts** under `content/blog/fr/`, closing the gap with English so the French blog matches the same article set (130 posts).
> 
> The new pieces are mostly the **`blockchain-concepts` series** (cryptographic primitives, consensus, VMs, scaling, privacy), plus a **domain holding-cost guide** and an **opinion piece** on DAO control of the primary domain. Each file is a full EN→FR translation: French titles, body, headings, image alt text, and tables, with **unchanged slugs, dates, asset paths, and citation URLs**. Internal links use **`/fr/...`** routes and the same related-article/glossary wiring as the English sources.
> 
> No app, API, or access-control changes—**editorial content only**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6730a8a1c6e9efd52fdb1b8caed35a552f320bd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->