### PR TITLE
content(de): translate all missing English blog articles

### DIFF
--- a/content/blog/de/agent-native.md
+++ b/content/blog/de/agent-native.md
@@ -1,0 +1,133 @@
+---
+title: "Was ist ein agent-nativer Domain-Registrar?"
+date: '2026-07-10'
+language: 'de'
+tags: ['ai-agents', 'domains', 'explainer']
+authors: ['namefiteam']
+draft: false
+format: explainer
+ogImage: ../../assets/agent-native-og.jpg
+description: "Registrare haben seit Jahrzehnten APIs, doch eine API allein ist nicht agent-native. Die Checkliste: Auffindbarkeit, Dokumentation, Fehler, Zahlung und Richtlinien-Kontrollen."
+keywords: ["agent-nativer Registrar", "Definition agent-nativ", "was ist ein agent-nativer Registrar", "agentenfähige API", "MCP-Server", "llms.txt", "maschinenlesbare Fehler", "Idempotenz", "agentische Zahlungen", "Domainregistrierung durch KI-Agenten", "API-Dokumentation in natürlicher Sprache", "Richtlinien-Kontrollen für KI-Agenten", "API-Schlüssel-Abrechnung", "Wallet-Checkout für Kryptodomains"]
+relatedArticles:
+  - /de/blog/ai-domain-platforms/
+  - /de/blog/cf-namecom-namefi/
+  - /de/blog/ai-agent-register/
+  - /de/blog/claude-mcp-domains/
+  - /de/blog/airo-vs-namefi/
+relatedTopics:
+  - /de/topics/web3-foundations/
+  - /de/topics/domain-basics/
+relatedSeries:
+  - /de/series/blockchain-concepts/
+  - /de/series/tokenize-your-com/
+relatedGlossary:
+  - /de/glossary/ai-agent/
+  - /de/glossary/registrar/
+  - /de/glossary/icann/
+  - /de/glossary/epp/
+  - /de/glossary/x402/
+---
+
+Domain-Registrare verfügen schon lange über Programmierschnittstellen. Das [Extensible Provisioning Protocol](https://en.wikipedia.org/wiki/Extensible_Provisioning_Protocol) (EPP), die Sprache für die Kommunikation zwischen Maschinen, mit der Registrare mit Registries kommunizieren, erreichte im [März 2004 den Status „Proposed Standard“](https://en.wikipedia.org/wiki/Extensible_Provisioning_Protocol#:~:text=Proposed%20Standard%20documents%20%28RFCs%203730%20-%203734%29%20were%20published%20by%20the%20RFC%20Editor%20in%20March%202004) — vor mehr als zwei Jahrzehnten. Jeder von der [ICANN](/de/glossary/icann/) akkreditierte [Registrar](/de/glossary/registrar/), der seither darauf aufbaut, verfügt über irgendeine Form von REST- oder SOAP-API, um Verfügbarkeit zu prüfen, eine Registrierung einzureichen und Einträge zu aktualisieren. Die ehrliche Antwort auf die Frage „Hat dieser Registrar eine API?“ lautet daher für fast jeden Registrar am Markt: ja, und zwar seit Jahren.
+
+Diese Frage erweist sich jedoch als die falsche. Ein [KI-Agent](/de/glossary/ai-agent/), der in Ihrem Auftrag eine Domain registrieren soll, scheitert nicht daran, dass dem Registrar eine API fehlt. Er scheitert, weil die API für einen Entwickler gebaut wurde, der die Dokumentation einmal liest, den Integrationscode von Hand schreibt und ihn ausliefert — nicht für ein System, das die API zur Laufzeit entdecken, aus einer JSON-Antwort ableiten muss, was passiert ist, und einen Kauf ohne eine Person abschließen muss, die eine Checkout-Seite beobachtet. Das sind unterschiedliche Anforderungen; die zweite zu erfüllen, ist mit **agent-native** in diesem Artikel gemeint.
+
+Dieser Beitrag definiert den Begriff präzise, legt eine Checkliste vor, mit der sich jeder Registrar (oder jede API) daran messen lässt, und wendet diese Checkliste dann ehrlich auf die Plattformen an, die 2026 ausgeliefert werden, einschließlich [Namefi](https://namefi.io). Den Plattformvergleich statt der Definition finden Sie unter [Cloudflare vs. Name.com vs. Namefi: agent-native Registrare](/de/blog/cf-namecom-namefi/) oder im umfassenderen Leitfaden [KI-agentische Domain-Plattformen](/de/blog/ai-domain-platforms/). Wenn Sie bei „KI und Domains“ noch an einen Namensgenerator denken, der markentaugliche Zeichenfolgen vorschlägt, zeigt die folgende Checkliste, wie viel höher die Messlatte für agent-native Systeme liegt — die vollständige Lücke erläutert [Über KI-Domainnamengeneratoren hinaus: Das Zeitalter der Agenten](/de/blog/beyond-generators/).
+
+## Warum „hat eine API“ und „agent-native“ nicht dasselbe meinen
+
+Eine traditionelle Registrar-API setzt voraus, dass bei der Gestaltung, nicht aber zur Laufzeit, ein Mensch eingebunden ist. Ein Entwickler legt ein Konto an, liest eine für Menschen geschriebene Referenzseite, kopiert ein Codebeispiel und hinterlegt Endpunkt, Authentifizierungs-Header und die erwartete Antwortform fest in seiner Anwendung. Ist das erledigt, läuft die Integration unbeaufsichtigt — aber nur, weil ein Mensch die Interpretationsarbeit bereits geleistet hat. An der API selbst ist nichts für ein System lesbar, das ohne vorherige Integration auftaucht und im Kontext herausfinden muss, welche Operationen es gibt und wie sie aufzurufen sind.
+
+Ein Agent startet immer wieder ohne Vorwissen. Jedes Gespräch mit einem Programmieragenten, jeder neue MCP-Client ist faktisch ein Entwickler, der Ihre API noch nie gesehen hat und nur Sekunden an Kontextbudget besitzt, um sie zu verstehen. Wenn die Antwort auf „Wie lernt ein Agent, diese API zu nutzen?“ lautet „Ein Mensch hat vor Jahren die Dokumentation gelesen und Integrationscode geschrieben“, steckt dauerhaft eine Person im Ausführungspfad der API, selbst wenn beim Kauf niemand etwas anklickt. Dieser Beitrag beschreibt, was beim Registrar selbst gegeben sein muss, damit ein Agent mit Kaltstart erfolgreich ist — die Sicht des Käufers auf dieselbe Übergabe finden Sie unter [Wie KI-Agenten Domains ohne Menschen kaufen (2026)](/de/blog/agents-buy-domains/).
+
+## Die agent-native Checkliste
+
+Ein agent-nativer Registrar ist ein Registrar, den ein KI-Agent vollständig selbst entdecken, verstehen und für Transaktionen nutzen kann — ohne Browser, ohne dass ein Mensch die Dokumentation vorab liest, ohne dass jemand eine Kartennummer eingibt. Dafür müssen sechs konkrete Dinge zutreffen, nicht nur „eine API zu haben“:
+
+| Anforderung | Registrar mit API | Agent-nativer Registrar |
+| --- | --- | --- |
+| Auffindbarkeit | Endpunkte existieren, aber einem Agenten müssen Basis-URL und Authentifizierungsschema außerhalb des Systems mitgeteilt werden | Ein Standardort (`llms.txt`, ein [MCP](https://modelcontextprotocol.io)-Server), den ein Agent selbstständig finden und lesen kann |
+| Dokumentation in natürlicher Sprache | Referenzdokumentation ist für Menschen geschrieben, die eine Seite überfliegen | Die Dokumentation ist so strukturiert, dass ein Agent sie zur Inferenzzeit nutzen kann — Operation, Pflichtfelder und Wirkung stehen an einer Stelle |
+| Maschinenlesbare Fehler | HTTP-Statuscodes plus Prosa für eine Person, die ein Log liest | Ein stabiler Fehlercode, ein `retryable`-Flag und strukturierte Details, auf die ein Agent programmatisch verzweigen kann |
+| Browserfreier Kauf | Die Registrierung wird auf einer gehosteten Checkout-Seite abgeschlossen, manchmal hinter einem CAPTCHA | Die Registrierung wird über die API oder das Protokoll selbst vollständig abgeschlossen, ohne dass eine Seite gerendert werden muss |
+| Programmatische Zahlung | Die Zahlung setzt eine hinterlegte Karte voraus, die an das Abrechnungskonto eines Menschen gebunden ist | Zahlung über einen API-Schlüssel, dessen Nutzung einem Konto in Rechnung gestellt wird, oder eine Wallet-signierte Transaktion — etwas, das ein nichtmenschliches System selbst halten kann |
+| Richtlinien-Kontrollen | Nichts hindert ein Skript daran, alles zu tun, was die Zugangsdaten erlauben | Ausgabenlimits, Bestätigungsschritte oder begrenzte Schlüssel, die ein Mensch einmal festlegt, damit der Agent innerhalb einer Grenze arbeitet |
+
+Das ist die verdichtete Definition: **Ein agent-nativer Registrar ist ein Registrar, der bei Auffindbarkeit, Dokumentation in natürlicher Sprache, maschinenlesbaren Fehlern, browserfreiem Kauf und programmatischer Zahlung jeweils mit Ja abschneidet — mit Richtlinien-Kontrollen als dem Teil, an dem die gesamte Kategorie noch arbeitet.**
+
+## Auffindbarkeit: llms.txt und MCP sind die Sitemap für Agenten
+
+Ein menschlicher Entwickler findet eine API durch Suchen oder Klicken auf einer Dokumentationswebsite. Ein Agent braucht entweder eine Datei, die er in einem Zug abrufen und lesen kann, oder eine Protokollverbindung, über die er verfügbare Operationen abfragen kann. Heute erfüllen zwei Dinge diese Rolle.
+
+[llms.txt](https://llmstxt.org) ist, in den Worten des Vorschlags selbst, [„ein Vorschlag zur Standardisierung der Verwendung einer Datei `/llms.txt`, die Informationen bereitstellt, damit LLMs eine Website zur Inferenzzeit nutzen können“](https://llmstxt.org/#:~:text=A%20proposal%20to%20standardise%20on%20using%20an%20/llms.txt%20file%20to%20provide%20information%20to%20help%20LLMs%20use%20a%20website%20at%20inference%20time). Die Idee entspricht `robots.txt`; statt einem Crawler mitzuteilen, was er indexieren darf, erklärt sie einem Sprachmodell, was eine Website ist und wie sie zu verwenden ist. Unter [llms.txt für Domains: Eine API, die jeder KI-Agent lesen kann](/de/blog/llms-txt/) sehen Sie, wie diese Datei aussieht, wenn ein Registrar sie veröffentlicht.
+
+[MCP (Model Context Protocol)](https://modelcontextprotocol.io) löst ein benachbartes Problem: Es ist [„ein Open-Source-Standard, um KI-Anwendungen mit externen Systemen zu verbinden“](https://modelcontextprotocol.io/#:~:text=MCP%20%28Model%20Context%20Protocol%29%20is%20an%20open-source%20standard%20for%20connecting%20AI%20applications%20to%20external%20systems). Während llms.txt ein Dokument ist, das ein Agent einmal zur Orientierung liest, ist MCP eine Live-Verbindung, die der Client eines Agenten zu einem Server öffnet, der einen definierten Satz aufrufbarer Tools bereitstellt. Beides ergänzt sich statt zu konkurrieren: llms.txt zeigt einem Agenten, dass ein Registrar existiert und was er ungefähr kann; MCP ermöglicht es dem Client des Agenten, sich tatsächlich zu verbinden und die Operationen aufzurufen.
+
+Namefi veröffentlicht beides. Der Einstiegspunkt unter [namefi.io/llms.txt](https://namefi.io/llms.txt) dokumentiert einen MCP-Server unter `api.namefi.io/mcp`, eine MCP-Discovery-Datei unter `namefi.io/.well-known/mcp/servers.json` und eine vollständige REST-Referenz sowie Begleitdateien für Wallet-basierte Zahlungen und ausgehende Agenten-Workflows. Bei direkter Prüfung zweier etablierter Anbieter zeigt sich: Die Registrar-Dokumentation von Cloudflare veröffentlicht ein eigenes `llms.txt` unter `developers.cloudflare.com/registrar/llms.txt`, doch in der öffentlichen Dokumentation steht nichts dazu, dass Cloudflare einen dedizierten MCP-Server für das Registrar-Produkt betreibt. Der Pitch der Beta lautet laut Berichterstattung, [die API sei „dafür ausgelegt, innerhalb der Tools zu funktionieren, in denen Entwickler bereits arbeiten: Code-Editoren mit MCP-Unterstützung wie Cursor und Claude Code“](https://webhosting.today/2026/04/22/ai-agents-can-now-register-domains-no-human-required/#:~:text=The%20API%20is%20designed%20to%20work%20inside%20the%20tools%20where%20developers%20already%20operate%2C%20code%20editors%20with%20MCP%20support%20such%20as%20Cursor%20and%20Claude%20Code). Das ist enger gefasst: Der Editor ist MCP-fähig, nicht zwingend Cloudflares Registrar selbst. Das Entwicklerportal von GoDaddy, ebenfalls direkt geprüft, dokumentiert REST-Endpunkte für menschliche Entwickler und zeigte zum Zeitpunkt der Erstellung weder einen Verweis auf `llms.txt` noch auf einen MCP-Server.
+
+## Zahlung: Warum hinterlegte Karten Agenten ausbremsen und was sie ersetzt
+
+Beim Kauf lässt sich die Annahme eines Menschen im Ablauf am schwersten beseitigen, denn die Zahlungsinfrastruktur des Verbraucher-Webs ist auf eine Person ausgerichtet: eine hinterlegte Karte, eine Rechnungsadresse und manchmal ein CAPTCHA, das alles herausfiltern soll, was keine Person ist. Ein Agent kann kein Kartenformular ausfüllen, und ihm die rohe Kartennummer eines Menschen zu geben, damit er sich als dieser ausgeben kann, ist selbst dann ein schlechtes Sicherheitsmodell, wenn es technisch möglich wäre.
+
+Zwei Alternativen werden bereits ausgeliefert. Die erste ist die Abrechnung per API-Schlüssel: Der Registrar stellt einen Zugangsschlüssel aus, der an ein vorfinanziertes oder auf Rechnung geführtes Konto gebunden ist, und der Agent authentifiziert jeden Aufruf mit diesem Schlüssel statt mit einer Karte. Die Dokumentation von Namefi beschreibt die Erstellung dieses Schlüssels unter [namefi.io/api-key](https://namefi.io/api-key) und seine Übergabe als `x-api-key`-Header bei jeder Anfrage — keine Browser-Sitzung, kein Kartenformular. Die `.ai`-Preisgestaltung von Cloudflare folgt derselben Kostenlogik: [Das Unternehmen bietet „.ai-Domainregistrierungen und -verlängerungen zu Großhandelspreisen ohne zusätzliche Aufschläge“ an](https://www.cloudflare.com/application-services/products/registrar/buy-ai-domains/#:~:text=Cloudflare%20offers%20.ai%20domain%20registrations%20and%20renewals%20at%20wholesale%20prices%2C%20with%20no%20additional%20markups). Ein fester, vorhersehbarer Preis ist für einen Agenten leichter zu beurteilen als ein Preis, der je nach Aktion schwankt.
+
+Die zweite Alternative ist eine Wallet-signierte Zahlung, die nicht nur die Karte, sondern das Konto selbst überflüssig macht. Die `web3`-Dokumentation von Namefi beschreibt einen Ablauf auf Basis des HTTP-Statuscodes 402 und des [x402](/de/glossary/x402/)-Musters: Eine Domainanfrage ohne Zahlung liefert Preise in einer 402-Antwort zurück; die Wallet des Aufrufers signiert eine EIP-3009-Autorisierung, und diese signierte Autorisierung wird als Header erneut übermittelt, um Registrierung und Abrechnung in einem Schritt abzuschließen — ausdrücklich [„kein Namefi-Konto und keine EIP-712-Signatur erforderlich“](https://namefi.io/web3/llms.txt). Der Punkt hier ist enger: Es handelt sich um eine Zahlungsmethode, die Software selbst halten und nutzen kann, was eine hinterlegte Kreditkarte strukturell nicht kann. Den vollständigen Ablauf finden Sie unter [Domains mit einer Krypto-Wallet bezahlen: Kein Konto erforderlich](/de/blog/wallet-checkout/).
+
+## Richtlinien-Kontrollen: Die Zeile, die die gesamte Kategorie noch nicht gelöst hat
+
+Das ist die ehrliche Lücke. Auffindbarkeit, maschinenlesbare Dokumentation, strukturierte Fehler und programmatische Zahlung sind Dinge, die ein Registrar einmal bauen und ausliefern kann. Richtlinien-Kontrollen — Ausgabenobergrenzen, ein Bestätigungsschritt oberhalb eines Schwellenwerts oder ein auf eine TLD beziehungsweise ein Budget beschränkter Schlüssel — sind anders, denn sie schützen den Menschen, der Autorität delegiert hat, nicht die einfache Nutzung der API.
+
+Beim am besten überprüfbaren Fall, der Dokumentation von Namefi selbst, zeigt sich: Sie kennzeichnet bestimmte Operationen als folgenreich und dokumentiert strukturierte, maschinenlesbare Fehler (stabile Codes, ein `retryable`-Flag, strukturierte Details) — ein echter Fortschritt in dieser Zeile. In der öffentlichen API-Referenz fanden wir jedoch weder ein dokumentiertes Ausgabenlimit noch ein serverseitiges Bestätigungsgate; diese Leitplanke liegt derzeit eine Ebene höher, in der Richtlinie, die der Mensch auf dem MCP-Client selbst festlegt. Auch in den Registrar-APIs von Cloudflare oder Name.com fanden wir keine öffentliche Dokumentation einer Ausgabenlimit-Primitiven — diese Zeile sollte jeder agent-native Registrar als Nächstes schließen.
+
+## Bewertung der heutigen Plattformen anhand der Checkliste
+
+So schneiden die drei in diesem Bereich am häufigsten genannten Plattformen bei der Checkliste mit sechs Punkten ab, basierend auf dem, was wir direkt anhand der jeweils eigenen, live verfügbaren Dokumentation verifiziert haben, nicht auf Marketingtexten:
+
+| Registrar | Auffindbarkeit | Dokumentation in natürlicher Sprache | Maschinenlesbare Fehler | Browserfreier Kauf | Programmatische Zahlung | Richtlinien-Kontrollen |
+| --- | --- | --- | --- | --- | --- | --- |
+| Namefi | Ja — llms.txt + MCP-Server | Ja — llms.txt-Familie | Ja — strukturierte Codes | Ja — REST + MCP | Ja — API-Schlüssel oder Wallet (x402) | Noch nicht dokumentiert |
+| Cloudflare Registrar | Teilweise — eigenes llms.txt; MCP auf Editor-Ebene, kein bestätigter dedizierter Server | Unklar — über den llms.txt-Index hinaus nicht verifiziert | Unklar — nicht in öffentlichen Dokumenten verifiziert | Ja — API-gesteuert laut Berichterstattung zur Beta | Ja — API-Schlüssel, Selbstkostenpreise | Noch nicht dokumentiert |
+| Name.com | Unklar — am direkt geprüften Domain-Root kein llms.txt gefunden | In der eigenen Ankündigung von Name.com behauptet, nicht weiter unabhängig verifiziert | In den geprüften älteren Dokumenten nicht gefunden; für die neuere API unklar | Nicht unabhängig verifiziert | Teilweise — nur Abrechnung über Kontoguthaben dokumentiert | Noch nicht dokumentiert |
+
+Die Zeile, die bei allen leer bleibt — Richtlinien-Kontrollen — ist eine echte branchenweite Lücke, kein Vorwurf an eine einzelne Plattform. Es lohnt sich, sie im Blick zu behalten, während sich dieser Bereich weiterentwickelt.
+
+## Häufig gestellte Fragen
+
+### Was ist ein agent-nativer Domain-Registrar?
+
+Ein agent-nativer Registrar ist ein Registrar, den ein KI-Agent selbst entdecken, verstehen und für Transaktionen nutzen kann — ohne Browser, ohne dass ein Mensch die Dokumentation vorab liest, ohne dass jemand eine Kartennummer eingibt. Er schneidet bei Auffindbarkeit (einer `llms.txt`-Datei oder einem MCP-Server), Dokumentation in natürlicher Sprache, maschinenlesbaren Fehlern, browserfreiem Kauf und programmatischer Zahlung jeweils mit Ja ab; Richtlinien-Kontrollen (Ausgabenobergrenzen, Bestätigungsgates) sind der Teil, den die Kategorie noch aufbaut.
+
+### Warum können KI-Agenten normale Registrar-APIs nicht verwenden?
+
+Technisch können sie die Endpunkte aufrufen, doch die meisten Registrar-APIs setzen voraus, dass ein menschlicher Entwickler die Dokumentation bereits gelesen und den Integrationscode vorab geschrieben hat. Ein Agent ohne vorherige Integration hat keinen Standardweg, die Basis-URL zu entdecken, das Authentifizierungsschema zu lernen oder eine Fehlernachricht in Prosa zu interpretieren — die API funktioniert nur, weil eine Person diese Interpretationsarbeit bereits geleistet hat, nicht weil sie für einen Agenten mit Kaltstart lesbar ist.
+
+### Was ist der Unterschied zwischen llms.txt und MCP?
+
+`llms.txt` ist eine Klartextdatei, die ein Agent einmal liest, um zu erfahren, was eine Website oder API ist und wie sie zu verwenden ist — dieselbe Rolle, die `robots.txt` für Crawler spielt, aber für Sprachmodelle geschrieben. [MCP](https://modelcontextprotocol.io) ist eine Live-Protokollverbindung, die der Client eines Agenten zu einem Server mit aufrufbaren Tools öffnet. Beides ergänzt sich: llms.txt ist die Auffindbarkeit, MCP ist die Verbindung, die ein Agent zum Handeln nutzt. Mehr zum Aspekt der Auffindbarkeit finden Sie unter [llms.txt für Domains: Eine API, die jeder KI-Agent lesen kann](/de/blog/llms-txt/).
+
+### Wie mache ich meine eigene API für Agenten nutzbar?
+
+Veröffentlichen Sie eine `llms.txt`, die Ihre API für Modelle beschreibt, stellen Sie einen MCP-Server (oder mindestens OpenAPI-dokumentierte Endpunkte) bereit, geben Sie strukturierte Fehler mit stabilen Codes statt Prosa zurück, sorgen Sie dafür, dass sich jede Schreiboperation ohne gehostete Checkout-Seite abschließen lässt, unterstützen Sie eine Zahlungsmethode, die keine menschliche Karte voraussetzt, und ergänzen Sie Ausgaben- oder Bestätigungsgrenzen, damit derjenige, der die Zugangsdaten hält, begrenzen kann, was ein Agent tun darf.
+
+### Ist Namefi agent-native?
+
+Nach der obigen Checkliste erhält Namefi bei fünf der sechs direkt verifizierten Zeilen ein Ja: Das Unternehmen veröffentlicht eine llms.txt-Familie und einen MCP-Server, seine Dokumentation ist für die Nutzung durch Agenten strukturiert, seine Outbound-API liefert strukturierte maschinenlesbare Fehler, die Registrierung wird vollständig über die API oder den x402-basierten Wallet-Ablauf abgeschlossen, ohne dass ein Dashboard erforderlich ist, und die Zahlung funktioniert per API-Schlüssel oder Wallet-signierter Transaktion, ohne dass ein Konto erforderlich ist. Richtlinien-Kontrollen sind in der öffentlichen API-Referenz noch nicht dokumentiert; diese Steuerung liegt derzeit auf Client-Seite. <!-- TODO: confirm with team — whether a spend-cap or purchase-confirmation feature is on the near-term roadmap -->
+
+### Macht ein MCP-Server einen Registrar automatisch agent-native?
+
+Nein. MCP-Unterstützung deckt Auffindbarkeit und browserfreien Kauf ab, doch ein Registrar kann einen MCP-Server bereitstellen und dennoch unstrukturierte Fehler zurückgeben, weiterhin eine hinterlegte Karte verlangen oder weiterhin keinen Mechanismus für Ausgabenobergrenzen haben. Agent-native ist die gesamte Checkliste, nicht eine einzelne Zeile.
+
+## Quellen und weiterführende Lektüre
+
+- Wikipedia — [Extensible Provisioning Protocol (EPP als Proposed Standard, März 2004)](https://en.wikipedia.org/wiki/Extensible_Provisioning_Protocol#:~:text=Proposed%20Standard%20documents%20%28RFCs%203730%20-%203734%29%20were%20published%20by%20the%20RFC%20Editor%20in%20March%202004)
+- CircleID — [Das Domain-Universum 2026: KI, Sicherheit, Marktreife und die neue gTLD-Grenze („KI-Agenten agieren zunehmend als Domain-Reseller…“)](https://circleid.com/posts/the-domain-universe-in-2026-ai-security-market-maturity-and-the-new-gtld-frontier#:~:text=AI%20agents%20are%20increasingly%20acting%20as%20domain%20resellers%20checking%20availability%2C%20registering%20names%2C%20and%20configuring%20DNS%20without%20human%20intervention)
+- webhosting.today — [KI-Agenten können jetzt Domains ohne Menschen registrieren (Cloudflare-Registrar-API-Beta, April 2026)](https://webhosting.today/2026/04/22/ai-agents-can-now-register-domains-no-human-required/#:~:text=The%20API%20is%20designed%20to%20work%20inside%20the%20tools%20where%20developers%20already%20operate%2C%20code%20editors%20with%20MCP%20support%20such%20as%20Cursor%20and%20Claude%20Code)
+- Name.com — [Die erste KI-native Domain-Plattform („unterstützt durch moderne Standards wie das Model Context Protocol…“)](https://www.name.com/blog/the-first-ai-native-domain-platform#:~:text=Our%20platform%20is%20supported%20by%20modern%20standards%20like%20Model%20Context%20Protocol)
+- llmstxt.org — [Der Vorschlag für die Datei /llms.txt](https://llmstxt.org/#:~:text=A%20proposal%20to%20standardise%20on%20using%20an%20/llms.txt%20file%20to%20provide%20information%20to%20help%20LLMs%20use%20a%20website%20at%20inference%20time)
+- modelcontextprotocol.io — [Was ist das Model Context Protocol (MCP)?](https://modelcontextprotocol.io/#:~:text=MCP%20%28Model%20Context%20Protocol%29%20is%20an%20open-source%20standard%20for%20connecting%20AI%20applications%20to%20external%20systems)
+- Schema.org — [FAQPage](https://schema.org/FAQPage)
+- Cloudflare — [.ai-Domains zu Selbstkosten kaufen](https://www.cloudflare.com/application-services/products/registrar/buy-ai-domains/#:~:text=Cloudflare%20offers%20.ai%20domain%20registrations%20and%20renewals%20at%20wholesale%20prices%2C%20with%20no%20additional%20markups)
+- Cloudflare Developers — [Registrar-Dokumentationsindex (llms.txt)](https://developers.cloudflare.com/registrar/llms.txt)
+- Namefi — [namefi.io/llms.txt (API- und MCP-Server-Referenz — maßgebliche Quelle für Namefi-Produktbehauptungen in diesem Artikel)](https://namefi.io/llms.txt)
+- Namefi — [namefi.io/web3/llms.txt (Wallet-signierter / x402-Zahlungsablauf, „kein Namefi-Konto und keine EIP-712-Signatur erforderlich“)](https://namefi.io/web3/llms.txt)

--- a/content/blog/de/agent-own-domain.md
+++ b/content/blog/de/agent-own-domain.md
@@ -1,0 +1,110 @@
+---
+title: "Kann ein KI-Agent eine Domain besitzen? WHOIS, Verwahrung und Token"
+date: '2026-07-10'
+language: 'de'
+tags: ['ai-agents', 'domains', 'web3']
+authors: ['namefiteam']
+draft: false
+format: faq
+ogImage: ../../assets/agent-own-domain-og.jpg
+description: "Der Registrant muss eine rechtsfähige Person sein, doch die Verwahrung kann delegiert werden. WHOIS, API-Schlüssel und tokenisierte Domains — das Spektrum der Verwahrung erklärt."
+keywords: ['kann ein ki-agent eine domain besitzen', 'domainbesitz durch ki-agenten', 'wer ist der registrant wenn ki eine domain registriert', 'ki-agent whois', 'domain-registrant rechtsfähige person', 'verwahrung tokenisierter domains', 'ki-agent wallet nft domain', 'spektrum der domainverwahrung', 'risiko agentenverwalteter domains', 'udrp-risiko für ki-agenten', 'domain an ki-agent delegieren', 'wallet-verwahrte domain', 'rdap-abfrage ki-agent', 'domainbesitz versus kontrolle']
+relatedArticles:
+  - /de/blog/wallet-checkout/
+  - /de/blog/agents-buy-domains/
+  - /de/blog/ai-agent-register/
+  - /de/blog/cf-namecom-namefi/
+  - /de/blog/namefi-mcp/
+relatedTopics:
+  - /de/topics/domain-tokenization/
+  - /de/topics/domain-security/
+relatedSeries:
+  - /de/series/blockchain-concepts/
+  - /de/series/tokenize-your-com/
+relatedGlossary:
+  - /de/glossary/registrant/
+  - /de/glossary/whois/
+  - /de/glossary/custodial-ownership/
+  - /de/glossary/tokenized-domain/
+  - /de/glossary/udrp/
+---
+
+„Kann mein KI-Agent eine Domain besitzen?“ Diese Frage taucht ständig auf, sobald ein [KI-Agent](/de/glossary/ai-agent/) im Auftrag einer Person Domains registriert, verlängert und verwaltet — [Wie KI-Agenten Domains ohne einen Menschen kaufen](/de/blog/agents-buy-domains/) zeigt, wie verbreitet das 2026 geworden ist. Die kurze Antwort steht ganz oben; der Rest dieser Seite erläutert *warum* anhand der konkreten Fragen, die Menschen tatsächlich stellen und die jeweils für sich beantwortet werden können.
+
+## Kann ein KI-Agent rechtlich eine Domain besitzen?
+
+Nicht im eigenen Namen. Das [Registrar Accreditation Agreement von 2013](https://www.icann.org/en/contracted-parties/accredited-registrars/registrar-accreditation-agreement/2013-registrar-accreditation-agreement-17-09-2013-en#:~:text=The%20Registered%20Name%20Holder%20with%20whom%20Registrar%20enters%20into%20a%20registration%20agreement%20must%20be%20a%20person%20or%20legal%20entity%20other%20than%20the%20Registrar) der [ICANN](/de/glossary/icann/) — der Vertrag, den jeder ICANN-akkreditierte Registrar unterzeichnet und nach dem er arbeitet — besagt unmittelbar, dass „the [Registered Name Holder](/de/glossary/registrant/) with whom Registrar enters into a registration agreement must be a person or legal entity other than the Registrar.“ Ein [Registrant](/de/glossary/registrant/) muss eine natürliche Person oder eine eingetragene juristische Person sein: eine Einzelperson, ein Unternehmen, eine gemeinnützige Organisation oder eine staatliche Stelle. Ein KI-Agent ist als Software keines davon. Daher kann der Agent selbst nie als Name in der Registrierung stehen.
+
+Was die Regel nicht ausschließt, ist Delegation. Nichts im RAA hindert einen Menschen oder eine Organisation daran, einen Agenten zu autorisieren, in ihrem Namen Domains zu suchen, zu registrieren, zu verlängern oder DNS zu verwalten — so wie heute eine Person einen Mitarbeitenden oder eine Automatisierung autorisieren könnte. Der Registrant bleibt eine rechtsfähige Person; die *Arbeit* der Domainverwaltung kann einem Agenten übertragen werden. Diese Unterscheidung — wer im Register steht und wer klickt (oder die API aufruft) — ist das ganze Thema dieser Seite.
+
+## Wer ist der Registrant, wenn ein KI-Agent eine Domain registriert?
+
+Die Person, die das Konto innehat, den Kauf finanziert und den Bedingungen des Registrars zugestimmt hat — niemals der Agent. Wenn ein Agent die API eines Registrars aufruft, um einen Namen zu registrieren, handelt er als Werkzeug unter der Autorisierung einer Person; rechtlich entspricht das der Nutzung eines Webformulars durch eine Person, nur automatisiert. Die eigene Anleitung der ICANN für Registrants benennt klar, wo diese Verantwortung liegt: „you will assume sole responsibility for the registration and use of your domain name“, wie auf der Seite [Benefits and Responsibilities for Registrants](https://www.icann.org/resources/pages/benefits-2013-09-16-en#:~:text=You%20will%20assume%20sole%20responsibility%20for%20the%20registration%20and%20use%20of%20your%20domain%20name) der ICANN steht. Diese Verantwortung liegt beim Kontoinhaber, der den Agenten freigibt, nicht bei der Software, die den Aufruf ausführt.
+
+Deshalb führt jeder glaubwürdige Ablauf zur Agentenregistrierung — auch der von [Namefi](https://namefi.io) — über Zugangsdaten, die von einer Person oder Organisation kontrolliert werden: einen API-Schlüssel, der an ein gedecktes Konto gebunden ist, oder ein [Wallet](/de/glossary/wallet/), dessen [privaten Schlüssel](/de/glossary/private-key/) jemand kontrolliert. [Wie Sie mit Ihrem KI-Agenten bei Namefi eine Domain registrieren](/de/blog/ai-agent-register/) zeigt, wie dieser Schritt mit Zugangsdaten praktisch funktioniert.
+
+## Was zeigt der WHOIS- oder RDAP-Datensatz bei einer agentenregistrierten Domain tatsächlich?
+
+Dieselben Felder wie bei jeder anderen Registrierung: den Registrar of Record, Registrierungs- und Ablaufdaten sowie — sofern nicht durch [WHOIS](/de/glossary/whois/)-Datenschutz verborgen, den die meisten Registrare inzwischen standardmäßig anwenden — Name, Organisation und Kontaktdaten des Registrants. Es gibt kein Feld für „von einem KI-Agenten registriert“, und keine ICANN-Richtlinie definiert ein solches Feld. Das [eigene RDAP-basierte Abfragetool der ICANN](https://lookup.icann.org) ist die maßgebliche Stelle, um den aktuellen Datensatz einer konkreten Domain zu prüfen; es liefert dasselbe Schema, unabhängig davon, ob ein Mensch das Registrierungsformular ausfüllt oder ein Agent per API dieselben Daten übermittelt.
+
+Praktisch bedeutet das: Ein Außenstehender — etwa ein Markeninhaber, Sicherheitsforscher oder potenzieller Käufer — kann allein anhand von WHOIS/RDAP nicht erkennen, dass eine Domain von einem Agenten registriert wurde. Der Datensatz benennt den rechtlichen Registrant. Was den API-Aufruf ausgelöst hat, der ihn erzeugte, gehört nicht zum Datenmodell.
+
+## Was ist der Unterschied zwischen einer vom Agenten *betriebenen* und einer vom Agenten *besessenen* Domain?
+
+Betreiben bedeutet, dass der Agent auf der Domain handeln kann — sie verlängern, DNS-Einträge ändern oder einen Transfer anstoßen — weil er Zugangsdaten mit entsprechendem Umfang besitzt. Besitzen bedeutet im einzigen rechtlich maßgeblichen Sinn, nach der obigen RAA-Definition als Registrant eingetragen zu sein: als eine Person oder juristische Person, die gegenüber dem Registrar und den ICANN-Richtlinien verantwortlich ist. Ein Agent kann eine Domain umfassend betreiben — der [MCP-Server von Namefi](/de/blog/namefi-mcp/) stellt genau diese Art von Werkzeugen bereit —, ohne je Eigentümer zu sein; so wie eine Hausverwaltung Schlüssel halten und Wartungsarbeiten veranlassen kann, ohne Eigentum am Gebäude zu haben.
+
+Die Lücke zwischen diesen beiden Rollen ist der Ort, an dem die meisten praktischen Fragen tatsächlich liegen. Deshalb behandeln die nächsten Abschnitte sie als Spektrum und nicht als ein einziges Ja oder Nein.
+
+## Was ist das Verwahrungsspektrum für eine vom Agenten verwaltete Domain?
+
+Drei Stufen, die dem Agenten jeweils zunehmend direktere Kontrolle geben, während der rechtliche Registrant gleich bleibt:
+
+- **Zugang zum Registrar-Konto.** Der Agent (oder das Skript, das im Auftrag des Agenten die Registrar-API aufruft) nutzt Zugangsdaten, die an das eigene Registrar-Konto der Person oder Organisation gebunden sind. Das Registrant-Feld ändert sich nie; der Agent handelt lediglich innerhalb eines Kontos, das bereits jemandem gehört, ähnlich wie bei einer heute üblichen Vereinbarung zur gemeinsamen Nutzung eines Logins.
+- **API-Schlüssel.** Zugangsdaten mit begrenztem Umfang für die API des Registrars, die gegen ein gedecktes Guthaben abgerechnet werden, ohne zwangsläufig den vollen Zugang zum Kontodashboard zu teilen. [Namefi stellt solche Schlüssel aus](https://namefi.io/api-key), damit ein Agent suchen, Preise abrufen und registrieren kann, ohne eine Browsersitzung anzufassen — behandelt in [Wie Sie mit Ihrem KI-Agenten bei Namefi eine Domain registrieren](/de/blog/ai-agent-register/). Registrant bleibt weiterhin die Person, deren Konto den Umfang des Schlüssels bestimmt.
+- **Wallet-verwahrte [tokenisierte Domain](/de/glossary/tokenized-domain/).** Die Registrierung wird als On-Chain-Token geprägt, und das [Wallet](/de/glossary/wallet/), das diesen Token hält — über einen von [x402](/de/glossary/x402/) signierten Wallet-Checkout oder eine festgelegte Empfangsadresse — kontrolliert unmittelbar den On-Chain-Transferweg der Domain, ganz ohne Registrar-Dashboard. [Domains mit einem Krypto-Wallet bezahlen: kein Konto erforderlich](/de/blog/wallet-checkout/) erklärt, wie eine Domain auf diese Weise in ein Wallet gelangt.
+
+Jede Stufe ist direkter als die vorige, doch die zuvor erläuterte Frage nach dem rechtlichen Registrant verschiebt sich nicht — sie wird unabhängig davon gleich beantwortet, auf welcher Stufe der Agent arbeitet.
+
+## Was ändert sich, wenn eine Domain tokenisiert wird?
+
+Die Tokenisierung einer Domain prägt ein [NFT](/de/glossary/nft/), das als parallele On-Chain-Kontrollebene über einer echten DNS-Registrierung fungiert; [Was sind tokenisierte Domains?](/de/blog/what-are-tokenized-domains/) erläutert dies ausführlicher. Namefi, ein ICANN-akkreditierter Registrar, erreicht dies, indem die zugrunde liegende Registrierung echt und von der ICANN anerkannt bleibt, während der Eigentums-Token an ein vom Käufer angegebenes Wallet geprägt wird. Die eigene Dokumentation von Namefi beschreibt die Registrierung einer Domain so, dass der resultierende Token direkt an eine vom Käufer kontrollierte Adresse `nftReceivingWallet` gesendet wird. Die Domain hat weiterhin einen WHOIS/RDAP-Datensatz und einen Registrar of Record; der Token fügt einen Weg hinzu, die *Kontrolle* über diesen Datensatz Peer-to-Peer und On-Chain zu übertragen, ohne einen vom Registrar vermittelten Transferantrag.
+
+Was die Tokenisierung nicht tut, ist neu zu definieren, wer Registrant sein darf. Der Standard [ERC-721](/de/glossary/erc-721/), auf dem tokenisierte Domains aufbauen, enthält [keine Einschränkung dafür, welche Art von Adresse einen Token halten kann](https://eips.ethereum.org/EIPS/eip-721): Jede Wallet-Adresse kann ein NFT besitzen, und der Standard sieht ausdrücklich auch Verträge als Tokenhalter vor. Das ist eine Aussage über den Token, nicht über die Regeln der ICANN für Registrants. Diese liegen auf der Registrar-Ebene darüber und verlangen weiterhin, dass die zugrunde liegende Registrierung auf eine natürliche oder juristische Person zurückführbar ist.
+
+## Kann das Wallet eines KI-Agenten tatsächlich eine tokenisierte Domain halten?
+
+Technisch ja, in dem engen Sinn, dass ein Wallet nur ein Schlüsselpaar ist und weder der ERC-721-Standard noch eine Präge-Transaktion prüft, ob die Partei, die den privaten Schlüssel kontrolliert, ein Mensch, ein Skript oder ein autonomer Prozess ist. Hat ein Agent Signaturberechtigung über ein Wallet — mit seinem eigenen Schlüssel oder mit delegierter Berechtigung über den Schlüssel einer anderen Person —, kann dieses Wallet das NFT einer tokenisierten Domain empfangen und halten wie jedes andere Wallet.
+
+Ob diese Anordnung den *Agenten* in einem rechtlich relevanten Sinn zum Eigentümer macht, ist eine wirklich offene Frage, die wir hier nicht entscheiden können. Keine ICANN-Richtlinie, kein Gerichtsurteil und keine von uns gefundene Quelle behandelt einen KI-Agenten — im Unterschied zu der Person oder Organisation, die dessen Wallet kontrolliert — als rechtlichen Eigentümer von irgendetwas. „Das Wallet des Agenten hält den Token“ sollte als Beschreibung technischer Verwahrung verstanden werden, nicht als abschließende rechtliche Folgerung. Die sicherere Einordnung, die alle obigen Quellen stützen, lautet: Der *Kontrolleur* des Wallets — wer den privaten Schlüssel hält oder anweisen kann — ist die Partei mit einem tatsächlichen Anspruch; und das soll weiterhin eine Person oder Organisation sein, nicht die Software selbst.
+
+## Was passiert bei Fehlverhalten des Agenten — kann eine Domain gesperrt oder zurückgeholt werden?
+
+Je nach Verwahrungsstufe greifen zwei unterschiedliche Schutzmechanismen, und sie bieten nicht dieselbe Art von Rechtsbehelf. Auf Registrar-Ebene schaffen die Transferregeln der ICANN bewusst Hürden: Eine Domain kann in der Regel innerhalb von 60 Tagen nach der Erstregistrierung nicht zu einem neuen Registrar transferiert werden, und nach einer Änderung von Name, Organisation oder E-Mail-Adresse des Registrants gilt eine **60-tägige Change-of-Registrant-Sperre**. Beides ist in den [FAQ der ICANN für Registrants](https://www.icann.org/resources/pages/name-holder-faqs-2017-10-10-en#:~:text=Another%20situation%20is%20if%20the%20domain%20name%20is%20subject%20to%20a%2060-day%20Change%20of%20Registrant%20lock) dokumentiert. Diese Zeitfenster geben einem Registrant Gelegenheit, eine unbefugte Änderung zu bemerken und anzufechten, bevor sie endgültig ist — ein realer, wenn auch begrenzter Schutz gegen einen außer Kontrolle geratenen Agenten bei einem gewöhnlichen Registrar-Konto oder API-Schlüssel.
+
+Sobald eine Domain tokenisiert ist und das NFT in einem Wallet liegt, sieht dieses Sicherheitsnetz anders aus. Ein On-Chain-Transfer ist nach seiner Bestätigung im Allgemeinen endgültig; es gibt keine Registrar-seitige Sperre, die einen Token zurückdreht, der an die falsche Adresse gesendet wurde. Die praktische Absicherung verlagert sich daher nach vorn, auf den Umfang der Befugnisse des Agenten-Wallets: etwa auf eine [Multi-Sig](/de/glossary/multi-sig/)-Anordnung, die einen zweiten Unterzeichner verlangt, oder darauf, einem Agenten keine dauerhafte Berechtigung über ein Wallet mit wertvollen tokenisierten Domains zu geben. Das ist dasselbe Prinzip der Leitplanken, das für Zahlungen in [Domains mit einem Krypto-Wallet bezahlen](/de/blog/wallet-checkout/#the-security-model-what-the-agent-can-and-cannot-do) behandelt wird.
+
+## Beseitigt die Tokenisierung einer Domain das UDRP-Risiko?
+
+Nein, und keine der geprüften Quellen deutet etwas anderes an. Verpflichtungen aus der [UDRP](/de/glossary/udrp/) hängen an der zugrunde liegenden, von der ICANN anerkannten DNS-Registrierung, die auch eine tokenisierte Domain weiterhin hat. Die Tokenisierung verändert, wer die Domain wie bewegen kann, nicht aber, ob Markenrecht oder die Streitbeilegungsrichtlinie der ICANN darauf anwendbar sind. Ein Beitrag über Domains im Besitz von Agenten formulierte das Risiko klar: „if an agent registers a domain that turns out to be a trademark conflict, there's no human to respond to a UDRP complaint“, wenn niemand überwacht, was ein Agent unter seinen Zugangsdaten registriert. Das wird ausführlicher in [Wie KI-Agenten Domains ohne einen Menschen kaufen](/de/blog/agents-buy-domains/#guardrails-no-human-required-still-needs-a-human-set-policy) behandelt. Eine UDRP-Beschwerde richtet sich gegen den eingetragenen Registrant — gegen die jeweilige natürliche oder juristische Person —, nicht gegen den Agenten, der die Registrierung übermittelt hat.
+
+## Wer haftet also tatsächlich, wenn die Domain eines Agenten ein rechtliches Problem verursacht?
+
+Der eingetragene Registrant: die natürliche oder juristische Person, deren Konto, API-Schlüssel oder Wallet die Registrierung autorisiert hat — niemals das KI-Modell selbst. Das ist die durchgängige Linie aller obigen Fragen: WHOIS/RDAP benennt eine rechtsfähige Person, das RAA verlangt eine solche, die Transfer-Sperren der ICANN und das UDRP-Risiko haften beide an demselben Namen, und die Tokenisierung verändert die Kontrollmechanik, nicht aber die darunterliegende Verantwortlichkeit. „Der Agent besitzt die Domain“ ist eine nützliche Kurzform für „dem Agenten wurde Kontrolle über die Domain delegiert“. Sie sollte als Kurzform behandelt werden, nicht als feststehende rechtliche Tatsache: Wie weit diese Delegation gehen kann und ob eine Rechtsordnung einen autonomen Agenten jemals als mehr als ein Werkzeug seines verantwortlichen Betreibers ansieht, ist unerprobt. Legen Sie vor der Übertragung von Kauf- oder Verwahrungsbefugnissen an einen Agenten auf jeder Stufe ausdrücklich fest, wer der rechtliche Registrant ist.
+
+## Mit einem echten Registrant im Datensatz registrieren und tokenisieren
+
+[Namefi](https://namefi.io) ist genau für diese Konstellation gebaut: eine echte [ICANN-akkreditierte](/de/glossary/icann/) Registrierung mit einem Registrant-Feld, das nach den ICANN-Vorgaben behandelt wird, und einer optionalen [tokenisierten](/de/glossary/tokenized-domain/) Ebene, die die On-Chain-Kontrolle in ein Wallet Ihrer Wahl legt — auch in eines, das ein Agent unter den von Ihnen gesetzten Leitplanken betreibt. Beginnen Sie mit [Wie Sie mit Ihrem KI-Agenten bei Namefi eine Domain registrieren](/de/blog/ai-agent-register/), oder gehen Sie direkt zum Wallet-signierten Checkout in [Domains mit einem Krypto-Wallet bezahlen](/de/blog/wallet-checkout/).
+
+**[Bei Namefi eine Domain suchen und registrieren](https://namefi.io).**
+
+## Quellen und weiterführende Lektüre
+
+- ICANN — [Registrar Accreditation Agreement 2013, §3.7.7](https://www.icann.org/en/contracted-parties/accredited-registrars/registrar-accreditation-agreement/2013-registrar-accreditation-agreement-17-09-2013-en#:~:text=The%20Registered%20Name%20Holder%20with%20whom%20Registrar%20enters%20into%20a%20registration%20agreement%20must%20be%20a%20person%20or%20legal%20entity%20other%20than%20the%20Registrar) („must be a person or legal entity other than the Registrar“ — die zentrale Regel zur Zulässigkeit als Registrant)
+- ICANN — [Benefits and Responsibilities for Registrants](https://www.icann.org/resources/pages/benefits-2013-09-16-en#:~:text=You%20will%20assume%20sole%20responsibility%20for%20the%20registration%20and%20use%20of%20your%20domain%20name) („you will assume sole responsibility for the registration and use of your domain name“)
+- ICANN — [FAQ für Registrants: Ihre Domain übertragen](https://www.icann.org/resources/pages/name-holder-faqs-2017-10-10-en#:~:text=Another%20situation%20is%20if%20the%20domain%20name%20is%20subject%20to%20a%2060-day%20Change%20of%20Registrant%20lock) (60-tägige Transfer-Sperren für Neuregistrierungen und Änderungen des Registrants)
+- ICANN — [ICANN Lookup (lookup.icann.org)](https://lookup.icann.org) (die offizielle RDAP-basierte WHOIS/RDAP-Abfrage für den aktuellen Registrant-Datensatz jeder Domain)
+- Ethereum — [EIP-721: Non-Fungible Token Standard](https://eips.ethereum.org/EIPS/eip-721) (keine Einschränkung, welche Adresse — einschließlich eines Vertrags — einen Token halten kann)
+- Namefi — [namefi.io/llms.txt](https://namefi.io/llms.txt) (Referenz zur Tokenisierung und zum Prägen an `nftReceivingWallet` — Quelle für Produktangaben zu Namefi in diesem Artikel)
+- dev.to — [Wie KI-Agenten ihre eigenen Domainnamen kaufen können und warum das wichtig ist](https://dev.to/purpleflea/how-ai-agents-can-buy-their-own-domain-names-and-why-this-matters-1l4j#:~:text=If%20an%20agent%20registers%20a%20domain%20that%20turns%20out%20to%20be%20a%20trademark%20conflict%2C%20there%27s%20no%20human%20to%20respond%20to%20a%20UDRP%20complaint) (UDRP-Risiko, wenn niemand die Registrierungen eines Agenten überwacht)
+- Namefi — [Wie KI-Agenten Domains ohne einen Menschen kaufen (2026)](/de/blog/agents-buy-domains/) (die Leitplanken und Reseller-Einordnung, auf denen dieser Artikel aufbaut)
+- Namefi — [Domains mit einem Krypto-Wallet bezahlen: kein Konto erforderlich](/de/blog/wallet-checkout/) (Mechanik der Wallet-signierten Verwahrung und Leitplanken für Ausgabenrichtlinien)

--- a/content/blog/de/agents-buy-domains.md
+++ b/content/blog/de/agents-buy-domains.md
@@ -1,0 +1,125 @@
+---
+title: "Wie KI-Agenten Domains ohne einen Menschen kaufen (2026)"
+date: '2026-07-10'
+language: 'de'
+tags: ['ai-agents', 'domains', 'explainer']
+authors: ['namefiteam']
+draft: false
+format: explainer
+ogImage: ../../assets/agents-buy-domains-og.jpg
+description: "Im April 2026 verlagerte sich die Domainregistrierung in die Agentenschicht. Wie KI-Agenten Domains suchen, bepreisen und registrieren — und welche Leitplanken weiterhin zählen."
+keywords: ['ki-agenten registrieren domains', 'domainregistrierung ohne menschen erforderlich', 'autonome domainregistrierung', 'domainregistrierung in der agentenschicht', 'cloudflare registrar api beta', 'agentische leitplanken', 'domainregistrierung durch ki-agenten 2026', 'ist es sicher ki domains kaufen zu lassen', 'agenten als domain-reseller', 'mcp domainregistrierung', 'llms.txt domainentdeckung', 'ausgabenlimit für ki-agenten', 'epp registry-provisionierung']
+relatedArticles:
+  - /de/blog/ai-domain-platforms/
+  - /de/blog/cf-namecom-namefi/
+  - /de/blog/agent-native/
+  - /de/blog/namefi-mcp/
+  - /de/blog/state-of-agentic/
+relatedTopics:
+  - /de/topics/domain-basics/
+  - /de/topics/domain-security/
+relatedSeries:
+  - /de/series/blockchain-concepts/
+  - /de/series/domain-apocalypse/
+relatedGlossary:
+  - /de/glossary/ai-agent/
+  - /de/glossary/epp/
+  - /de/glossary/registrar/
+  - /de/glossary/registry/
+  - /de/glossary/reseller/
+---
+
+Zwanzig Jahre lang bedeutete die Registrierung einer Domain immer dasselbe kleine Ritual: Einen Namen in ein Suchfeld eingeben, auf ein grünes Häkchen warten, eine Kartennummer eintragen, durch das Erkennen von Zebrastreifen auf einem Foto beweisen, dass man ein Mensch ist, und auf „Kaufen“ klicken. Dieses Ritual war zum Teil ein bewusster Filter — das [CAPTCHA](https://en.wikipedia.org/wiki/CAPTCHA), das Checkout-Formular und das Kartenfeld dienen alle dazu, alles zu bremsen, was keine Person ist.
+
+Am 15. April 2026 hörte dieser Filter auf, universell zu gelten. Cloudflare stellte eine Registrar-API als öffentliche Beta bereit, begleitet von einer Botschaft, die die Branchenberichterstattung unverblümt zusammenfasste: [Cloudflare „verschob diese Transaktion in die Agentenschicht“](https://webhosting.today/2026/04/22/ai-agents-can-now-register-domains-no-human-required/#:~:text=On%20April%2015%2C%202026%2C%20Cloudflare%20moved%20that%20transaction%20into%20the%20agent%20layer) — jene Architekturebene, auf der Software statt einer Person, die ein Formular anklickt, den Kauf auslöst. Registrierung, DNS und einige weitere Aufgaben, die sich einer vollständigen Automatisierung widersetzt hatten, weil sie einen Menschen an der Tastatur voraussetzten, hörten stillschweigend auf, dies vorauszusetzen.
+
+Dieser Beitrag behandelt genau diesen Wandel: Was sich technisch geändert hat, was ein [KI-Agent](/de/glossary/ai-agent/) tatsächlich tut, wenn er in Ihrem Auftrag eine Domain registriert, und — weil „kein Mensch erforderlich“ eine Aussage ist, der man mit Skepsis begegnen sollte — was weiterhin gelten muss, damit das sicher ist. Einen Überblick Plattform für Plattform darüber, wer das heute anbietet, finden Sie in [KI-agentische Domainplattformen: Der Leitfaden für 2026](/de/blog/ai-domain-platforms/) und [Cloudflare vs. Name.com vs. Namefi](/de/blog/cf-namecom-namefi/). Die zugrunde liegende Definition dafür, was einen Registrar überhaupt für einen Agenten nutzbar macht, behandelt [Was ist ein Agent-Native Domain Registrar?](/de/blog/agent-native/)
+
+## Was sich technisch geändert hat
+
+Die Domainbranche hat ihre Regeln im April 2026 nicht neu geschrieben. [Registrare](/de/glossary/registrar/) hatten bereits seit [Jahrzehnten](/de/glossary/epp/) programmierbare APIs; geändert hat sich, für wen diese APIs verständlich und zugänglich waren.
+
+Ein herkömmlicher Registrar-Checkout ist darauf ausgelegt, dass eine Person die Seite liest, eine Karte eingibt und vor Abschluss des Kaufs beweist, dass sie kein Bot ist — drei Annahmen, die für einen Agenten jeweils eine Mauer darstellen. Ein CAPTCHA existiert gerade, um alles auszusperren, was kein Mensch ist; deshalb blockiert es einen legitimen Agenten, der auf Anweisung eines Menschen handelt, genauso zuverlässig wie Missbrauch. Ein MCP-Tutorial eines Drittanbieters, das auf Cloudflares Beta aufbaut, beschrieb das alte Modell treffend: [„Domain registrars are built for humans: CAPTCHAs, dashboards, forms, credit card fields. Not exactly agent-friendly.“](https://dev.to/marsheer/how-to-register-a-domain-name-with-your-ai-agent-no-human-needed-h26#:~:text=Domain%20registrars%20are%20built%20for%20humans%3A%20CAPTCHAs%2C%20dashboards%2C%20forms%2C%20credit%20card%20fields.%20Not%20exactly%20agent-friendly.)
+
+Drei Dinge ersetzten dieses Modell; sie ergänzen sich, statt miteinander zu konkurrieren:
+
+- **Authentifizierte REST-APIs**, sodass ein Kauf als HTTP-Aufruf statt über eine gerenderte Checkout-Seite abgeschlossen werden kann. Cloudflares Beta deckt Suche, Verfügbarkeit und Registrierung auf diese Weise ab; laut Berichterstattung zum Start wird die Registrierung für Standarddomains „synchronously within seconds“ abgeschlossen.
+- **[MCP](https://modelcontextprotocol.io) (Model Context Protocol)**, ein offener Standard, den seine eigene Dokumentation als [„an open-source standard for connecting AI applications to external systems“](https://modelcontextprotocol.io/#:~:text=MCP%20%28Model%20Context%20Protocol%29%20is%20an%20open-source%20standard%20for%20connecting%20AI%20applications%20to%20external%20systems) beschreibt. Er macht den Unterschied zwischen einem Agenten mit maßgeschneidertem Integrationscode und einem Agenten aus, der die Werkzeuge eines Registrars (`search`, `register`, `set_dns_record`) entdecken und direkt in Claude, Cursor oder einem anderen kompatiblen Client aufrufen kann. Cloudflare band seine Registrar-API in diese Ebene ein, sodass nach eigener Darstellung „an agent working in Cursor, Claude Code, or any MCP-compatible environment can discover and call Registrar endpoints“ — ohne einen separaten Integrationsschritt.
+- **[llms.txt](https://llmstxt.org)-Entdeckung**, eine Klartext-Konvention — [„a proposal to standardise on using an `/llms.txt` file to provide information to help LLMs use a website at inference time“](https://llmstxt.org/#:~:text=A%20proposal%20to%20standardise%20on%20using%20an%20/llms.txt%20file%20to%20provide%20information%20to%20help%20LLMs%20use%20a%20website%20at%20inference%20time) —, die einem Agenten, der einen bestimmten Registrar noch nie gesehen hat, ermöglicht herauszufinden, was er tun kann, ohne dass ein Mensch zuerst API-Dokumentation in das Gespräch einfügen muss.
+
+Keines dieser drei Elemente ist für sich genommen neu; MCP wurde Ende 2024 veröffentlicht, und llms.txt wurde im selben Jahr vorgeschlagen. Neu ist, dass ein großer Registrar alle drei hinter einem Live-Kauffluss bereitstellt — der Teil, der „KI-Agenten registrieren Domains“ von einer Demo für Hobbyisten zu einer Schlagzeile gemacht hat.
+
+## Was der Agent tatsächlich tut
+
+Lässt man das Marketing beiseite, besteht ein agentischer Domainkauf aus einer kurzen, mechanischen Abfolge — derselben, der ein Mensch auf einer Checkout-Seite folgen würde, nur als API-Aufrufe statt als Klicks. Dabei sind drei Parteien beteiligt: der Agent, die API des Registrars und die dahinterliegende [Registry](/de/glossary/registry/).
+
+1. **Suchen.** Der Agent ruft den Suchendpunkt des Registrars (oder das entsprechende MCP-Werkzeug) mit einem Kandidatennamen oder einer Beschreibung des Bedarfs auf und erhält eine Liste verfügbarer und belegter Varianten.
+2. **Verfügbarkeit und Preis prüfen.** Für einen konkreten Namen fragt der Agent die aktuelle Verfügbarkeit und den exakten Preis ab — Registrierungsgebühr, etwaiger Premium-Aufschlag und gegebenenfalls die Transaktionsgebühr der [ICANN](/de/glossary/icann/). Eine kuratierte [TLD](/de/glossary/tld/)-Liste ist hier wichtig: Mehrere agentenorientierte Betas, einschließlich der von Cloudflare, decken zum Start nur eine Auswahl beliebter TLDs statt eines vollständigen Katalogs ab.
+3. **Authentifizieren und autorisieren.** Der Agent legt Zugangsdaten vor, die der Registrar programmgesteuert prüfen kann — einen API-Schlüssel, der an ein gedecktes Konto gebunden ist, oder eine Wallet-Signatur — statt einer gespeicherten Karte hinter einer Anmeldeseite.
+4. **Registrieren.** Der Agent ruft den Registrierungsendpunkt auf. Der Registrar leitet die Anfrage über [EPP](/de/glossary/epp/), das [Extensible Provisioning Protocol](https://en.wikipedia.org/wiki/Extensible_Provisioning_Protocol), mit dem Registrare seit dessen Status als Proposed Standard im Jahr 2004 mit Registries kommunizieren, an die [Registry](/de/glossary/registry/) der Domain weiter. Die Registry erstellt den Datensatz, und die API gibt eine Bestätigung zurück, typischerweise innerhalb von Sekunden.
+5. **DNS konfigurieren.** Sobald der Name gesichert ist, setzt der Agent [Nameserver](/de/glossary/nameserver/) oder einzelne DNS-Einträge — einen A-Eintrag, der auf einen Server verweist, oder einen CNAME, der auf eine Hosting-Plattform verweist — oft direkt mit dem nächsten Aufruf in derselben Unterhaltung, in der die Domain registriert wurde.
+6. **Dem Menschen zurückmelden.** In einem gut gestalteten Agentenablauf erfährt der Mensch nicht erst aus einem Kartenauszug nachträglich vom Kauf; der Agent meldet den Namen, den Preis und das Ziel, auf das er die Domain verwiesen hat, zurück.
+
+Dieser sechste Schritt leistet mehr, als es zunächst scheint — darum geht es im nächsten Abschnitt.
+
+## Leitplanken: „Kein Mensch erforderlich“ braucht dennoch eine von Menschen gesetzte Richtlinie
+
+„Kein Mensch erforderlich“ beschreibt den Mechanismus, nicht die Governance. Die API benötigt keine Person, die mitten in der Transaktion einen Knopf drückt — aber jemand muss vorab festlegen, was der Agent mit der ihm gegebenen Befugnis tun darf. Die eigene Dokumentation von Cloudflare zur Beta benennt klar, wo diese Verantwortung liegt: [„it is the responsibility of the human to design an agent flow that will not buy domains without your approval.“](https://blog.cloudflare.com/registrar-api-beta/) Die API ermöglicht eine Registrierung ohne Checkout-Seite; sie trifft nicht selbst die Entscheidung, wann eine Domain registriert werden soll. Diese Richtlinie muss die Person schreiben, die den Agenten integriert.
+
+Drei Leitplanken erledigen in der Praxis den Großteil der Arbeit:
+
+- **Zahlungsautorisierung, die nicht nur aus einer nackten Kartennummer besteht.** Ein API-Schlüssel, der gegen ein im Voraus bezahltes oder in Rechnung gestelltes Guthaben abgerechnet wird, begrenzt die Gesamtexposition konstruktionsbedingt; der Agent kann nicht mehr ausgeben als gedeckt ist. Eine Wallet-signierte Transaktion wird für jeden Kauf autorisiert und kann nicht wiederverwendet werden. Beides hat ein deutlich anderes Risikoprofil als eine gespeicherte Kreditkarte, die keine eingebaute Obergrenze besitzt.
+- **Ausgabenlimits und Bestätigungsschwellen**, die der Mensch setzt, bevor der Agent tätig wird. Cloudflares Empfehlung für einen „well-designed agent flow“ lautet, Domainname und Preis mit dem Nutzer zu bestätigen, bevor der Registrierungsendpunkt aufgerufen wird, nicht danach — ein Muster, das die API unterstützt, aber nicht erzwingt.
+- **Ein klarer Träger der rechtlichen Verantwortung.** Ein Agent, der einen Namen registriert, beseitigt nicht die rechtliche Tatsache, dass eine Domain einen eingetragenen [Registrant](/de/glossary/registrant/) hat. Ein Beitrag über Domains im Besitz von Agenten formulierte das Risiko klar: [„If an agent registers a domain that turns out to be a trademark conflict, there's no human to respond to a UDRP complaint“](https://dev.to/purpleflea/how-ai-agents-can-buy-their-own-domain-names-and-why-this-matters-1l4j#:~:text=If%20an%20agent%20registers%20a%20domain%20that%20turns%20out%20to%20be%20a%20trademark%20conflict%2C%20there%27s%20no%20human%20to%20respond%20to%20a%20UDRP%20complaint), wenn niemand überwacht, was unter dessen Zugangsdaten registriert wird. Das Entfernen der Checkout-Seite beseitigt weder das [UDRP](/de/glossary/udrp/)-Verfahren, den Verlängerungstermin noch den [WHOIS](/de/glossary/whois/)-Datensatz; jemand muss diese Überwachung weiterhin bewusst einbauen.
+
+Das sollte man sich vor Augen halten: Ein Agent, der eine Domain registrieren kann, kann auch Geld ausgeben und ein Portfolio von Namen aufbauen, ohne dass jemand jede Transaktion prüft — genau die Fähigkeit, die dies nützlich macht, und genau der Grund, warum die Richtlinienebene nicht optional ist.
+
+## Wer bietet das heute an, und die Reseller-These
+
+Cloudflares Beta ist der meistbeachtete Fall dieses Wandels, aber nicht der einzige. Name.com baute ab Mitte 2025 eine vergleichbare API nach demselben MCP-und-OpenAPI-Ansatz auf, und Namefi betreibt einen MCP-Server sowie einen Wallet-signierten Checkout, der die Kontoerstellung vollständig überspringt. Die Funktionsunterschiede — Preismodell, TLD-Abdeckung, ob die Zahlung ein bestehendes Konto braucht — finden Sie in [Cloudflare vs. Name.com vs. Namefi: Agent-Native Registrars](/de/blog/cf-namecom-namefi/); die gesamte Landschaft, einschließlich der Frage, wo große Consumer-Registrare vor dieser Kategorie haltmachen, behandelt [KI-agentische Domainplattformen: Der Leitfaden für 2026](/de/blog/ai-domain-platforms/).
+
+Neuer als jede einzelne Plattform ist, was Agenten mit dieser Fähigkeit zu tun beginnen, sobald sie sie haben. Die Mitte-2026-Umfrage von CircleID zur Domainbranche formulierte es so: [„AI agents are increasingly acting as domain resellers checking availability, registering names, and configuring DNS without human intervention.“](https://circleid.com/posts/the-domain-universe-in-2026-ai-security-market-maturity-and-the-new-gtld-frontier#:~:text=AI%20agents%20are%20increasingly%20acting%20as%20domain%20resellers%20checking%20availability%2C%20registering%20names%2C%20and%20configuring%20DNS%20without%20human%20intervention) Das Wort [Reseller](/de/glossary/reseller/) ist bewusst gewählt: Es bezeichnet eine etablierte Rolle, nämlich eine Partei, die Domains unter der Akkreditierung eines Registrars verkauft oder bereitstellt, statt selbst eine solche zu besitzen. Die Einordnung von Agenten als informelle Reseller statt als neue Kategorie besagt, dass der Ablauf wiedererkennbar ist, obwohl der Betreiber keine Person ist: suchen, bepreisen, registrieren, konfigurieren, im Auftrag anderer und in großem Umfang. Wie weit dieses Muster tatsächlich gegangen ist und was noch bloß angekündigt ist, verfolgen wir in [Der Stand des agentischen Domainmanagements, 2026](/de/blog/state-of-agentic/). Der [MCP-Server von Namefi](/de/blog/namefi-mcp/) ist ein konkretes Beispiel für die Werkzeuge, die ein Agent im Reseller-Stil aufrufen würde.
+
+## Häufig gestellte Fragen
+
+### Was genau hat sich am 15. April 2026 geändert?
+
+Cloudflare stellte eine Registrar-API als öffentliche Beta bereit, die Domainsuche, Verfügbarkeits- und Preisprüfungen sowie die Registrierung abdeckt und in den Cloudflare-MCP-Server eingebunden ist, den Agenten bereits in Werkzeugen wie Cursor und Claude Code verwenden. Es war nicht die erste von Agenten aufrufbare Registrar-API — die von Name.com startete Mitte 2025, und die von Namefi lief bereits —, aber es war der meistbeachtete Fall, in dem ein großer, bekannter Registrar den gesamten Kauf durch einen Agenten statt nur durch einen Browser-Checkout abschließbar machte.
+
+### Braucht ein KI-Agent meine Erlaubnis für jede Domain, die er registriert?
+
+Nicht standardmäßig auf API-Ebene: Der Endpunkt schließt eine Registrierung ab, sobald er gültige, autorisierte Zugangsdaten und einen belastbaren Preis erhält. Ob es einen Bestätigungsschritt gibt, wird durch die Konfiguration des Agenten entschieden, nicht automatisch durch den Registrar erzwungen. Cloudflares eigene Anleitung sagt ausdrücklich, dass die Person, die den Agentenablauf baut, vor dem Kauf eine Genehmigung verlangen muss.
+
+### Ist es wirklich sicher, einen KI-Agenten Domains kaufen zu lassen, ohne jede Transaktion zu überwachen?
+
+Es ist nur so sicher wie die vorher gesetzten Leitplanken, nicht standardmäßig sicherer. Praktikable Muster sind ein vorausbezahltes oder in Rechnung gestelltes Guthaben, das die Gesamtexposition begrenzt, eine Wallet-Signatur, die genau einen Kauf autorisiert und nicht wiederverwendet werden kann, sowie ein Bestätigungsschritt oberhalb einer selbst gewählten Schwelle. Keine der Plattformen in diesem Bereich erzwingt für Sie ein universelles Ausgabenlimit; Sie setzen es selbst.
+
+### Wer ist rechtlich verantwortlich, wenn ein KI-Agent eine Domain registriert?
+
+Die Domain hat weiterhin einen eingetragenen [Registrant](/de/glossary/registrant/) — eine Person oder Organisation, nicht das KI-Modell selbst —, und dieser Registrant trägt das Risiko eines Markenstreits, einer [UDRP](/de/glossary/udrp/)-Beschwerde oder eines Verlängerungstermins. Das Entfernen des Menschen aus dem Kaufschritt entfernt ihn nicht aus dem Eigentumsdatensatz; es bedeutet nur, dass möglicherweise niemand diese Risiken beobachtet, wenn Sie diese Überwachung nicht einbauen.
+
+### Werden KI-Agenten im formellen, akkreditierten Sinn zu Domain-Resellern?
+
+Nicht im Sinn einer ICANN-Akkreditierung: Ein [Reseller](/de/glossary/reseller/) ist normalerweise ein Unternehmen, das unter dem Akkreditierungsvertrag eines Registrars tätig ist. Die Einordnung von CircleID verwendet „Reseller“ beschreibend für das Verhaltensmuster, nicht als rechtliche Bezeichnung. Ob sich dieses Verhalten zu einer formell anerkannten Kategorie verdichtet, ist eine der offenen Fragen in [Der Stand des agentischen Domainmanagements, 2026](/de/blog/state-of-agentic/).
+
+### Funktioniert das für jede TLD oder nur für die beliebten?
+
+Das hängt von der Plattform ab; prüfen Sie es direkt, statt eine vollständige Abdeckung anzunehmen. Cloudflares Beta startete mit einer kuratierten Auswahl beliebter TLDs, wie die eigenen Materialien sie nennen, und nicht mit dem vollständigen Katalog. Die Abdeckung nimmt mit der Reife einer Beta tendenziell zu. Prüfen Sie daher die aktuelle TLD-Unterstützung anhand der Live-Dokumentation einer Plattform, bevor Sie sich auf eine bestimmte Endung verlassen.
+
+## Die nächste Domain mit Ihrem eigenen Agenten registrieren — ohne Checkout-Seite
+
+[Namefi](https://namefi.io) bietet denselben agentenorientierten Kaufpfad, den dieser Artikel beschreibt: einen MCP-Server, mit dem sich Ihr Agent direkt verbindet, eine dokumentierte REST-API und einen Wallet-signierten Checkout, der die Kontoerstellung vollständig überspringt — plus [tokenisiertes](/de/glossary/tokenized-domain/) Eigentum, wenn die Domain selbst ein Vermögenswert sein soll, den das Wallet Ihres Agenten halten kann. Legen Sie Ihre Ausgabenrichtlinie einmal fest und lassen Sie den Agenten Suche, Preis und Registrierung so übernehmen, wie es dieser Beitrag beschreibt.
+
+**[Bei Namefi eine Domain suchen und registrieren](https://namefi.io).**
+
+## Quellen und weiterführende Lektüre
+
+- Cloudflare Blog — [Ankündigung der Registrar-API-Beta](https://blog.cloudflare.com/registrar-api-beta/) (Startdatum, unterstützte Vorgänge, At-Cost-Preise, MCP-Integration, Hinweise zur menschlichen Genehmigung)
+- webhosting.today — [KI-Agenten können jetzt Domains registrieren, kein Mensch erforderlich](https://webhosting.today/2026/04/22/ai-agents-can-now-register-domains-no-human-required/#:~:text=On%20April%2015%2C%202026%2C%20Cloudflare%20moved%20that%20transaction%20into%20the%20agent%20layer) (Einordnung der Cloudflare-Beta als Wechsel in die „Agentenschicht“, April 2026)
+- dev.to — [Eine Domain mit Ihrem KI-Agenten registrieren, kein Mensch nötig](https://dev.to/marsheer/how-to-register-a-domain-name-with-your-ai-agent-no-human-needed-h26#:~:text=Domain%20registrars%20are%20built%20for%20humans%3A%20CAPTCHAs%2C%20dashboards%2C%20forms%2C%20credit%20card%20fields.%20Not%20exactly%20agent-friendly.) (MCP-Tutorial eines Drittanbieters zum alten Checkout-Modell und zur von Agenten aufrufbaren Registrierung)
+- dev.to — [Wie KI-Agenten ihre eigenen Domainnamen kaufen können und warum das wichtig ist](https://dev.to/purpleflea/how-ai-agents-can-buy-their-own-domain-names-and-why-this-matters-1l4j#:~:text=If%20an%20agent%20registers%20a%20domain%20that%20turns%20out%20to%20be%20a%20trademark%20conflict%2C%20there%27s%20no%20human%20to%20respond%20to%20a%20UDRP%20complaint) (Beitrag über Domains im Besitz von Agenten und die Lücke bei der rechtlichen Verantwortung)
+- CircleID — [Das Domainuniversum 2026: KI, Sicherheit, Marktreife und die neue gTLD-Grenze](https://circleid.com/posts/the-domain-universe-in-2026-ai-security-market-maturity-and-the-new-gtld-frontier#:~:text=AI%20agents%20are%20increasingly%20acting%20as%20domain%20resellers%20checking%20availability%2C%20registering%20names%2C%20and%20configuring%20DNS%20without%20human%20intervention) (Analyse von Agenten als Resellern, April 2026)
+- modelcontextprotocol.io — [Was ist das Model Context Protocol (MCP)?](https://modelcontextprotocol.io/#:~:text=MCP%20%28Model%20Context%20Protocol%29%20is%20an%20open-source%20standard%20for%20connecting%20AI%20applications%20to%20external%20systems) (Protokollüberblick)
+- llmstxt.org — [Der Vorschlag für die Datei /llms.txt](https://llmstxt.org/#:~:text=A%20proposal%20to%20standardise%20on%20using%20an%20/llms.txt%20file%20to%20provide%20information%20to%20help%20LLMs%20use%20a%20website%20at%20inference%20time) (Spezifikation und Begründung)
+- Wikipedia — [Extensible Provisioning Protocol (Proposed Standard, März 2004)](https://en.wikipedia.org/wiki/Extensible_Provisioning_Protocol#:~:text=Proposed%20Standard%20documents%20%28RFCs%203730%20-%203734%29%20were%20published%20by%20the%20RFC%20Editor%20in%20March%202004)
+- Namefi — [namefi.io/llms.txt](https://namefi.io/llms.txt) (Referenz für den MCP-Server, die REST-API und den Wallet-Checkout von Namefi)

--- a/content/blog/de/ai-agent-register.md
+++ b/content/blog/de/ai-agent-register.md
@@ -1,0 +1,267 @@
+---
+title: "So registrieren Sie eine Domain mit Ihrem KI-Agenten bei Namefi"
+date: '2026-07-10'
+language: 'de'
+tags: ['ai-agents', 'guide']
+authors: ['namefiteam']
+draft: false
+format: guide
+ogImage: ../../assets/ai-agent-register-og.jpg
+description: "Der maßgebliche Leitfaden zur Domainregistrierung bei Namefi mit jedem KI-Agenten — Claude, Codex, Cursor und weiteren — über MCP, REST oder Wallet-Checkout."
+keywords: ['domain mit ki-agent registrieren', 'namefi tutorial', 'claude domainregistrierung', 'codex domainregistrierung', 'cursor mcp domain', 'windsurf mcp domain', 'gemini cli mcp domain', 'anleitung agenten-domain', 'x-api-key', 'mcp-server', 'wallet-checkout', 'namefi mcp domainregistrierung', 'ki-agent domain bei namefi kaufen', 'tutorial domainregistrierung mcp']
+relatedArticles:
+  - /de/blog/claude-mcp-domains/
+  - /de/blog/cf-namecom-namefi/
+  - /de/blog/ai-domain-platforms/
+  - /de/blog/agent-native/
+  - /de/blog/airo-vs-namefi/
+relatedTopics:
+  - /de/topics/domain-tokenization/
+  - /de/topics/domain-basics/
+relatedSeries:
+  - /de/series/tokenize-your-com/
+  - /de/series/blockchain-concepts/
+relatedGlossary:
+  - /de/glossary/ai-agent/
+  - /de/glossary/registrar/
+  - /de/glossary/wallet/
+  - /de/glossary/x402/
+  - /de/glossary/tokenized-domain/
+---
+
+Diese Seite sollten Sie als Lesezeichen speichern, wenn ein [KI-Agent](/de/glossary/ai-agent/) — irgendein KI-Agent, nicht der eines bestimmten Anbieters — für Sie bei [Namefi](https://namefi.io), einem ICANN-akkreditierten [Registrar](/de/glossary/registrar/), eine echte Domain registrieren soll. Sie behandelt zunächst die Mechanik, die sich unabhängig vom verwendeten Client nicht ändert, und liefert dann genaue, jeweils einzeln verifizierte Einrichtungsschritte für die sechs Agenten, die Menschen heute tatsächlich nutzen: Claude Desktop, Claude Code, OpenAI Codex, Cursor, Windsurf und Gemini CLI. Falls Ihr Agent nicht auf dieser Liste steht, endet der Leitfaden mit einem direkten REST-Weg, der mit allem funktioniert, was eine HTTP-Anfrage stellen kann, denn die gesamte API-Oberfläche von Namefi wird genau zu diesem Zweck auch als Klartext veröffentlicht.
+
+Dieser Leitfaden wird vom Namefi-Team geschrieben und gepflegt; die Namefi-Seite jedes Schritts stammt daher aus erster Hand. Er erklärt in lesbarer Form dieselbe API, die wir für Agenten unter [namefi.io/llms.txt](https://namefi.io/llms.txt) und [docs.namefi.io](https://docs.namefi.io) veröffentlichen. Die Einrichtung bei jedem Agenten-Anbieter wurde am Veröffentlichungsdatum dieses Leitfadens anhand der jeweils aktuellen Dokumentation des Anbieters überprüft. Wo die Dokumentation eines Anbieters keine klare Antwort gibt, wird das ausdrücklich gekennzeichnet, statt eine Vermutung einzufügen.
+
+Wenn Sie bereits wissen, dass Sie Claude nutzen, und eine vollständige kommentierte Anleitung mit einem echten Transkript wünschen, geht [Eine Domain mit Claude kaufen: Namefi MCP Schritt-für-Schritt-Leitfaden](/de/blog/claude-mcp-domains/) über die komprimierten Claude-Abschnitte hier hinaus. Diese Seite ist der Knotenpunkt; jener Beitrag und die weiteren hier verteilten Links sind die Speichen.
+
+## Was „eine Domain mit einem KI-Agenten registrieren“ tatsächlich bedeutet
+
+Damit ein Agent in Ihrem Auftrag eine Domain registrieren kann, ohne dass Sie selbst ein Formular ausfüllen, müssen zwei Dinge gelten. Erstens benötigt der Agent einen Weg, die API von Namefi zu *entdecken und aufzurufen*: das ist das [Model Context Protocol](https://modelcontextprotocol.io) (MCP), ein offener Standard, über den ein KI-Client sich mit einem externen Tool-Server verbinden und eine definierte Liste aufrufbarer Vorgänge sehen kann, oder eine reine HTTP-Anfrage, wenn der Agent skriptgesteuert statt dialogorientiert arbeitet. Zweitens braucht der Agent eine *Ausgabenautorisierung*: einen API-Schlüssel, der an ein gedecktes Guthaben gebunden ist, oder ein Krypto-[Wallet](/de/glossary/wallet/), das eine Zahlung sofort signieren kann. Alles in diesem Leitfaden ist eines dieser beiden Elemente.
+
+Namefi betreibt für seine gesamte API einen MCP-Server unter `https://api.namefi.io/mcp` über den Streamable-HTTP-Transport. Ein Agent — oder die Person, die ihn konfiguriert — kann ihn entdecken, ohne diese Seite zu lesen: Wir veröffentlichen unter [namefi.io/.well-known/mcp/servers.json](https://namefi.io/.well-known/mcp/servers.json) einen maschinenlesbaren Deskriptor, der den Server `namefi-api` nennt und seinen Transport als `streamable-http` aufführt. Jeder unten genannte Client verbindet sich mit derselben URL; unterschiedlich ist nur, wie die Konfigurationsdatei oder Kommandozeile des jeweiligen Clients auf diesen Server verweist.
+
+## Der universelle Ablauf in fünf Schritten
+
+Dies ist die Abfolge hinter jedem weiter unten stehenden agentenspezifischen Abschnitt. Sobald Sie sie hier verstanden haben, sind die Anweisungen pro Agent nur noch: „Wie führe ich Schritt 2 in diesem speziellen Werkzeug aus?“
+
+1. **Zugangsdaten beschaffen.** Erzeugen Sie einen [API-Schlüssel](https://namefi.io/api-key) — eine mit `nfk_` beginnende Zeichenfolge, die für jeden Vorgang funktioniert: Registrierung, Erstellung, Aktualisierung und Löschung von DNS-Einträgen. Der Schlüssel erbt die Berechtigungen des Wallets, das ihn erzeugt hat; erzeugen Sie ihn daher aus dem Wallet, das die Domain besitzen soll. Wenn Sie lieber gar keinen Namefi-API-Schlüssel halten möchten, wechseln Sie zum unten beschriebenen Wallet-Zahlungsweg — dieser benötigt kein Konto.
+2. **Ihren Agenten mit dem MCP-Server verbinden.** Richten Sie Ihren Client mit dem Header `x-api-key`, der Ihren Schlüssel enthält, auf `https://api.namefi.io/mcp` aus. Die genaue Syntax ist clientspezifisch; siehe den Abschnitt zu Ihrem Agenten unten.
+3. **Suchen und bepreisen.** Fragen Sie in natürlicher Sprache, ob ein Name verfügbar ist. Dies ruft den Vorgang `checkAvailability` (`GET /v-next/search/availability?domain=…`) auf, der überhaupt keine Authentifizierung benötigt, oder seine Bulk-Variante, um mehrere Kandidaten gleichzeitig zu prüfen.
+4. **Registrieren und dann abfragen.** Nach der Bestätigung übermittelt der Agent `registerDomain` (`POST /v-next/orders/register-domain`), oder die kombinierte Variante `register-domain/records`, wenn Sie DNS im selben Aufruf setzen möchten. Die Registrierung ist asynchron: Der Request-Body nimmt `normalizedDomainName` und `durationInYears` entgegen; der Endpunkt `register-domain/records` akzeptiert zusätzlich ein Array `records` (`name`, `type`, `rdata`, `ttl` je Eintrag), sodass DNS geschrieben wird, sobald die Bestellung abgeschlossen ist. Der Agent (oder Sie) fragt `getOrder` (`GET /v-next/orders/{orderId}`) ab, bis ein Endstatus erreicht ist: `SUCCEEDED`, `FAILED`, `CANCELLED` oder `PARTIALLY_COMPLETED`.
+5. **DNS konfigurieren und überprüfen.** Ergänzen oder ändern Sie [DNS-Einträge](/de/glossary/dns-record-types/) über `createDnsRecord` (`POST /v-next/dns/records`), setzen Sie bei Bedarf die Delegation auf [Nameserver](/de/glossary/nameserver/)-Ebene und geben Sie der [DNS-Propagation](/de/glossary/dns-propagation/) einige Minuten Zeit, bevor Sie bestätigen, dass die Domain auflöst.
+
+Der Registrierungsrequest akzeptiert außerdem ein Objekt `domainSetupOptions` mit Überschreibungen pro Domain: `autoPark`, `autoEns`, `autoRenew`, `dnssec` und `keepExistingNameservers`. Letzteres weist Namefi an, die bestehende Nameserver-Delegation der Domain unverändert zu lassen, statt sie neu auszurichten; das ist nützlich, wenn Sie eine Domain registrieren, die sofort weiterhin an einem anderen Ort auflösen soll. Ein optionales Feld `nftReceivingWallet` steuert, wo der Eigentums-Token der Domain landet. Wenn Sie es weglassen, wird die Domain als NFT auf Base an das mit Ihrem API-Schlüssel verknüpfte Wallet registriert.
+
+## Einrichtungsmatrix nach Agent
+
+| Agent | Verbindungsmethode | Ort der Konfiguration | Benutzerdefinierter Auth-Header unterstützt | Verifiziert anhand von |
+| --- | --- | --- | --- | --- |
+| Claude Code | MCP, Streamable HTTP | CLI-Befehl `claude mcp add` (schreibt in `~/.claude.json` oder `.mcp.json`) | Ja — Flag `--header` | [code.claude.com/docs/en/mcp](https://code.claude.com/docs/en/mcp), überprüft am 2026-07-10 |
+| Claude Desktop / claude.ai | MCP, Streamable HTTP über Custom Connector | Settings → Connectors → Add custom connector | Servergesteuerte Authentifizierungsabfrage (OAuth, API-Schlüssel oder Zugangsdaten, je nach Serveranforderung) | [modelcontextprotocol.io](https://modelcontextprotocol.io/docs/develop/connect-remote-servers), überprüft am 2026-07-10 |
+| OpenAI Codex CLI | MCP, Streamable HTTP | `~/.codex/config.toml`, Tabelle `[mcp_servers.<name>]` | Ja — `http_headers` (statisch) oder `env_http_headers` (aus Umgebungsvariablen) | [learn.chatgpt.com/docs/extend/mcp](https://learn.chatgpt.com/docs/extend/mcp?surface=cli) (das aktuelle Weiterleitungsziel von `developers.openai.com/codex/mcp`), überprüft am 2026-07-10 |
+| Cursor | MCP, Streamable HTTP | `.cursor/mcp.json` (Projekt) oder `~/.cursor/mcp.json` (global) | Ja — Objekt `headers` mit `${env:VAR}`-Interpolation | [cursor.com/docs/mcp](https://cursor.com/docs/mcp), überprüft am 2026-07-10 |
+| Windsurf (Cascade) | MCP, Streamable HTTP | `~/.codeium/windsurf/mcp_config.json` | Ja — Objekt `headers` in einem `serverUrl`-Eintrag mit `${env:VAR}`-Interpolation | [docs.windsurf.com/windsurf/cascade/mcp](https://docs.windsurf.com/windsurf/cascade/mcp) (zum Veröffentlichungsdatum dieses Leitfadens leitet die URL auf `docs.devin.ai/desktop/cascade/mcp` weiter; siehe den Windsurf-Abschnitt unten), überprüft am 2026-07-10 |
+| Gemini CLI | MCP, Streamable HTTP | `~/.gemini/settings.json` (Nutzer) oder `.gemini/settings.json` (Projekt) | Ja — Objekt `headers` in einem `httpUrl`-Eintrag | [geminicli.com/docs/tools/mcp-server](https://geminicli.com/docs/tools/mcp-server/), überprüft am 2026-07-10 |
+| Jeder andere MCP-Client | MCP, Streamable HTTP | Jedes Konfigurationsformat, das der Client dokumentiert | Abhängig vom Client — die Serverseite von Namefi ändert sich nicht | [namefi.io/.well-known/mcp/servers.json](https://namefi.io/.well-known/mcp/servers.json) |
+| Jedes Skript oder jeder Nicht-MCP-Agent | Direktes REST | N/A — direkte HTTPS-Aufrufe | Ja — Header `x-api-key` bei jedem Schreibvorgang | [namefi.io/llms.txt](https://namefi.io/llms.txt), [docs.namefi.io](https://docs.namefi.io) |
+
+Jede obige Zeile verbindet sich mit demselben Server und demselben Satz von Vorgängen. Pro Agent ändert sich nur die Syntax, mit der diesem bestimmten Client gesagt wird: „Hier ist ein entfernter MCP-Server, und dies ist der Header, den er mitsenden soll.“
+
+**Jedes Mal derselbe Test-Prompt.** Führen Sie nach dem Verbinden jedes der unten genannten Agenten genau diesen Prompt aus, damit Sie die Ergebnisse von Client zu Client vergleichen können:
+
+> „Prüfe, ob `example.com` zur Registrierung bei Namefi verfügbar ist, und teile mir mit, welches Werkzeug oder welchen Vorgang du dazu aufgerufen hast. Registriere noch nichts.“
+
+Dies ist ein reiner Leseaufruf: `checkAvailability` benötigt keine Authentifizierung. Er kann daher sicher mit einem frisch verbundenen Agenten ausgeführt werden, selbst bevor Sie Guthaben eingezahlt haben, und zeigt sofort, ob Verbindung und Werkzeugliste funktionieren.
+
+## Claude Desktop und claude.ai
+
+Claude Desktop und claude.ai verbinden sich über **Custom Connectors** mit entfernten MCP-Servern. Öffnen Sie Settings, gehen Sie zu Connectors, wählen Sie „Add custom connector“ und geben Sie `https://api.namefi.io/mcp` als Server-URL ein. Nach dem Klick auf Add fordert Claude Sie auf, die Authentifizierung abzuschließen. Anthropic beschreibt diesen Schritt so, dass dabei häufig „OAuth, API keys, or username/password combinations“ vorkommen; die genaue Aufforderung wird durch die Anforderungen des verbundenen Servers bestimmt.
+
+<!-- TODO: verify — the exact field Claude Desktop's Custom Connector screen presents for an x-api-key-style header --> Wenn Ihre Desktop-Einrichtung keinen offensichtlichen Ort zum Einfügen des Schlüssels anbietet, ist Claude Code (als Nächstes) heute der verifizierte Weg für Schreibvorgänge; schreibgeschützte Werkzeuge wie die Verfügbarkeitssuche funktionieren über den Connector ganz ohne Schlüssel. Die vollständige Anleitung, einschließlich des Connector-Ablaufs nach der Verbindung, finden Sie in [Eine Domain mit Claude kaufen: Namefi MCP Schritt-für-Schritt-Leitfaden](/de/blog/claude-mcp-domains/).
+
+## Claude Code
+
+Die eigene Dokumentation von Claude Code gibt eine genaue allgemeine Syntax an, um einen entfernten HTTP-MCP-Server mit benutzerdefiniertem Header hinzuzufügen:
+
+```bash
+claude mcp add --transport http namefi https://api.namefi.io/mcp --header "x-api-key: YOUR_KEY"
+```
+
+Führen Sie dies einmal im Terminal aus und ersetzen Sie `YOUR_KEY` durch Ihren echten Schlüssel. Standardmäßig schreibt dies den Server in den **lokalen** Bereich, sodass er nur für Sie im aktuellen Projekt verfügbar ist; ältere Claude-Code-Versionen nannten diesen Bereich „project“. Ergänzen Sie `--scope user`, wenn die Verbindung in jedem Projekt auf Ihrem Rechner verfügbar sein soll, oder `--scope project`, um sie über eine eingecheckte `.mcp.json` mit allen Personen im Projekt zu teilen. Bestätigen Sie die Verbindung mit `claude mcp list` und prüfen Sie die Live-Anzahl der Werkzeuge innerhalb einer Sitzung mit `/mcp`.
+
+## OpenAI Codex CLI
+
+Codex CLI speichert die MCP-Konfiguration standardmäßig in der TOML-Datei `~/.codex/config.toml` (oder in einer projektbezogenen `.codex/config.toml` für vertrauenswürdige Projekte). Jeder Server erhält seine eigene Tabelle; der Transport wird anhand der vorhandenen Schlüssel abgeleitet: Ein Schlüssel `command` bedeutet einen lokalen stdio-Server, ein Schlüssel `url` bedeutet Streamable HTTP. Die Codex-Dokumentation schreibt ausdrücklich vor, dass der Tabellenname `mcp_servers` mit Unterstrich heißen muss; `mcp-servers` oder ähnliche Varianten werden stillschweigend ignoriert.
+
+```toml
+# ~/.codex/config.toml
+[mcp_servers.namefi]
+url = "https://api.namefi.io/mcp"
+env_http_headers = { "x-api-key" = "NAMEFI_API_KEY" }
+```
+
+Diese Form holt den Schlüssel aus einer Umgebungsvariablen namens `NAMEFI_API_KEY`, statt ihn in die Datei zu schreiben. Setzen Sie sie in Ihrer Shell, bevor Sie Codex ausführen. Wenn Sie ihn lieber fest eintragen möchten — nicht empfohlen für eine Datei, die Sie möglicherweise committen —, lautet die gleichwertige statische Form `http_headers = { "x-api-key" = "YOUR_KEY" }`. Codex dokumentiert außerdem ein Feld `bearer_token_env_var` speziell für die Authentifizierung nach dem Muster `Authorization: Bearer …`; der Header `x-api-key` von Namefi benötigt jedoch die allgemeinen Felder `http_headers` beziehungsweise `env_http_headers`, nicht das bearer-spezifische Feld.
+
+## Cursor
+
+Cursor liest MCP-Serverdefinitionen aus `mcp.json`: einer projektbezogenen Kopie unter `.cursor/mcp.json` im Root Ihres Repositories oder einer globalen Kopie unter `~/.cursor/mcp.json`, die überall gilt. Die Cursor-Dokumentation zeigt die Form für Remote-Server direkt, einschließlich headerbasierter Authentifizierung und Umgebungsvariablen-Interpolation, sodass der Schlüssel selbst nicht in der Datei stehen muss:
+
+```json
+{
+  "mcpServers": {
+    "namefi": {
+      "url": "https://api.namefi.io/mcp",
+      "headers": {
+        "x-api-key": "${env:NAMEFI_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+`${env:NAMEFI_API_KEY}` wird zur Verbindungszeit durch den Wert dieser Umgebungsvariablen ersetzt. [Namefi MCP Quickstart: Claude Code, Cursor & Windsurf](/de/blog/mcp-quickstart/) bietet die komprimierte Version derselben Einrichtung.
+
+## Windsurf (Cascade)
+
+Die MCP-Integration von Windsurf — im Produkt als **Cascade** bezeichnet — liest ihre Serverliste aus `~/.codeium/windsurf/mcp_config.json`. Entfernte HTTP-Server verwenden ein Feld `serverUrl` (nicht `command`) sowie dieselbe Art von `headers`-Objekt und `${env:VAR}`-Interpolation wie Cursor:
+
+```json
+{
+  "mcpServers": {
+    "namefi": {
+      "serverUrl": "https://api.namefi.io/mcp",
+      "headers": {
+        "x-api-key": "${env:NAMEFI_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+Etwas sollte klar angesprochen werden: Zum Veröffentlichungsdatum dieses Leitfadens leitet `docs.windsurf.com/windsurf/cascade/mcp` auf `docs.devin.ai/desktop/cascade/mcp` weiter. Die Dokumentation von Windsurf liegt jetzt unter der Produktdokumentations-Domain Devin von Cognition, und die Seite selbst nennt „Windsurf“, „Cascade“ und „Devin Desktop“. Das obige Konfigurationsformat ist das, was diese aktuelle Seite dokumentiert. Wenn Sie eine ältere Windsurf-Version nutzen, sollten die Feldnamen übereinstimmen; prüfen Sie jedoch die URL, auf die die In-App-Hilfe Ihrer Version verlinkt.
+
+## Gemini CLI
+
+Gemini CLI liest MCP-Server aus `settings.json`: einer Kopie auf Nutzerebene unter `~/.gemini/settings.json` oder einer Kopie auf Projektebene unter `.gemini/settings.json`, die nur in diesem Projekt gilt. Die Form für entfernte Server verwendet `httpUrl` statt `url`:
+
+```json
+{
+  "mcpServers": {
+    "namefi": {
+      "httpUrl": "https://api.namefi.io/mcp",
+      "headers": {
+        "x-api-key": "YOUR_KEY"
+      }
+    }
+  }
+}
+```
+
+Die Gemini-CLI-Dokumentation beschreibt zudem ein Feld `timeout` (in Millisekunden, Standardwert 600,000), falls ein bestimmter Werkzeugaufruf länger als üblich benötigt. Für das Abfragen des Registrierungsstatus sollte dies nicht nötig sein, da der Client nur auf jeden einzelnen Aufruf wartet, nicht auf die gesamte Abfrageschleife.
+
+## Jeder andere MCP-fähige Agent
+
+Wenn Ihr Agent MCP unterstützt, aber nicht zu den sechs oben genannten gehört, ist die Serverseite unabhängig vom verbundenen Client identisch: Richten Sie ihn über Streamable HTTP auf `https://api.namefi.io/mcp` aus und verwenden Sie `x-api-key: YOUR_KEY` als benutzerdefinierten Header. Schlagen Sie die konkrete Konfigurationsdatei oder Befehlssyntax in der Dokumentation Ihres Clients nach. Der Deskriptor unter [namefi.io/.well-known/mcp/servers.json](https://namefi.io/.well-known/mcp/servers.json) existiert genau dafür, damit ein Agent — oder die Person, die ihn konfiguriert — URL, Transport und Authentifizierungsanforderungen des Servers finden kann, ohne dass ein Mensch sie von Hand einfügt.
+
+Ein Muster, das Sie kennen sollten, wenn Ihr Client nur **lokale (stdio) MCP-Server** unterstützt und nicht direkt Remote-HTTP oder SSE: Das Community-Paket `mcp-remote` überbrückt einen entfernten Streamable-HTTP-Server zu einem lokalen Prozess, den Ihr Client normal starten kann, und leitet die von Ihnen konfigurierten Header weiter. Dies ist kein Weg, den dieser Leitfaden anhand der eigenen Dokumentation von Namefi überprüfen kann, da es sich um eine Brücke eines Drittanbieters und nicht um einen von Namefi veröffentlichten Pfad handelt. Behandeln Sie ihn als Rückfalloption, wenn Ihr spezieller Client tatsächlich keine native Remote-HTTP-Unterstützung besitzt, nicht als Standardwahl. <!-- TODO: verify — an exact mcp-remote invocation for Namefi's server if a client without native Streamable HTTP support needs it -->
+
+## Ganz ohne MCP: der direkte REST-Weg
+
+Jeder oben beschriebene Vorgang ist auch ein reiner HTTPS-Endpunkt, der einzeln unter [namefi.io/llms.txt](https://namefi.io/llms.txt) und vollständig unter [docs.namefi.io](https://docs.namefi.io) dokumentiert ist. Ein Agenten-Framework, das HTTP-Aufrufe machen kann, aber kein MCP spricht — ein benutzerdefiniertes Skript, eine andere Agentenlaufzeit oder ein CI-Job — kann denselben Ablauf direkt steuern:
+
+```bash
+# 1. Check availability (no auth required)
+curl "https://api.namefi.io/v-next/search/availability?domain=example.com"
+
+# 2. Register (requires x-api-key)
+curl -X POST "https://api.namefi.io/v-next/orders/register-domain" \
+  -H "x-api-key: YOUR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"normalizedDomainName": "example.com", "durationInYears": 1}'
+
+# 3. Poll the order until it reaches a terminal status
+curl "https://api.namefi.io/v-next/orders/{orderId}" \
+  -H "x-api-key: YOUR_KEY"
+```
+
+llms.txt ist eine Klartext-Konvention: ein maschinenlesbarer Index, den eine Website im Root veröffentlicht, damit ein KI-Agent entdecken kann, was eine API tut, ohne gerenderte Dokumentationsseiten zu durchsuchen. Die Datei von Namefi ist kurz genug, um sie direkt unter [namefi.io/llms.txt](https://namefi.io/llms.txt) zu lesen, wenn Sie die vollständige Fassung statt der komprimierten Zusammenfassung oben möchten. Mehr über die Konvention selbst finden Sie in [llms.txt für Domains: Eine API, die jeder KI-Agent lesen kann](/de/blog/llms-txt/).
+
+## Bezahlen: API-Schlüssel oder Wallet-Checkout
+
+Alles in den obigen Abschnitten setzt einen API-Schlüssel voraus, der gegen ein gedecktes NFSC-Guthaben (Namefi Service Credit) abgerechnet wird. Sie können dieses jederzeit unter `GET /v-next/balance` prüfen (`x-api-key` erforderlich), es in Entwicklungsumgebungen über einen Faucet-Endpunkt auffüllen oder in der Produktion über das Namefi-Dashboard. <!-- TODO: confirm with team — the exact production NFSC top-up flow: accepted payment methods, and whether it's purchasable through chat/API or only the dashboard UI -->
+
+Namefi unterstützt auch die Registrierung einer Domain mit einem Krypto-Wallet und **ganz ohne Namefi-Konto** über das Protokoll [x402](/de/glossary/x402/): Das Wallet eines Agenten signiert eine EIP-3009-Autorisierung; wenn noch keine Zahlung beigefügt wurde, antwortet die API mit HTTP 402 und dem Preis, und die Registrierung wird abgeschlossen, sobald eine gültige signierte Zahlung eintrifft — typischerweise in einem [Stablecoin](/de/glossary/stablecoin/) wie USDC. Es gibt außerdem eine verwandte Challenge-Response-Variante von MPP (Machine Payable Protocol) und einen manuellen EIP-712-Signaturweg für Wallets, die keine der beiden Abkürzungen verwenden. Dieser Wallet-first-Weg ist gerade für die Agenten wichtig, um die es in diesem Leitfaden geht: Er entfernt die Kontoerstellung vollständig, sodass ein autonomer Prozess überhaupt keinen API-Schlüssel halten oder preisgeben muss. [Domains mit einem Krypto-Wallet bezahlen: kein Konto erforderlich](/de/blog/wallet-checkout/) behandelt diesen Ablauf für sich.
+
+## Leitplanken, bevor Sie einem Agenten Kaufbefugnis geben
+
+Ein Agent, der eine Domain registrieren kann, kann auch Geld ausgeben und DNS für eine aktive Infrastruktur umschreiben. Einige Entscheidungen sollten Sie daher bewusst treffen, statt sie beim Standard zu belassen:
+
+- **Nutzen Sie für den API-Schlüssel ein Wallet mit minimalen Berechtigungen.** Ein Schlüssel erbt die Berechtigungen des Wallets, das ihn erzeugt hat. Erzeugen Sie ihn aus dem Wallet, das neue Registrierungen besitzen soll, nicht aus einem Wallet mit Vermögenswerten, die nicht durch den Schlüssel eines Agenten gefährdet werden sollen.
+- **Begrenzen Sie die Ausgaben des Agenten.** Ein NFSC-Guthaben ist selbst ein Ausgabenlimit: Statten Sie es nur mit so viel aus, wie ein unbeaufsichtigter Agent ausgeben darf, statt ein großes dauerhaftes Guthaben bereitzuhalten.
+- **Entscheiden Sie, wo ein Mensch im Ablauf bleibt.** Lesevorgänge wie die Verfügbarkeitssuche brauchen keine Authentifizierung und bergen kein Risiko. Sobald ein Aufruf `registerDomain` übermittelt, die automatische Verlängerung umschaltet oder einen DNS-Eintrag auf einer Domain schreibt, die bereits Traffic verarbeitet, sollten Sie eine ausdrückliche Bestätigung verlangen, statt den Agenten autonom fortfahren zu lassen.
+- **Prüfen Sie DNS-Schreibvorgänge, bevor Sie sie bestätigen,** so wie jede andere Infrastrukturänderung. Die Validierung von Namefi weist fehlerhafte Einträge zurück, statt sie stillschweigend zu akzeptieren (siehe die Tabelle zur Fehlerbehebung unten). Sie erkennt jedoch Formatfehler, nicht einen syntaktisch korrekten, aber falschen Wert.
+
+[Was ist ein agent-nativer Domain-Registrar?](/de/blog/agent-native/) enthält eine ausführlichere Prüfliste — Auffindbarkeit, maschinenlesbare Fehler und Zahlungswege, die keinen Menschen mit Kreditkarte voraussetzen —, um die Agentenoberfläche jedes Registrars einschließlich Namefi zu bewerten.
+
+## Fehlerbehebung
+
+| Symptom | Wahrscheinliche Ursache | Lösung |
+| --- | --- | --- |
+| `401 UNAUTHORIZED` bei jedem Schreibaufruf | API-Schlüssel ungültig, abgelaufen oder aus einem Wallet erzeugt, das die Zieldomain nicht besitzt | Erzeugen Sie unter [namefi.io/api-key](https://namefi.io/api-key) einen neuen Schlüssel aus dem Wallet, das die Domain besitzt oder besitzen wird |
+| `403 FORBIDDEN` | Schlüssel ist gültig, aber sein Wallet besitzt diese konkrete Domain nicht | Prüfen Sie den Besitz, bevor Sie es erneut versuchen |
+| Codex ignoriert Ihren Eintrag `[mcp_servers.namefi]` | Tippfehler im Tabellennamen — Codex verlangt die Unterstrichform `mcp_servers`, nicht `mcp-servers` | Korrigieren Sie die Tabellenüberschrift in `config.toml` |
+| Cursor oder Windsurf zeigt den Server als getrennt an | Objekt `headers` fehlerhaft oder `${env:VAR}` verweist auf eine nicht gesetzte Variable | Prüfen Sie, ob das JSON gültig ist und die referenzierte Umgebungsvariable tatsächlich in der Shell exportiert wurde, die den Editor gestartet hat |
+| Gemini CLI findet die Konfiguration nicht | Die falsche `settings.json` wurde bearbeitet — Dateien auf Nutzer- und Projektebene sind getrennt | Prüfen Sie, ob Sie im aktuellen Projekt `~/.gemini/settings.json` oder `.gemini/settings.json` verwenden wollten |
+| Registrierungsauftrag hängt in einem nicht finalen Status | Normal — die Registrierung ist asynchron | Fragen Sie `getOrder` weiter ab; behandeln Sie sie erst als hängend, wenn nie `SUCCEEDED`, `FAILED`, `CANCELLED` oder `PARTIALLY_COMPLETED` erreicht wird |
+| Erstellung/Aktualisierung eines DNS-Eintrags wird mit Validierungsfehler abgelehnt | `zoneName` hat einen abschließenden Punkt oder ein `rdata` für CNAME/MX/NS hat nicht den erforderlichen abschließenden Punkt | `zoneName` = kein abschließender Punkt; `rdata` von FQDN-Typen = abschließender Punkt erforderlich |
+| Registrierung schlägt vollständig fehl | Ungenügendes NFSC-Guthaben im zahlenden Wallet | Prüfen Sie `GET /v-next/balance` und füllen Sie über Faucet (Entwicklung) oder Dashboard (Produktion) auf |
+| Agent sagt, keine Domainwerkzeuge verfügbar zu haben | MCP-Server nicht verbunden oder ohne Header verbunden, der für Schreibvorgänge erforderlich ist | Prüfen Sie die Konfigurationsdatei Ihres Clients erneut oder führen Sie dessen Befehl zum Hinzufügen des Servers mit Header erneut aus |
+
+## Häufig gestellte Fragen
+
+### Muss ich einen Agenten auswählen und bei ihm bleiben?
+
+Nein. Der MCP-Server und jeder REST-Endpunkt sind unabhängig vom verbundenen Client identisch. Sie können die Einrichtung heute für Claude Code und morgen für Cursor mit demselben API-Schlüssel und demselben NFSC-Guthaben ausführen; ein Migrationsschritt ist nicht erforderlich.
+
+### Welcher dieser Agenten ist „am besten“ für die Registrierung einer Domain?
+
+Für diese Aufgabe gibt es keinen wesentlichen Fähigkeitsunterschied, da jeder Client dieselben serverseitigen Vorgänge aufruft. Die Unterschiede liegen ausschließlich in der MCP-Konfigurationssyntax des jeweiligen Clients. Genau deshalb hat dieser Leitfaden für jeden einen eigenen Abschnitt und denselben Test-Prompt: Führen Sie ihn einmal pro Client aus und vergleichen Sie die Transkripte selbst.
+
+### Was ist, wenn mein Agent MCP überhaupt nicht unterstützt?
+
+Nutzen Sie den oben beschriebenen direkten REST-Weg. Jeder Vorgang, den ein MCP-Tool-Aufruf erreicht, ist auch ein dokumentierter HTTPS-Endpunkt; `namefi.io/llms.txt` ist ausdrücklich als Klartext-Einstiegspunkt gestaltet, den ein Agent oder die Person, die ihn konfiguriert, ohne Browser lesen kann.
+
+### Wird meine Domain bei einer Registrierung auf diesem Weg automatisch tokenisiert?
+
+Ja, standardmäßig. Wenn Sie im Registrierungsrequest kein `nftReceivingWallet` angeben, wird die Domain auf Base als NFT an das mit Ihrem API-Schlüssel verknüpfte Wallet registriert. Sie können sie bei der Registrierung an ein anderes Wallet umleiten.
+
+### Kann ein Agent eine Domain registrieren, ohne dass ich überhaupt einen API-Schlüssel halte?
+
+Ja — der Wallet-signierte x402-Checkout benötigt kein Namefi-Konto und keinen API-Schlüssel, nur ein gedecktes Wallet. Der Zahlungsabschnitt oben behandelt das Wesentliche dieses Ablaufs; [Domains mit einem Krypto-Wallet bezahlen: kein Konto erforderlich](/de/blog/wallet-checkout/) enthält die vollständige Anleitung.
+
+### Kostet die Registrierung über einen Agenten mehr als über die Website von Namefi?
+
+Dieser Leitfaden stellt keinen Preisvergleich in die eine oder andere Richtung an. <!-- TODO: confirm with team — whether Namefi's MCP/API pricing matches its standard registration pricing, or differs --> In jedem Fall belastet jeder Weg dasselbe NFSC-Guthaben, unabhängig davon, ob die Anfrage aus einem Browser, einem Skript oder dem Werkzeugaufruf eines Agenten stammt.
+
+## Beginnen Sie mit dem Agenten, den Sie bereits geöffnet haben
+
+Sie brauchen nicht sechs Clients installiert, um diesen Leitfaden zu nutzen — Sie brauchen genau einen plus einen Namefi-API-Schlüssel oder ein gedecktes Wallet. Wählen Sie oben den Abschnitt, der zu dem Agenten passt, mit dem Sie bereits arbeiten, führen Sie die Einrichtung aus und probieren Sie den Test-Prompt. Danach geschieht der weitere Ablauf dieser Seite — suchen, registrieren, DNS konfigurieren — in derselben Unterhaltung.
+
+**[Einen Namefi-API-Schlüssel erzeugen](https://namefi.io/api-key)** oder tiefer einsteigen mit der [Claude-Anleitung samt vollständigem Transkript](/de/blog/claude-mcp-domains/) und dem [direkten Vergleich der agentenorientierten Registrare](/de/blog/cf-namecom-namefi/). Zu den Bausteinen unterhalb dieses Leitfadens siehe [Namefi MCP Server: Domain Tools for AI Agents](/de/blog/namefi-mcp/), [Namefi MCP Quickstart: Claude Code, Cursor & Windsurf](/de/blog/mcp-quickstart/), [Domains mit einem Krypto-Wallet bezahlen: kein Konto erforderlich](/de/blog/wallet-checkout/) und [llms.txt für Domains: Eine API, die jeder KI-Agent lesen kann](/de/blog/llms-txt/).
+
+## Quellen und weiterführende Lektüre
+
+- Namefi — [namefi.io/llms.txt](https://namefi.io/llms.txt) (MCP-Server-URL, Transport, Authentifizierung, Referenz für Registrierungs-/DNS-Endpunkte, Felder von `domainSetupOptions` — Primärquelle für jede Namefi-spezifische Aussage in diesem Leitfaden)
+- Namefi — [namefi.io/web3/llms.txt](https://namefi.io/web3/llms.txt) (Zahlungsflüsse für x402, MPP und EIP-712 über Wallets)
+- Namefi — [namefi.io/.well-known/mcp/servers.json](https://namefi.io/.well-known/mcp/servers.json) (MCP-Entdeckungsdeskriptor: Servername, URL, Transport, Authentifizierungstyp)
+- Namefi — [docs.namefi.io: Authentifizierung](https://docs.namefi.io/docs/02-authentication.mdx) (API-Schlüssel, EIP-712- und SIWE-Authentifizierungsmodi; Authentifizierungsanforderungen pro Vorgang)
+- Namefi — [docs.namefi.io: Eine Domain registrieren](https://docs.namefi.io/docs/03-getting-started/01-your-first-domain.mdx) (Felder für Registrierungsanfragen, Abfrageablauf, Werte für Auftragsstatus)
+- Namefi — [docs.namefi.io: Ihr Guthaben verwalten](https://docs.namefi.io/docs/03-getting-started/02-your-balance.mdx) (NFSC-Guthaben und Faucet-Endpunkte)
+- Anthropic / Claude Code — [Claude Code über MCP mit Werkzeugen verbinden](https://code.claude.com/docs/en/mcp#:~:text=claude%20mcp%20add%20%2D%2Dtransport%20http) (Syntax `claude mcp add --transport http`, Flags `--header`, `--scope`)
+- Model Context Protocol — [Mit entfernten MCP-Servern verbinden](https://modelcontextprotocol.io/docs/develop/connect-remote-servers#:~:text=Most%20remote%20MCP%20servers%20require%20authentication) (Ablauf für Custom Connectors in Claude Desktop / claude.ai)
+- OpenAI — [learn.chatgpt.com: Model Context Protocol (Codex CLI)](https://learn.chatgpt.com/docs/extend/mcp?surface=cli) (Tabelle `[mcp_servers.<name>]` in `config.toml`, Felder `url`, `http_headers`, `env_http_headers`, `bearer_token_env_var`)
+- Cursor — [cursor.com/docs/mcp](https://cursor.com/docs/mcp) (Format für Remote-Server in `mcp.json`, `headers`, `${env:VAR}`-Interpolation, Orte für Projekt- und globale Konfiguration)
+- Windsurf / Cascade — [docs.windsurf.com/windsurf/cascade/mcp](https://docs.windsurf.com/windsurf/cascade/mcp) (leitet zum Veröffentlichungsdatum dieses Leitfadens auf [docs.devin.ai/desktop/cascade/mcp](https://docs.devin.ai/desktop/cascade/mcp) weiter; Format von `mcp_config.json`, `serverUrl`, `headers`)
+- Google — [geminicli.com: MCP-Server mit der Gemini CLI](https://geminicli.com/docs/tools/mcp-server/) (Format `settings.json`, `httpUrl`, `headers`, `timeout`)
+- llmstxt.org — [Die Datei /llms.txt](https://llmstxt.org) (Spezifikation und Begründung der Entdeckungskonvention, der `namefi.io/llms.txt` folgt)

--- a/content/blog/de/ai-domain-platforms.md
+++ b/content/blog/de/ai-domain-platforms.md
@@ -1,0 +1,142 @@
+---
+title: "KI-agentische Domain-Plattformen: Der Leitfaden für 2026"
+date: '2026-07-10'
+language: 'de'
+tags: ['ai-agents', 'domains', 'guide']
+authors: ['namefiteam']
+draft: false
+format: guide
+ogImage: ../../assets/ai-domain-platforms-og.jpg
+description: "Jede Plattform, auf der ein KI-Agent 2026 eine Domain suchen, bepreisen und registrieren kann — Cloudflare, Name.com, Namefi — nach Schnittstelle, Zahlung und Autonomie."
+keywords: ["Domainregistrierung durch KI-Agenten", "agentische Domain-Plattform", "Domain mit KI kaufen", "Domainkauf in natürlicher Sprache", "MCP-Domain-Registrar", "KI-Domain-API", "Plattformen für agentische Domainregistrierung", "agent-nativer Registrar", "Cloudflare Registrar API", "Namefi MCP", "KI-native API von Name.com", "llms.txt Domain-Registrar", "kann eine KI eine Domain kaufen", "Plattformen zum Kauf von Domainnamen durch KI-Agenten 2026", "welche Plattformen lassen KI-Agenten Domains registrieren"]
+relatedArticles:
+  - /de/blog/cf-namecom-namefi/
+  - /de/blog/agent-native/
+  - /de/blog/claude-mcp-domains/
+  - /de/blog/ai-agent-register/
+  - /de/blog/airo-vs-namefi/
+relatedTopics:
+  - /de/topics/domain-tokenization/
+  - /de/topics/domain-basics/
+relatedSeries:
+  - /de/series/tokenize-your-com/
+  - /de/series/best-tlds-by-industry/
+relatedGlossary:
+  - /de/glossary/ai-agent/
+  - /de/glossary/registrar/
+  - /de/glossary/tld/
+  - /de/glossary/tokenized-domain/
+  - /de/glossary/wallet/
+---
+
+Vor einem Jahr bedeutete „KI und Domains“ einen Namensgenerator: Sie gaben eine Geschäftsidee in ein Feld ein, er warf eine Liste von `.com`- und `.ai`-Vorschlägen aus, und Sie klickten sich zu einem normalen Checkout für Menschen durch. Das ist weiterhin eine reale und nützliche Kategorie. Sie erzählt aber nicht mehr die ganze Geschichte.
+
+Seit Anfang 2026 ist eine zweite Kategorie Realität: Plattformen, auf denen ein [KI-Agent](/de/glossary/ai-agent/) — und nicht eine Person, die mit der Maus klickt — die Verfügbarkeit suchen, einen Preis lesen und die Registrierung selbst abschließen kann, als einen Schritt innerhalb einer längeren Aufgabe wie „Richte eine Landingpage für diese Idee ein und stelle sie auf eine echte Domain.“ Das unterscheidet sich wesentlich von einem intelligenteren Vorschlagsfeld, doch beide Dinge werden ständig verwechselt, auch in vielen der Marketingtexte, die darüber geschrieben werden.
+
+Dieser Leitfaden ist die Landkarte. Er behandelt die Schnittstellenmuster, die eine Plattform überhaupt für Agenten nutzbar machen, geht die konkreten Plattformen durch, die heute agentische Registrierung unterstützen (was jede tatsächlich kann und nicht kann, anhand ihrer eigenen Dokumentation verifiziert), und stellt dem gegenüber, was die großen etablierten Registrare stattdessen anbieten. Er schließt mit einer Entscheidungstabelle und häufig gestellten Fragen. Wenn Sie die direkten Vergleichszahlen bereits kennen möchten, springen Sie direkt zu [Cloudflare vs. Name.com vs. Namefi](/de/blog/cf-namecom-namefi/).
+
+Ein Hinweis vorab: Mehrere der untenstehenden Plattformen befinden sich in einer öffentlichen Beta, und Beta-Funktionen ändern sich. Alles hier wurde zum Veröffentlichungsdatum dieses Leitfadens anhand öffentlich verfügbarer Dokumentation geprüft — behandeln Sie jede konkrete Fähigkeitsbehauptung als zu diesem Zeitpunkt aktuell, nicht als dauerhafte Spezifikation.
+
+## Warum die Domainregistrierung in die Agentenebene gerückt ist
+
+Über mehr als zwanzig Jahre bedeutete die Registrierung einer Domain eine Browser-Sitzung: ein Suchfeld, ein Warenkorb, ein Zahlungsformular und oft ein CAPTCHA als Nachweis, dass ein Mensch am Steuer sitzt. Registrare hatten die meiste Zeit davon programmatische APIs, doch diese APIs wurden für andere Softwaresysteme gebaut — ein Hosting-Dashboard, ein Skript zur Massenverlängerung — nicht für ein Sprachmodell, das mitten in einer Unterhaltung entscheidet, ein Projekt brauche einen Namen.
+
+Zwei Dinge änderten sich kurz hintereinander. Erstens kündigte Name.com im Juli 2025 an, was das Unternehmen die erste KI-native Domain-Plattform nannte: eine API auf Basis von [Model Context Protocol](https://modelcontextprotocol.io) (MCP) und OpenAPI-Schemas, ausdrücklich so gestaltet, dass ein Programmieragent die Spezifikation lesen und aus einer Anfrage in natürlicher Sprache wie „Füge meiner App eine Domainregistrierung hinzu“ funktionsfähigen Registrierungscode schreiben kann ([Name.com](https://www.name.com/blog/the-first-ai-native-domain-platform#:~:text=the%20first%20registrar%20to%20bring%20together%20intelligent%20domain%20capabilities%20and%20seamless%20integration%20for%20AI%20agents)). Zweitens brachte Cloudflare am 15. April 2026 eine Registrar-API in die öffentliche Beta, mit der ausdrücklichen Aussage, „die Registrar-API ermögliche es, Domains zu suchen, die Verfügbarkeit zu prüfen und sie programmatisch zu registrieren“ (Cloudflare Blog, über [Branchenberichterstattung](https://webhosting.today/2026/04/22/ai-agents-can-now-register-domains-no-human-required/)) — und band sie bemerkenswerterweise direkt in den Cloudflare-MCP-Server ein, auf den Agenten in Cursor und Claude Code bereits zugreifen konnten.
+
+Über diesen zweiten Schritt wurde breit berichtet, weil Cloudflare ein großer, bekannter Registrar ist und die Einordnung unmissverständlich war: Domainregistrierung, eine Aufgabe, die sich der Automatisierung widersetzt hatte, weil ein Mensch auf „Ich stimme zu“ klicken und eine Kartennummer eingeben musste, war unauffällig zu etwas geworden, das ein Agent als Unterroutine erledigen konnte. Die Mitte-2026-Umfrage von CircleID zur Domainbranche formulierte es direkt: „KI-Agenten agieren zunehmend als Domain-Reseller, prüfen Verfügbarkeit, registrieren Namen und konfigurieren DNS ohne menschliches Eingreifen“ ([CircleID, April 2026](https://circleid.com/posts/the-domain-universe-in-2026-ai-security-market-maturity-and-the-new-gtld-frontier#:~:text=AI%20agents%20are%20increasingly%20acting%20as%20domain%20resellers%20checking%20availability%2C%20registering%20names%2C%20and%20configuring%20DNS%20without%20human%20intervention)).
+
+Nichts davon geschah, weil Registries ihre Regeln geändert hätten. Es geschah, weil einige Plattformen beschlossen, ihren bestehenden Kaufablauf für einen maschinellen Aufrufer verständlich zu machen statt nur für einen Browser. Das erfordert, wie sich herausstellt, mehr als „eine API veröffentlichen“.
+
+## Drei Schnittstellenmuster: rohe API, MCP-Server und llms.txt
+
+Nicht jede API ist für einen Agenten nutzbar; die Lücke ist wichtig genug, um sie präzise zu benennen. Die vollständige Checkliste finden Sie unter [Was ist ein agent-nativer Registrar?](/de/blog/agent-native/); die Kurzfassung lautet, dass bei den Plattformen dieses Leitfadens drei sich überlappende Muster auftreten.
+
+- **Eine rohe REST-API.** Das älteste Muster. Jeder Registrar mit einer Entwickler-API ermöglicht es Software technisch, eine Domain zu registrieren. Der Haken ist die Auffindbarkeit: Ein Agent muss bereits wissen, dass die API existiert, die Dokumentation bereits in seinem Kontext haben und bereits einen dagegen geschriebenen Client besitzen. Eine REST-API allein sagt einem universell einsetzbaren Agenten weder, dass sie da ist, noch wie sie richtig zu verwenden ist.
+- **Ein MCP-Server.** [MCP](https://modelcontextprotocol.io) ist ein offenes, modellunabhängiges Protokoll — von seinen Betreuern als „standardisierte Möglichkeit, KI-Anwendungen mit externen Systemen zu verbinden“ beschrieben, vergleichbar mit „einem USB-C-Anschluss für KI-Anwendungen“ ([modelcontextprotocol.io](https://modelcontextprotocol.io#:~:text=Think%20of%20MCP%20like%20a%20USB%2DC%20port%20for%20AI%20applications)) — um jedem kompatiblen KI-Client, etwa Claude, Cursor, Windsurf und anderen, einen definierten Satz aufrufbarer Tools bereitzustellen. Ein Registrar, der einen MCP-Server ausliefert, gibt einem Agenten ein Menü exakter Operationen (`search_domain`, `register_domain`, `set_dns_record`) anstelle einer Wand aus REST-Dokumentation, die er rückentwickeln müsste.
+- **Eine über llms.txt auffindbare API.** [llms.txt](https://llmstxt.org) ist eine Klartext-Konvention — eine Datei `/llms.txt` im Root einer Website — die 2024 vorgeschlagen wurde, um Sprachmodellen einen knappen, kuratierten Index der wichtigsten Dokumentation und Fähigkeiten einer Website zu geben, ähnlich wie `robots.txt` Crawlern Berechtigungsregeln gibt. Ein Registrar, der etwa unter `namefi.io/llms.txt` eine solche Datei veröffentlicht, ermöglicht einem Agenten, der die Plattform noch nie gesehen hat, ohne dass ein Mensch zuerst API-Dokumentation in die Unterhaltung einfügt, herauszufinden, was die Plattform kann.
+
+Diese Standards konkurrieren nicht miteinander; die stärksten Plattformen schichten alle drei: llms.txt für die Auffindbarkeit, einen MCP-Server für die tatsächlichen Tool-Aufrufe und die REST-API unter beiden.
+
+## Plattform für Plattform
+
+### Cloudflare Registrar API (Beta)
+
+Die Beta von Cloudflare, die seit dem 15. April 2026 live ist, deckt drei Vorgänge ab: Suche, Verfügbarkeits- und Preisprüfungen sowie Registrierung — das, was Cloudflare selbst als „den ersten kritischen Moment im Lebenszyklus einer Domain“ beschreibt; Transfers, Verlängerungen und Aktualisierungen von Kontaktdaten wurden für später im Jahr zugesagt (Cloudflare Blog). Die Preisgestaltung folgt Cloudflares langjährigem Registrar-Modell: „Wir berechnen genau das, was die Registry berechnet“, ohne Aufschlag, unabhängig davon, ob der Aufruf vom Dashboard, der API oder einem Agenten kommt (Cloudflare Blog).
+
+Der agentenorientierte Teil ist die Integration, kein separates Produkt: „Die Registrar-API ist Teil der vollständigen Cloudflare-API, was bedeutet, dass Agenten heute bereits über Cloudflare MCP Zugriff darauf haben“, und „ein Agent, der in Cursor, Claude Code oder einer MCP-kompatiblen Umgebung arbeitet, kann Registrar-Endpunkte entdecken und aufrufen“ (Cloudflare Blog). Cloudflares eigene Beschreibung des vorgesehenen Ablaufs behält einen Kontrollpunkt bei: Ein Agent kann „Namen vorschlagen, bestätigen, welcher tatsächlich registrierbar ist, den Preis zur Genehmigung anzeigen und dann den Kauf abschließen“ (Cloudflare Blog). Wie dokumentiert, ist das jedoch ein Gestaltungsvorschlag und kein von der API selbst erzwungener Mechanismus für Ausgabenobergrenzen.
+
+Zwei Vorbehalte sollten Sie kennen, bevor Sie darauf planen: Die Beta deckt noch nicht den vollständigen TLD-Katalog von Cloudflare ab, sondern nur das, was Cloudflare „zu Beginn eine kuratierte Auswahl beliebter TLDs“ nennt (Cloudflare Blog). Außerdem wird sie einem bestehenden Cloudflare-Konto in Rechnung gestellt — einer Fiat-Beziehung, in die ein Mensch eingebunden wurde, selbst wenn der Agent die API aufruft.
+
+### KI-native API von Name.com
+
+Die im Juli 2025 angekündigte Plattform von Name.com baut auf derselben Idee von natürlicher Sprache zu Code auf: Ein Entwickler oder Agent beschreibt, was er möchte („Füge meiner App eine Domainregistrierung hinzu“), und die Dokumentation der Plattform ist so strukturiert, dass ein KI-Client daraus funktionsfähigen Integrationscode erzeugen kann. MCP und OpenAPI bilden dabei das zugrunde liegende Gerüst; hinzu kommen Self-Service-Entwicklerzugang und Unterstützung für Tools wie Claude und Cursor ([Name.com](https://www.name.com/blog/the-first-ai-native-domain-platform#:~:text=leverages%20modern%20standards%20including%20Model%20Context%20Protocol)). Die Preise sind transparent und volumenbasiert, mit der für Registrar-APIs üblichen Reseller-Aufschlagsstruktur.
+
+Was die Ankündigung von Name.com nicht dokumentiert, ist ein Zahlungsweg mit Krypto oder Wallet oder ein expliziter, in die API selbst eingebauter Bestätigungsschritt durch einen Menschen. Beides ist bei einem üblichen Entwicklerkontomodell plausibel, doch in der Quelle nicht ausgeführt. Behandeln Sie daher „Fiat-Abrechnung auf Kontobasis“ als Arbeitshypothese, nicht als vollständig bestätigtes Detail.
+
+### Namefi: MCP-Server plus Wallet-Checkout
+
+Der eigene maschinenlesbare Funktionsindex von Namefi — [namefi.io/llms.txt](https://namefi.io/llms.txt) — ist selbst ein Beispiel für das dritte Schnittstellenmuster oben und die maßgebliche Quelle für das Folgende. Namefi betreibt einen MCP-Server unter `api.namefi.io/mcp` über Streamable HTTP und stellt typisierte Tools für Registrierung, Verfügbarkeitsprüfungen und DNS-Verwaltung bereit. Er lässt sich mit einem einzigen Befehl zu Claude Code hinzufügen (`claude mcp add --transport http namefi https://api.namefi.io/mcp`). Darunter liegt eine REST-API (`api.namefi.io/v-next/`), die mit einem `x-api-key`-Header authentifiziert wird. Der Schlüssel muss aus der Wallet erzeugt werden, der die Domain gehört, wodurch der API-Zugang direkt an die On-Chain-Verwahrung statt an einen separaten Ablauf zur Kontowiederherstellung gebunden ist.
+
+Das Unterscheidungsmerkmal ist die Zahlung. Namefi dokumentiert zwei Wege: den Standardweg über einen API-Schlüssel, der gegen ein vorausbezahltes NFSC-Guthaben (Namefi Service Credits) abgerechnet wird, und einen kryptonativen Weg mit Wallet-Signaturen — einschließlich SIWE (Sign-In With Ethereum) — für das, was die Dokumentation als Web3-Nutzer und „agentische Wallets“ beschreibt. Dadurch kann ein Kauf autorisiert werden, ohne überhaupt ein Registrar-Konto anzulegen. Nach der Registrierung unterstützt Namefi vollständiges DNS-Record-CRUD (A, AAAA, CNAME, MX, TXT und mehr), automatische Verlängerung, Domain-Parking und -Weiterleitung, automatische Generierung von ENS-Records sowie — das Merkmal, das sie strukturell von den anderen beiden Plattformen unterscheidet — die Möglichkeit, eine reale, bei der ICANN registrierte Domain als [Tokenisierte Domain](/de/glossary/tokenized-domain/) zu repräsentieren: als On-Chain-Asset, das in einer [Wallet](/de/glossary/wallet/) gehalten wird. Die schrittweise Einrichtung für Claude, Codex, Cursor und drei weitere Agenten finden Sie unter [So registrieren Sie eine Domain mit Ihrem KI-Agenten auf Namefi](/de/blog/ai-agent-register/); die Claude-spezifische Vertiefung steht unter [Eine Domain mit Claude kaufen: Namefi MCP Schritt-für-Schritt-Leitfaden](/de/blog/claude-mcp-domains/). Wie diese Anfrage in natürlicher Sprache tatsächlich aussieht, sehen Sie unter [Wie man eine Domain mit natürlicher Sprache kauft (2026)](/de/blog/nl-domain-purchase/).
+
+Eine Lücke ist klar zu benennen: Die llms.txt von Namefi veröffentlicht keine feste Liste der unterstützten TLDs. <!-- TODO: confirm with team — full supported TLD list --> Wenn die TLD-Abdeckung für Ihren Anwendungsfall ausschlaggebend ist, prüfen Sie sie vor einer Festlegung direkt in der aktuellen Dokumentation.
+
+## Was etablierte Anbieter wie GoDaddy und Namecheap stattdessen anbieten
+
+Es lohnt sich, präzise zu erklären, warum die großen [Registrare](/de/glossary/registrar/) für Endverbraucher nicht in der obigen Tabelle stehen, denn [„KI-Domain-Suche“ beschreibt zwei tatsächlich unterschiedliche Produkte](/de/blog/ai-search-meanings/). Die großen etablierten Anbieter haben stark in KI-gestützte Namensvorschläge und Onboarding investiert: Tools, die eine Beschreibung Ihres Geschäfts entgegennehmen und markentaugliche Namenskandidaten erzeugen, manchmal gebündelt mit einem Logo- oder Starter-Website-Generator. Das ist ein reales, nützliches Produkt. Es gehört jedoch nicht in dieselbe Kategorie wie die Plattformen oben, weil die KI in diesem Ablauf die Entscheidung eines Menschen unterstützt. Sie besitzt nicht die Befugnis, eigenständig nach einer Domain zu suchen, sie zu bepreisen und eine Registrierung abzuschließen, die von einem externen Agenten als Tool aufgerufen werden kann. Eine Person landet weiterhin auf einer Checkout-Seite und klickt auf „Kaufen“. Bis ein etablierter Anbieter eine von Agenten aufrufbare API, einen MCP-Server oder eine llms.txt-Datei mit derselben Autorität veröffentlicht, wie sie die drei Plattformen oben dokumentieren, gehört er in die Kategorie „KI hilft einem Menschen bei der Auswahl“ und nicht in diese.
+
+## Die zentrale Entscheidungstabelle
+
+| Plattform | Schnittstelle | Zahlung | Mensch in der Schleife | TLD-Abdeckung |
+| --- | --- | --- | --- | --- |
+| **Cloudflare Registrar API** (Beta) | REST-API + Cloudflare MCP; funktioniert nativ in Cursor, Claude Code und jedem MCP-Client | Fiat, einem bestehenden Cloudflare-Konto in Rechnung gestellt | Das Gestaltungsmuster zeigt den Preis vor dem Kauf „zur Genehmigung“ an; keine dokumentierte, von der API selbst erzwungene Ausgabenobergrenze | Kuratierte Auswahl beliebter TLDs beim Beta-Start — nicht der vollständige Cloudflare-Katalog |
+| **KI-native API von Name.com** | REST + OpenAPI-Schema, MCP-kompatibel; Workflow von natürlicher Sprache zu Code | Fiat, Standardabrechnung über Entwicklerkonto, volumenbasierte Reseller-Preise | In der öffentlichen Ankündigung nicht dokumentiert | In der Ankündigung nicht aufgeschlüsselt |
+| **Namefi** | REST-API (`x-api-key`) + MCP-Server (`api.namefi.io/mcp`, Streamable HTTP) | Fiat über vorausbezahltes API-Schlüssel-Guthaben **oder** Krypto-Wallet-Signatur (SIWE), kein Konto erforderlich | Optional nach Design: Der API-Schlüsselpfad ist durch ein vorausbezahltes Guthaben begrenzt; der Wallet-Pfad erfordert eine Signatur pro Transaktion | In öffentlichen Dokumenten nicht aufgeschlüsselt — prüfen Sie die aktuelle Abdeckung für Ihre TLD |
+
+Die vollständige Funktionsversion dieser Tabelle — Verfügbarkeitssuche, DNS-Verwaltung, Verlängerungsautomatisierung, tokenisierte Eigentümerschaft und mehr — finden Sie unter [Cloudflare vs. Name.com vs. Namefi: agent-native Registrare](/de/blog/cf-namecom-namefi/).
+
+## So wählen Sie aus
+
+- **Sie leben bereits im Cloudflare-Ökosystem und brauchen heute nur Suche-Prüfung-Registrierung.** Die Registrar-API ist die Option mit der geringsten Reibung, wenn Ihre Domains und Ihr DNS bereits bei Cloudflare liegen. Der Kompromiss: Die TLD-Liste und der Funktionsumfang der Beta sind noch schmaler als bei einem vollständigen Registrar.
+- **Sie entwickeln ein Reseller- oder Mandantenprodukt auf Basis der Domainregistrierung.** Die volumenbasierte Preisgestaltung und der Self-Service-Entwicklerzugang von Name.com wurden für Reseller konzipiert.
+- **Ihr Agent muss ohne ein bereits vorhandenes, einem Menschen gehörendes Konto Transaktionen durchführen, oder die Domain selbst soll ein portables Asset in einer Wallet sein.** Genau für diese Lücke ist [Namefi](https://namefi.io) gebaut: Wallet-signierter Checkout ohne Registrierungsschritt plus [tokenisierte Domains](/de/glossary/tokenized-domain/), wenn die Domain wie jedes andere On-Chain-Asset bewegt werden und die Verwahrung nachweisen soll.
+- **Sie sind nicht sicher, ob Sie überhaupt agentische Kaufbefugnis brauchen.** Wenn Sie in Wahrheit Hilfe bei der Namensauswahl wollen, während ein Mensch weiterhin auf „Kaufen“ klickt, ist ein KI-gestützter Namensgenerator besser geeignet als jede Plattform dieses Leitfadens. Die vollständige Unterscheidung finden Sie unter [„KI-Domain-Suche“ bedeutet 2026 zwei unterschiedliche Dinge](/de/blog/ai-search-meanings/).
+
+## Häufig gestellte Fragen
+
+### Können ChatGPT oder Claude jetzt sofort eine Domain für mich kaufen?
+
+Das hängt vollständig davon ab, auf welche Tools dieser konkrete Chat-Client Zugriff hat, nicht vom Modell selbst. Ein Modell wie Claude besitzt keine eingebaute Fähigkeit, eine Domain zu registrieren; es muss mit dem MCP-Server oder der API einer Plattform verbunden sein (etwa mit dem MCP-Server von Namefi oder der Registrar-API von Cloudflare über Cloudflare MCP), bevor es suchen, bepreisen und einen Kauf abschließen kann. Ohne diese Verbindung kann ein KI-Assistent Ihnen nur Namen vorschlagen, die Sie selbst registrieren.
+
+### Ist es sicher, einen KI-Agenten Domains registrieren und Geld ausgeben zu lassen, ohne vorher bei mir nachzufragen?
+
+Behandeln Sie es wie jede automatisierte Einkaufsbefugnis: Begrenzen Sie sie, bevor Sie sie erteilen. Die sichersten, plattformübergreifend dokumentierten Muster sind ein vorausbezahltes Guthaben, das die Gesamtexponierung begrenzt (der API-Schlüsselpfad von Namefi), eine Signatur pro Transaktion, die nicht wiederverwendet werden kann (Wallet-signierter Checkout), oder ein manueller Bestätigungsschritt vor dem endgültigen Kaufaufruf. Keine der Plattformen dieses Leitfadens erzwingt in Ihrem Namen eine universelle Ausgabenobergrenze — Sie setzen die Leitplanke, typischerweise über Finanzierungslimits des Kontos oder einen ausdrücklichen Bestätigungsschritt im Workflow Ihres eigenen Agenten.
+
+### Was ist der tatsächliche Unterschied zwischen einer API, einem MCP-Server und llms.txt?
+
+Eine REST-API ist die zugrunde liegende Menge aufrufbarer Operationen. Ein MCP-Server verpackt eine definierte Teilmenge dieser Operationen als einzelne Tools, die jeder MCP-kompatible KI-Client direkt und ohne benutzerdefinierten Integrationscode aufrufen kann. Eine llms.txt-Datei ist eine Auffindbarkeitsebene — ein kurzer, kuratierter Index im Root einer Website, der einem Agenten zunächst mitteilt, welche Dokumentation und Fähigkeiten vorhanden sind, so wie robots.txt einem Crawler mitteilt, was er indexieren darf. Eine Plattform kann eines der drei allein haben; die stärksten agent-nativen Plattformen kombinieren jedoch alle drei: llms.txt zum Gefundenwerden, MCP zum Aufrufen und REST darunter für beides.
+
+### Brauche ich eine Kryptowährungs-Wallet, um eine dieser Plattformen zu nutzen?
+
+Nein. Cloudflare und Name.com nutzen beide Standard-Fiat-Abrechnung auf Kontobasis, und Namefi unterstützt dieselbe Art der API-Schlüssel-Abrechnung gegen ein vorausbezahltes Guthaben. Eine Wallet ist nur erforderlich, wenn Sie speziell den Wallet-signierten Checkout ohne Konto oder die Funktion für tokenisierte Eigentümerschaft von Namefi wünschen.
+
+### Welche dieser Plattformen ist heute am „fertigsten“?
+
+Keine von ihnen sollte als fertige, unveränderliche Spezifikation behandelt werden. Die von Cloudflare ist ausdrücklich als Beta mit einer schmaleren TLD-Liste als dem vollständigen Katalog gekennzeichnet, und Beta-Funktionen können sich definitionsgemäß ändern. Prüfen Sie die aktuellen Fähigkeiten anhand der live verfügbaren Dokumentation jeder Plattform, bevor Sie eine Abhängigkeit von einer bestimmten Funktion aufbauen.
+
+## Kaufen und tokenisieren Sie Ihre nächste Domain bei Namefi
+
+Unabhängig davon, welches Schnittstellenmuster zu Ihrem Workflow passt, ist [Namefi](https://namefi.io) für den Fall gebaut, dass der Käufer genauso oft ein Agent, eine Wallet oder ein Skript wie eine Person ist, die ein Formular durchklickt: ein von der [ICANN](/de/glossary/icann/) akkreditierter [Registrar](/de/glossary/registrar/) mit MCP-Server, dokumentierter REST-API und Wallet-signiertem Checkout, der die Kontoerstellung vollständig überspringt, sowie optionalen [Tokenisierten Domains](/de/glossary/tokenized-domain/), sodass die Domain selbst zu einem Asset wird, das die Wallet Ihres Agenten halten und bewegen kann.
+
+**[Eine Domain bei Namefi suchen und registrieren](https://namefi.io).**
+
+## Quellen und weiterführende Lektüre
+
+- Cloudflare Blog — [Ankündigung der Registrar-API-Beta](https://blog.cloudflare.com/registrar-api-beta/) (Startdatum, unterstützte Vorgänge, Selbstkostenpreise, MCP-Integration, kuratierte TLD-Auswahl)
+- webhosting.today — [KI-Agenten können jetzt Domains ohne Menschen registrieren](https://webhosting.today/2026/04/22/ai-agents-can-now-register-domains-no-human-required/) (Einordnung der Cloudflare-Beta durch die Branche und ihre Implikationen für die Governance)
+- Name.com — [Die erste KI-native Domain-Plattform](https://www.name.com/blog/the-first-ai-native-domain-platform#:~:text=the%20first%20registrar%20to%20bring%20together%20intelligent%20domain%20capabilities%20and%20seamless%20integration%20for%20AI%20agents) (Ankündigung, Juli 2025)
+- CircleID — [Das Domain-Universum 2026: KI, Sicherheit, Marktreife und die neue gTLD-Grenze](https://circleid.com/posts/the-domain-universe-in-2026-ai-security-market-maturity-and-the-new-gtld-frontier#:~:text=AI%20agents%20are%20increasingly%20acting%20as%20domain%20resellers%20checking%20availability%2C%20registering%20names%2C%20and%20configuring%20DNS%20without%20human%20intervention) (Analyse von Agenten als Resellern, April 2026)
+- dev.to — [So registrieren Sie einen Domainnamen mit Ihrem KI-Agenten, ohne dass ein Mensch nötig ist](https://dev.to/marsheer/how-to-register-a-domain-name-with-your-ai-agent-no-human-needed-h26) (MCP-Tutorial eines Dritten auf Basis der Registrar-API von Cloudflare)
+- llmstxt.org — [Die Datei /llms.txt](https://llmstxt.org) (Spezifikation und Begründung)
+- modelcontextprotocol.io — [Was ist das Model Context Protocol?](https://modelcontextprotocol.io#:~:text=Think%20of%20MCP%20like%20a%20USB%2DC%20port%20for%20AI%20applications) (Protokollüberblick)
+- Namefi — [namefi.io/llms.txt](https://namefi.io/llms.txt) (Namefis eigener Fähigkeitsindex: API, MCP-Server, Authentifizierungsmodell, DNS- und Tokenisierungsfunktionen)

--- a/content/blog/de/ai-search-meanings.md
+++ b/content/blog/de/ai-search-meanings.md
@@ -1,0 +1,124 @@
+---
+title: '„KI-Domainsuche“ bedeutet 2026 zwei verschiedene Dinge'
+date: '2026-07-10'
+language: 'de'
+tags: ['ai-agents', 'domains', 'explainer']
+authors: ['namefiteam']
+draft: false
+format: explainer
+ogImage: ../../assets/ai-search-meanings-og.jpg
+description: '„KI-Domainsuche“ kann einen Assistenten meinen, der Vorschläge macht, oder einen Agenten, der kauft. Ein Test mit zwei Spalten zeigt, was Sie benötigen und wo Sie es bekommen.'
+keywords: ['ki-domainsuche', 'ki-assistent versus ki-agent', 'ki-domainfinder versus ki-agent', 'was bedeutet ki-domainsuche', 'ki hilft bei der domainwahl versus ki kauft eine domain', 'unterstützte domainsuche', 'agentischer domainkauf', 'brauche ich einen ki-agenten um eine domain zu kaufen', 'ki-unterstützte domainsuche', 'domainsuche in natürlicher sprache', 'selbsttest ki-domainsuche', 'mcp domain-agent']
+relatedArticles:
+  - /de/blog/airo-vs-namefi/
+  - /de/blog/best-ai-tools-2026/
+  - /de/blog/ai-agent-register/
+  - /de/blog/cf-namecom-namefi/
+  - /de/blog/ai-domain-platforms/
+relatedTopics:
+  - /de/topics/domain-basics/
+  - /de/topics/choosing-a-tld/
+relatedSeries:
+  - /de/series/best-tlds-by-industry/
+  - /de/series/domain-flipping-skills/
+relatedGlossary:
+  - /de/glossary/ai-agent/
+  - /de/glossary/brandable-domain/
+  - /de/glossary/registrar/
+  - /de/glossary/tld/
+  - /de/glossary/premium-domain/
+---
+
+Wenn Sie 2026 „KI-Domainsuche“ in eine Suchleiste eingeben, erhalten Sie zwei völlig verschiedene Arten von Ergebnissen. Den meisten Menschen fällt nicht auf, dass sie über zwei verschiedene Produkte lesen. Die eine Art verwandelt „etwas wie eine Kaffeemarke, verspielt, kurz“ in eine Liste von Namensideen, die Sie anschließend selbst kaufen. Die andere prüft Verfügbarkeit, ruft einen Preis ab und schließt eine Domainregistrierung eigenständig ab, ganz ohne Browser-Checkout. Derselbe Ausdruck, zwei Mechanismen, zwei sehr unterschiedliche Antworten auf die Frage: „Kann KI mir eine Domain kaufen?“
+
+Das ist keine bloße semantische Spitzfindigkeit. Wenn Sie einen Namensgenerator wollen und auf Dokumentation für einen autonomen Kaufagenten stoßen, wirkt das übertrieben. Wenn Sie eine Domainregistrierung in eine automatisierte Pipeline integrieren möchten und bei einem Namenswerkzeug landen, schließen Sie einen Schritt zu früh: „KI kann gar keine Domains kaufen.“ Im Folgenden finden Sie die Grenze zwischen beiden, einen Test mit fünf Fragen, um herauszufinden, was Sie brauchen, und ehrliche Links zu beiden.
+
+## Spalte A: KI-unterstützte Suche — Sie klicken weiterhin selbst auf „Kaufen“
+
+Dies ist die ältere und bei weitem häufigere Bedeutung dessen, was die meisten [Registrare](/de/glossary/registrar/) heute mit „KI-Domainsuche“ meinen. Jedes Mal dieselben drei Schritte:
+
+1. **Sie geben einen Prompt ein.** Einen Satz, der Ihr Unternehmen oder die gewünschte Stimmung beschreibt — etwa „eine freundliche Budget-App für Freiberufler“.
+2. **Das Werkzeug liefert Vorschläge.** Eine Liste [markenfähiger Domains](/de/glossary/brandable-domain/), manchmal mit passendem Logo oder einer Starter-Website, die aus Ihrem Prompt erzeugt und nicht aus einer festen Liste abgerufen wird.
+3. **Sie klicken auf „Kaufen“.** Sie prüfen die Vorschläge wie ein Käufer, wählen einen aus und schließen die Registrierung über den normalen Checkout des Registrars ab — Kartendaten, Konto, Bestätigungs-E-Mail.
+
+GoDaddy Airo und die KI-Werkzeuge von Namecheap für Benennung und Branding gehören beide hierher. Das ist keineswegs eine minderwertige Kategorie: Für jemanden mit einer Idee, aber noch ohne Namen, ist ein Werkzeug, das einen Satz in zehn Kandidaten verwandelt, wirklich nützlich. Was diese Kategorie zu Spalte A macht, ist strukturell, nicht qualitativ: Die Aufgabe der KI endet beim Vorschlag, und eine Person muss die Transaktion jedes Mal abschließen.
+
+## Spalte B: agentische Suche und Kauf — der Agent erledigt alles
+
+Die zweite Bedeutung ist neuer und entspricht dem, wofür Namefi gebaut wurde. Hier ist die „KI“ kein Vorschlagsfeld in einer Checkout-Seite, sondern ein [KI-Agent](/de/glossary/ai-agent/): Software, die in Ihrem Auftrag eine API aufruft, nicht eine Person, die Ergebnisse anklickt. Die Struktur:
+
+1. **Ein Agent, kein Formular, löst die Anfrage aus.** Ein Coding-Assistent, ein zeitgesteuertes Skript oder ein Chat-Client fragt per API-Aufruf: „Ist dieser Name verfügbar, was kostet er?“, nicht über ein Suchfeld.
+2. **Der Agent ruft die API des Registrars direkt auf.** Bei Namefi geschieht das über einen MCP-Server (Model Context Protocol) unter `api.namefi.io/mcp` oder über eine reine REST-API für Agenten, die kein MCP sprechen. Die Authentifizierung erfolgt über einen API-Schlüssel im Header `x-api-key` oder über eine Wallet-Signatur, die ganz ohne Konto eine Zahlung autorisiert.
+3. **Die Domain wird ohne Browser-Checkout registriert.** Der Agent übermittelt die Bestellung, fragt sie bis zum Abschluss ab und kann im selben Ablauf [DNS](/de/glossary/dns/) konfigurieren — kein Kartenformular, kein „hier klicken, um zu bestätigen“.
+4. **Sie legen die Richtlinie vorab fest, nicht den Klick im Moment.** Statt jeden Kauf manuell zu genehmigen, entscheiden Sie im Voraus, was der Agent ausgeben darf und wofür.
+
+Auch die Beta-Registrar-API von Cloudflare und die KI-native API von Name.com gehören neben Namefi hierher. Das bestimmende Merkmal dieser Spalte ist nicht intelligentere Software, sondern dass ein *Kauf* und nicht nur ein *Vorschlag* die Arbeitseinheit ist, die die KI abschließt.
+
+## Die beiden Spalten im direkten Vergleich
+
+| | Spalte A: KI-unterstützte Suche | Spalte B: agentische Suche und Kauf |
+|---|---|---|
+| Was die KI tut | Schlägt Namen, Logos und manchmal eine Starter-Website vor | Prüft Verfügbarkeit, Preise und registriert die Domain |
+| Wer den Kauf abschließt | Sie über eine normale Checkout-Seite | Der Agent über einen API- oder MCP-Aufruf |
+| Schnittstelle | Ein Prompt-Feld auf der Website des Registrars | API-Schlüssel, Wallet-Signatur oder MCP-Verbindung |
+| Wo Sie Grenzen setzen | Im Moment des Checkouts | Vorab, als Ausgabenrichtlinie, innerhalb derer der Agent handelt |
+| Typischer Nutzer | Jemand mit einer Idee, aber noch ohne Namen | Ein Entwickler, Skript oder Coding-Agent, der bereits weiß, was registriert werden soll |
+| Beispielprodukte | GoDaddy Airo, Visual-Naming-Werkzeuge von Namecheap | MCP-Server und API von Namefi, Registrar-API von Cloudflare, KI-native API von Name.com |
+| Was Sie anschließend erhalten | Eine Domain in einem Registrar-Konto, in das Sie sich einloggen | Dasselbe, zusätzlich bei Namefi eine optionale [tokenisierte](/de/glossary/tokenized-domain/) On-Chain-Repräsentation des Eigentums |
+
+## Der Selbsttest mit fünf Fragen
+
+Antworten Sie ehrlich, und die passende Spalte wird offensichtlich.
+
+1. **Wissen Sie bereits, was Sie registrieren möchten, oder sammeln Sie noch Ideen für einen Namen?** Noch Ideen sammeln → A. Bereits entschieden → weiter.
+2. **Ist jedes Mal eine Person verfügbar, um auf „Kaufen“ zu klicken, oder muss dies unbeaufsichtigt laufen?** Eine Person ist in Ordnung → A. Muss unbeaufsichtigt laufen → B.
+3. **Ist dies ein einmaliger Kauf oder Teil eines wiederholbaren Ablaufs (eine Build-Pipeline, ein Portfolio-Skript)?** Einmalig → A ist einfacher. Wiederholbar → B lohnt sich.
+4. **Möchten Sie ein Logo und eine Starter-Website zum Namen oder nur die Registrierung?** Sie möchten das Paket → A. Nur die Domain, programmgesteuert → B.
+5. **Fühlen Sie sich damit wohl, ein Ausgabenlimit vorab festzulegen, statt jeden Kauf im Moment zu genehmigen?** Noch nicht → A. Ja → Das Richtlinienmodell von B passt.
+
+Antworten, die sich in der ersten Hälfte häufen, bedeuten ein Namenswerkzeug. Antworten in der zweiten Hälfte bedeuten einen Agenten, der Transaktionen ausführt.
+
+## Wo Sie beides erhalten
+
+Beide Spalten beschreiben reale Produkte; genau darum geht es in diesem Leitfaden, über beide ehrlich zu sein.
+
+**Spalte A:** [GoDaddy Airo vs. Namecheap AI vs. Namefi](/de/blog/airo-vs-namefi/) vergleicht, was die „KI“ jedes Produkts tatsächlich erzeugt; [Die besten KI-Domainwerkzeuge 2026](/de/blog/best-ai-tools-2026/) bewertet Namenswerkzeuge nach ihren eigenen Maßstäben.
+
+**Spalte B:** [So registrieren Sie eine Domain mit Ihrem KI-Agenten bei Namefi](/de/blog/ai-agent-register/) ist die maßgebliche Einrichtungsanleitung, und [Cloudflare vs. Name.com vs. Namefi](/de/blog/cf-namecom-namefi/) vergleicht die drei für agentische Käufe aufgebauten Registrare. Die breitere Landschaft finden Sie in [KI-agentische Domainplattformen: Der Leitfaden für 2026](/de/blog/ai-domain-platforms/).
+
+## Häufig gestellte Fragen
+
+### Ist GoDaddy Airo dieselbe Art von „KI“ wie die Agentenwerkzeuge von Namefi?
+
+Nein. Airo erzeugt Vorschläge für Namen, Logos und Starter-Websites, die Sie prüfen und anschließend selbst über den Checkout von GoDaddy kaufen — Spalte A. Namefi stellt die Registrierung als API und MCP-Server bereit, die ein Agent direkt aufrufen kann, um einen Kauf ohne Browser-Checkout abzuschließen — Spalte B.
+
+### Können ChatGPT oder Claude mir einfach eine Domain kaufen, wenn ich darum bitte?
+
+Nur wenn der jeweilige Chat-Client mit einer agentenorientierten Schnittstelle eines Registrars verbunden ist. Eine gewöhnliche Chat-Sitzung ohne Werkzeugzugriff kann nur Namen vorschlagen und Ihnen sagen, dass Sie eine Domain selbst registrieren sollen — weiterhin Spalte A, auch innerhalb eines Chatfensters. Verbinden Sie denselben Client mit einem MCP-Server wie dem von Namefi, und er wechselt in Spalte B. [Die vollständige Einrichtungsanleitung](/de/blog/ai-agent-register/) erklärt, wie das geht.
+
+### Muss ich programmieren können, um ein Werkzeug aus Spalte B zu verwenden?
+
+Nicht unbedingt. Namefi funktioniert auch als normale Website, die Sie von Hand nutzen können. Programmierung ist nur erforderlich, wenn Sie die agentische Seite selbst über ein Skript steuern möchten; mit einem bereits verbundenen Client wie Claude Desktop ist kein Programmieren nötig, nur eine kurze einmalige Einrichtung.
+
+### Ist eine der beiden Spalten strikt besser als die andere?
+
+Nein, sie lösen unterschiedliche Probleme. Spalte A passt, wenn Sie noch über einen Namen entscheiden und die endgültige Wahl von einer Person prüfen lassen möchten. Spalte B passt, wenn der Name feststeht und Sie eine Registrierung ohne Checkout-Seite möchten, besonders als Teil eines wiederholbaren oder automatisierten Ablaufs.
+
+### Warum baut Namefi für Spalte B statt für Spalte A?
+
+Namefi ist ein ICANN-akkreditierter Registrar, der so aufgebaut ist, dass ein KI-Agent — nicht nur ein Mensch mit Browser — eine Domain suchen, bepreisen und registrieren kann. Das Ergebnis kann optional als [tokenisierter](/de/glossary/tokenized-domain/) Vermögenswert dargestellt werden, den ein Wallet halten kann. Das schließt eine Nutzung der Spalte A nicht aus: Wenn Sie den Namen bereits kennen, funktioniert die eigene Website von Namefi wie jeder Registrar für einen Menschen, der sich durchklickt.
+
+## Richten Sie Ihren Agenten auf das richtige Werkzeug aus
+
+Wenn Sie bereits wissen, welche [TLD](/de/glossary/tld/) und welchen Namen Sie möchten, ist der Vorschlagsschritt erledigt. Übrig bleibt nur, ihn ohne einen Menschen am Checkout zu registrieren — genau dafür sind die Agentenwerkzeuge von Namefi da. Unabhängig davon, ob Sie mit einem API-Schlüssel oder einer Wallet-Signatur zahlen und ob der Name eine Standardregistrierung oder eine [Premium-Domain](/de/glossary/premium-domain/) ist, kann der Agent ihn in einem Aufruf von „verfügbar“ zu „registriert“ bringen.
+
+**[Erfahren Sie, wie die Agentenwerkzeuge von Namefi funktionieren](https://namefi.io).**
+
+## Quellen und weiterführende Lektüre
+
+- webhosting.today — [KI-Agenten können jetzt Domains registrieren, kein Mensch erforderlich](https://webhosting.today/2026/04/22/ai-agents-can-now-register-domains-no-human-required/#:~:text=increasingly%20acting%20as%20domain%20resellers%2C%20checking%20availability%2C%20registering%20names%2C%20and%20configuring%20DNS) — Berichterstattung über die Registrar-API-Beta von Cloudflare im April 2026, das klarste Beispiel für den Mechanismus der Spalte B in der Produktion.
+- Name.com — [Die erste KI-native Domainplattform](https://www.name.com/blog/the-first-ai-native-domain-platform#:~:text=supported%20by%20modern%20standards%20like%20Model%20Context%20Protocol%20%28MCP%29%20and%20OpenAPI%20specification%2C%20which%20enable%20AI%20agents%20to%20interact%20directly%20with%20domain) — Ankündigung von Name.com zur eigenen agentenorientierten API auf Basis von MCP und OpenAPI, ein weiteres Beispiel für Spalte B.
+- GoDaddy — [.ai-Domainregistrierung](https://www.godaddy.com/tlds/ai-domain) — Produktseite von GoDaddy, die die `.ai`-Registrierung mit dem Namensassistenten Airo verbindet, ein Beispiel für Spalte A.
+- Namecheap — [.ai-Domainregistrierung](https://www.namecheap.com/domains/registration/cctld/ai/) — Produktseite von Namecheap für die `.ai`-Registrierung neben den kostenlosen KI-Werkzeugen für Benennung und Branding, ebenfalls Spalte A.
+- Wix — [Wie man KI nutzt, um einen Domainnamen zu kaufen](https://www.wix.com/blog/buy-a-domain-name-with-ai) — Eigene Anleitung von Wix zum KI-unterstützten Ablauf für Namensfindung und Kauf, ein weiterer Bezugspunkt für Spalte A.
+- Namefi — [llms.txt](https://namefi.io/llms.txt) — Maschinenlesbare Beschreibung des MCP-Servers, der REST-API und des Authentifizierungsmodells von Namefi; Quelle für alle Produktangaben zu Namefi in diesem Artikel.

--- a/content/blog/de/ai-tld-registrars.md
+++ b/content/blog/de/ai-tld-registrars.md
@@ -1,0 +1,126 @@
+---
+title: "Die besten .ai-Domain-Registrare für KI-Startups (2026)"
+date: '2026-07-10'
+language: 'de'
+tags: ['ai-agents', 'comparison']
+authors: ['namefiteam']
+draft: false
+format: roundup
+ogImage: ../../assets/ai-tld-registrars-og.jpg
+description: "Wo KI-Startups .ai 2026 registrieren sollten: verifizierte Preisspannen und Verlängerungsbedingungen bei fünf Registraren sowie welche davon ein KI-Agent tatsächlich nutzen kann."
+keywords: [".ai-Domain-Registrar", "bester .ai-Registrar", ".ai-Domainpreis 2026", ".ai-Domain-Verlängerungskosten", ".ai-Domain registrieren", "Domainname für KI-Startup", ".ai-Domain-Mindestlaufzeit", "günstigster .ai-Registrar", ".ai-Domain mit KI-Agent kaufen", ".ai-Domain Anguilla", "ccTLD-Registrarvergleich", "Cloudflare .ai-Registrar", "Namefi .ai-Domain", ".ai-Domain Mindestlaufzeit 2 Jahre"]
+relatedArticles:
+  - /de/blog/ai-vs-io-domain/
+  - /de/blog/cf-namecom-namefi/
+  - /de/blog/airo-vs-namefi/
+  - /de/blog/ai-agent-register/
+  - /de/blog/ai-domain-platforms/
+relatedTopics:
+  - /de/topics/choosing-a-tld/
+  - /de/topics/domain-basics/
+relatedSeries:
+  - /de/series/best-tlds-by-industry/
+  - /de/series/tokenize-your-com/
+relatedGlossary:
+  - /de/glossary/cctld/
+  - /de/glossary/tld/
+  - /de/glossary/registrar/
+  - /de/glossary/registry/
+  - /de/glossary/premium-domain/
+---
+
+Wenn Sie 2026 ein KI-Produkt entwickeln, haben Sie wahrscheinlich bereits `whatever.ai` in das Suchfeld eines Registrars eingegeben. Sie sind nicht allein: .ai hat sich von einer verschlafenen karibischen [ccTLD](/de/glossary/cctld/) zum Standard-Namensraum für eine ganze Branche entwickelt, und die Registrare, die sie verkaufen, reagieren darauf mit allem von Großhandelspreisen zu Selbstkosten bis hin zu vollständig von Agenten aufrufbaren APIs. Dieser Leitfaden vergleicht fünf von ihnen anhand der drei Dinge, die für ein KI-Startup tatsächlich zählen: Was die Domain kostet, was die eigenen Regeln der Registry verlangen und ob der Registrar von einem KI-Agenten gesteuert werden kann statt von einem Menschen, der ein Checkout-Formular ausfüllt.
+
+Die vollständige Vorgeschichte, wie .ai hierherkam — der Cypherpunk, der die Registry von einem Strand aus betrieb, der von ChatGPT ausgelöste Aufschwung und die Übergabe an Identity Digital — finden Sie unter [Was ist die .ai-Domain?](/de/tld/ai/). Dieser Beitrag bleibt enger gefasst: Welchen Registrar sollten Sie tatsächlich nutzen, und mit welchen Kosten sollten Sie rechnen?
+
+## Der .ai-Aufschwung in überprüfbaren Zahlen
+
+Die zentrale Tatsache ist real und keine Schätzung: Am **20. Januar 2026** [gab die Regierung von Anguilla bekannt, dass die Zahl der .ai-Domainregistrierungen weltweit eine Million überschritten hatte](https://www.facebook.com/anguillagovernment/posts/ai-surpasses-one-million-registered-domains-powering-transformational-growth-in-/1301992901974445/). Premierministerin Cora Richardson Hodge nannte dies einen Meilenstein, der „weit mehr als Domainregistrierungen“ betreffe. Identity Digital — das Unternehmen, das seit Januar 2025 das technische Backend der .ai-Registry betreibt — ließ seinen CEO Akram Atallah denselben Meilenstein in derselben Veröffentlichung bestätigen und versprach „erstklassige Sicherheit, Schutz und Unterstützung für die .ai-Domain“. Das ist eine primäre, offizielle Quelle: eine Pressemitteilung der Regierung, die vom Betreiber der Registry selbst bestätigt wird, und keine Schätzung aus einem sekundären Blog.
+
+Die Transaktionsdaten stützen die Einschätzung, dass das Wachstum nicht nur auf spekulativem Horten von Registrierungen beruht. Eine Analyse der .ai-Verkaufsaktivitäten für Q2 2026 ergab, dass [der Transaktionswert von .ai-Domains von $9.4 Millionen in 2024 auf $27.1 Millionen in 2025 stieg](https://dnchase.com/article/ai-domain-sales-data-2026-what-the-ai-domain-surge-actually-means-for-potential-buyers); bei etwa zwei Dritteln eines Stichprobenbündels von Aftermarket-Verkäufen waren bereits aktive Websites in Betrieb, statt dass die Domains geparkt waren. Die Diskussion dieser Daten auf NamePros kam zu einer ähnlichen Einschätzung: [Bestimmte Namen, meist kurze, klare, kommerzielle und an reale Einsatzfälle künstlicher Intelligenz gebundene Namen, ziehen allmählich ernsthaftes Geld an](https://www.namepros.com/threads/ai-domain-sales-data-2026-what-the-ai-domain-surge-actually-means-for-potential-buyers.1392044/). Ein Kommentator dort, nicenic, fasste die aktuelle Stimmung unverblümt zusammen: „Der .AI-Markt wirkt heute weit weniger nachsichtig … Jetzt geht es mehr darum, ob ein echtes Unternehmen auf diesem Namen tatsächlich etwas aufbauen kann.“ Zusammengenommen stimmen beide Quellen überein: Der Boom hat sich über reine Hype-Phase hinaus zu einem Markt entwickelt, in dem finanzierte Unternehmen, die Domains zum Aufbau kaufen, das dominierende Muster sind und nicht die Ausnahme.
+
+## Was ein KI-Startup tatsächlich von einer Domain braucht
+
+Bei einem Domainkauf für ein KI-natives Unternehmen kommen in Wirklichkeit zwei übereinandergestapelte Entscheidungen zusammen. Die erste ist dieselbe wie bei jedem Startup: ein Name, eine Endung, ein Checkout. Die zweite ist spezifisch für die Art, wie KI-native Teams tatsächlich entwickeln: Zunehmend erledigt ein [KI-Agent](/de/glossary/ai-agent/) die Registrierung mitten in einer Sitzung, statt dass ein Gründer sie zwischen Besprechungen in einem Browser-Tab vornimmt.
+
+Deshalb sind für diese Zielgruppe die Fragen „Welcher .ai-Registrar?“ und „Mit welchem Registrar kann mein Agent sprechen?“ zunehmend dieselbe Frage. Eine API, deren Dokumentation ein Entwickler lesen kann, ist nicht automatisch eine API, die ein autonomer Agent steuern kann. Sie muss außerdem ohne einen Menschen, der darauf zeigt, auffindbar sein (über einen [Model Context Protocol](https://modelcontextprotocol.io)-Server oder eine Klartextdatei `llms.txt`) und eine Zahlungsmöglichkeit bieten, die nicht voraussetzt, dass ein Mensch eine physische Kreditkarte hält. Die vollständige Checkliste behandelt [Was ist ein agent-nativer Registrar?](/de/blog/agent-native/); die Kurzfassung lautet: „Hat eine API“ und „agent-native“ sind unterschiedliche Hürden, und die meisten Registrare, die 2026 .ai verkaufen, überwinden weiterhin nur die erste.
+
+Für ein Team, das bereits auf MCP aufbaut oder eigene Agentenwerkzeuge integriert, lohnt es sich, diese Unterscheidung vor der Wahl eines Registrars zu prüfen statt danach. Ein späterer Registrarwechsel für eine Domain ist möglich, schafft aber Reibung, die Sie am ersten Tag lieber überspringen.
+
+## .ai-Registrare vergleichen: Preis, Laufzeit und Agentenzugang
+
+Exakte Preise ändern sich. Die .ai-Registry selbst erhöhte 2026 die Großhandelspreise (mehr dazu unten), und die Einzelhandelsregistrare schlagen darauf unterschiedliche Beträge auf. Behandeln Sie die folgenden Angaben als **Preisspannen**, die jeweils mit ihrer Quelle angegeben sind, nicht als Live-Angebot. Prüfen Sie aktuelle Preise unmittelbar vor dem Kauf.
+
+| Registrar | Registrierung (typisch) | Verlängerung (typisch) | Mindestlaufzeit | Kann ein KI-Agent registrieren? |
+| --- | --- | --- | --- | --- |
+| **Cloudflare Registrar** | Selbstkosten / Großhandel, kein Aufschlag | Wie Registrierung — kein Aufschlag | 2 Jahre (von der Registry vorgeschrieben) | Ja — Registrar-API in Beta, Editor-Unterstützung über MCP (siehe unseren [vollständigen Vergleich](/de/blog/cf-namecom-namefi/)) |
+| **Namecheap** | ~$93 erstes Jahr | ~$115/Jahr | 2 Jahre (von der Registry vorgeschrieben) | Keine dedizierte Agenten-API — KI-Tools schlagen Namen vor, ein Mensch schließt den Checkout ab |
+| **GoDaddy** | $49.99 im ersten Jahr als Aktionspreis | $159.99 ab dem zweiten Jahr | 2 Jahre (von der Registry vorgeschrieben) | Nein — Airo ist ein Assistent für das Onboarding von Endkunden, keine von Agenten aufrufbare Schnittstelle (siehe [GoDaddy Airo vs. Namecheap AI vs. Namefi](/de/blog/airo-vs-namefi/)) |
+| **Porkbun** | ~$82.70/Jahr pauschal | ~$82.70/Jahr pauschal | 2 Jahre (von der Registry vorgeschrieben) | Nicht dokumentiert — Standard-Registrar-API, in öffentlichen Quellen keine agentspezifischen Werkzeuge gefunden |
+| **Namefi** | Preise variieren — aktuell prüfen<!-- TODO: confirm — Namefi .ai pricing --> | Preise variieren — aktuell prüfen | 2 Jahre (von der Registry vorgeschrieben) | Ja — MCP-Server plus Wallet-signierter Checkout, kein Konto erforderlich (siehe [Registrierung mit Ihrem KI-Agenten](/de/blog/ai-agent-register/)) |
+
+Die Zahlen von Cloudflare sind unter den Anbietern am ausdrücklichsten dokumentiert: Das Unternehmen erklärt direkt, dass es [.ai-Domainregistrierungen und -verlängerungen zu Großhandelspreisen ohne zusätzliche Aufschläge anbietet](https://www.cloudflare.com/application-services/products/registrar/buy-ai-domains/). Jede dort registrierte .ai-Domain wird mit [kostenlosem DNSSEC, kostenlosem SSL, Zwei-Faktor-Authentifizierung und einer standardmäßig aktivierten Domain-Sperre](https://www.cloudflare.com/application-services/products/registrar/buy-ai-domains/) ausgeliefert, außerdem mit kostenlosem WHOIS-Datenschutz, statt diesen als Zusatzleistung zu verkaufen. Eine erfolgreich abgerufene Registrar-Übersicht — bei der die eigenen `.ai`-Seiten von GoDaddy und Namecheap bei der direkten Prüfung für diesen Beitrag mit Zugriffsblockaden antworteten — bestätigt das Muster unabhängig: Sie beschreibt Cloudflare mit [genau dem Preis, den die Registry berechnet, und null Aufschlag auf Registrierungs- oder Verlängerungsgebühren](https://www.unite.ai/registrars/), setzt Namecheap bei [etwa $93 für das erste Jahr und Verlängerungen um $115/Jahr](https://www.unite.ai/registrars/), GoDaddy bei [einem Aktionspreis von $49.99 im ersten Jahr innerhalb einer verpflichtenden Laufzeit von 2 Jahren, wobei das zweite Jahr mit $159.99 berechnet wird](https://www.unite.ai/registrars/) und Porkbun bei [konstanten $82.70/Jahr für Registrierung und Verlängerung](https://www.unite.ai/registrars/). Dieselbe Übersicht weist auf den Mechanismus hin, den jeder Käufer verstehen muss: [Alle .ai-Domains erfordern eine Mindestregistrierung von 2 Jahren](https://www.unite.ai/registrars/), sodass ein niedriger Preis „pro Jahr“ dennoch eine tatsächliche Rechnung im Voraus bedeutet. Da die eigenen Preiseseiten von GoDaddy und Namecheap nicht abgerufen werden konnten, behandeln Sie die obigen Werte als aus der Übersicht stammend und rufen Sie vor dem Kauf aktuelle Preise direkt ab.
+
+Namefi veröffentlicht in seiner maschinenlesbaren API-Dokumentation keine Zusage von Selbstkostenpreisen, die mit Cloudflare vergleichbar wäre; dieser Leitfaden wird daher keine Zahl erfinden. Prüfen Sie die aktuellen .ai-Preise direkt auf namefi.io. Was Namefi dokumentiert und für Käufer, die Agenten in den Mittelpunkt stellen, wirklich unterscheidend ist, ist die Verbindungsmethode: ein dedizierter MCP-Server unter `https://api.namefi.io/mcp` und ein Wallet-signierter [x402](/de/glossary/x402/)-Checkout, über den die Wallet eines Agenten mit einer Stablecoin zahlen kann, ohne zuvor ein Konto anzulegen. Weder die Beta von Cloudflare noch ein etablierter Registrar in dieser Tabelle dokumentiert einen vergleichbaren Zahlungsweg ohne Konto. Die vollständige Funktionsweise steht unter [Cloudflare vs. Name.com vs. Namefi: agent-native Registrare](/de/blog/cf-namecom-namefi/).
+
+## Die eigenen Regeln der .ai-Registry — verifiziert
+
+Drei Tatsachen zur Richtlinie zählen mehr als der Aufschlag eines einzelnen Registrars, weil sie von der Registry selbst stammen und unabhängig davon gelten, bei wem Sie kaufen.
+
+**Die Mindestlaufzeit von zwei Jahren ist real und von der Registry vorgeschrieben, kein Upsell des Registrars.** Die Berichterstattung über die Preisgestaltung der Registry selbst bestätigt den Mechanismus: [Die Mindestregistrierung von zwei Jahren kostet $70 pro Jahr, was bedeutet, dass Registranten für die zweijährige Registrierung mindestens $140 zahlen](https://domainnamewire.com/2026/02/02/ai-domain-name-prices-going-up-20/) — eine Preisuntergrenze, die für jeden der obigen Registrare gilt, und keine Vorgabe, die einer von ihnen gewählt hat. Sie können .ai nicht für ein einzelnes Jahr registrieren oder verlängern, wie es bei `.com` möglich ist.
+
+**Die Großhandelspreise stiegen 2026.** Dieselbe Berichterstattung dokumentiert: [Ab dem 5. März 2026 steigen die Großhandelskosten um $10 pro Jahr beziehungsweise $20 pro Registrierung oder Verlängerung](https://domainnamewire.com/2026/02/02/ai-domain-name-prices-going-up-20/) — [eine Steigerung um 14%](https://domainnamewire.com/2026/02/02/ai-domain-name-prices-going-up-20/), die den Großhandelssatz von $70/Jahr auf $80/Jahr hebt, also für die verpflichtende Laufzeit von zwei Jahren ungefähr $160 statt $140. Der Einzelhandelspreis jedes Registrars bewegt sich mit diesem Mindestbetrag, selbst bei denen, die keinen weiteren Aufschlag berechnen.
+
+**Die Richtlinienhoheit liegt bei Anguilla, nicht bei ICANN.** .ai ist eine ccTLD und liegt daher außerhalb des Standardrahmens für gTLD-Registry-Vereinbarungen der [ICANN](/de/glossary/icann/). Die Regierung von Anguilla legt die eigenen Registrierungsregeln für .ai fest, während Identity Digital seit Januar 2025 das technische Backend betreibt. Die eigene Richtlinienreferenz der Registry finden Sie unter [nic.ai](https://nic.ai/). Prüfen Sie dort direkt die aktuell veröffentlichte Laufzeitstruktur (Schritte von 2–10 Jahren), bevor Sie annehmen, dass die Zahlen dieses Artikels beim Lesen nicht erneut verschoben wurden.
+
+Nichts davon ist einem einzelnen Registrar eigen. Deshalb erscheint dieselbe Angabe „2 Jahre“ in jeder Zeile der obigen Vergleichstabelle. Von Registrar zu Registrar unterscheiden sich der Aufschlag oberhalb dieses Großhandelsmindestbetrags und die Frage, ob ein Mensch durch die Schnittstelle klicken muss oder ein Agent sie direkt aufrufen kann.
+
+## .ai mit Ihrem Programmieragenten registrieren
+
+Wenn Sie bereits in einem MCP-fähigen Client arbeiten — Claude Code, Cursor, Windsurf, Gemini CLI oder einem ähnlichen — muss die Registrierung der .ai-Domain, die Ihr Projekt braucht, nicht bedeuten, den Editor zu verlassen und ein Checkout-Formular eines Registrars auszufüllen. [So registrieren Sie eine Domain mit Ihrem KI-Agenten auf Namefi](/de/blog/ai-agent-register/) ist die vollständige Anleitung: Besorgen Sie einen API-Schlüssel oder verbinden Sie eine Wallet, verbinden Sie Ihren Agenten mit dem MCP-Server von Namefi, bitten Sie ihn um eine Verfügbarkeitsprüfung und bestätigen Sie die Registrierung in derselben Unterhaltung, in der Sie bereits das Produkt bauen, für das die Domain gedacht ist. Derselbe Leitfaden deckt für Agenten, die MCP nicht unterstützen, auch den rohen REST-Pfad ab und verwendet [namefi.io/llms.txt](https://namefi.io/llms.txt) als Klartext-Einstiegspunkt.
+
+Unabhängig davon, welchen Registrar Sie aus Preisgründen wählen, lohnt es sich, vor der Festlegung zu prüfen, ob er die oben beschriebene agent-native Hürde nimmt. Eine .ai-Domain, die Sie alle zwei Jahre durch einen Browser-Checkout verlängern müssen, ist ein kleiner, aber wiederkehrender manueller Aufwand, den ein von Agenten aufrufbarer Registrar vollständig beseitigt.
+
+## Häufig gestellte Fragen
+
+### Warum verlangen alle .ai-Registrare eine Mindestlaufzeit von zwei Jahren?
+
+Das ist eine Regel der Registry, keine Richtlinie eines Registrars. Die von Anguilla betriebene .ai-Registry verkauft Registrierungen und Verlängerungen in Laufzeiten von zwei bis zehn Jahren statt im für `.com` üblichen Einjahreszyklus, und jeder akkreditierte Registrar — einschließlich Cloudflare, Namecheap, GoDaddy, Porkbun und Namefi — übernimmt diese Untergrenze. Bei keinem von ihnen können Sie .ai für nur ein Jahr registrieren.
+
+### Welcher .ai-Registrar ist am günstigsten?
+
+Cloudflare Registrar veröffentlicht die eindeutigste Zusage ohne Aufschlag und berechnet direkt den Großhandelssatz der Registry ohne zusätzliche Gebühr. Auch Porkbuns pauschale $82.70/Jahr (laut unabhängig abgerufener Registrar-Übersicht) liegt nahe an diesem Großhandelsmindestbetrag. Der Aktionspreis von GoDaddy im ersten Jahr wirkt isoliert betrachtet günstig, doch im zweiten Jahr derselben verpflichtenden Laufzeit steigt er stark. Vergleichen Sie daher die Gesamtsumme über zwei Jahre und nicht nur die Preisangabe für das erste Jahr.
+
+### Sind die .ai-Preise 2026 tatsächlich gestiegen?
+
+Ja. Die Berichterstattung über die Preisgestaltung der Registry selbst bestätigt eine Erhöhung des Großhandelspreises um $10 pro Jahr (etwa 14%), gültig ab dem 5. März 2026. Dadurch stieg der Großhandelsmindestbetrag von $70/Jahr auf $80/Jahr. Diese Erhöhung schlägt unabhängig von der Aufschlagsrichtlinie auf den Einzelhandelspreis jedes Registrars durch.
+
+### Ist die Zahl von „1 Million .ai-Domains“ echt?
+
+Ja, sie lässt sich auf eine primäre Quelle zurückführen. Die Regierung von Anguilla gab den Meilenstein am 20. Januar 2026 direkt bekannt; der CEO des Registry-Betreibers Identity Digital bestätigte ihn in derselben Veröffentlichung. Das unterscheidet ihn von früheren, weniger belastbaren Schätzungen zum „.ai-Domain-Aufschwung“, die nur in sekundären Kommentaren erschienen.
+
+### Kann ein KI-Agent eine .ai-Domain registrieren, ohne dass ein Mensch den Checkout durchklickt?
+
+Bei einigen Registraren ja. Namefi dokumentiert einen MCP-Server und einen Wallet-signierten Checkout, die genau dafür gebaut wurden. Die Registrar-API in der Beta von Cloudflare unterstützt agentengesteuerte Registrierung für Domains allgemein, einschließlich .ai, obwohl die Verwaltung des Lebenszyklus über die Erstregistrierung hinaus zum Zeitpunkt der Erstellung noch ausgerollt wurde. Die KI-Tools von GoDaddy und Namecheap unterstützen dagegen einen menschlichen Käufer; sie stellen einem externen Agenten keine Registrierung bereit.
+
+### Registriert Namefi .ai-Domains?
+
+Namefi ist ein von der ICANN akkreditierter Registrar, der Standard-TLDs neben seinen agent-nativen und Tokenisierungswerkzeugen registriert. Seine veröffentlichte API-Dokumentation nennt derzeit keine spezifische Preisrichtlinie für .ai, daher variieren die Preise. Prüfen Sie die aktuelle .ai-Verfügbarkeit und Preisgestaltung direkt auf namefi.io, bevor Sie von derselben Preisgestaltung wie bei einem der Registrare in der obigen Tabelle ausgehen.<!-- TODO: confirm — Namefi .ai pricing -->
+
+## Registrieren Sie Ihre .ai-Domain bei Namefi
+
+Nachdem Sie Preis und Agentenfreundlichkeit des Registrars abgewogen haben, kann [Namefi](https://namefi.io) die Registrierung selbst übernehmen — als von der ICANN akkreditierter Registrar, über denselben MCP-Server und Wallet-signierten Checkout wie in [So registrieren Sie eine Domain mit Ihrem KI-Agenten auf Namefi](/de/blog/ai-agent-register/) beschrieben, mit der Option, die Domain als [Tokenisierte Domain](/de/glossary/tokenized-domain/) in Form eines On-Chain-NFT zu halten statt nur als Zeile in der internen Datenbank eines Registrars.
+
+**[Ihre .ai-Domain bei Namefi suchen und registrieren](https://namefi.io).**
+
+## Quellen und weiterführende Lektüre
+
+- Regierung von Anguilla — [offizielle Pressemitteilung: .ai überschreitet eine Million registrierte Domains (Facebook, 20. Januar 2026)](https://www.facebook.com/anguillagovernment/posts/ai-surpasses-one-million-registered-domains-powering-transformational-growth-in-/1301992901974445/)
+- dnchase.com — [Verkaufsdaten zu KI-Domains 2026: Was der .ai-Domain-Aufschwung für potenzielle Käufer tatsächlich bedeutet](https://dnchase.com/article/ai-domain-sales-data-2026-what-the-ai-domain-surge-actually-means-for-potential-buyers)
+- NamePros — [Diskussionsthread zu den .ai-Domain-Verkaufsdaten 2026](https://www.namepros.com/threads/ai-domain-sales-data-2026-what-the-ai-domain-surge-actually-means-for-potential-buyers.1392044/)
+- Domain Name Wire — [Die Preise für .ai-Domainnamen steigen um 20% (Großhandelspreiserhöhung, gültig ab 5. März 2026)](https://domainnamewire.com/2026/02/02/ai-domain-name-prices-going-up-20/)
+- Cloudflare — [.ai-Domains kaufen: Selbstkostenpreise und enthaltene Sicherheitsfunktionen](https://www.cloudflare.com/application-services/products/registrar/buy-ai-domains/)
+- Unite.AI — [Registrarvergleich und Preisübersicht](https://www.unite.ai/registrars/)
+- Anguilla-.ai-Registry — [nic.ai](https://nic.ai/)
+- Namefi — [namefi.io/llms.txt](https://namefi.io/llms.txt) (MCP-Server, API und Authentifizierungsreferenz)
+- Model Context Protocol — [Was ist MCP?](https://modelcontextprotocol.io)

--- a/content/blog/de/airo-vs-namefi.md
+++ b/content/blog/de/airo-vs-namefi.md
@@ -1,0 +1,128 @@
+---
+title: "GoDaddy Airo vs. Namecheap AI vs. Namefi: Die wichtigsten Unterschiede"
+date: '2026-07-10'
+language: 'de'
+tags: ['ai-agents', 'domains', 'comparison']
+authors: ['namefiteam']
+draft: false
+format: comparison
+ogImage: ../../assets/airo-vs-namefi-og.jpg
+description: "GoDaddy Airo und Namecheap AI schlagen Namen vor; Namefi ermöglicht einem Agenten, sie zu registrieren. Was die KI jedes Produkts tatsächlich tut — in einer Tabelle verglichen."
+keywords: ["GoDaddy Airo", "Namecheap AI", "KI-Domainassistent", "KI-Namensgenerator", "KI-Vergleich für Registrare", "KI kauft Domain", "Namefi", "GoDaddy-Airo-Test", "Namecheap-KI-Tools", "GoDaddy Airo vs. Namecheap AI", "GoDaddy-Airo-Alternativen", "KI-Vergleich von Domain-Registraren", "agent-nativer Registrar"]
+relatedArticles:
+  - /de/blog/cf-namecom-namefi/
+  - /de/blog/claude-mcp-domains/
+  - /de/blog/ai-domain-platforms/
+  - /de/blog/ai-agent-register/
+  - /de/blog/agent-native/
+relatedTopics:
+  - /de/topics/domain-basics/
+  - /de/topics/choosing-a-tld/
+relatedSeries:
+  - /de/series/best-tlds-by-industry/
+  - /de/series/domain-flipping-skills/
+relatedGlossary:
+  - /de/glossary/ai-agent/
+  - /de/glossary/registrar/
+  - /de/glossary/brandable-domain/
+  - /de/glossary/tokenized-domain/
+  - /de/glossary/dns/
+---
+
+Suchen Sie 2026 nach „GoDaddy Airo“ oder „Namecheap KI-Domain-Suche“, finden Sie zahlreiche Tests, die beschreiben, was diese Tools erzeugen: Namen, Logos, Starter-Websites. Suchen Sie daneben nach „Namefi“, wird der Vergleich verwirrend, denn die „KI“ von Namefi beantwortet nicht dieselbe Frage. GoDaddy und Namecheap haben KI entwickelt, die einem Menschen bei der Kaufentscheidung hilft. Namefi stellt KI-Werkzeuge bereit, mit denen ein [KI-Agent](/de/glossary/ai-agent/) — Software, die über eine API in Ihrem Auftrag handelt, statt dass eine Person sich durch eine Website klickt — den Kauf tatsächlich abschließen kann.
+
+Beide Ansätze sind legitim. Sie lösen lediglich unterschiedliche Probleme für unterschiedliche Menschen an unterschiedlichen Punkten des Prozesses. Dieser Leitfaden vergleicht, was die „KI“ jedes Produkts tatsächlich tut, damit Sie wissen, welches zu Ihrem Vorhaben passt — sei es ein Kleinunternehmer, der seine erste Domain auswählt, oder ein Entwickler, der die Domainregistrierung in einen autonomen Workflow einbindet.
+
+## Drei Produkte, ein Wort, drei unterschiedliche Aufgaben
+
+„KI-gestützte Domainsuche“ ist zu einem Kontrollkästchen geworden, das jeder [Registrar](/de/glossary/registrar/) abhaken möchte. Dadurch ist die Formulierung für sich genommen fast bedeutungslos geworden. Bevor Funktionen verglichen werden, hilft es, das tatsächliche Angebot in zwei Kategorien einzuordnen.
+
+Die erste Kategorie ist **KI, die einem menschlichen Käufer hilft**. Sie beschreiben Ihr Unternehmen in einem Satz, das Tool liefert eine engere Auswahl von Namensideen, vielleicht ein Logo, vielleicht eine Starter-Website, und Sie klicken weiterhin selbst auf „Kaufen“, geben Zahlungsdaten ein und schließen die Registrierung über eine normale Checkout-Seite ab. GoDaddy Airo und die KI-Tools von Namecheap gehören beide hierher.
+
+Die zweite Kategorie ist **KI als Agent des Käufers**. Statt dass eine Person durch eine Ergebnisseite navigiert, ruft ein Programmierassistent oder automatisierter Workflow eine API auf — oder zunehmend ein speziell für KI-Tools entwickeltes Protokoll wie MCP —, um Verfügbarkeit zu prüfen, einen Preis abzurufen und die Registrierung selbst innerhalb der zuvor von einem Menschen gesetzten Richtliniengrenzen abzuschließen. Namefi ist für diese Kategorie gebaut, nicht als Ersatz für die erste, sondern als zusätzlicher programmatischer Weg zu denselben Registrar-Funktionen.
+
+Wenn Sie wissen, zu welcher Kategorie ein Produkt gehört, beantwortet das den größten Teil der Frage „Welches ist besser?“, noch bevor Sie eine Vergleichstabelle öffnen.
+
+## GoDaddy Airo: eine KI-Onboarding-Suite, kein Kaufagent
+
+GoDaddy Airo ist das KI-gestützte Onboarding-Erlebnis des Unternehmens, das neuen Domainkäufen beiliegt und darauf ausgerichtet ist, ein kleines Unternehmen schnell online zu bringen. Statt einer einzelnen Funktion ist es ein Paket: eine AI Domain Search, die aus einer kurzen Eingabe Geschäfts- und Domainnamen vorschlägt; ein Logo Maker, der aus Vorlagen ein individuelles Logo erzeugt; ein AI Builder, der eine Starter-Website oder einfache Web-App zusammenstellen kann (GoDaddy bewirbt ihn als inklusive Hosting, Zahlungen und Authentifizierung); ein SEO Wizard, der Optimierungen auf der Seite vorschlägt; und sogar Hilfe bei der Gründung einer LLC. Wie ein Test großer Registrare zusammenfasst, kann [GoDaddy Airo, sein KI-Einrichtungsassistent, nach der Registrierung auch einen Namen, ein Logo und eine Starter-Website vorschlagen](https://www.hostinger.com/tutorials/best-domain-registrars/#:~:text=GoDaddy%20Airo%2C%20its%20AI%20setup%20assistant%2C%20can%20also%20suggest%20a%20name%2C%20logo%2C%20and%20starter%20site%20once%20you%20register).
+
+Das Detail „nach der Registrierung“ ist entscheidend. Airo ist ein auf Endkunden ausgerichteter Assistent, der in den eigenen Checkout und das Dashboard von GoDaddy eingebettet ist. Für das, wofür er gebaut wurde, ist er wirklich nützlich: für Kleinunternehmer, die zum ersten Mal eine Idee haben und ohne jemanden einzustellen einen Namen, ein Logo und eine live geschaltete Seite möchten. Er ist jedoch kein Werkzeug, das ein externer KI-Agent aufrufen kann. Ein Programmierassistent kann Airo nicht bitten, in Ihrem Auftrag eine Domain zu registrieren, wie er eine API aufrufen kann; ein Mensch muss weiterhin an der Tastatur sitzen, um den Vorschlag zu akzeptieren und den Kauf abzuschließen. GoDaddy unterhält außerhalb von Airo zwar herkömmliche Entwickler-APIs für die Domainregistrierung, doch Airo selbst ist das Endkundenprodukt und keine von Agenten aufrufbare Schnittstelle.
+
+## Die KI-Tools von Namecheap: dasselbe Generatormodell, andere Marke
+
+Das Gegenstück von Namecheap ist eine Reihe kostenloser Werkzeuge, die unter der Marke „Visual“ vermarktet werden: ein Business Name Generator, der aus einer kurzen Eingabe markentaugliche Unternehmensnamen, passende Domainvorschläge und Logos erzeugt; ein Logo Maker mit vorlagenbasierten Gestaltungsoptionen; und ein Site Maker, der Sie durch einige Fragen zu Vorlage, Farbe und Schrift führt, um eine einfache persönliche oder geschäftliche Website zusammenzustellen. Das Muster ist mit dem von Airo identisch: Beschreiben Sie in natürlicher Sprache, was Sie möchten, erhalten Sie KI-generierte Vorschläge und schließen Sie Registrierung und Checkout anschließend auf der Website von Namecheap auf die normale Weise als Mensch ab.
+
+Zwischen dem Angebot von GoDaddy und Namecheap gibt es hier keinen bedeutenden architektonischen Unterschied. Beide sind Endkundenwerkzeuge zur Generierung, die um einen traditionellen Registrar-Checkout gelegt sind. Keines legt seine „KI“ so offen, dass ein externer Agent sie steuern könnte — die KI hilft Ihnen bei der Entscheidung, und Sie kaufen weiterhin selbst. Das sollte klar gesagt werden, denn der Vergleich „GoDaddy Airo vs. Namecheap AI“, nach dem viele suchen, vergleicht hauptsächlich die Ausgestaltung der Oberfläche und die gebündelten Extras (LLC-Gründung auf der einen Seite, eine breitere Visual-Suite aus Designwerkzeugen auf der anderen), nicht grundlegend unterschiedliche Technologie.
+
+## Namefi: Die KI ist Ihr Agent, nicht der Upsell-Assistent des Verkäufers
+
+Namefi verfolgt einen anderen Ansatz dafür, was „KI“ bei einem Registrar bedeutet, und der Unterschied ist architektonisch statt kosmetisch. Statt einen chatartigen Assistenten zu bauen, der einem Menschen Namen zum Anklicken empfiehlt, stellt Namefi die Kernoperationen des Registrars — Suche, Registrierung, DNS-Konfiguration — als Tools bereit, die ein KI-Agent direkt aufrufen kann. So schließt der Agent die Transaktion selbst innerhalb der Richtliniengrenzen ab, die Sie vorab setzen.
+
+Laut der eigenen maschinenlesbaren API-Beschreibung von Namefi unter [namefi.io/llms.txt](https://namefi.io/llms.txt) geschieht dies über einen MCP-Server (Model Context Protocol) unter `api.namefi.io/mcp`, der „jeden Vorgang als typisiertes Tool“ bereitstellt — Suche, Registrierung, DNS und Domainkonfiguration — für KI-Clients wie Claude, die das Protokoll unterstützen, sowie über eine REST-API für Clients, die dies nicht tun. Die Authentifizierung erfolgt über einen API-Schlüssel (erzeugt unter namefi.io/api-key, als `x-api-key`-Header gesendet und in der Dokumentation als für Agenten „empfohlene“ Methode beschrieben) oder, für [Wallet](/de/glossary/wallet/)-basierte Workflows, über eine kryptografische Wallet-Signatur, die einen Kauf autorisiert, ohne überhaupt einen Schlüssel zu speichern. Die Registrierung selbst folgt einer kurzen asynchronen Abfolge: Verfügbarkeit prüfen, die Bestellung mit einem Domainnamen und einer Laufzeit einreichen und dann die Bestellung abfragen, bis sie abgeschlossen ist.
+
+Der andere strukturelle Unterschied liegt darin, was Sie am Ende besitzen. Eine über Namefi registrierte Domain wird neben der üblichen ICANN-Registrierung als On-Chain-Token repräsentiert — als [Tokenisierte Domain](/de/glossary/tokenized-domain/). Das ermöglicht es, die Eigentümerschaft über eine Wallet zu verifizieren und zu übertragen, statt ausschließlich über die Anmeldung bei einem Registrar-Konto. Die vollständige Erklärung, wie das funktioniert und was sich dadurch bei der Verwahrung ändert, finden Sie unter [Was sind tokenisierte Domains?](/de/blog/what-are-tokenized-domains/). Nichts davon ersetzt die normale Registrar-Erfahrung für jemanden, der lieber selbst durch eine Website klickt; es ist eine zusätzliche, für Agenten nutzbare Ebene auf den Funktionen eines akkreditierten Registrars.
+
+## Vergleichstabelle: Was die „KI“ jedes Produkts tatsächlich tut
+
+| Funktion | GoDaddy Airo | Namecheap AI (Visual) | Namefi |
+|---|---|---|---|
+| Schlägt aus einer Eingabe markentaugliche Namen vor | Ja | Ja | Nicht der Schwerpunkt — Verfügbarkeitssuche ist programmatisch, kein Werkzeug zum Brainstorming von Namen |
+| Erzeugt ein Logo | Ja | Ja | Nein |
+| Erstellt eine Starter-Website oder App | Ja (AI Builder, einschließlich Hosting/Zahlungen/Authentifizierung) | Ja (Site Maker) | Nein |
+| Wer schließt den Kauf ab? | Ein Mensch über den Checkout von GoDaddy | Ein Mensch über den Checkout von Namecheap | Ein KI-Agent, der die API bzw. den MCP-Server direkt aufruft, oder ein Mensch über die normale Website |
+| Für einen externen KI-Agenten aufrufbar (MCP/API) | Nein — Airo ist ein Endkundenassistent, kein Werkzeug für Agenten | Nein — Visual-Werkzeuge sind für Endkunden, nicht für Agenten | Ja — MCP-Server + REST-API wurden dafür gebaut |
+| Verwaltet DNS-Einträge programmatisch | Nicht über Airo | Nicht über Visual | Ja, über API (Auflisten ohne Authentifizierung, Schreiben mit API-Schlüssel) |
+| Eigentumsmodell | Standard-Registrar-Konto | Standard-Registrar-Konto | Standard-ICANN-Registrierung plus tokenisierte On-Chain-Repräsentation |
+| Zahlung für einen autonomen Agenten | Nicht unterstützt | Nicht unterstützt | Durch API-Schlüssel oder Wallet-Signatur autorisiert |
+| Am besten geeignet für | Kleinunternehmer, die in einer Sitzung Name auswählen und starten möchten | Preisbewusste Nutzer, die kostenlose Branding-Werkzeuge neben der Registrierung wünschen | Entwickler oder Teams, die Domainsuche und -registrierung in einen Agenten oder automatisierten Workflow einbinden |
+
+## Welches sollten Sie tatsächlich nutzen?
+
+Wenn Sie ein Kleinunternehmer mit einer Idee, aber noch ohne Namen sind und heute ein Logo und eine live geschaltete Seite möchten, ist GoDaddy Airo eine wirklich starke Option. Das sollte klar gesagt werden, statt sie abzutun, weil dieser Artikel von einem Wettbewerber veröffentlicht wird. Airo bündelt die Schritte Benennung, Markenauftritt und erste Website in einem geführten Ablauf. Für jemanden, der nicht getrennt über DNS oder Hosting nachdenken möchte, hat diese Bequemlichkeit echten Wert. Die Visual-Werkzeuge von Namecheap lösen ein ähnliches Problem zu einem niedrigeren Preis, mit einem etwas stärker zerstückelten Werkzeugset (Namensgenerator, Logo Maker und Site Builder als getrennte Schritte statt eines geführten Ablaufs) und einem Ruf für transparente Preisgestaltung.
+
+Keines von beiden ist das richtige Werkzeug, wenn Sie möchten, dass ein KI-Agent — ein Programmierassistent, eine automatisierte Pipeline oder ein zeitgesteuertes Skript — eine Domain sucht, bepreist und registriert, ohne dass jedes Mal ein Mensch einen Checkout durchklickt. Das ist eine andere Aufgabe; dafür wurden der MCP-Server und die API von Namefi gebaut. Wenn Sie einen Domainnamen auswählen und einen geführten KI-Assistenten für Benennung und Markenauftritt möchten, sind Airo oder die Visual-Suite von Namecheap für diesen Schritt sinnvoll. Wenn Sie hingegen einen Domain-*Registrar* auswählen, den Sie einem Programmieragenten als Teil eines Build-and-Deploy-Workflows übergeben, lesen Sie stattdessen [unseren direkten Vergleich der agent-nativen Registrare](/de/blog/cf-namecom-namefi/), denn GoDaddy und Namecheap sind für diesen Vergleich überhaupt nicht gebaut.
+
+## Häufig gestellte Fragen
+
+### Hat GoDaddy eine API, die mein Agent zum Kauf einer Domain nutzen kann?
+
+GoDaddy unterhält herkömmliche Entwickler-APIs für die Domainregistrierung, doch Airo — der KI-gekennzeichnete Onboarding-Assistent, den die meisten meinen, wenn sie diese Frage stellen — ist ein Endkundenwerkzeug, das in den eigenen Checkout von GoDaddy eingebettet ist, und keine Schnittstelle für einen externen KI-Agenten. Ein Mensch schließt weiterhin den Kauf ab, dessen Planung Airo unterstützt. Eine Übersicht von Registraren, die eine von Agenten aufrufbare Registrierung bereitstellen (darunter die Registrar-API in der Beta von Cloudflare, die KI-native API von Name.com sowie MCP-Server und API von Namefi), finden Sie in unserem [Vergleich agent-nativer Registrare](/de/blog/cf-namecom-namefi/).
+
+### Ist GoDaddy Airo tatsächlich KI oder nur eine Vorlagenauswahl?
+
+Es ist KI-generiert, keine feste Vorlagenliste: Airo nimmt eine kurze Beschreibung Ihres Unternehmens entgegen und erzeugt daraus Namen, ein Logo und Inhalte für eine Starter-Website, statt Sie aus einem vorgegebenen Katalog auswählen zu lassen. Agentisch ist Airo jedoch nicht: Sie prüfen und bestätigen jeden Vorschlag selbst und schließen die Registrierung über den normalen Checkout von GoDaddy ab.
+
+### Was erzeugt die KI von Namecheap tatsächlich?
+
+Die kostenlose „Visual“-Suite von Namecheap enthält einen Business Name Generator (Namen, passende Domains und Logos aus einer Eingabe), einen eigenständigen Logo Maker und einen Site Maker, der aus einigen Vorlagen- und Stilentscheidungen eine einfache Website erstellt. Wie Airo sind dies auf Endkunden ausgerichtete Vorschlagswerkzeuge; den Domainkauf schließen Sie anschließend selbst ab.
+
+### Welches ist besser: GoDaddy Airo oder Namecheap AI?
+
+Sie lösen dasselbe Problem auf ähnliche Weise, daher hängt die Entscheidung vor allem davon ab, welches Paket Sie wünschen und zu welchem Preis: Airo bündelt Benennung, Markenauftritt, eine Starter-Website und sogar LLC-Gründung in einem geführten Ablauf; die Visual-Werkzeuge von Namecheap stehen einzeln und werden im Allgemeinen mit dem Ruf von Namecheap für einfache, budgetfreundliche Preisgestaltung verbunden. Keines wurde dafür gebaut, von einem externen KI-Agenten gesteuert zu werden. Dafür betrachten Sie eine ganz andere Produktkategorie.
+
+### Kann ich die KI-Tools von Namefi nur für Namensvorschläge wie Airo nutzen?
+
+Der MCP-Server und die API von Namefi konzentrieren sich auf Verfügbarkeitssuche, Registrierung und DNS-Verwaltung statt auf kreatives Brainstorming von Namen. Wenn Sie eine KI möchten, die markentaugliche Namen und ein Logo vorschlägt, sind Airo oder die Visual-Werkzeuge von Namecheap für diesen konkreten Schritt besser geeignet. Namefi ist die Ebene, die Sie wählen, sobald Sie oder Ihr Agent bereits wissen, was registriert werden soll, und dies programmatisch erledigen müssen, mit der Option, die Domain anschließend als [tokenisiertes Asset](/de/blog/what-are-tokenized-domains/) zu halten.
+
+### Muss ich programmieren können, um Namefi zu nutzen?
+
+Nein. Namefi funktioniert über seine Website als normaler, von der [ICANN](/de/glossary/icann/) akkreditierter Registrar für alle, die lieber selbst eine Domain suchen und registrieren möchten. Der MCP-Server und die API sind eine zusätzliche Option für Menschen, die möchten, dass ein KI-Agent oder automatisiertes Skript diese Arbeit stattdessen erledigt.
+
+## Geben Sie Ihrem Agenten eine Möglichkeit, tatsächlich zu kaufen
+
+Wenn Ihr KI-Agent bereits den Code entwerfen, den Text schreiben und den Namen auswählen kann, sollte der letzte Schritt — die Domain tatsächlich zu registrieren — nicht der einzige sein, an dem ein Mensch übernehmen muss. [Namefi](https://namefi.io) stellt Domainsuche, Registrierung und DNS-Verwaltung als Tools bereit, die ein MCP-fähiger KI-Client direkt aufrufen kann, authentifiziert über einen API-Schlüssel oder eine Wallet-Signatur. Die resultierende Domain kann optional als tokenisiertes, in einer Wallet gehaltenes Asset neben ihrer üblichen ICANN-Registrierung repräsentiert werden.
+
+**[Erfahren Sie, wie die Agentenwerkzeuge von Namefi funktionieren](https://namefi.io).**
+
+## Quellen und weiterführende Lektüre
+
+- Hostinger — [8 beste Domain-Registrare 2026: getestet und verglichen](https://www.hostinger.com/tutorials/best-domain-registrars/#:~:text=GoDaddy%20Airo%2C%20its%20AI%20setup%20assistant%2C%20can%20also%20suggest%20a%20name%2C%20logo%2C%20and%20starter%20site%20once%20you%20register) — bestätigt, was GoDaddy Airo erzeugt und dass die Registrierung weiterhin über den eigenen Checkout von GoDaddy abgeschlossen wird.
+- GoDaddy — [Airo: Ein KI-gestütztes Erlebnis, das Ihnen beim Online-Wachstum hilft](https://www.godaddy.com/airo) — Beschreibung von GoDaddy selbst zu Namensvorschlägen, Logo Maker, AI Builder und SEO Wizard von Airo.
+- Namecheap — [Visual: Business Name Generator](https://www.namecheap.com/visual/business-name-generator/), [Logo Maker](https://www.namecheap.com/logo-maker/) und [Site Maker](https://www.namecheap.com/visual/site-maker/) — Beschreibung von Namecheap selbst zu seinen kostenlosen KI-Werkzeugen für Branding und Websites.
+- GoDaddy — [.ai-Domainregistrierung](https://www.godaddy.com/tlds/ai-domain) — Produktseite von GoDaddy zur direkten Registrierung von `.ai`-Domains.
+- Namecheap — [.ai-Domainregistrierung](https://www.namecheap.com/domains/registration/cctld/ai/) — Produktseite von Namecheap zur direkten Registrierung von `.ai`-Domains.
+- Forbes Advisor — [10 beste Domain-Registrare 2026](https://www.forbes.com/advisor/business/software/best-domain-registrar/) — unabhängige Registrar-Übersicht; beschreibt GoDaddy als weltweit größten Registrar nach verwalteten Domains und vergleicht Preise und Funktionen mit Namecheap.
+- webhosting.today — [KI-Agenten können jetzt Domains ohne Menschen registrieren](https://webhosting.today/2026/04/22/ai-agents-can-now-register-domains-no-human-required/#:~:text=increasingly%20acting%20as%20domain%20resellers%2C%20checking%20availability%2C%20registering%20names%2C%20and%20configuring%20DNS) — Berichterstattung über die Registrar-API-Beta von Cloudflare im April 2026 und die breitere Verlagerung der Domainregistrierung in von Agenten aufrufbare APIs.
+- Name.com — [Die erste KI-native Domain-Plattform](https://www.name.com/blog/the-first-ai-native-domain-platform#:~:text=91%25%20of%20respondents%20envision%20AI%20agents%20handling%20at%20least%20some%20of%20their%20domain%20management%20in%20the%20next%20two%20years) — Ankündigung von Name.com selbst zu seiner MCP- und OpenAPI-basierten, agentenorientierten Plattform, einschließlich der Umfrageerkenntnis, dass 91% der Befragten erwarten, KI-Agenten würden innerhalb von zwei Jahren einen Teil ihrer Domainverwaltung übernehmen.
+- Namefi — [llms.txt](https://namefi.io/llms.txt) — die maschinenlesbare Beschreibung von Namefi zu MCP-Server, REST-API, Authentifizierungsmodell und Registrierungsablauf; Quelle für jede Namefi-Produktbehauptung in diesem Artikel.

--- a/content/blog/de/best-ai-tools-2026.md
+++ b/content/blog/de/best-ai-tools-2026.md
@@ -1,0 +1,141 @@
+---
+title: "Die besten KI-Domainwerkzeuge 2026: Generatoren vs. Agentenplattformen"
+date: '2026-07-10'
+language: 'de'
+tags: ['ai-agents', 'domains', 'roundup']
+authors: ['namefiteam']
+draft: false
+format: roundup
+ogImage: ../../assets/best-ai-tools-2026-og.jpg
+description: "Gerankter Leitfaden für 2026 zu KI-Domainwerkzeugen in drei Stufen: Namensgeneratoren, Registrar-Assistenten und vollständig agentische Plattformen, die für Sie registrieren."
+keywords: ['beste ki-domainwerkzeuge 2026', 'ki-domainnamengenerator', 'ki-registrar 2026', 'markenfähige namen ki', 'agentische domainregistrierung', 'vergleich ki-domainfinder', 'godaddy airo', 'namecheap ai', 'namefi mcp', 'cloudflare registrar api', 'name.com ki api', 'beste domainregistrare mit ki', 'ki-domainsuche', 'agent-native registrar']
+relatedArticles:
+  - /de/blog/airo-vs-namefi/
+  - /de/blog/cf-namecom-namefi/
+  - /de/blog/ai-domain-platforms/
+  - /de/blog/agent-native/
+  - /de/blog/claude-mcp-domains/
+relatedTopics:
+  - /de/topics/domain-basics/
+  - /de/topics/domain-tokenization/
+relatedSeries:
+  - /de/series/tokenize-your-com/
+  - /de/series/best-tlds-by-industry/
+relatedGlossary:
+  - /de/glossary/ai-agent/
+  - /de/glossary/registrar/
+  - /de/glossary/brandable-domain/
+  - /de/glossary/tokenized-domain/
+  - /de/glossary/premium-domain/
+---
+
+Wenn Sie 2026 „beste KI-Domainwerkzeuge“ in eine Suchleiste eingeben, erhalten Sie eine Reihe von Übersichten, die unter „KI“ alle etwas anderes verstehen. Einige ranken Namensgeneratoren. Einige beschreiben den Onboarding-Assistenten eines Registrars. Ein paar sprechen tatsächlich über Software, die die Domain selbst registrieren kann, ohne dass ein Mensch auf „Kaufen“ klickt. Dies ist der eigene Blog von Namefi, und wir bauen eines der Werkzeuge in dieser letzten Gruppe. Das sagen wir gleich offen und bewerten dennoch die übrigen nach ihren eigenen Vorzügen, einschließlich derjenigen, die uns bei Preis oder Ausarbeitung übertreffen.
+
+Der schnellste Weg durch die Verwirrung ist eine Taxonomie, keine Rangliste. Jedes Werkzeug, das 2026 „KI-Domains“ beansprucht, gehört zu einer von drei Stufen, und die Stufe sagt mehr als das Marketing.
+
+## Die drei Stufen, jeweils in einem Absatz
+
+**Stufe 1 — Generatoren.** Sie geben eine Geschäftsidee in ein Textfeld ein; das Werkzeug liefert eine Vorauswahl [markenfähiger](/de/glossary/brandable-domain/) Namen und verfügbarer Domains. Den normalen Checkout bei einem [Registrar](/de/glossary/registrar/) schließen Sie weiterhin selbst ab. Dies ist die älteste und häufigste Nutzung von „KI“ bei Domainwerkzeugen und für die konkrete Aufgabe, einen Namen zu finden, wirklich nützlich.
+
+**Stufe 2 — KI-Assistenten von Registraren.** Die KI erledigt mehr der umgebenden Arbeit — prüft die Verfügbarkeit für mehrere TLDs zugleich, entwirft eine Starter-Website, stellt sogar eine Domainreservierung in die Warteschlange —, läuft aber weiterhin im eigenen Dashboard des Registrars und benötigt weiterhin eine menschliche Kaufgenehmigung. Die KI erledigt Aufgaben für eine Person, sie handelt nicht als unabhängiger Käufer.
+
+**Stufe 3 — Agentische Plattformen.** Ein externer [KI-Agent](/de/glossary/ai-agent/) — ein Coding-Assistent, ein automatisierter Workflow, ein Skript — ruft eine dafür entwickelte API oder ein Protokoll auf und schließt die Registrierung selbst innerhalb von Ausgabenlimits ab, die ein Mensch vorab gesetzt hat. Keine Browsersitzung, kein Checkout-Formular. Dies ist die neueste Stufe, und Stand 2026 unterstützen sie nur wenige Registrare.
+
+Nichts davon ist eine strenge Qualitätshierarchie. Ein Solo-Gründer, der seinem ersten Projekt einen Namen gibt, möchte Stufe 1. Ein Entwickler, der die Domainregistrierung in eine Deployment-Pipeline einbaut, möchte Stufe 3. Wichtiger als das „fortschrittlichste“ Werkzeug auszuwählen ist, das Werkzeug für Ihre tatsächliche Aufgabe zu wählen.
+
+## Stufe 1: Namensgeneratoren kurz bewertet
+
+### GoDaddy Airo
+
+Die Airo-Suite von GoDaddy bündelt eine KI-Domainsuche, einen Logo Maker, eine KI-generierte Starter-Website und einen SEO Wizard hinter einem Dashboard. Eine unabhängige Registrar-Übersicht fasst es gut zusammen: [GoDaddy Airo, der KI-Einrichtungsassistent, kann nach Ihrer Registrierung auch Namen, Logo und Starter-Website vorschlagen](https://www.hostinger.com/tutorials/best-domain-registrars/#:~:text=GoDaddy%20Airo%2C%20its%20AI%20setup%20assistant%2C%20can%20also%20suggest%20a%20name%2C%20logo%2C%20and%20starter%20site%20once%20you%20register). Das Detail „nach Ihrer Registrierung“ markiert die Stufe: Den Kauf schließen Sie selbst über den normalen Checkout von GoDaddy ab. Es ist eine starke Option für Kleinunternehmer, die zum ersten Mal eine Domain kaufen und Name, Logo und eine Live-Seite in einer Sitzung möchten.
+
+### Namecheap Visual Tools
+
+Die kostenlose „Visual“-Suite von Namecheap deckt unter einer anderen Marke dasselbe ab: einen Business Name Generator, der [markenfähige Namensideen aus einer kurzen Beschreibung oder einem Keyword-Prompt erzeugt](https://www.toolworthy.ai/tool/namecheap-business-name-generator#:~:text=brandable%20name%20ideas%20from%20a%20short%20description%20or%20keyword%20prompt), zusammen mit verfügbaren Domains und einem passenden Logo, sowie einen eigenständigen Logo Maker, bei dem [die KI Ihre Markeninformationen und Präferenzen analysiert, um Logos vorzuschlagen, die zur Ästhetik und den Werten Ihrer Marke passen](https://10web.io/ai-tools/namecheap-free-logo-maker/#:~:text=The%20AI%20analyzes%20your%20brand%20information%20and%20preferences%20to%20suggest%20logos%20that%20align%20with%20your%20brand%27s%20aesthetic%20and%20values%2C%20offering%20a%20variety%20of%20customizable%20options). Architektonisch ist dies dasselbe Muster wie Airo: Sie beschreiben, was Sie wollen, die KI erzeugt Optionen, und Sie kaufen die Domain selbst.
+
+### Wix KI-Domainnamengenerator
+
+Die Version von Wix befindet sich auf dessen Domainsuchseite statt in einer separaten App. Nach der eigenen Beschreibung von Wix [geben Sie einfach ein Keyword in den KI-gestützten Domaingenerator ein und erhalten innerhalb von Sekunden eine Liste kreativer, markenfähiger und verfügbarer Domainnamen-Vorschläge](https://www.wix.com/domains/domain-name-generator#:~:text=Within%20seconds%2C%20it%20will%20provide%20you%20with%20a%20list%20of%20creative%2C%20brandable%20and%20available%20domain%20name%20suggestions). Danach kaufen Sie über den eigenen Checkout von Wix, entweder einzeln oder zusammen mit einem Wix-Websiteplan. Dieselbe Stufe, dasselbe Muster, andere Verkaufsstelle.
+
+### NameBuddy
+
+NameBuddy ist ein engeres Werkzeug mit nur einem Zweck. Nach seiner eigenen Startseite [ist es ein kostenloser KI-Domainnamengenerator](https://namebuddy.ai/#:~:text=is%20a%20free%20AI%20domain%20name%20generator), der eine ein- oder zweisätzige Beschreibung dessen annimmt, was Sie bauen, verfügbare Namen für eine Handvoll TLDs (`.ai`, `.com`, `.io`, `.app`, `.net`) zurückliefert und dann endet. Es [hilft Ihnen, verfügbare Domains zu finden](https://namebuddy.ai/#:~:text=helps%20you%20find%20available%20domains); die gewünschte Domain registrieren Sie bei einem akkreditierten Registrar Ihrer Wahl. Es ist das reinste Werkzeug der Stufe 1 in dieser Liste: kein Logo Maker, kein Website-Builder, kein eigener Checkout.
+
+Alle vier Werkzeuge haben dieselbe Form: Beschreiben Sie Ihr Geschäft, erhalten Sie Namen, kaufen Sie manuell. Alle erledigen diese Aufgabe gut; die Unterschiede liegen in den gewünschten Extras — Logo, Starter-Website, LLC-Gründung — neben dem Namen.
+
+## Stufe 2: KI-Assistenten von Registraren, die mehr erledigen, aber weiterhin von Menschen freigegeben werden
+
+Das klarste Beispiel dieser Stufe im Jahr 2026 ist das Agenten-Framework Airo.ai von GoDaddy, das am 13. November 2025 als Weiterentwicklung der obigen Airo-Suite gestartet wurde. Statt eines Generators lieferte GoDaddy eine Reihe aufgabenspezifischer Agenten, die von einem zentralen „Airo Agent“ orchestriert werden. Der **Domain Search and Registration Agent** [schlägt markenfähige Geschäftsnamen vor, die zur Idee und Stimme des Nutzers passen, prüft die Verfügbarkeit für beliebte TLDs, reserviert die gewählte Domain und konfiguriert sie automatisch für die Website](https://aboutus.godaddy.net/newsroom/news-releases/press-release-details/2025/GoDaddy-Brings-Agentic-AI-to-Small-Businesses-with-Launch-of-Airo-ai/default.aspx#:~:text=checks%20availability%20across%20popular%20TLDs%2C%20reserves%20the%20selected%20domain%2C%20and%20configures%20it%20for%20the%20site%20automatically). Das ist ein echter Schritt über einen statischen Generator hinaus: Das System prüft mehrere TLDs und reserviert eigenständig, statt auf eine erneute Suche von Ihnen zu warten.
+
+Die Grenze, die es in Stufe 2 statt Stufe 3 hält, steht in derselben Ankündigung: Der orchestrierende Airo Agent [fordert die Genehmigung für wichtige Aktionen an, etwa die Registrierung einer Domain oder die Veröffentlichung einer Website](https://aboutus.godaddy.net/newsroom/news-releases/press-release-details/2025/GoDaddy-Brings-Agentic-AI-to-Small-Businesses-with-Launch-of-Airo-ai/default.aspx#:~:text=requests%20approval%20for%20significant%20actions%20%28registering%20a%20domain%20or%20publishing%20a%20website%2C%20for%20example%29). Ein Mensch klickt weiterhin auf „Bestätigen“, bevor die Domain registriert wird, und das System läuft im eigenen Dashboard von GoDaddy. Die Ankündigung beschreibt die Agenten als arbeitend „across GoDaddy products and trusted services“, ohne eine externe API oder ein Protokoll zu erwähnen, das ein KI-Client eines Drittanbieters aufrufen könnte. Weder Namecheap noch Wix haben etwas Vergleichbares veröffentlicht; beide bleiben Werkzeuge für einmalige Vorschläge.
+
+Kurz gesagt lautet Stufe 2: „Die KI erledigt Ihre Aufgaben, aber Sie geben noch frei, bevor etwas real wird.“ Für jemanden, der den Kauf weiterhin selbst tätigt, ist das gegenüber Stufe 1 eine echte Komfortverbesserung. Für einen externen Agenten ist es jedoch nicht gebaut.
+
+## Stufe 3: agentische Plattformen, kurz
+
+In Stufe 3 ist der Käufer überhaupt keine Person mehr. Drei Registrare stellen Domainregistrierung derzeit als Funktion bereit, die ein externer KI-Agent — nicht der eigene Assistent des Registrars — direkt aufrufen kann: **die Registrar-API von Cloudflare** (Beta, Start April 2026, [zu Großhandelspreisen ohne zusätzliche Aufschläge](https://www.cloudflare.com/application-services/products/registrar/buy-ai-domains/#:~:text=Cloudflare%20offers%20.ai%20domain%20registrations%20and%20renewals%20at%20wholesale%20prices%2C%20with%20no%20additional%20markups) und ausgelegt für Editoren wie Cursor und Claude Code); **die KI-native API von Name.com**, die um die Idee herum neu aufgebaut wurde, dass [die Plattform moderne Standards wie Model Context Protocol (MCP) und die OpenAPI-Spezifikation unterstützt](https://www.name.com/blog/the-first-ai-native-domain-platform#:~:text=our%20platform%20is%20supported%20by%20modern%20standards%20like%20Model%20Context%20Protocol%20%28MCP%29%20and%20OpenAPI%20specification), die KI-Agenten eine direkte Interaktion mit Domainvorgängen ermöglichen; und **Namefi**, das einen [MCP](/de/blog/namefi-mcp/)-Server unter `api.namefi.io/mcp` betreibt, der Suche, Registrierung, DNS und Domainkonfiguration als aufrufbare Werkzeuge bereitstellt, authentifiziert durch einen API-Schlüssel oder eine Wallet-Signatur. Die resultierende Domain kann optional als [tokenisierte Domain](/de/blog/what-are-tokenized-domains/) gehalten werden statt nur als Zeile in einer Kontodatenbank.
+
+Alle drei erfüllen die grundlegende Schwelle der Stufe 3: Ein Agent kann ohne ein von einer Person ausgefülltes Checkout-Formular suchen, bepreisen und registrieren. Danach unterscheiden sie sich deutlich — bei Preistransparenz, Tiefe der DNS-Verwaltung, Zahlungsmethode und Eigentumsmodell. Wir haben diesen Vergleich vollständig geschrieben, statt ihn hier zu wiederholen. [Cloudflare vs. Name.com vs. Namefi: Agent-Native Registrars](/de/blog/cf-namecom-namefi/) bietet die Funktionsmatrix, und [GoDaddy Airo vs. Namecheap AI vs. Namefi: Wesentliche Unterschiede](/de/blog/airo-vs-namefi/) den direkten Vergleich zwischen den etablierten Anbietern der Stufen 1/2 und Namefi.
+
+## Die Bewertungstabelle
+
+| Rang | Werkzeug | Stufe | Urteil in einem Satz |
+|---|---|---|---|
+| 1 | NameBuddy | 1 — Generator | Der reinste und schnellste Namensgenerator hier; ohne eigenen Kaufablauf, daher mit jedem Registrar kombinierbar. |
+| 2 | GoDaddy Airo (Suite) | 1 — Generator | Bestes Paket für Erstbesitzer, die Namen, Logo und eine Live-Seite in einer Sitzung möchten. |
+| 3 | Namecheap Visual | 1 — Generator | Dieselbe Aufgabe wie Airo, eigenständige kostenlose Werkzeuge statt eines geführten Ablaufs, kombiniert mit budgetfreundlicher Preisgestaltung. |
+| 4 | Wix KI-Domain-Generator | 1 — Generator | In Ordnung, wenn Sie die Website ohnehin mit Wix bauen; als eigenständiges Namenswerkzeug weniger nützlich. |
+| 5 | GoDaddy Airo.ai agents | 2 — Registrar-Assistent | Das autonomste verfügbare Werkzeug eines etablierten Anbieters 2026 — weiterhin menschlich genehmigt und weiterhin für externe Agenten geschlossen. |
+| 6 | Cloudflare Registrar API | 3 — Agentische Plattform | Bester Preis und beste Sicherheitsstandards für eine reine Registrierungs-Beta; noch keine DNS-Verwaltung oder Kryptozahlung. |
+| 7 | Name.com AI-native API | 3 — Agentische Plattform | Beste Wahl, wenn ein Agent Ihren Integrationscode schreiben soll, statt nur feste Endpunkte aufzurufen. |
+| 8 | Namefi (MCP + Wallet) | 3 — Agentische Plattform | Einziger Anbieter mit Wallet-signiertem Checkout und tokenisiertem Eigentum; keine veröffentlichte Zusage zu At-Cost-Preisen. |
+
+## So wählen Sie aus
+
+Gehen Sie von der Aufgabe aus, nicht von der Stufe. Wenn Sie noch keinen Namen haben und die KI einen brainstormen soll, genügt jeder Generator der Stufe 1 — NameBuddy, wenn Sie Geschwindigkeit und sonst nichts möchten, GoDaddy Airo oder Namecheap Visual, wenn ein Logo und eine Starter-Website enthalten sein sollen. Wenn Sie bereits einen Namen haben und die KI die umgebende Routinearbeit erledigen soll — mehrere TLDs prüfen, den Gewinner reservieren, ihn mit einer Website verbinden —, während Sie die finale Entscheidung behalten, sind die Airo.ai-Agenten von GoDaddy die derzeit leistungsfähigste Variante dieses Musters.
+
+Wenn der tatsächliche Käufer Software ist — ein Coding-Agent, der eine App baut und eine eigene Domain braucht, eine automatisierte Pipeline zur Bereitstellung von Infrastruktur oder ein Skript, das nach Zeitplan läuft —, funktionieren weder Stufe 1 noch Stufe 2, denn keine davon stellt einen Kaufweg bereit, den ein externer Agent aufrufen kann. Das ist ausdrücklich ein Problem der Stufe 3. Die Wahl zwischen Cloudflare, Name.com und Namefi hängt davon ab, was Sie zusätzlich zu „den Namen registrieren“ benötigen: Cloudflare, wenn Preis und Sicherheitsstandards am wichtigsten sind und Sie noch keine DNS-Verwaltung benötigen; Name.com, wenn ein Agent den Integrationscode selbst schreiben soll; Namefi, wenn Sie Wallet-native Zahlung und [On-Chain](/de/glossary/on-chain/)-Eigentum neben der normalen [ICANN](/de/glossary/icann/)-Registrierung wünschen. Die Schritt-für-Schritt-Version dieses letzten Wegs finden Sie in [Eine Domain mit Claude kaufen: Namefi MCP Schritt-für-Schritt-Leitfaden](/de/blog/claude-mcp-domains/).
+
+## Häufig gestellte Fragen
+
+### Was ist der Unterschied zwischen einem KI-Domainnamengenerator und einem KI-Agenten, der Domains kauft?
+
+Ein Generator (Stufe 1) nimmt einen Prompt entgegen und liefert Namensvorschläge; den Kauf schließen Sie weiterhin selbst über einen normalen Checkout ab. Ein Agent (Stufe 3) ruft eine für KI-Clients entwickelte API oder ein Protokoll auf und schließt die Registrierung selbst innerhalb von Grenzen ab, die ein Mensch vorab gesetzt hat — ganz ohne Browser-Checkout. Stufe 2 liegt dazwischen: stärker automatisiert als ein Generator, aber weiterhin von einem Menschen abhängig, der im Dashboard des Registrars auf „Genehmigen“ klickt.
+
+### Ist GoDaddy Airo dasselbe wie die Airo.ai-Agenten von GoDaddy?
+
+Sie sind verwandt, aber nicht identisch. Airo ist die ursprüngliche KI-Suite (Namensvorschläge, Logo Maker, KI-generierte Starter-Website, SEO Wizard), die nach einer Domainregistrierung bereitsteht. Airo.ai, gestartet im November 2025, ist eine neuere und breitere Ebene zur Agentenorchestrierung auf dieser Suite. Sie kann mehrere TLDs prüfen und eine Domain mit weniger manuellen Wiederholungssuchen reservieren, doch der Schritt der Domainregistrierung erfordert weiterhin die Genehmigung des Nutzers.
+
+### Kann ein externer KI-Agent wie Claude oder ein Coding-Assistent eines dieser Werkzeuge aufrufen?
+
+Nur die Plattformen der Stufe 3: die Registrar-API von Cloudflare, die KI-native API von Name.com sowie MCP-Server und REST-API von Namefi. Die KI-Werkzeuge von GoDaddy, Namecheap und Wix, einschließlich der neueren Airo.ai-Agenten von GoDaddy, laufen auf der jeweiligen Website oder im Dashboard des Unternehmens. Keines von ihnen veröffentlicht derzeit eine API oder ein Protokoll, das ein externer KI-Client zum Auslösen eines Kaufs nutzen kann.
+
+### Welches Werkzeug ist am günstigsten?
+
+Unter den Generatoren der Stufe 1 sind alle vier hier besprochenen kostenlos nutzbar, da die Kosten erst bei der anschließenden Domainregistrierung entstehen, nicht beim Benennungsschritt. Ein kurzer, einprägsamer Vorschlag kann jedoch bei einer [Premium-Domain](/de/glossary/premium-domain/) landen, deren Preis deutlich über einer Standardregistrierung liegt; prüfen Sie daher den Preis, bevor Sie sich an einen Namen binden. Unter den Plattformen der Stufe 3 ist Cloudflare der einzige Anbieter mit einer veröffentlichten Zusage für Preise zu Kosten ohne Aufschlag. Name.com und Namefi veröffentlichen keine gleichwertige Richtlinie; prüfen Sie daher die Live-Preise direkt, statt Gleichheit anzunehmen.
+
+### Ich möchte nur einen Namen — muss ich überhaupt über agentische Plattformen nachdenken?
+
+Nein. Wenn ohnehin eine Person den Kauf abschließen wird, ist ein Generator der Stufe 1 — oder Stufe 2, falls Sie mehr Routinearbeit automatisieren möchten — das richtige Werkzeug, Punkt. Stufe 3 ist erst relevant, wenn der Käufer Software statt einer Person ist, zum Beispiel wenn ein Agent im Zuge des eigenständigen Baus und Deployments einer App eine Domain registriert.
+
+### Hat Namefi einen Namensgenerator wie GoDaddy Airo oder NameBuddy?
+
+Nein. Die Werkzeuge von Namefi sind auf Verfügbarkeitssuche, Registrierung, DNS-Verwaltung und tokenisiertes Eigentum ausgerichtet, nicht auf kreatives Brainstorming von Namen. Wenn Sie KI-generierte Namensideen möchten, verwenden Sie zunächst ein Werkzeug der Stufe 1 wie die oben bewerteten und bringen Sie den gewählten Namen anschließend zu Namefi oder einem anderen Registrar zur Registrierung.
+
+## Registrieren Sie den Namen, den Ihr Agent bereits gewählt hat
+
+Sobald ein Name gewählt ist — sei es von einer Person aus der Vorauswahl eines Generators oder von einem Agenten beim Bau Ihrer App —, kann [Namefi](https://namefi.io) ihn über einen MCP-Server oder eine REST-API registrieren, die ein KI-Agent direkt aufrufen kann. Authentifiziert wird mit einem API-Schlüssel oder einer Wallet-Signatur, mit der Option, die Domain als tokenisierten, Wallet-kontrollierten Vermögenswert neben ihrer normalen ICANN-Registrierung zu halten.
+
+**[Erfahren Sie, wie die Agentenwerkzeuge von Namefi funktionieren](https://namefi.io).**
+
+## Quellen und weiterführende Lektüre
+
+- Hostinger — [8 beste Domainregistrare 2026: getestet und verglichen](https://www.hostinger.com/tutorials/best-domain-registrars/#:~:text=GoDaddy%20Airo%2C%20its%20AI%20setup%20assistant%2C%20can%20also%20suggest%20a%20name%2C%20logo%2C%20and%20starter%20site%20once%20you%20register) — bestätigt, was GoDaddy Airo erzeugt und dass ein Mensch die Registrierung weiterhin abschließt.
+- GoDaddy — [GoDaddy bringt agentische KI für kleine Unternehmen mit dem Start von Airo.ai](https://aboutus.godaddy.net/newsroom/news-releases/press-release-details/2025/GoDaddy-Brings-Agentic-AI-to-Small-Businesses-with-Launch-of-Airo-ai/default.aspx) — eigene Ankündigung von GoDaddy zum Airo.ai-Agenten-Framework, seinen Beschreibungen der Fähigkeiten je Agent und der Voraussetzung menschlicher Genehmigung für eine Domainregistrierung.
+- Toolworthy — [Namecheap Business Name Generator](https://www.toolworthy.ai/tool/namecheap-business-name-generator#:~:text=brandable%20name%20ideas%20from%20a%20short%20description%20or%20keyword%20prompt) — unabhängige Beschreibung dessen, was der kostenlose Generator von Namecheap erzeugt.
+- 10Web — [Namecheap Free Logo Maker](https://10web.io/ai-tools/namecheap-free-logo-maker/#:~:text=The%20AI%20analyzes%20your%20brand%20information%20and%20preferences%20to%20suggest%20logos%20that%20align%20with%20your%20brand%27s%20aesthetic%20and%20values%2C%20offering%20a%20variety%20of%20customizable%20options) — unabhängige Beschreibung des KI-Logo-Werkzeugs von Namecheap.
+- Wix — [Kostenloser Domainnamengenerator](https://www.wix.com/domains/domain-name-generator#:~:text=Within%20seconds%2C%20it%20will%20provide%20you%20with%20a%20list%20of%20creative%2C%20brandable%20and%20available%20domain%20name%20suggestions) — eigene Beschreibung von Wix zum KI-gestützten Generator und Checkout-Ablauf.
+- NameBuddy — [namebuddy.ai](https://namebuddy.ai/#:~:text=is%20a%20free%20AI%20domain%20name%20generator) — eigene Beschreibung von NameBuddy zu Generator und Übergabe der Registrierung.
+- Cloudflare — [.ai-Domains kaufen: Preise zu Kosten und enthaltene Sicherheitsfunktionen](https://www.cloudflare.com/application-services/products/registrar/buy-ai-domains/#:~:text=Cloudflare%20offers%20.ai%20domain%20registrations%20and%20renewals%20at%20wholesale%20prices%2C%20with%20no%20additional%20markups)
+- Name.com — [Die erste KI-native Domainplattform](https://www.name.com/blog/the-first-ai-native-domain-platform#:~:text=our%20platform%20is%20supported%20by%20modern%20standards%20like%20Model%20Context%20Protocol%20%28MCP%29%20and%20OpenAPI%20specification)
+- Namefi — [namefi.io/llms.txt](https://namefi.io/llms.txt) — Maschinenlesbare Beschreibung des MCP-Servers, der REST-API und des Authentifizierungsmodells von Namefi; Quelle für jede Produktangabe zu Namefi in diesem Artikel.

--- a/content/blog/de/beyond-generators.md
+++ b/content/blog/de/beyond-generators.md
@@ -1,0 +1,135 @@
+---
+title: "Jenseits des KI-Domainnamengenerators: die Agentenära"
+date: '2026-07-10'
+language: 'de'
+tags: ['ai-agents', 'domains', 'explainer']
+authors: ['namefiteam']
+draft: false
+format: explainer
+ogImage: ../../assets/beyond-generators-og.jpg
+description: "KI-Namensgeneratoren enden bei Vorschlägen. Die Fähigkeitsleiter vom Vorschlagen über Suchen, Konfigurieren und Transagieren bis zum Verwalten — und wer jede Stufe anbietet."
+keywords: ['grenzen von ki-namensgeneratoren', 'automatisierung des domainlebenszyklus', 'agentenära', 'vorschlagen versus transagieren', 'fähigkeitsleiter', 'registrar-funnel', 'jenseits des ki-namensgenerators', 'ki hat einen namen erzeugt was nun', 'domainregistrierung automatisieren', 'domainverwaltung durch ki-agenten', 'agent-native registrar', 'mcp domainregistrierung', 'domaintransfer ki-agent', 'automatisierung der automatischen verlängerung', 'upsell-funnel ki-domain']
+relatedArticles:
+  - /de/blog/airo-vs-namefi/
+  - /de/blog/agent-native/
+  - /de/blog/nl-domain-purchase/
+  - /de/blog/best-ai-tools-2026/
+  - /de/blog/ai-search-meanings/
+relatedTopics:
+  - /de/topics/domain-basics/
+  - /de/topics/web3-foundations/
+relatedSeries:
+  - /de/series/blockchain-concepts/
+  - /de/series/tokenize-your-com/
+relatedGlossary:
+  - /de/glossary/ai-agent/
+  - /de/glossary/registrar/
+  - /de/glossary/brandable-domain/
+  - /de/glossary/domain-renewal/
+  - /de/glossary/transfer-lock/
+---
+
+Sie haben einen Satz in einen KI-Namensgenerator eingegeben — „eine Abo-Box für Zimmerpflanzen“ oder was auch immer Ihre Idee war — und dreißig Sekunden später hatten Sie eine Vorauswahl [markenfähiger Domains](/de/glossary/brandable-domain/), ein Logo und vielleicht eine Starter-Website. Dieser Teil fühlte sich magisch an. Dann endete die Magie, und Sie waren wieder bei dem, was Menschen seit 1995 tun: sich durch eine Checkout-Seite klicken, eine Kartennummer eingeben und hoffen, rechtzeitig vor Ablauf an die Verlängerung zu denken.
+
+Diese Lücke — zwischen „die KI hat einen Namen ausgewählt“ und „der Name ist tatsächlich eine funktionierende, besessene und verlängerte Domain“ — ist der Punkt, an dem die meisten Gespräche über KI und Domains stillschweigend enden. Dieser Beitrag handelt von dem, was dahinter liegt: einer Fähigkeitsleiter, die von der Namensvorschlag bis zur Verwaltung des gesamten Lebens einer Domain reicht, und davon, warum die Werkzeuge, die jeder bereits kennt, nur die ersten zwei Sprossen erklimmen.
+
+## Sie haben einen Generator genutzt. Was jetzt? Die Realität in 12 Schritten
+
+Das passiert tatsächlich, nachdem ein Generator Ihnen einen Namen geliefert hat, wenn danach nichts Automatisches übernimmt:
+
+1. Bestätigen Sie, dass der Name wirklich verfügbar ist — die Vorauswahl eines Generators kann der Echtzeitverfügbarkeit hinterherhinken, bis Sie zum Kauf kommen.
+2. Vergleichen Sie die Preise der vorgeschlagenen TLD-Varianten; Premiumpreise und Mindestlaufzeiten über mehrere Jahre unterscheiden sich je nach Endung erheblich.
+3. Erstellen Sie ein Konto beim [Registrar](/de/glossary/registrar/), zu dem der Generator Sie führt, falls Sie noch keines haben.
+4. Geben Sie Kontaktdaten des Registrants und Rechnungsdaten ein.
+5. Schließen Sie den Checkout ab: Kartennummer, eventuelles WHOIS-Datenschutz-Add-on, Bestellung bestätigen.
+6. Bestätigen Sie die E-Mail-Adresse des Registrants, da nicht verifizierte Kontaktdaten eine neue Registrierung aufhalten können.
+7. Entscheiden Sie, wohin die Domain verweisen soll, und setzen Sie ihre Nameserver auf Ihren Host oder DNS-Anbieter.
+8. Erstellen Sie die tatsächlichen [DNS](/de/glossary/dns/)-Einträge, die die Website braucht — einen A- oder CNAME-Eintrag für die App, MX für E-Mail, TXT für Verifizierung und SPF.
+9. Warten Sie die DNS-Propagation ab, bevor die Domain überall zuverlässig auflöst.
+10. Stellen Sie ein SSL/TLS-Zertifikat bereit oder bestätigen Sie, dass Ihr Host dies automatisch erledigt.
+11. Schalten Sie die automatische Verlängerung ein oder setzen Sie rechtzeitig vor dem Ablaufdatum eine eigene Erinnerung, damit die Domain nicht verfällt.
+12. Wenn Sie jemals den Registrar wechseln wollen, entsperren Sie die Domain, holen Sie beim bisherigen Registrar den Autorisierungscode und starten Sie den Transfer — anschließend warten Sie das Sperrfenster nach dem Transfer ab, bevor ein erneuter Umzug möglich ist.
+
+Keiner dieser Schritte ist für sich schwer. Zusammen sind es zwölf manuelle Aktionen, verteilt über ein Registrar-Dashboard, ein DNS-Panel und Ihren Kalender — für eine Entscheidung, bei der die KI Ihnen angeblich schon mit einem Prompt geholfen hat. Schritt 12 ist keine Folklore: [Die Zusammenfassung des Domaintransferprozesses bei Wikipedia](https://en.wikipedia.org/wiki/Domain_name_registrar) beschreibt, wie der Registrant „the authentication code (EPP transfer code) from the old registrar“ erhält und „any domain lock“ entfernt; historisch folgte darauf ein Fenster, in dem „the domain cannot be transferred again for 60 days“. Diese Sperre stimmte die ICANN im März 2025 darauf ab, sie auf 30 Tage zu verkürzen, mit Einführung über die folgenden 18 Monate. In jedem Fall muss ein Mensch die Regel kennen und manuell danach handeln.
+
+## Die Fähigkeitsleiter: vom Vorschlagen zum Transagieren
+
+Die Generatoren haben ihre Berechtigung: Sie lösen ein reales, enges Problem, nämlich aus einer vagen Idee Wörter zu machen. Die Verwirrung entsteht, wenn „KI hat bei meiner Domain geholfen“ als eine Fähigkeit behandelt wird, obwohl es tatsächlich fünf sind und die meisten Produkte auf dem Markt heute nur die ersten zwei bereitstellen.
+
+| Sprosse | Die KI... | Was weiterhin manuell ist | Konkretes Beispiel |
+|---|---|---|---|
+| 1. Vorschlagen | Schlägt aus einem Prompt markenfähige Namen vor | Alles nach dem Namen | GoDaddy Airo und der Visual-Generator von Namecheap machen aus einer einzeiligen Beschreibung Namen und ein Logo — [Airo „can also suggest a name, logo, and starter site once you register“](https://www.hostinger.com/tutorials/best-domain-registrars/#:~:text=GoDaddy%20Airo%2C%20its%20AI%20setup%20assistant%2C%20can%20also%20suggest%20a%20name%2C%20logo%2C%20and%20starter%20site%20once%20you%20register) |
+| 2. Suchen | Prüft die aktuelle Verfügbarkeit und den Preis eines konkreten Namens | Auf „Kaufen“ klicken und danach konfigurieren | Eine Verfügbarkeitsabfrage bestätigt, dass ein Name wirklich noch frei ist — Vorauswahlen können inzwischen veraltet sein —, doch das Ergebnis landet weiterhin auf einer Seite, auf der ein Mensch zum Kauf klickt |
+| 3. Konfigurieren | Liest und schreibt DNS-Einträge einer bereits gehaltenen Domain | Nichts, wenn die API Schreibvorgänge abdeckt | Die DNS-Endpunkte von Namefi erlauben einem Aufrufer, A-, CNAME-, MX- und TXT-Einträge mit einem API-Schlüssel zu erstellen, zu aktualisieren und zu löschen, sodass eine neue Domain ohne Dashboard auf ein Live-Deployment zeigen kann |
+| 4. Transagieren | Schließt die Registrierung über einen API- oder Protokollaufruf ab, ohne Checkout-Seite | Ein Ausgabenlimit vorab genehmigen | Die Registrar-API-Beta von Cloudflare [ermöglicht einem KI-Agenten, die Domainverfügbarkeit zu suchen, Preise zu prüfen und die Registrierung programmgesteuert ohne Browserinteraktion oder manuelle Genehmigung abzuschließen](https://webhosting.today/2026/04/22/ai-agents-can-now-register-domains-no-human-required/); der MCP-Server von Namefi stellt denselben Schritt als aufrufbares Werkzeug bereit |
+| 5. Lebenszyklus verwalten | Behandelt über Jahre Verlängerungen, DNS-Änderungen und [Transfers](/de/glossary/transfer-lock/), ohne ein Dashboard erneut zu öffnen | Die Richtlinie einmal festlegen | Die API von Namefi stellt [automatische Verlängerung](/de/glossary/domain-renewal/) als Schalter bereit, den ein Agent am Registrierungstag aktivieren kann. Die Beta von Cloudflare erklärt dagegen, dass [„post-registration management, including transfers, renewals, and contact updates, is not in the current beta“](https://webhosting.today/2026/04/22/ai-agents-can-now-register-domains-no-human-required/) |
+
+Lesen Sie die Leiter von oben nach unten, wird das Muster deutlich: Die Sprossen 1 und 2 betreffen *Informationen* — wie soll sie heißen, ist sie frei, was kostet sie. Die Sprossen 3 bis 5 betreffen *Handlungen* — konfigurieren, kaufen, am Laufen halten. Fast jedes Produkt, das 2026 als „KI-Domains“ vermarktet wird, lebt vollständig in der Informationshälfte.
+
+## Wo etablierte Anbieter aufhören und warum
+
+GoDaddy Airo und die Visual-Werkzeuge von Namecheap sind bei Sprosse 1 wirklich gut, und es gibt keinen Grund, das anders darzustellen. Für jemanden, der erstmals ein kleines Unternehmen benennt, haben eine generierte Vorauswahl, ein Logo und eine Starter-Website in einer Sitzung echten Wert. Unser eigener [Vergleich von GoDaddy Airo, Namecheap AI und Namefi](/de/blog/airo-vs-namefi/) beschreibt, was jeder dort tatsächlich liefert.
+
+Keines der beiden Produkte übergibt die Entscheidung jedoch an etwas anderes als Sie. Das ist kein Versehen, sondern strukturell. Die Vorschläge von Airo führen in den eigenen Checkout von GoDaddy, wo AI Builder, Logo Maker, SEO Wizard und der Ablauf zur LLC-Gründung als nächste Schritte derselben geführten Reise warten. Die Visual-Suite von Namecheap ist gleich verkettet: Generator, dann Logo Maker, dann Site Maker, jeweils innerhalb des eigenen Produkts von Namecheap. Die Aufgabe der KI besteht in beiden Fällen darin, *Sie* eher zum Abschluss *ihres* Checkouts zu bewegen, nicht darin, einen Kauf in Ihrem Namen abzuschließen, ohne dass Sie ihn jemals sehen. Ein Registrar, dessen KI auf Sprosse 4 autonom transagiert, würde genau die Seite überspringen, auf der die eigenen Upsells liegen — kein geschäftlicher Grund, das heute zu liefern.
+
+Das ist die ehrliche Antwort auf „warum etablierte Anbieter bei Sprosse 2 aufhören“: Nicht weil die Technik schwierig wäre — Registrare betreiben seit zwei Jahrzehnten programmierbare APIs, wie wir in [Was ist ein Agent-Native Domain Registrar?](/de/blog/agent-native/) behandeln —, sondern weil ein Agent, der den Kauf selbst abschließt, genau den Moment entfernt, um den ihr Geschäftsmodell gebaut ist.
+
+## Wie die Sprossen 3–5 in der Praxis aussehen
+
+Die Sprossen 3 bis 5 sehen weniger wie ein Formular und mehr wie eine Unterhaltung mit einem angeschlossenen Werkzeug aus. Ein Agent, der mit dem [MCP](https://modelcontextprotocol.io)-Server oder der REST-API eines Registrars verbunden ist, prüft einen Namen, erhält einen echten Preis, registriert ihn und setzt seine DNS-Einträge. Das sind Aufrufe, die er selbst innerhalb von vorab gesetzten Grenzen vornimmt, nicht Schritte, die Seite für Seite angeklickt werden. [Die Branchenanalyse von CircleID aus 2026](https://circleid.com/posts/the-domain-universe-in-2026-ai-security-market-maturity-and-the-new-gtld-frontier#:~:text=AI%20agents%20are%20increasingly%20acting%20as%20domain%20resellers%20checking%20availability%2C%20registering%20names%2C%20and%20configuring%20DNS%20without%20human%20intervention) formuliert es schlicht: „AI agents are increasingly acting as domain resellers, checking availability, registering names, and configuring DNS without human intervention.“ 
+
+Die vollständigen Arbeitsbeispiele haben wir an anderer Stelle beschrieben, statt sie hier zu wiederholen. [So kaufen Sie eine Domain mit natürlicher Sprache](/de/blog/nl-domain-purchase/) führt durch eine kommentierte Unterhaltung vom Prompt in natürlicher Sprache bis zur registrierten und DNS-konfigurierten Domain — die Mechanik der Sprossen 3 und 4 im Detail. [So registrieren Sie eine Domain mit Ihrem KI-Agenten bei Namefi](/de/blog/ai-agent-register/) ist die maßgebliche Einrichtungsanleitung für wichtige Agenten-Clients mit dem universellen Ablauf in fünf Schritten: Zugangsdaten beschaffen, verbinden, suchen und bepreisen, registrieren, DNS konfigurieren. Sprosse 5 ist der neuere Teil: Ein Agent, der eine Domain registriert hat, kann Monate später auch die automatische Verlängerung umschalten, DNS-Einträge bearbeiten oder einen Transfer starten — mit denselben Werkzeugen, die er schon bei der Registrierung verwendet hat, ohne separate Dashboard-Anmeldung.
+
+## Fünf Fragen an jeden Registrar, bevor Sie ihm Ihren Agenten anvertrauen
+
+Nicht jeder Registrar, der „KI“ sagt, gehört auf Sprosse 3 oder höher. Bevor Sie einen Agenten mit einem verbinden, sollten Sie fragen:
+
+1. **Kann mein Agent herausfinden, was Sie anbieten, ohne dass eine Person zuerst Ihre Dokumentation liest?** Wenn die einzige Möglichkeit, die API kennenzulernen, darin besteht, dass ein Mensch eine Referenzseite liest und Integrationscode von Hand schreibt, hat ein unbekannter Agent nichts, womit er arbeiten kann.
+2. **Findet „Kaufen“ wirklich über die API statt, oder gibt sie mir nur einen Link zum Anklicken?** Viele „KI-gestützte“ Registrierungen enden noch bei einer gehosteten Checkout-Seite. Damit ist beim genau zu automatisierenden Schritt wieder ein Mensch im Ablauf.
+3. **Wie wird bezahlt — braucht es meine Karte in einem Browser oder kann die Software ihre eigenen Zugangsdaten halten?** Eine gespeicherte Karte setzt eine Person voraus, die ein Formular ausfüllt. Einen API-Schlüssel oder eine Wallet-Signatur kann Software tatsächlich halten und nutzen.
+4. **Wenn etwas fehlschlägt, erhält mein Agent einen Code, auf den er reagieren kann, oder einen für mich bestimmten Absatz?** Eine Fehlermeldung in Prosa ist für eine Person in einem Log in Ordnung. Ein Agent braucht einen strukturierten, stabilen Fehler, auf dessen Basis er verzweigen kann.
+5. **Was hindert ihn nach der Verbindung daran, mehr auszugeben, als ich beabsichtigt habe?** Suchen Sie nach einem Ausgabenlimit oder einem Bestätigungsschritt, den Sie einmal setzen, nicht nach Zugangsdaten, die ein Skript zu allem Technisch-Möglichen befähigen.
+
+Diese Fragen ähneln der ausführlicheren Prüfliste in [Was ist ein Agent-Native Domain Registrar?](/de/blog/agent-native/), sind aber nicht mit ihr identisch. Jener Beitrag bewertet konkrete Plattformen anhand von sechs präzisen Kriterien. Diese kürzere Fassung soll die sein, die Sie vor dem Verbinden von etwas tatsächlich im Kopf behalten.
+
+## Häufig gestellte Fragen
+
+### Was ist eigentlich falsch daran, einen KI-Domainnamengenerator zu verwenden?
+
+Nichts, für seine Aufgabe. Ein Generator ist ein Werkzeug der Sprosse 1: Er verwandelt eine vage Idee in Kandidatennamen, oft mit einem Logo oder einer Starter-Website dazu. Das Problem entsteht nur, wenn Menschen erwarten, dass dasselbe Werkzeug auch die Verfügbarkeit prüft, den Namen registriert, DNS konfiguriert und Verlängerungen verwaltet — eine andere Aufgabe, die andere Werkzeuge erledigen.
+
+### Werden GoDaddy oder Namecheap irgendwann Sprosse 4 oder 5 erreichen?
+
+Möglich, aber es gibt einen strukturellen Grund, es langsamer zu erwarten, als es die Technik erlauben würde: Ihre KI-Werkzeuge sollen Kunden durch den eigenen Checkout- und Upsell-Ablauf führen, und ein autonom transagierender Agent umgeht diesen Ablauf vollständig. Registrare, die speziell für agentengesteuerte Transaktionen gebaut sind — die Beta-Registrar-API von Cloudflare sowie MCP-Server und REST-API von Namefi — liefern heute die Sprossen 3 und 4, wie unser [Vergleich agentennativer Registrare](/de/blog/cf-namecom-namefi/) zeigt.
+
+### Was umfasst „Lebenszyklus verwalten“ außer dem Verlängern?
+
+Die Verlängerung ist der offensichtlichste Teil, doch Lebenszyklusverwaltung umfasst auch das Bearbeiten von DNS-Einträgen nach dem Start, das Einleiten eines Transfers zu einem anderen Registrar bei Bedarf und das Aktualisieren der Kontaktdaten des Registrants — alles über dieselbe programmgesteuerte Schnittstelle, die die Domain registriert, und nicht bei jedem Mal über eine separate manuelle Anmeldung.
+
+### Verliere ich die Kontrolle, wenn ein Agent den Lebenszyklus einer Domain verwaltet?
+
+Nicht, wenn der Registrar die oben genannten Leitplanken unterstützt. Ein menschlicher Kontrollpunkt, ein Ausgabenlimit oder ein Bestätigungsschritt für folgenreiche Aktionen ermöglicht es Ihnen, die wiederkehrenden Teile an Ihren [KI-Agenten](/de/glossary/ai-agent/) zu delegieren und zugleich die Genehmigung für alles oberhalb einer von Ihnen gesetzten Schwelle zu behalten.
+
+### Ist Namefi heute auf Sprosse 5?
+
+Nach der eigenen veröffentlichten API-Referenz: ja, für die dokumentierten Teile. Die Registrierung wird per API oder MCP ohne Checkout-Seite abgeschlossen, DNS-Einträge können programmgesteuert gelesen und geschrieben werden und die automatische Verlängerung ist als Schalter verfügbar, den ein Agent am Registrierungstag setzen kann. Nicht öffentlich dokumentiert ist bisher ein serverseitiges Ausgabenlimit als Primitive; diese Leitplanke liegt derzeit bei dem MCP-Client oder der Richtlinienebene, die Sie darum herum einrichten.
+
+### Ist das nicht einfach „ein Registrar mit einer API“? Registrare haben die doch seit Jahren.
+
+Eine API zu besitzen und von einem Agenten Ende zu Ende nutzbar zu sein, sind nicht dieselbe Aussage. Warum die meisten Registrar-APIs für einen menschlichen Entwickler gebaut wurden, der sie einmal integriert, und nicht für einen Agenten, der sie ohne Vorwissen entdecken und nutzen kann, ist das ganze Thema von [Was ist ein Agent-Native Domain Registrar?](/de/blog/agent-native/).
+
+## Geben Sie Ihrem Agenten den Rest der Leiter
+
+Wenn Ihr Agent den Code bereits entwerfen und den Namen auswählen kann, gibt es keinen Grund, warum die nächsten neun Schritte — prüfen, kaufen, DNS konfigurieren, verlängern, transferieren — wieder auf Sie und ein Dashboard zurückfallen sollten. [Namefi](https://namefi.io) stellt Domainsuche, Registrierung, DNS-Verwaltung und Verlängerungssteuerung als Werkzeuge bereit, die ein MCP-fähiger Agent direkt aufrufen kann, authentifiziert mit einem API-Schlüssel oder einer Wallet-Signatur. Die Leiter muss also nicht beim Namen enden.
+
+**[Erfahren Sie, wie die Agentenwerkzeuge von Namefi funktionieren](https://namefi.io).**
+
+## Quellen und weiterführende Lektüre
+
+- Hostinger — [8 beste Domainregistrare 2026: getestet und verglichen](https://www.hostinger.com/tutorials/best-domain-registrars/#:~:text=GoDaddy%20Airo%2C%20its%20AI%20setup%20assistant%2C%20can%20also%20suggest%20a%20name%2C%20logo%2C%20and%20starter%20site%20once%20you%20register) — verifiziert unabhängig, dass die Vorschläge von GoDaddy Airo weiterhin in den eigenen Registrierungsablauf von GoDaddy führen.
+- webhosting.today — [KI-Agenten können jetzt Domains registrieren, kein Mensch erforderlich](https://webhosting.today/2026/04/22/ai-agents-can-now-register-domains-no-human-required/) — Berichterstattung über die Registrar-API-Beta von Cloudflare im April 2026, einschließlich der genannten Lücke, dass die Verwaltung nach der Registrierung (Transfers, Verlängerungen, Kontaktaktualisierungen) noch nicht Teil der Beta ist.
+- Wikipedia — [Domain Name Registrar](https://en.wikipedia.org/wiki/Domain_name_registrar) — das Standardverfahren für Transfers, die Rolle des EPP-Autorisierungscodes und die ICANN-Richtlinie von 2025, die die Sperre nach einem Transfer von 60 auf 30 Tage verkürzt.
+- CircleID — [Das Domainuniversum 2026: KI, Sicherheit, Marktreife und die neue gTLD-Grenze](https://circleid.com/posts/the-domain-universe-in-2026-ai-security-market-maturity-and-the-new-gtld-frontier#:~:text=AI%20agents%20are%20increasingly%20acting%20as%20domain%20resellers%20checking%20availability%2C%20registering%20names%2C%20and%20configuring%20DNS%20without%20human%20intervention) — Branchenanalyse von Agenten, die als Domain-Reseller handeln.
+- GoDaddy — [Airo: Eine KI-gestützte Erfahrung, die Ihnen beim Online-Wachstum hilft](https://www.godaddy.com/airo) — eigene Produktbeschreibung von GoDaddy zur Suite von Airo für Namensfindung, Logos und Website-Bau.
+- Namecheap — [Visual: Business Name Generator](https://www.namecheap.com/visual/business-name-generator/) — eigene Beschreibung von Namecheap zu den kostenlosen KI-Werkzeugen für Benennung und Branding.
+- Namefi — [namefi.io/llms.txt](https://namefi.io/llms.txt) — maschinenlesbare API-Referenz von Namefi; Quelle für jede Aussage über die Fähigkeiten von Namefi in diesem Artikel, einschließlich MCP-Server, DNS-Eintragsendpunkten, Registrierungsablauf und Schalter für automatische Verlängerung.

--- a/content/blog/de/blockchain-consensus-mechanisms.md
+++ b/content/blog/de/blockchain-consensus-mechanisms.md
@@ -1,0 +1,136 @@
+---
+title: "Die wichtigsten Blockchain-Konsensmechanismen: Proof of Work, Proof of Stake und mehr"
+date: '2026-07-02'
+language: de
+tags: ['guide']
+authors: ['namefiteam']
+draft: false
+cluster: web3-foundations
+series: blockchain-concepts
+seriesOrder: 20
+format: roundup
+description: Ein klarer Leitfaden zu Blockchain-Konsensmechanismen — Proof of Work, Proof of Stake, Delegated Proof of Stake, BFT-Konsens und dazu, wie sie jeweils ein Netzwerk absichern.
+ogImage: ../../assets/blockchain-consensus-mechanisms-og.jpg
+keywords: ['blockchain-konsensmechanismen', 'konsensmechanismus', 'proof of work', 'proof of stake', 'delegated proof of stake', 'byzantinische fehlertoleranz', 'tendermint', 'cometbft', 'proof of history', 'proof of authority', 'proof of space', 'doppelausgabenproblem', 'blockchain-finalität', 'ethereum merge', 'bitcoin-mining', 'validator', 'staking', 'sybil-resistenz', 'namefi']
+relatedArticles:
+  - /de/blog/blockchain-virtual-machines/
+  - /de/blog/blockchain-scaling-approaches/
+  - /de/blog/blockchain-cryptographic-primitives/
+  - /de/blog/blockchain-privacy-technologies/
+  - /de/blog/what-are-tokenized-domains/
+relatedGlossary:
+  - /de/glossary/consensus-mechanism/
+  - /de/glossary/proof-of-work/
+  - /de/glossary/proof-of-stake/
+  - /de/glossary/blockchain/
+  - /de/glossary/ethereum/
+relatedTopics:
+  - /de/topics/web3-foundations/
+  - /de/topics/domain-tokenization/
+relatedSeries:
+  - /de/series/tokenize-your-com/
+  - /de/series/domain-flipping-skills/
+---
+
+Jede [Blockchain](/de/glossary/blockchain/) muss eine Frage beantworten, bevor ihr jemand Geld anvertrauen kann: Wer darf entscheiden, was passiert ist und in welcher Reihenfolge? Es gibt keine Bank, keinen Notar und keinen zentralen Server, der das Sagen hat. Ein **Konsensmechanismus** ist die Menge von Regeln, denen die Teilnehmenden eines Netzwerks folgen, um sich auf eine einzige, gemeinsame Transaktionshistorie zu einigen — ohne zentrale Instanz und ohne dass jemand dieselbe Coin zweimal ausgeben kann.
+
+Dieser Leitfaden erläutert die heute wichtigen Konsensmechanismen, wie jeder von ihnen tatsächlich den nächsten Block auswählt und worin die jeweiligen Abwägungen liegen.
+
+---
+
+## Welches Problem Konsens tatsächlich löst
+
+Zwei Probleme machen eine dezentrale Einigung schwierig.
+
+**Das Doppelausgabenproblem.** In einem digitalen System ist eine Werteinheit nur Daten, und Daten lassen sich kopieren. Ohne Schiedsinstanz hindert nichts jemanden daran, zwei widersprüchliche Transaktionen zu verbreiten, die beide dieselbe Coin ausgeben. Satoshi Nakamotos Bitcoin-Whitepaper formuliert das Ziel direkt: Das Netzwerk braucht „ein System, mit dem sich die Teilnehmenden auf eine einzige Historie der Reihenfolge einigen, in der sie empfangen wurden“, damit ein Empfänger darauf vertrauen kann, dass eine frühere Zahlung nicht durch eine spätere, widersprüchliche rückgängig gemacht wird ([Bitcoin-Whitepaper](https://bitcoin.org/bitcoin.pdf)).
+
+**Einigung ohne zentrale Instanz.** In einer normalen Datenbank hat das Wort eines Betreibers das letzte Gewicht. In einem öffentlichen, erlaubnisfreien Netzwerk kann jeder einen Node betreiben, Transaktionen vorschlagen und versuchen, den nächsten Block hinzuzufügen — auch Teilnehmende, die lügen, zensieren oder die Historie umschreiben wollen. Ein Konsensmechanismus muss Angriffe auf das Ledger unerschwinglich teuer machen oder auf andere Weise unattraktiv gestalten und zugleich günstig genug sein, damit ehrliche Teilnehmende das Netzwerk weiter betreiben können.
+
+Jeder der folgenden Mechanismen beantwortet die Frage „Wer schlägt den nächsten Block vor und woher wissen wir, dass wir ihm vertrauen können?“ anders. Beim Vergleich sind zwei Achsen besonders wichtig: **[Sybil-Resistenz](/de/glossary/consensus-mechanism/)** — was einen Angreifer daran hindert, unbegrenzt viele falsche Identitäten zu erzeugen und damit alle anderen zu überstimmen — und **Finalität** — wie schnell und wie endgültig eine Transaktion unumkehrbar wird.
+
+---
+
+## Proof of Work
+
+![Mehrere Miner wetteifern darum, dasselbe Hash-Rätsel zu lösen; einer hält einen Block mit der Aufschrift „gefunden!“ hoch, während Blitze die hohen Energiekosten des Minings zeigen](../../assets/blockchain-consensus-mechanisms-01-proof-of-work.jpg)
+
+[Proof of Work](/de/glossary/proof-of-work/) (PoW) ist der Mechanismus, den Bitcoin 2009 eingeführt hat, und der, an den die meisten Menschen bei „Blockchain“ denken. Miner konkurrieren darum, ein kryptografisches Rätsel zu lösen: Sie hashen die Daten eines Kandidatenblocks wiederholt mit einer Nonce, bis der resultierende Hash unter einen Zielwert fällt. Die Entwicklerdokumentation von Ethereum beschreibt das Rennen schlicht: Ein Miner führt „wiederholt einen Datensatz ... durch eine mathematische Funktion“, um vor allen anderen eine gültige Lösung zu finden ([ethereum.org: Proof-of-work](https://ethereum.org/en/developers/docs/consensus-mechanisms/pow/#:~:text=When%20racing%20to%20create%20a%20block%2C%20a%20miner%20repeatedly%20put%20a%20dataset)). Wer zuerst einen gültigen Hash findet, darf den nächsten Block vorschlagen und erhält die Blockbelohnung plus Transaktionsgebühren.
+
+Die **Sybil-Resistenz** entsteht durch das Rätsel selbst: Hashes zu berechnen kostet reale Elektrizität und Hardware; viele falsche Identitäten vorzutäuschen bringt daher keinen Vorteil — nur reine Rechenleistung zählt. Die **Finalität ist probabilistisch.** Das Bitcoin-Whitepaper beschreibt, dass Nodes stets „die längste Chain als die korrekte“ erweitern ([Bitcoin-Whitepaper](https://bitcoin.org/bitcoin.pdf)); ein Empfänger gewinnt Vertrauen darin, dass eine Transaktion abgewickelt ist, indem er abwartet, bis weitere Blöcke darauf gemined werden. Jeder neue Block macht es exponentiell teurer, die Historie umzuschreiben, aber kein einzelner Block ist sofort und mathematisch endgültig.
+
+Der Nachteil ist Energie. Ein Netzwerk durch reale Berechnungen abzusichern bedeutet realen Stromverbrauch; deshalb wird Bitcoin-Mining in Terawattstunden pro Jahr gemessen. **Beispiel-Chains:** Bitcoin, Litecoin, Dogecoin und Ethereum vor 2022.
+
+---
+
+## Proof of Stake
+
+![Ein Validator sperrt einen Stapel Coins als gestakte Einlage in einem Tresor ein und wird anschließend per Glücksrad ausgewählt, den nächsten Block vorzuschlagen; am Tresor hängt ein Warnhinweis zu Slashing](../../assets/blockchain-consensus-mechanisms-02-proof-of-stake.jpg)
+
+[Proof of Stake](/de/glossary/proof-of-stake/) (PoS) ersetzt Rechenarbeit durch eine wirtschaftliche Sicherheit. Statt Mining **staken** Teilnehmende den nativen Vermögenswert des Netzwerks, also sperren ihn ein, und das Protokoll wählt pseudozufällig einen Staker aus, um jeden Block vorzuschlagen. Die Validator-Rolle von Ethereum ist ein gutes Referenzdesign: Ein Validator hinterlegt 32 ETH und betreibt Client-Software; das Protokoll wählt dann zufällig „einen Validator ... als Block-Proposer in jedem Slot“ aus, während ein zufällig ausgewähltes Komitee anderer Validatoren die Gültigkeit dieses Blocks attestiert ([ethereum.org: Proof-of-stake](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/#:~:text=One%20validator%20is%20randomly%20selected%20to%20be%20a%20block%20proposer%20in%20every%20slot)).
+
+Die **Sybil-Resistenz** kommt aus dem Stake selbst: Viele falsche Validatoren zu erstellen bedeutet nur, dass dasselbe Kapital auf mehr Identitäten verteilt wird, was keinen zusätzlichen Einfluss verschafft. Unehrliches Verhalten, etwa widersprüchliche Blöcke oder gegensätzliche Attestierungen vorzuschlagen, wird durch **Slashing** bestraft: Das Protokoll verbrennt einen Teil des Stakes des betreffenden Validators ([ethereum.org: Proof-of-stake](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/#:~:text=Two%20primary%20behaviors%20can%20be%20considered%20dishonest)). Ethereum finalisiert Blöcke in Epochen mithilfe eines Checkpoint-Mechanismus (Casper FFG kombiniert mit der Fork-Choice-Regel LMD-GHOST). Das bietet stärkere Finalitätsgarantien als reines PoW, ohne eine BFT-artige Abstimmung in einer einzigen Runde zu benötigen.
+
+Der wesentliche Unterschied zu PoW ist Energie: Staking benötigt keine spezialisierte Hardware, die um das Lösen von Rätseln konkurriert; wie ethereum.org formuliert, „muss nicht viel Energie für Proof-of-Work-Berechnungen eingesetzt werden“ ([ethereum.org: Proof-of-stake](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/#:~:text=there%20is%20no%20need%20to%20use%20lots%20of%20energy%20on%20proof)). Das Ausmaß dieser Einsparung ist gut belegt: Eine unabhängige Analyse (CCRI) ergab, dass Ethereums Übergang von PoW zu PoS im September 2022 — „The Merge“ — den annualisierten Stromverbrauch des Netzwerks um mehr als 99.988% senkte ([ethereum.org: Energy consumption](https://ethereum.org/en/energy-consumption/#:~:text=CCRI%20estimates%20that%20The%20Merge%20reduced%20Ethereum%27s%20annualized%20electricity%20consumption%20by%20more%20than%2099.988%25)). **Beispiel-Chains:** Ethereum, Cardano, Solana (nutzt PoS neben Proof of History für wirtschaftliche Sicherheit) und Polkadot.
+
+---
+
+## Delegated Proof of Stake
+
+Delegated Proof of Stake (DPoS) behält das Staking-Modell bei, fügt aber eine Wahlebene hinzu. Statt jeden Staker einzeln zum Vorschlagen von Blöcken zuzulassen, stimmen Token-Inhaber mit ihrem Stake für eine kleine Gruppe von **Delegierten** (auch Witnesses oder Block-Produzenten genannt); nur diese gewählte Gruppe produziert tatsächlich Blöcke. Die Stimmkraft wächst mit der Anzahl der gehaltenen Token. Die Fachliteratur erklärt den Kernmechanismus treffend: „Die Stimmkraft jedes Token-Inhabers ist proportional zur Anzahl der von ihm gehaltenen Token.“ Zudem laufen die Wahlen kontinuierlich, sodass Inhaber ihre Stimmen jederzeit neu zuweisen oder leistungsschwache Delegierte abwählen können ([Binance Academy: Delegated Proof of Stake erklärt](https://www.binance.com/en/academy/articles/delegated-proof-of-stake-explained)).
+
+Die **Sybil-Resistenz** bleibt Stake-basiert — Stimmen werden nach gehaltenen Token und nicht nach Kontenanzahl gewichtet —, doch die Block*produktion* ist in einem kleinen, gewählten Komitee konzentriert, statt allen Stakern offenzustehen. Genau das ist der Zweck dieser Konzentration: Weil die aktive Validator-Gruppe klein ist und im Voraus bekannt ist, können DPoS-Netzwerke „schnelle Blockzeiten, oft deutlich unter drei Sekunden“ erreichen ([Binance Academy: Delegated Proof of Stake erklärt](https://www.binance.com/en/academy/articles/delegated-proof-of-stake-explained)). Der Preis dafür ist eine geringere Dezentralisierung: Die meisten DPoS-Netzwerke arbeiten mit ungefähr „21 bis 101 aktiven Validatoren“, einer weitaus kleineren Gruppe als den Hunderten oder Tausenden von Validatoren, die für offene PoS-Netzwerke typisch sind. Wahlmüdigkeit kann zudem dazu führen, dass sich dieselben Delegierten mit der Zeit festsetzen ([Binance Academy: Delegated Proof of Stake erklärt](https://www.binance.com/en/academy/articles/delegated-proof-of-stake-explained)). **Beispiel-Chains:** EOS, TRON und — in modifizierter Form — viele frühe Anwendungschains auf dem Cosmos SDK.
+
+---
+
+## BFT-artiger Konsens (Tendermint / CometBFT, PBFT)
+
+![Ein Rat aus Validatoren sitzt an einem Tisch; mehr als zwei Drittel heben grüne Paddel mit Häkchen zur Zustimmung, wodurch ein Block mit Schloss-Symbol sofort finalisiert wird](../../assets/blockchain-consensus-mechanisms-03-bft.jpg)
+
+Byzantine Fault Tolerant (BFT)-Konsens verfolgt einen ganz anderen Ansatz: Statt zu konkurrieren oder für jeden Block zufällig einen Proposer auszuwählen, führt eine bekannte Gruppe von Validatoren ausdrückliche Abstimmungsrunden durch und finalisiert einen Block erst, wenn eine Supermehrheit — typischerweise mehr als zwei Drittel der Stimmkraft — ihm in derselben Runde zustimmt. **CometBFT** (der Nachfolger von Tendermint Core, der Konsens-Engine hinter dem Cosmos SDK) beschreibt sich als System, das „byzantinisch fehlertolerante (BFT-)Replikation von Zustandsautomaten (SMR) für beliebige deterministische, endliche Zustandsautomaten“ ausführt ([Cosmos-Dokumentation: CometBFT](https://docs.cosmos.network/cometbft)). Das bedeutet: Es verwandelt eine Gruppe unabhängig betriebener Nodes in ein einheitliches, repliziertes Ledger, selbst wenn einige davon fehlerhaft oder böswillig sind.
+
+Die **Sybil-Resistenz** in Tendermint-artigen Chains wird typischerweise durch Staking ergänzt (Validatoren werden wie bei PoS nach Stake gewichtet), während das BFT-Abstimmungsprotokoll selbst die **Finalität** liefert: Sobald ein Block in einer Runde die erforderliche Supermehrheit an Validator-Signaturen sammelt, wird er finalisiert und kann nicht wie ein PoW-Block reorganisiert werden. Das führt zu einer schnellen, praktischen Abwicklung — das Cosmos Network hebt für CometBFT-basierte Chains eine Transaktionsabwicklung unter einer Sekunde hervor ([Cosmos Network](https://cosmos.network/#:~:text=%3C1%20second%20transaction%20settlement)) — im Gegensatz zum Bestätigungsmodell von PoW, das auf Warten beruht. Der Nachteil ist, dass BFT-Protokolle eine bekannte und in ihrer Größe begrenzte Validator-Gruppe benötigen (der Kommunikationsaufwand wächst mit der Anzahl der Validatoren); dadurch ist begrenzt, wie viele Validatoren direkt teilnehmen können. **Beispiel-Chains:** Cosmos Hub und andere Chains auf dem Cosmos SDK (CometBFT), Binance Chain sowie erlaubnispflichtige Unternehmens-Ledger, die auf dem ursprünglichen Design der Practical Byzantine Fault Tolerance (PBFT) beruhen.
+
+---
+
+## Darüber hinaus: Proof of History, Proof of Authority, Proof of Space
+
+Einige weitere Mechanismen runden das Bild ab. Jeder von ihnen löst ein engeres Problem, statt die grundlegende Frage der Sybil-Resistenz zu ersetzen.
+
+**Proof of History (PoH)**, den Solana neben PoS verwendet, ist kein eigenständiger Konsensmechanismus, sondern eine kryptografische Uhr. Er fügt überprüfbare Zeitstempel direkt in die Chain ein, indem „die Daten der zuvor erzeugten Zustände“ wiederholt gehasht werden. Dadurch entsteht eine Sequenz, die belegt, wie viel Zeit zwischen Ereignissen verging, ohne dass Validatoren über die Zeit kommunizieren müssen ([Solana: Proof of History](https://solana.com/news/proof-of-history#:~:text=inserting%20data%20into%20the%20sequence%20by%20appending%20the%20hash%20of%20the%20data%20of%20the%20previously%20generated%20states)). Indem es die Zeit selbst überprüfbar macht, ermöglicht es Validatoren, Transaktionen parallel zu verarbeiten und zu prüfen, und reduziert so den Kommunikationsaufwand, der Konsens normalerweise verlangsamt.
+
+**Proof of Authority (PoA)** verzichtet vollständig auf wirtschaftliche und rechnerische Kosten und setzt stattdessen auf Reputation. Eine feste Gruppe bekannter, identifizierter Validatoren — „namhafte Unternehmen“ oder geprüfte Einzelpersonen — wird mit der Produktion von Blöcken betraut; Fehlverhalten wird durch Reputations- und rechtliche Verantwortlichkeit abgeschreckt, nicht durch gekürzten Stake oder verschwendete Rechenleistung ([ethereum.org: Proof-of-authority](https://ethereum.org/en/developers/docs/consensus-mechanisms/poa/#:~:text=The%20reputation%20in%20this%20context%20is%20not%20a%20quantified%20thing)). Dafür wird Dezentralisierung gegen Geschwindigkeit und niedrige Kosten eingetauscht. Deshalb wird PoA überwiegend in privaten Chains, Testnets und lokalen Entwicklungsnetzwerken eingesetzt, nicht in öffentlichen Netzwerken mit gegnerischen Akteuren.
+
+**Proof of Space** (und seine Variante Proof of Space-Time) ersetzt Rechenleistung oder Stake durch zugewiesenen Festplattenspeicher: Teilnehmende weisen nach, dass sie ungenutzten Speicherplatz auf Festplatten reserviert haben, und das Protokoll fordert sie regelmäßig auf zu belegen, dass sie ihn weiterhin vorhalten. Das bietet PoW-ähnliche Sybil-Resistenz bei deutlich geringerem Energieverbrauch, setzt jedoch große Mengen an Speicherhardware voraus. Chia ist das bekannteste Beispiel.
+
+---
+
+## Vergleich der Mechanismen
+
+| Mechanismus | Grundlage der Sybil-Resistenz | Finalität | Energiekosten | Dezentralisierung | Beispiel-Chains |
+|---|---|---|---|---|---|
+| Proof of Work | Rechenkosten (Hashing) | Probabilistisch (Bestätigungen) | Sehr hoch | Hoch (erlaubnisfreies Mining) | Bitcoin, Litecoin, Dogecoin |
+| Proof of Stake | Wirtschaftlicher Stake im Risiko | Über Checkpoints / innerhalb von Epochen nahezu endgültig | Sehr niedrig | Hoch (Hunderttausende Validatoren) | Ethereum, Cardano, Polkadot |
+| Delegated Proof of Stake | Nach Stake gewichtete Wahl von Delegierten | Schnell, pro gewähltem Produzenten nahezu sofort | Sehr niedrig | Niedriger (kleine gewählte Validator-Gruppe) | EOS, TRON |
+| BFT-artig (Tendermint/CometBFT, PBFT) | Stake oder erlaubnispflichtige Identität + Supermehrheitsabstimmung | Sofort/deterministisch nach Übernahme | Niedrig | Mittel (begrenzte Validator-Gruppe) | Cosmos Hub, Binance Chain |
+| Proof of Authority | Geprüfte Identität/Reputation | Schnell, nahezu sofort | Sehr niedrig | Niedrig (kleine vertrauenswürdige Validator-Gruppe) | Private/Unternehmens-Chains, Testnets |
+| Proof of Space | Zugewiesene Speicherkapazität | Probabilistisch (blockbasiert) | Niedrig | Mittel (abhängig von Speicherhardware) | Chia |
+
+---
+
+## Wie dies mit tokenisierten Domains zusammenhängt
+
+Konsensmechanismen bilden die unsichtbare Grundlage unter jeder [tokenisierten Domain](/de/blog/what-are-tokenized-domains/). Wenn eine `.com`-, `.ai`- oder `.io`-Domain als [NFT](/de/glossary/nft/) geprägt wird, ist die Aufzeichnung darüber, wem dieses Token gehört — ebenso wie jede spätere Übertragung, jeder Verkauf oder jede Verlängerung — nur so vertrauenswürdig wie der Konsensmechanismus, der die Chain absichert, auf der sie liegt. Eine auf [Ethereum](/de/glossary/ethereum/) geprägte Domain-NFT übernimmt die schnelle, kostengünstige Finalität von PoS und dessen Validator-Gruppe mit Hunderttausenden Teilnehmern; derselbe Vermögenswert auf einer PoW-Chain würde probabilistische Finalität und deutlich höhere Transaktionskosten übernehmen. Zu verstehen, welcher Mechanismus einer Chain zugrunde liegt und was seine Garantien für Sybil-Resistenz und Finalität tatsächlich bedeuten, gehört zur Bewertung jedes On-Chain-Vermögenswerts, einschließlich tokenisierter Domains.
+
+---
+
+## Quellen und weiterführende Lektüre
+
+- [Bitcoin: Ein elektronisches Peer-to-Peer-Geldsystem (Nakamoto-Whitepaper)](https://bitcoin.org/bitcoin.pdf)
+- [ethereum.org — Proof-of-work](https://ethereum.org/en/developers/docs/consensus-mechanisms/pow/)
+- [ethereum.org — Proof-of-stake](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/)
+- [ethereum.org — Proof-of-authority](https://ethereum.org/en/developers/docs/consensus-mechanisms/poa/)
+- [ethereum.org — Energieverbrauch](https://ethereum.org/en/energy-consumption/)
+- [Cosmos-Dokumentation — CometBFT](https://docs.cosmos.network/cometbft)
+- [Cosmos Network](https://cosmos.network/)
+- [Binance Academy — Delegated Proof of Stake erklärt](https://www.binance.com/en/academy/articles/delegated-proof-of-stake-explained)
+- [Solana — Proof of History](https://solana.com/news/proof-of-history)

--- a/content/blog/de/blockchain-cryptographic-primitives.md
+++ b/content/blog/de/blockchain-cryptographic-primitives.md
@@ -1,0 +1,128 @@
+---
+title: "Die wichtigsten kryptografischen Primitive hinter jeder Blockchain"
+date: '2026-07-02'
+language: de
+tags: ['guide']
+authors: ['namefiteam']
+draft: false
+cluster: web3-foundations
+series: blockchain-concepts
+seriesOrder: 10
+format: roundup
+description: "Ein Leitfaden zu den zentralen kryptografischen Primitiven, die Blockchains ermöglichen: Hashfunktionen, digitale Signaturen, Merkle-Bäume, Elliptische-Kurven-Kryptografie und Commitment-Schemata."
+ogImage: ../../assets/blockchain-cryptographic-primitives-og.jpg
+keywords: ['blockchain-kryptografie', 'kryptografische primitive', 'hashfunktion', 'SHA-256', 'Keccak-256', 'digitale signatur', 'ECDSA', 'EdDSA', 'BLS-signatur', 'merkle-baum', 'elliptische-kurven-kryptografie', 'secp256k1', 'commitment-schema', 'post-quanten-kryptografie', 'public-key-kryptografie', 'blockchain-sicherheit']
+relatedArticles:
+  - /de/blog/blockchain-privacy-technologies/
+  - /de/blog/blockchain-consensus-mechanisms/
+  - /de/blog/blockchain-virtual-machines/
+  - /de/blog/blockchain-scaling-approaches/
+  - /de/blog/perfect-vs-computational-zero-knowledge/
+relatedGlossary:
+  - /de/glossary/hash-function/
+  - /de/glossary/digital-signature/
+  - /de/glossary/merkle-tree/
+  - /de/glossary/public-key/
+  - /de/glossary/private-key/
+relatedTopics:
+  - /de/topics/web3-foundations/
+  - /de/topics/domain-tokenization/
+relatedSeries:
+  - /de/series/tokenize-your-com/
+  - /de/series/domain-flipping-skills/
+---
+
+Jede Aussage einer Blockchain — „Diese Transaktion ist endgültig“, „Diese Adresse besitzt diesen Vermögenswert“, „Dieser Verlauf wurde nicht verändert“ — lässt sich letztlich auf eine Handvoll kryptografischer Primitive zurückführen, die enge, klar definierte Aufgaben erfüllen. Keine von ihnen ist eine Erfindung der Blockchain. Hashfunktionen, digitale Signaturen und Merkle-Bäume gab es schon Jahrzehnte vor Bitcoin. Blockchains kombinierten sie zu einem System, in dem für keine dieser Aussagen einer einzelnen Partei vertraut werden muss.
+
+Dieser Leitfaden behandelt die Primitive, die tatsächlich die Last tragen: [Hashfunktionen](/de/glossary/hash-function/), die Daten mit einem Fingerabdruck versehen, [digitale Signaturen](/de/glossary/digital-signature/), die Transaktionen autorisieren, [Merkle-Bäume](/de/glossary/merkle-tree/), die riesige Datensätze stückweise überprüfbar machen, die Mathematik elliptischer Kurven, auf der diese Signaturen beruhen, sowie Commitment-Schemata — die Grundlage, die zu [Zero-Knowledge-Proofs](/de/glossary/zero-knowledge-proof/) führt. Jede einzelne zu verstehen, ist der schnellste Weg zu verstehen, was eine Blockchain unter der Haube wirklich tut.
+
+---
+
+## Kryptografische Hashfunktionen (SHA-256, Keccak)
+
+![Ein Dokument wird in eine Hashfunktionsmaschine eingespeist und erzeugt einen Fingerabdruck fester Länge; die Änderung eines einzigen Buchstabens in der Eingabe erzeugt eine völlig andere Prüfsumme und veranschaulicht den Avalanche-Effekt](../../assets/blockchain-cryptographic-primitives-01-hash-function.jpg)
+
+Eine [Hashfunktion](/de/glossary/hash-function/) nimmt eine Eingabe beliebiger Größe und erzeugt deterministisch eine Ausgabe fester Größe — einen „Digest“. Das Ändern eines einzigen Bits der Eingabe verändert die Ausgabe vollständig, und zwei verschiedene Eingaben zu finden, die denselben Hashwert ergeben, ist rechnerisch nicht praktikabel. Diese Eigenschaft, die Kollisionsresistenz, macht einen Hash als kompakten, manipulationssichtbaren Fingerabdruck für beliebig große Daten nutzbar.
+
+Bitcoin verwendet SHA-256 überall: Block-Header werden verkettet, indem der Hash SHA256(SHA256()) des vorherigen Headers in jeden neuen eingebettet wird. Eine Änderung an einem vergangenen Block verändert damit seinen Hash und bricht jeden folgenden Header ([Bitcoin Developer Guide](https://developer.bitcoin.org/devguide/block_chain.html#:~:text=Each%20block%20also%20stores%20the%20hash%20of%20the%20previous%20block%27s%20header%2C%20chaining%20the%20blocks%20together)). Dieselbe Double-SHA-256-Konstruktion hasht Transaktionen in den [Merkle-Baum](/de/glossary/merkle-tree/) des Blocks ([Bitcoin.org-Referenz](https://developer.bitcoin.org/reference/block_chain.html#:~:text=A%20SHA256%28SHA256%28%29%29%20hash%20in%20internal%20byte%20order)).
+
+Ethereum standardisiert stattdessen Keccak-256 als Hashfunktion für allgemeine Zwecke — die ursprüngliche Keccak-Einreichung und nicht den späteren NIST-Standard SHA-3. Jede Kontoadresse wird aus den letzten 20 Byte des Keccak-256-Hashs des [öffentlichen Schlüssels](/de/glossary/public-key/) des Kontos abgeleitet ([ethereum.org](https://ethereum.org/en/developers/docs/accounts/#:~:text=You%20get%20a%20public%20address%20for%20your%20account%20by%20taking%20the%20last%2020%20bytes%20of%20the%20Keccak-256%20hash%20of%20the%20public%20key)). Dieselbe Funktion liegt der Schlüssel/Wert-Content-Adressierung im [Merkle Patricia Trie](https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/#:~:text=key%20%3D%3D%20keccak256%28rlp%28value%29%29) zugrunde, der den Zustand von Ethereum speichert.
+
+Hashing macht Block-Header außerdem zu einer echten Kette statt zu einer losen Sammlung von Datensätzen: Der Hash jedes Headers hängt vom Hash des vorherigen Headers ab. Um den Verlauf umzuschreiben, müssten daher alle Blöcke ab dem gewünschten Änderungspunkt neu berechnet und zugleich die laufende Arbeit des ehrlichen Netzwerks übertroffen werden. Diese Eigenschaft der „Verkettung“ ist der wörtliche Grund, warum diese Datenstruktur **Blockchain** heißt.
+
+---
+
+## Public-Key-Kryptografie und digitale Signaturen (ECDSA, EdDSA, BLS)
+
+![Ein privater Schlüssel signiert eine Transaktion und erzeugt eine digitale Signatur; der passende öffentliche Schlüssel bestätigt sie mit einem grünen Häkchen als gültig, während ein nicht passender öffentlicher Schlüssel sie mit einem roten X zurückweist](../../assets/blockchain-cryptographic-primitives-02-signatures.jpg)
+
+Eine Blockchain hat kein Anmeldeformular und braucht daher einen anderen Weg, um zu beweisen: „Diese Transaktion stammt wirklich vom Eigentümer dieses Kontos.“ [Public-Key-Kryptografie](/de/glossary/public-key/) löst dies mit einem Schlüsselpaar: einem geheim gehaltenen [privaten Schlüssel](/de/glossary/private-key/) und einem frei teilbaren öffentlichen Schlüssel. Das Signieren einer Transaktion mit dem privaten Schlüssel erzeugt eine [digitale Signatur](/de/glossary/digital-signature/), die jeder gegen den öffentlichen Schlüssel prüfen kann. Damit wird die Autorisierung nachgewiesen, ohne den privaten Schlüssel selbst offenzulegen.
+
+Ethereum-Konten leiten ihren öffentlichen Schlüssel aus dem privaten Schlüssel ab, indem sie den Elliptic Curve Digital Signature Algorithm, ECDSA, über der Kurve secp256k1 verwenden — derselben Kurve wie Bitcoin ([ethereum.org-Dokumentation zu Konten](https://ethereum.org/en/developers/docs/accounts/#:~:text=The%20public%20key%20is%20generated%20from%20the%20private%20key%20using%20the%20Elliptic%20Curve%20Digital%20Signature%20Algorithm); [EIP-2, Korrektur der Formbarkeit von secp256k1-Signaturen](https://eips.ethereum.org/EIPS/eip-2#:~:text=secp256k1n%2F2)). ECDSA ist schnell zu verifizieren und wurde jahrzehntelang geprüft, hat aber eine für neuere Entwürfe relevante operative Schwäche: Einzelne ECDSA-Signaturen lassen sich nicht effizient aggregieren. Tausende zu prüfen bedeutet daher Tausende getrennte Prüfungen.
+
+Genau diese Lücke schließen EdDSA- und BLS-Signaturen. EdDSA, verwendet von Chains wie Solana und Stellar, nutzt eine andere Kurvenkonstruktion, die deterministisch ist und bestimmten Implementierungsfallen widersteht, welche historisch ECDSA-Fehler durch Wiederverwendung von Nonces verursachten. BLS-Signaturen gehen weiter: Aufgrund der mathematischen Pairing-Eigenschaft ihrer Kurven lassen sich viele BLS-Signaturen zu einer einzigen aggregierten Signatur verbinden, die sie alle zugleich prüft. Die Proof-of-Stake-Konsensschicht von Ethereum beruht genau darauf. Validatoren signieren Attestierungen mit BLS-Schlüsseln, sodass die Beacon Chain Stimmen von Hunderttausenden Validatoren in Signaturen aggregieren kann, die kompakt genug für eine schnelle Verifizierung sind. Das macht Proof of Stake in großem Maßstab überhaupt erst praktikabel ([ethereum.org, *The Beacon Chain*](https://eth2book.info/capella/part2/building_blocks/signatures/#:~:text=BLS%20signatures%20can%20be%20aggregated%20together%2C%20making%20them%20efficient%20to%20verify%20at%20large%20scale)). Ethereum stellt BLS12-381-Kurvenoperationen außerdem als EVM-Precompiles bereit, um insbesondere die Verifizierung von BLS-Signaturen in Smart Contracts zu unterstützen ([EIP-2537](https://eips.ethereum.org/EIPS/eip-2537#:~:text=Add%20functionality%20to%20efficiently%20perform%20operations%20over%20the%20BLS12-381%20curve%2C%20including%20those%20for%20BLS%20signature%20verification)).
+
+---
+
+## Merkle-Bäume
+
+![Eine Pyramide von Hashknoten eines Merkle-Baums wird paarweise zu einer einzigen Wurzel zusammengeführt; ein orange hervorgehobener Beweispfad von einem Blatt zur Wurzel zeigt einen Merkle-Beweis eines Light Clients](../../assets/blockchain-cryptographic-primitives-03-merkle-tree.jpg)
+
+Ein [Merkle-Baum](/de/glossary/merkle-tree/) ermöglicht es einer Blockchain, Tausende Transaktionen in einem einzigen 32-Byte-Hash zusammenzufassen, ohne jeden Teilnehmer zum Speichern jeder Transaktion zu zwingen. Blätter sind Hashwerte einzelner Datenelemente (Transaktionen, Kontozustände); jedes Hashpaar wird verkettet und erneut gehasht, bis ein Hash — die Wurzel — übrig bleibt ([Bitcoin Developer Guide](https://developer.bitcoin.org/devguide/block_chain.html#:~:text=Copies%20of%20each%20transaction%20are%20hashed%2C%20and%20the%20hashes%20are%20then%20paired%2C%20hashed%2C%20paired%20again%2C%20and%20hashed%20again%20until%20a%20single%20hash%20remains%2C%20the%20merkle%20root%20of%20a%20merkle%20tree)). Diese Wurzel wird direkt im Block-Header gespeichert. So kann ein Full Node sich mit fast keinem zusätzlichen Speicherplatz auf den gesamten Inhalt eines Blocks festlegen.
+
+Der Gewinn liegt in der Größe des Beweises. Um zu zeigen, dass eine Transaktion in einem Block enthalten ist, benötigt man nicht den gesamten Block, sondern nur die Transaktion plus einen „Merkle-Zweig“, also die Geschwister-Hashes entlang des Pfads von diesem Blatt zur Wurzel, typischerweise in der Größenordnung von log₂(n) Hashes bei n Transaktionen. Darauf basiert Simplified Payment Verification (SPV): Ein schlanker Client, der nur Block-Header besitzt, kann weiterhin prüfen, ob eine konkrete Transaktion stattgefunden hat, indem er ihren Merkle-Zweig gegen die Wurzel des Headers prüft, ohne die gesamte Blockchain herunterzuladen ([Bitcoin Developer Guide](https://developer.bitcoin.org/devguide/operating_modes.html#:~:text=the%20merkle%20root%20in%20the%20block%20header%20along%20with%20a%20merkle%20branch%20can%20prove%20to%20the%20SPV%20client%20that%20the%20transaction%20in%20question%20is%20embedded%20in%20a%20block%20in%20the%20block%20chain)).
+
+Ethereum erweitert die Idee mit dem Merkle Patricia Trie, einem Hybrid aus Merkle-Baum und Präfix- oder Radix-Trie, der den gesamten Kontozustand statt nur einer Transaktionsliste speichert. Jeder Block-Header enthält drei getrennte Trie-Wurzeln — `stateRoot`, `transactionsRoot` und `receiptsRoot` —, die jeweils unabhängig nachweisbar sind ([ethereum.org](https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/#:~:text=From%20a%20block%20header%20there%20are%203%20roots%20from%203%20of%20these%20tries)). Dies erlaubt einem Smart Contract oder einem Light Client, einen einzelnen Kontostand oder Storage-Slot zu überprüfen, ohne die gesamte Chain erneut auszuführen.
+
+---
+
+## Elliptische-Kurven-Kryptografie
+
+Die Elliptische-Kurven-Kryptografie (ECC) ist die mathematische Grundlage von ECDSA, EdDSA und BLS. Statt sich auf die Schwierigkeit der Faktorisierung großer Zahlen zu stützen, wie klassisches RSA, beruht ECC auf der Schwierigkeit des diskreten Logarithmusproblems auf elliptischen Kurven: Ist ein Punkt auf der Kurve gegeben, der durch vielfaches Addieren eines Basispunkts zu sich selbst erreicht wurde, ist es rechnerisch nicht praktikabel zu bestimmen, wie oft addiert wurde. Den Punkt selbst vorwärts zu berechnen ist dagegen einfach. Diese Asymmetrie — in eine Richtung leicht, rückwärts schwer — macht einen privaten Schlüssel für Signaturen sicher nutzbar, während der daraus abgeleitete öffentliche Schlüssel sicher veröffentlicht werden kann.
+
+Die konkrete Kurve ist wichtig. Bitcoin und Ethereum verwenden beide secp256k1, eine Koblitz-Kurve, die von der Standards for Efficient Cryptography Group mit gut untersuchten 256-Bit-Parametern standardisiert wurde ([SEC 2: Recommended Elliptic Curve Domain Parameters](https://www.secg.org/sec2-v2.pdf)). Andere Ökosysteme verwenden andere Kurven für andere Abwägungen. Ed25519, die Kurve hinter EdDSA in Solana und Stellar, priorisiert Implementierungssicherheit und Geschwindigkeit; BLS12-381 wird speziell ausgewählt, weil sie die für Aggregation benötigten Pairing-Operationen unterstützt. Alle liefern pro Schlüsselbit ungefähr dasselbe praktische Sicherheitsniveau, erzeugen jedoch deutlich kürzere Schlüssel und Signaturen als äquivalentes RSA. Deshalb wurde ECC und nicht RSA zum Standard für Blockchain-Konten.
+
+---
+
+## Commitment-Schemata (eine Brücke zu Zero Knowledge)
+
+Ein Commitment-Schema ermöglicht es, einen Wert „festzulegen“: Sie veröffentlichen etwas, das Sie an ein konkretes Datenelement bindet, ohne das Datenelement selbst offenzulegen, und können das Commitment später „öffnen“, um zu beweisen, was es war. Die Alltagsanalogie ist ein versiegelter Umschlag. Sie können heute jemandem einen verschlossenen Umschlag geben als Beweis, dass Sie bereits eine Antwort entschieden haben, ohne dass diese Person sie sieht, bis Sie sich später zum Öffnen entschließen. Nach dem Versiegeln können Sie die darin enthaltene Antwort nicht mehr austauschen.
+
+Das klingt wie ein kleines Primitiv, ist jedoch das tragende Bauteil unter den meisten Zero-Knowledge-Proof-Systemen. Das blobbasierte Data-Availability-Design von Ethereum verwendet beispielsweise KZG-Commitments — ein polynomiales Commitment-Schema —, um einen großen Blob mit Rollup-Daten auf ein einzelnes kleines kryptografisches Commitment zu reduzieren, das Prover und Verifier prüfen können, ohne den gesamten Blob zu verarbeiten ([ethereum.org, Danksharding](https://ethereum.org/en/roadmap/danksharding/#:~:text=KZG%20stands%20for%20Kate-Zaverucha-Goldberg)). Eine Merkle-Wurzel ist selbst ein einfaches Commitment-Schema: Sie bindet einen gesamten Datensatz über ihren Root-Hash, und ein Merkle-Zweig ist die „Öffnung“, die ein einzelnes Element enthüllt. ZK-Rollups bauen auf fortgeschritteneren Commitment-Schemata (polynomialen und Vektor-Commitments) auf, um die Ausführung eines ganzen Transaktionsbatches in einen günstig On-Chain prüfbaren Beweis zu komprimieren. Dieses Thema behandelt [Perfektes vs. computationelles Zero Knowledge](/de/blog/perfect-vs-computational-zero-knowledge/) ausführlich.
+
+---
+
+## Vergleich: kryptografische Primitive der Blockchain
+
+| Primitiv | Bereitgestellte Eigenschaft | On-Chain-Einsatz | Klassisches vs. Post-Quanten-Risiko |
+|---|---|---|---|
+| Hashfunktionen (SHA-256, Keccak-256) | Kollisionsresistenter Fingerabdruck; verkettet Blöcke | Block-Hashing, Adressableitung, Merkle-Wurzeln | Bei heutigen Ausgabegrößen klassisch stark; hashbasierte Schemata gelten im Allgemeinen als widerstandsfähiger gegen Quantenangriffe als heutige Signaturen elliptischer Kurven |
+| Digitale Signaturen — ECDSA | Transaktionsautorisierung über ein privates/öffentliches Schlüsselpaar | Bitcoin- und Ethereum-Kontosignaturen | Klassisch sicher; ein ausreichend leistungsfähiger Quantencomputer großen Maßstabs soll auf elliptischen Kurven beruhende Schemata brechen können, weshalb das NIST Post-Quanten-Alternativen standardisiert hat ([NIST, 2024](https://www.nist.gov/news-events/news/2024/08/nist-releases-first-3-finalized-post-quantum-encryption-standards#:~:text=A%20sufficiently%20capable%20quantum%20computer%2C%20though%2C%20would%20be%20able%20to%20sift%20through%20a%20vast%20number%20of%20potential%20solutions%20to%20these%20problems%20very%20quickly%2C%20thereby%20defeating%20current%20encryption)) |
+| Digitale Signaturen — EdDSA / BLS | Deterministisches Signieren (EdDSA); effiziente Signaturaggregation (BLS) | Signieren in Solana/Stellar (EdDSA); Attestierungen von Ethereum-Validatoren (BLS) | Dieselbe zugrunde liegende Annahme elliptischer Kurven wie bei ECDSA — dieselbe langfristige Quantenexponierung |
+| Merkle-Bäume | Kompaktes Commitment für einen großen Datensatz; kleine Inklusionsbeweise | Block-Header, Prüfung durch Light Clients (SPV), Tries für Zustand/Transaktionen/Receipts von Ethereum | Hängt allein von der Kollisionsresistenz der zugrunde liegenden Hashfunktion ab und übernimmt damit deren Quantenprofil, ohne eine neue Exponierung hinzuzufügen |
+| Elliptische-Kurven-Kryptografie | Mathematische Basis kompakter Schlüssel und Signaturen | secp256k1 (Bitcoin, Ethereum), Ed25519, BLS12-381 | In gleicher Weise wie ECDSA/EdDSA/BLS durch einen künftigen Quantencomputer großen Maßstabs gefährdet; dies ist der wichtigste Treiber der Forschung zur Post-Quanten-Migration |
+| Commitment-Schemata | Jetzt an einen Wert binden, ihn später enthüllen/nachweisen, ohne ihn vorab offenzulegen | KZG-Commitments für die Data Availability von Ethereum; Merkle-Wurzeln als einfache Commitments; Baustein für ZK-Rollups | Die Sicherheit hängt von der Hash- oder Elliptische-Kurven-Annahme ab, die zum Aufbau des Schemas verwendet wird |
+
+---
+
+## Verbindung zu tokenisierten Domains
+
+Jedes dieser Primitive kommt direkt zum Einsatz, wenn Sie eine Domain [tokenisieren](/de/glossary/tokenize/). Das [NFT](/de/glossary/nft/), das Eigentum repräsentiert, ist durch dieselben ECDSA-Signaturen gesichert wie jeder andere Blockchain-Vermögenswert. Wer den privaten Schlüssel kontrolliert, kontrolliert den Domain-Token — ohne Ausnahme. Deshalb sind [Hardware-Wallets](/de/glossary/hardware-wallet/) und die sorgfältige Verwahrung einer [Seed Phrase](/de/glossary/seed-phrase/) für eine tokenisierte `.com` genauso wichtig wie für jeden anderen On-Chain-Vermögenswert. Der Eigentumsdatensatz der Domain lebt in demselben durch Merkle-Commitments abgesicherten Zustand, der jeden anderen Kontostand und [Smart Contract](/de/glossary/smart-contract/) auf der Chain sichert. Genau das verleiht einer tokenisierten Domain dieselbe Manipulationssichtbarkeit wie jedem anderen On-Chain-Vermögenswert: Sie ist übertragbar, überprüfbar und ihr Eigentum ist nachweisbar, ohne dass die Datenbank eines Registrars die einzige Quelle der Wahrheit ist.
+
+Das Verständnis dieser Primitive macht auch klar, was Tokenisierung verändert und was nicht: DNS-Eintrag und Registry-Status der Domain folgen weiterhin den ICANN-Regeln, aber ihr Eigentumsnachweis beruht nun auf der oben beschriebenen Kryptografie statt auf einem durch Login geschützten [Registrar](/de/glossary/registrar/)-Konto. Das größere Bild finden Sie in [Blockchain-Konsensmechanismen](/de/blog/blockchain-consensus-mechanisms/) und [Ansätze zur Skalierung von Blockchains](/de/blog/blockchain-scaling-approaches/), oder beginnen Sie die Tokenisierung bei [namefi.io](https://namefi.io).
+
+---
+
+## Quellen und weiterführende Lektüre
+
+- Bitcoin Developer Guide — [Block Chain](https://developer.bitcoin.org/devguide/block_chain.html), Verkettung über SHA256(SHA256()) des vorherigen Headers
+- Bitcoin Developer Reference — [Block Chain](https://developer.bitcoin.org/reference/block_chain.html), Aufbau der Merkle-Wurzel
+- Bitcoin Developer Guide — [Operating Modes](https://developer.bitcoin.org/devguide/operating_modes.html), SPV und Merkle-Zweige
+- ethereum.org — [Ethereum Accounts](https://ethereum.org/en/developers/docs/accounts/), ECDSA und Ableitung von Keccak-256-Adressen
+- ethereum.org — [Merkle Patricia Trie](https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/), Wurzeln für Zustand/Transaktionen/Receipts
+- ethereum.org — [Danksharding](https://ethereum.org/en/roadmap/danksharding/), polynomiale KZG-Commitments
+- EIP-2 — [Homestead Hard-fork Changes](https://eips.ethereum.org/EIPS/eip-2), Einschränkungen für secp256k1-Signaturen
+- EIP-2537 — [Precompile for BLS12-381 curve operations](https://eips.ethereum.org/EIPS/eip-2537)
+- SEC 2: Recommended Elliptic Curve Domain Parameters — [secg.org](https://www.secg.org/sec2-v2.pdf)
+- *The Eth2 Book* — [Signatures and BLS aggregation](https://eth2book.info/capella/part2/building_blocks/signatures/)
+- NIST — [NIST Releases First 3 Finalized Post-Quantum Encryption Standards](https://www.nist.gov/news-events/news/2024/08/nist-releases-first-3-finalized-post-quantum-encryption-standards)

--- a/content/blog/de/blockchain-privacy-technologies.md
+++ b/content/blog/de/blockchain-privacy-technologies.md
@@ -1,0 +1,152 @@
+---
+title: "Die wichtigsten Blockchain-Datenschutztechnologien: Zero-Knowledge-Proofs, FHE, MPC, TEEs und Ringsignaturen"
+date: '2026-07-02'
+language: de
+tags: ['guide']
+authors: ['namefiteam']
+draft: false
+cluster: web3-foundations
+series: blockchain-concepts
+seriesOrder: 50
+format: roundup
+description: "Ein verständlicher Leitfaden zu den fünf führenden Blockchain-Datenschutztechnologien — Zero-Knowledge-Proofs, FHE, MPC, TEEs und Ringsignaturen — im direkten Vergleich."
+ogImage: ../../assets/blockchain-privacy-technologies-og.jpg
+keywords: ['blockchain-datenschutz', 'zero-knowledge-proof', 'zkp', 'vollständig homomorphe verschlüsselung', 'fhe', 'sichere mehrparteienberechnung', 'mpc', 'vertrauenswürdige ausführungumgebung', 'tee', 'ringsignaturen', 'stealth-adressen', 'monero', 'zcash', 'zksync', 'starknet', 'datenschutztechnologie', 'vertrauliches rechnen', 'onchain-datenschutz', 'blockchain-kryptografie', 'privacy coins']
+relatedArticles:
+  - /de/blog/blockchain-cryptographic-primitives/
+  - /de/blog/blockchain-scaling-approaches/
+  - /de/blog/blockchain-virtual-machines/
+  - /de/blog/blockchain-consensus-mechanisms/
+  - /de/blog/perfect-vs-computational-zero-knowledge/
+relatedGlossary:
+  - /de/glossary/zero-knowledge-proof/
+  - /de/glossary/fully-homomorphic-encryption/
+  - /de/glossary/secure-multiparty-computation/
+  - /de/glossary/trusted-execution-environment/
+  - /de/glossary/cryptographic-security/
+relatedTopics:
+  - /de/topics/web3-foundations/
+  - /de/topics/domain-tokenization/
+relatedSeries:
+  - /de/series/tokenize-your-com/
+  - /de/series/domain-flipping-skills/
+---
+
+Jede Transaktion auf einer öffentlichen [Blockchain](/de/glossary/blockchain/) ist standardmäßig für jeden sichtbar, der hinsieht. Guthaben, Transferbeträge und Gegenparteien stehen dauerhaft im offenen Ledger. Diese Transparenz ist die Quelle der Vertrauensgarantien einer Blockchain, aber auch eine Belastung: Keine Bank veröffentlicht Kundenguthaben, und kein Unternehmen möchte, dass Wettbewerber seine Lieferantenzahlungen oder Gehaltsläufe lesen können.
+
+Blockchain-Datenschutztechnologien sollen diese Lücke schließen, ohne die Eigenschaften aufzugeben, die Chains überhaupt nützlich machen: Überprüfbarkeit, Dezentralisierung und die Fähigkeit Fremder, ohne vertrauenswürdigen Mittelsmann miteinander zu handeln. Fünf Techniken prägen die heutige Landschaft: [Zero-Knowledge-Proofs](/de/glossary/zero-knowledge-proof/), [vollständig homomorphe Verschlüsselung](/de/glossary/fully-homomorphic-encryption/) (FHE), [sichere Mehrparteienberechnung](/de/glossary/secure-multiparty-computation/) (MPC), [vertrauenswürdige Ausführungsumgebungen](/de/glossary/trusted-execution-environment/) (TEEs) sowie Ringsignaturen mit Stealth-Adressen. Jede verbirgt einen anderen Teil des Puzzles, beruht auf einer anderen Vertrauensannahme und erfordert unterschiedlich viel Rechenleistung. Dieser Leitfaden erklärt alle fünf, vergleicht sie direkt und zeigt, warum die Wahl für jeden wichtig ist, der auf [Web3](/de/glossary/web3/) baut oder es einfach verstehen möchte.
+
+---
+
+## Zero-Knowledge-Proofs
+
+![Ein Prover überreicht einem Verifier ein leuchtendes Abzeichen für einen gültigen Beweis und hält dabei ein Dokument hinter seinem Rücken verschlossen, was zeigt, wie ein Zero-Knowledge-Proof überzeugt, ohne die zugrunde liegende Aussage offenzulegen](../../assets/blockchain-privacy-technologies-01-zero-knowledge.jpg)
+
+Ein [Zero-Knowledge-Proof](/de/glossary/zero-knowledge-proof/) (ZKP) ermöglicht einer Partei — dem *Prover* —, eine andere — den *Verifier* — davon zu überzeugen, dass eine Aussage wahr ist, ohne etwas anderes darüber preiszugeben. Die Entwicklerdokumentation von Ethereum fasst es so: „A zero-knowledge proof is a way of proving the validity of a statement without revealing the statement itself“; der „prover“ versucht eine Behauptung zu beweisen, während der „verifier“ sie validiert ([ethereum.org](https://ethereum.org/en/zero-knowledge-proofs/#:~:text=A%20zero%2Dknowledge%20proof%20is,without%20revealing%20the%20statement%20itself)).
+
+Damit ein Beweissystem ein echter Zero-Knowledge-Protokoll ist, muss es drei Eigenschaften erfüllen: Vollständigkeit („if the input is valid, the zero-knowledge protocol always returns 'true'“), Korrektheit („if the input is invalid, it is theoretically impossible to fool the zero-knowledge protocol to return 'true'“) und Zero Knowledge selbst, also dass der Verifier über eine Aussage außer ihrer Wahrheit oder Falschheit nichts erfährt ([ethereum.org](https://ethereum.org/en/zero-knowledge-proofs/)). Konkret besteht ein Beweis aus einem Witness, also dem dem Prover bekannten Geheimnis, einer Challenge des Verifiers und einer Antwort, durch die der Verifier das Wissen prüft, ohne den Witness zu sehen.
+
+**Was verborgen wird:** die zugrunde liegenden Daten oder Berechnungen — offenbart wird nur der Beweis, dass eine Behauptung wahr ist.
+
+**Heutige Nutzung:** ZK-Rollups sind der größte Produktionseinsatz von ZKPs bei der Skalierung von Blockchains. Sie „bundle (or 'roll up') transactions into batches that are executed offchain“ und erzeugen dann einen einzelnen Gültigkeitsbeweis, den Ethereum vor der Finalisierung der Zustandsänderungen des Batches prüft ([ethereum.org](https://ethereum.org/en/developers/docs/scaling/zk-rollups/#:~:text=ZK%2Drollups%20bundle%20)). zkSync Era von Matter Labs ist ein „EVM-compatible ZK Rollup...powered by its own zkEVM“ ([ethereum.org](https://ethereum.org/en/developers/docs/scaling/zk-rollups/)); Starknet von StarkWare ist ein Validity Rollup, das statt der EVM seine eigene Cairo-VM ausführt, wobei Solidity-Verträge separat überbrückt werden. L2BEAT erfasst beide als durch Validity Proofs gesicherte Rollups statt durch das Fraud-Proof-Anfechtungsfenster optimistischer Rollups ([l2beat.com](https://l2beat.com/scaling/summary)). Auf der Datenschutzseite war [Zcash](https://z.cash/technology/) Pionier bei zk-SNARKs (Zero-Knowledge Succinct Non-Interactive Arguments of Knowledge) für abgeschirmte Transaktionen; Adressen der Nutzer, Transaktionsbetrag und weitere Details bleiben verschlüsselt, während das Netzwerk die Gültigkeit der Transaktion weiterhin bestätigt ([z.cash](https://z.cash/technology/)).
+
+**Der Kompromiss:** Das Erzeugen eines ZK-Beweises ist rechenintensiv — Beweisschaltkreise durchlaufen jede Transaktion eines Batches und führen dessen Prüfungen erneut aus. Beweiszeit und Hardwarekosten sind daher reale Grenzen, auch wenn die On-Chain-Prüfung günstig und schnell ist. Das Vertrauen in das System reduziert sich auf die Mathematik und bei einigen Beweissystemen auf eine einmalige Trusted-Setup-Zeremonie.
+
+---
+
+## Vollständig homomorphe Verschlüsselung (FHE)
+
+![Eine verschlossene Box durchläuft eine Rechenmaschine, die von einem Cloud-Server ohne Schlüssel betrieben wird, und kommt weiterhin verschlossen, aber mit einem berechneten Ergebnis heraus; dies veranschaulicht Berechnungen direkt auf verschlüsselten Daten](../../assets/blockchain-privacy-technologies-02-fhe.jpg)
+
+[Vollständig homomorphe Verschlüsselung](/de/glossary/fully-homomorphic-encryption/) verfolgt einen anderen Ansatz: Statt eine Tatsache über verborgene Daten zu beweisen, erlaubt sie, *direkt auf verschlüsselten Daten zu rechnen* und ein verschlüsseltes Ergebnis zu erhalten, das nach Entschlüsselung dieselbe Antwort ergibt wie eine Rechnung auf Klartext. Zama, eines der führenden Forschungs- und Infrastrukturunternehmen für FHE, beschreibt dies so: „FHE enables data processing without decryption—companies provide services without accessing user data, while users experience unchanged functionality“ ([zama.org](https://www.zama.org/introduction-to-homomorphic-encryption)).
+
+**Was verborgen wird:** Rohdaten, Zwischenzustand und Ausgaben einer Berechnung — jeder außer dem Schlüsselinhaber sieht nur Ciphertext, auch die Partei, die die Berechnung durchführt.
+
+**Funktionsweise auf hoher Ebene:** FHE-Schemata kodieren Klartextwerte in auf Gittermathematik aufgebauten Ciphertexts und definieren verschlüsselte Entsprechungen von Addition und Multiplikation, sodass beliebige Schaltkreise auf Ciphertexts ausgeführt werden können. Auf eine Blockchain angewandt bedeutet das, dass ein Smart Contract Tokens bewegen oder Logik auswerten kann, ohne die betreffenden Beträge zu sehen. Wie Zamas Beispiel sagt: „the blockchain verified Alice has sufficient funds without ever seeing the actual amounts“ ([zama.org](https://www.zama.org/introduction-to-homomorphic-encryption#:~:text=The%20blockchain%20verified%20Alice%20has%20sufficient%20funds%20without%20ever%20seeing%20the%20actual%20amounts)). Zama weist außerdem darauf hin, dass gitterbasierte FHE-Schemata „inherently post-quantum resilient“ sind, was für langfristige kryptografische Risiken wichtig ist ([zama.org](https://www.zama.org/introduction-to-homomorphic-encryption)).
+
+**Beispielprojekte:** [Zama](https://www.zama.org/) entwickelt die Open-Source-FHE-Bibliotheken TFHE-rs und Concrete sowie die fhEVM, die vertrauliche Smart-Contract-Ausführung für EVM-Chains ermöglicht. [Fhenix](https://cofhe-docs.fhenix.zone/) ist eine Blockchain, die speziell dafür gebaut wurde, dass „developers build privacy-preserving smart contracts using Fully Homomorphic Encryption“, sodass „sensitive data remains encrypted throughout computation“. Dazu gehören die JavaScript-Bibliothek Cofhejs für clientseitige Verschlüsselung und eine Solidity-FHE-Bibliothek für verschlüsselte On-Chain-Operationen ([cofhe-docs.fhenix.zone](https://cofhe-docs.fhenix.zone/)).
+
+**Der Kompromiss:** FHE bietet die stärkste Datenschutzgarantie in dieser Liste — nichts wird jemals entschlüsselt, auch nicht während der Berechnung —, ist gegenüber Klartextausführung aber zugleich mit Abstand am rechenintensivsten. Deshalb führen FHE-basierte Chains heute vertraulichkeitskritische Logik statt jeder Transaktion aus, und deshalb ist Hardwarebeschleunigung für FHE ein aktives Forschungsrennen.
+
+---
+
+## Sichere Mehrparteienberechnung (MPC)
+
+![Drei Personen halten jeweils einen Schlüsselsplitter in Form eines Puzzleteils; gestrichelte Linien verbinden sie zu einer einzelnen signierten Transaktion und zeigen, wie sichere Mehrparteienberechnung ein gemeinsames Ergebnis erzeugt, ohne dass eine Partei das ganze Geheimnis sieht](../../assets/blockchain-privacy-technologies-03-mpc.jpg)
+
+[Sichere Mehrparteienberechnung](/de/glossary/secure-multiparty-computation/) löst ein verwandtes, aber anderes Problem: Statt dass eine Partei auf verschlüsselten Daten rechnet, berechnen *mehrere* Parteien, die jeweils einen privaten Teil der Eingabe halten, gemeinsam eine Funktion, ohne einander ihre individuellen Eingaben zu offenbaren. Nach der formalen Definition ist MPC „a subfield of cryptography with the goal of creating methods for parties to jointly compute a function over their inputs while keeping those inputs private“; für drei Teilnehmer können „Alice, Bob, and Charlie ... F(x, y, z)“ lernen, ohne offenzulegen, wer was einbringt ([Wikipedia](https://en.wikipedia.org/wiki/Secure_multi-party_computation#:~:text=Secure%20multi%2Dparty%20computation%20)).
+
+**Was verborgen wird:** die individuelle Eingabe jeder Partei vor allen anderen — nur die vereinbarte Ausgabe wird offengelegt, und kein einzelner Teilnehmer sieht jemals das gesamte Geheimnis.
+
+**Vertrauensannahme:** Die Sicherheit hängt davon ab, wie viele Teilnehmer unehrlich sein dürfen, bevor das Schema bricht. Klassische Secret-Sharing-Konstruktionen liefern informationstheoretische Sicherheit, solange weniger als ein Drittel der Parteien aktiv böswillig ist oder weniger als die Hälfte bloß neugierig ist ([Wikipedia](https://en.wikipedia.org/wiki/Secure_multi-party_computation)). Mit anderen Worten ersetzt MPC „einem Verwahrer vertrauen“ durch „darauf vertrauen, dass sich nicht zu viele dieser N Parteien absprechen“.
+
+**Heutige Nutzung — Verwahrung mit Threshold-Signaturen:** Die sichtbarste Blockchain-Anwendung von MPC teilt einen privaten Schlüssel auf unabhängige Parteien auf, sodass kein Gerät und keine Person je den gesamten Schlüssel hält. Der Verwahrungsinfrastrukturanbieter Fireblocks beschreibt es direkt: „Multi-party computation (MPC) is a cryptographic method that splits a private key into separate shares distributed across multiple independent parties“; entscheidend ist, dass „the complete key is never assembled in one place, at any point in time“ ([fireblocks.com](https://www.fireblocks.com/what-is-mpc#:~:text=Multi%2Dparty%20computation%20)). Wenn eine Transaktion signiert werden soll, prüfen Endpunkte eines Quorums jeweils die Transaktion und liefern eine Teilsignatur. Zu keinem Zeitpunkt wird der private Schlüssel zusammengesetzt; selbst wenn ein Endpunkt kompromittiert ist, sind die anderswo gehaltenen Key Shares isoliert nutzlos ([fireblocks.com](https://www.fireblocks.com/what-is-mpc)). Dieses Threshold-Signature-Muster liegt heute dem Großteil der institutionellen Krypto-Verwahrung und vielen Multi-Signer-Wallets zugrunde.
+
+**Der Kompromiss:** MPC vermeidet den einzelnen Ausfallpunkt eines privaten Schlüssels auf einem Gerät, fügt jedoch Kommunikationsrunden zwischen den Parteien und damit Latenz hinzu und verlangt sorgfältiges Protokolldesign. Die Sicherheitsgarantie eines MPC-Schemas ist nur so stark wie die angenommene Schwelle ehrlicher Mehrheiten; das ist eine soziale und operative, nicht nur mathematische Annahme.
+
+---
+
+## Vertrauenswürdige Ausführungsumgebungen (TEEs)
+
+Eine [vertrauenswürdige Ausführungsumgebung](/de/glossary/trusted-execution-environment/) geht einen weiteren Weg: Statt Daten während einer Berechnung durchgehend zu verschlüsseln, isoliert sie die Berechnung in einem hardwaregeschützten Bereich eines Chips — einer *Secure Enclave* —, den selbst das Betriebssystem der Maschine nicht einsehen kann. Intels SGX (Software Guard Extensions), die bekannteste Implementierung, wird auf Wikipedia als „a set of instruction codes implementing trusted execution environment that are built into some Intel central processing units (CPUs)“ beschrieben ([Wikipedia](https://en.wikipedia.org/wiki/Software_Guard_Extensions#:~:text=Intel%20Software%20Guard%20Extensions)). Mechanisch verschlüsselt SGX durch die CPU einen Teil des Speichers, die Enclave; Daten und Code aus ihr werden innerhalb der CPU im laufenden Betrieb entschlüsselt und dadurch vor Inspektion oder Lesen durch anderen Code geschützt, auch durch Code auf höheren Privilegstufen wie Betriebssystem und Hypervisor ([Wikipedia](https://en.wikipedia.org/wiki/Software_Guard_Extensions)).
+
+**Was verborgen wird:** die Daten und der Code innerhalb der Enclave vor jedem anderen Prozess auf derselben Maschine, einschließlich eines kompromittierten Betriebssystems — nützlich, wenn Sie der Ausführung eines bestimmten Codeteils vertrauen müssen, aber nicht dem Serverbetreiber.
+
+**Vertrauensannahme:** Anders als ZKPs, FHE oder MPC, die rein auf Mathematik beruhen, verlangt ein TEE Vertrauen in Hardware und Firmware des Chipherstellers. Dieses Vertrauen wurde geprüft: SGX „does not protect against side-channel attacks“, und Forscher zeigten wiederholt praktische Brüche, von der Extraktion von RSA-Schlüsseln aus SGX-Enclaves auf demselben System innerhalb von fünf Minuten im Jahr 2017 bis zur Foreshadow-Attacke, die speculative execution und buffer overflow kombiniert, um SGX zu umgehen, im Jahr 2018, sowie späteren Schwachstellen wie Plundervolt, LVI, SGAxe und ÆPIC Leak ([Wikipedia](https://en.wikipedia.org/wiki/Software_Guard_Extensions#:~:text=While%20this%20can%20mitigate%20many%20kinds%20of%20attacks%2C%20it%20does%20not%20protect%20against%20side%2Dchannel%20attacks)). Deshalb werden TEEs gewöhnlich als pragmatischer, schneller Mittelweg und nicht als kryptografisch wasserdichte Garantie beschrieben.
+
+**Beispielprojekte:** Das Sapphire-Netzwerk von [Oasis Protocol](https://oasis.net/technology) führt Smart Contracts in Hardware-Enclaves aus, sodass Nutzer „run code inside hardware-secured enclaves“ können, in denen „data stays encrypted even from server operators“, während „every execution produces cryptographic proof that users can verify without blind trust“. So liefert es „confidential smart contracts“ mit „EVM compatibility and composability“ ([oasis.net](https://oasis.net/technology)). Secret Network und mehrere Datenschutzprodukte im Umfeld von Restaking bauen ebenfalls auf TEEs, häufig zusammen mit anderen Techniken für Defense in Depth.
+
+**Der Kompromiss:** TEEs laufen nahezu mit nativer Geschwindigkeit — weit schneller als FHE oder aufwendige ZK-Beweiserzeugung — und sind dadurch für latenzempfindliche Anwendungen attraktiv. Diese Geschwindigkeit kommt jedoch vom Vertrauen in Hardware mit einer realen, dokumentierten Geschichte von Side-Channel-Brüchen. TEE-basierte Systeme haben bei den Vertrauensannahmen im Worst Case daher gewöhnlich schwächere Garantien als rein kryptografische Ansätze.
+
+---
+
+## Ringsignaturen und Stealth-Adressen
+
+Das letzte Technikenpaar schützt ein engeres, aber sehr praktisches Ziel: zu verbergen, *wer* eine Transaktion gesendet und *wer* sie erhalten hat, obwohl die Transaktion selbst On-Chain sichtbar ist. [Monero](https://www.getmonero.org/) ist das führende Produktionsbeispiel für beides.
+
+**Ringsignaturen** verbergen den Sender. Die eigene Dokumentation von Monero erklärt, dass „a ring signature is a type of digital signature that can be performed by any member of a group of users that each have keys“ und dass es rechnerisch nicht praktikabel sein soll festzustellen, welcher Schlüssel der Gruppenmitglieder die Signatur erzeugt hat ([getmonero.org](https://www.getmonero.org/resources/moneropedia/ring-signatures.html#:~:text=a%20ring%20signature%20is%20a%20type%20of%20digital%20signature)). Praktisch mischt eine Monero-Transaktion den Schlüssel des tatsächlichen Ausgebers mit Köder-öffentlichen-Schlüsseln, die mittels einer Gamma-Verteilung aus der Blockchain gezogen werden. In einem Ring möglicher Signierer sind alle Ringmitglieder gleich und gültig; ein externer Beobachter kann nicht feststellen, welcher mögliche Signierer einer Signaturgruppe zu Ihrem Konto gehört ([getmonero.org](https://www.getmonero.org/resources/moneropedia/ring-signatures.html)).
+
+**Stealth-Adressen** verbergen den Empfänger. Statt eine öffentliche Adresse wiederzuverwenden, erzeugt der Sender für jede Transaktion im Namen des Empfängers zufällige Einmaladressen. Eingehende Zahlungen gelangen so auf einzigartige Adressen in der Blockchain und können weder mit der veröffentlichten Adresse des Empfängers noch mit den Adressen anderer Transaktionen verknüpft werden ([getmonero.org](https://www.getmonero.org/resources/moneropedia/stealthaddress.html#:~:text=They%20allow%20and%20require%20the%20sender%20to%20create%20random%20one%2Dtime%20addresses)). Ein Empfänger durchsucht die Chain mit einem privaten View Key nach Zahlungen und bewegt sie mit einem privaten Spend Key; nur Sender und Empfänger können daher bestimmen, wohin eine Zahlung ging ([getmonero.org](https://www.getmonero.org/resources/moneropedia/stealthaddress.html)).
+
+**Was verborgen wird:** Identität des Senders (Ringsignaturen) und Identität des Empfängers (Stealth-Adressen). Transaktions*beträge* werden durch einen separaten Mechanismus, Confidential Transactions / RingCT, verborgen; diese beiden Techniken allein decken ihn nicht ab.
+
+**Der Kompromiss:** Beide Techniken laufen effizient auf gewöhnlicher Hardware, ohne Aufwand für Beweiserzeugung oder Abhängigkeit von Enclaves, und passen daher gut zu einem live betriebenen Zahlungsnetz. Ihr Vertrauensmodell beruht jedoch darauf, dass Ködermengen statistisch nicht vom tatsächlichen Signierer zu unterscheiden sind. Schwache Köderauswahl oder Heuristiken der Blockchain-Analyse haben Anonymitätsmengen in frühen Ringsignatur-Deployments historisch eingeengt. Daher zählen Parameterentscheidungen wie Ringgröße und Köderverteilung ebenso wie das zugrunde liegende Primitiv.
+
+---
+
+## Vergleich der fünf Ansätze
+
+| Technologie | Was sie verbirgt | Vertrauensannahme | Leistungskosten | Reife heute | Beispielprojekte |
+|---|---|---|---|---|---|
+| Zero-Knowledge-Proofs | Zugrunde liegende Daten/Berechnung; nur die Beweisgültigkeit wird offengelegt | Kryptografische Mathematik (+ Trusted Setup bei manchen Systemen) | Hoher Aufwand zur Beweiserzeugung; günstige Prüfung | Produktion im Maßstab (Rollups, abgeschirmte Zahlungen) | zkSync, Starknet, Zcash |
+| Vollständig homomorphe Verschlüsselung | Alle Daten während der Berechnung, auch vor dem Rechenanbieter | Kryptografische Mathematik (gitterbasiert) | Sehr hoher Rechenaufwand | Frühe Produktion; aktive Forschung an Hardwarebeschleunigung | Zama, Fhenix |
+| Sichere Mehrparteienberechnung | Individuelle Eingabe jeder Partei | Ehrliche Mehrheit/Schwelle unter den Teilnehmern | Moderat; zusätzliche Kommunikationsrunden | Reif und in der Verwahrung breit eingesetzt | Fireblocks und andere Verwahrer mit Threshold-Signaturen |
+| Vertrauenswürdige Ausführungsumgebungen | Daten/Code vor jedem anderen Prozess, einschließlich Betriebssystem | Hardware-/Firmware-Anbieter (Chiphersteller) | Nahezu native Geschwindigkeit | Produktion, aber dokumentierte Geschichte von Side-Channel-Angriffen | Intel SGX, Oasis Sapphire |
+| Ringsignaturen und Stealth-Adressen | Identität von Sender und Empfänger | Statistische Ununterscheidbarkeit der Ködermengen | Gering; effizient auf Standardhardware | Reif, seit über einem Jahrzehnt live | Monero |
+
+Keine einzelne Technologie gewinnt auf jeder Achse. Daher kombiniert die aktuelle Forschung sie zunehmend, etwa indem ZK-Proofs die Korrektheit einer MPC-Berechnung prüfen oder TEEs zusammen mit FHE für Defense in Depth genutzt werden.
+
+---
+
+## Verbindung zu tokenisierten Domains
+
+[Tokenisierte Domains](/de/glossary/tokenize/) erben dieselbe Standardtransparenz wie jeder andere On-Chain-Vermögenswert: Eigentumsübertragungen, Gebote und Metadatenaktualisierungen sind öffentlich lesbar. Das ist überwiegend ein Vorteil — Provenienz und Eigentumshistorie machen eine [tokenisierte Domain](/de/blog/what-are-tokenized-domains/) gerade als handelbaren Vermögenswert vertrauenswürdig —, doch es bedeutet auch, dass Bestände und Verkaufspreise eines Domainportfolios für jeden sichtbar sind, der die Chain beobachtet.
+
+Die Datenschutztechnologien dieses Leitfadens zeigen, wohin Infrastruktur für Domains als NFTs künftig gehen könnte: MPC-basierte Threshold-Verwahrung sichert bereits institutionelle [Wallets](/de/glossary/wallet/) mit Domain-NFTs genauso wie andere digitale Vermögenswerte. ZK-Proofs könnten einem Bieter irgendwann ermöglichen nachzuweisen, dass er ein Angebot finanzieren kann, ohne seinen gesamten Kontostand zu offenbaren. Und vertrauliche Berechnungstechniken könnten es einem Registrar oder Marktplatz erlauben, Berechtigungsregeln zu prüfen, ohne die vollständige Identität eines Käufers offenzulegen. Nichts davon ist heute in der Domaintokenisierung eingesetzt, aber die zugrunde liegenden Primitive sind dieselben, die derzeit Milliarden Dollar in DeFi und Verwahrungsinfrastruktur sichern.
+
+---
+
+## Quellen und weiterführende Lektüre
+
+- [Zero-Knowledge Proofs — ethereum.org](https://ethereum.org/en/zero-knowledge-proofs/)
+- [ZK-Rollups — ethereum.org](https://ethereum.org/en/developers/docs/scaling/zk-rollups/)
+- [L2BEAT Scaling Summary](https://l2beat.com/scaling/summary)
+- [Zcash Technology Overview](https://z.cash/technology/)
+- [Introduction to Homomorphic Encryption — Zama](https://www.zama.org/introduction-to-homomorphic-encryption)
+- [Fhenix cofhe Documentation](https://cofhe-docs.fhenix.zone/)
+- [Secure Multi-Party Computation — Wikipedia](https://en.wikipedia.org/wiki/Secure_multi-party_computation)
+- [What Is MPC? — Fireblocks](https://www.fireblocks.com/what-is-mpc)
+- [Software Guard Extensions (SGX) — Wikipedia](https://en.wikipedia.org/wiki/Software_Guard_Extensions)
+- [Oasis Protocol Technology](https://oasis.net/technology)
+- [Ring Signatures — Monero Moneropedia](https://www.getmonero.org/resources/moneropedia/ring-signatures.html)
+- [Stealth Addresses — Monero Moneropedia](https://www.getmonero.org/resources/moneropedia/stealthaddress.html)

--- a/content/blog/de/blockchain-scaling-approaches.md
+++ b/content/blog/de/blockchain-scaling-approaches.md
@@ -1,0 +1,121 @@
+---
+title: "Die wichtigsten Blockchain-Skalierungsansätze: Rollups, Sidechains, Channels und Sharding"
+date: '2026-07-02'
+language: de
+tags: ['guide']
+authors: ['namefiteam']
+draft: false
+cluster: web3-foundations
+series: blockchain-concepts
+seriesOrder: 40
+format: roundup
+description: Ein Leitfaden für Einsteiger zur Blockchain-Skalierung — Optimistic Rollups, ZK Rollups, Sidechains, Payment Channels, Sharding und Datenverfügbarkeitsschichten im Vergleich.
+ogImage: ../../assets/blockchain-scaling-approaches-og.jpg
+keywords: ['blockchain-skalierung', 'blockchain-skalierungslösungen', 'layer-2-skalierung', 'rollups', 'optimistic rollup', 'zk rollup', 'sidechains', 'payment channels', 'state channels', 'sharding', 'datenverfügbarkeit', 'skalierbarkeits-trilemma', 'Arbitrum', 'Optimism', 'zkSync', 'Starknet', 'Celestia', 'EigenDA', 'Polygon PoS', 'Lightning Network']
+relatedArticles:
+  - /de/blog/blockchain-virtual-machines/
+  - /de/blog/blockchain-consensus-mechanisms/
+  - /de/blog/blockchain-privacy-technologies/
+  - /de/blog/blockchain-cryptographic-primitives/
+  - /de/blog/premium-web3-tlds/
+relatedGlossary:
+  - /de/glossary/rollup/
+  - /de/glossary/optimistic-rollup/
+  - /de/glossary/zk-rollup/
+  - /de/glossary/data-availability/
+  - /de/glossary/layer-2/
+relatedTopics:
+  - /de/topics/web3-foundations/
+  - /de/topics/domain-tokenization/
+relatedSeries:
+  - /de/series/tokenize-your-com/
+  - /de/series/domain-flipping-skills/
+---
+
+Das Ethereum-Mainnet verarbeitet ungefähr 15 Transaktionen pro Sekunde. Ein Zahlungsnetzwerk wie Visa verarbeitet Zehntausende. Diese Lücke erklärt, warum Blockchains skalieren müssen: Sie brauchen eine Möglichkeit, mehr Arbeit zu erledigen, ohne dass jeder Teilnehmer jede Transaktion auf der Basischain verifizieren muss. In den vergangenen Jahren hat sich die Branche auf einige unterschiedliche Ansätze geeinigt — [Rollups](/de/glossary/rollup/), Sidechains, Payment Channels und Sharding — die jeweils Sicherheit, Dezentralisierung und Kosten anders gegeneinander abwägen.
+
+Dieser Leitfaden führt durch die wichtigsten Skalierungsansätze, erklärt den Mechanismus hinter jedem und vergleicht sie direkt, damit der Unterschied beim nächsten Auftauchen in der Dokumentation eines Projekts klar ist.
+
+---
+
+## Das Skalierbarkeits-Trilemma
+
+Vitalik Buterins Beschreibung des **Skalierbarkeits-Trilemmas** ist das Denkmodell, auf dem der Großteil dieses Bereichs beruht. Eine Blockchain möchte drei Eigenschaften zugleich: „Skalierbarkeit: Die Chain kann mehr Transaktionen verarbeiten, als ein einzelner gewöhnlicher Node ... verifizieren kann“, „Dezentralisierung: Die Chain kann ohne Vertrauensabhängigkeiten von einer kleinen Gruppe großer zentralisierter Akteure laufen“ und „Sicherheit: Die Chain kann einem hohen Anteil teilnehmender Nodes widerstehen, die versuchen, sie anzugreifen“. Herkömmliche Designs erreichen jedoch nur zwei dieser drei Eigenschaften ([vitalik.eth.limo](https://vitalik.eth.limo/general/2021/04/07/sharding.html#:~:text=Scalability%3A%20the%20chain%20can%20process%20more%20transactions%20than%20a%20single%20regular%20node)). Bitcoin und das frühe Ethereum priorisierten Dezentralisierung und Sicherheit gegenüber Durchsatz; Chains mit hoher TPS-Zahl, die auf einer kleinen Gruppe leistungsstarker Validatoren beruhen, erhalten Skalierbarkeit und Sicherheit, opfern dafür aber Dezentralisierung. Einfache Multi-Chain-Designs können skalieren und dezentral bleiben, werden jedoch unsicher, wenn ein Angreifer nur eine Chain kompromittieren muss.
+
+Jeder der folgenden Ansätze beantwortet im Kern dieselbe Frage: Wie lässt sich der Durchsatz erhöhen, ohne die beiden anderen Ecken des Dreiecks aufzugeben?
+
+## Rollups: Off-Chain ausführen, On-Chain abrechnen
+
+![Flaches Vektordiagramm: Viele kleine Transaktionsbelege laufen in einen Verdichter mit der Aufschrift „Rollup Compressor“, der sie zu einem komprimierten Batch-Würfel presst, der anschließend auf eine Basisschicht-Chain aus verbundenen Blöcken geschrieben wird](../../assets/blockchain-scaling-approaches-01-rollup-batching.jpg)
+
+Ein **[Rollup](/de/glossary/rollup/)** führt Transaktionen außerhalb von Layer 1 (L1) aus und veröffentlicht dann eine kompakte Zusammenfassung — und die zugrunde liegenden Transaktionsdaten — zurück auf der Basischain. L2BEAT, der führende Tracker für diese Systeme, definiert Rollups als „L2s, die regelmäßig Zustandszusagen an Ethereum übermitteln“; diese Zusagen werden „entweder durch Validity Proofs validiert oder ... optimistisch akzeptiert und können innerhalb eines bestimmten Fraud-Proof-Fensters über einen Fraud-Proof-Mechanismus angefochten werden“ ([l2beat.com](https://l2beat.com/scaling/summary)). Da sowohl die Daten als auch die Zusage auf L1 landen, kann jeder den Zustand eines Rollups allein aus Ethereum rekonstruieren. Das ermöglicht einem Rollup, die Sicherheit von L1 zu erben, statt Nutzer zu bitten, einer neuen Validator-Gruppe zu vertrauen. Das ist die Technologie hinter den [Layer-2](/de/glossary/layer-2/)-Netzwerken, mit denen die meisten Menschen heute interagieren: Base, Arbitrum, Optimism, zkSync und Starknet sind alles Rollups.
+
+Rollups teilen sich danach in zwei Familien, je nachdem, wie sie die Richtigkeit ihrer Off-Chain-Ausführung nachweisen.
+
+### Optimistic Rollups
+
+![Flache Vektorillustration von zwei Türen nebeneinander: eine orange Tür „Optimistic“ mit einer 7-Tage-Uhr und einer Flagge für die Anfechtungsfrist, die das Fraud-Proof-Fenster darstellt, und eine grüne Tür „ZK“ mit einem sofortigen grünen Häkchen für den Validity Proof](../../assets/blockchain-scaling-approaches-02-optimistic-vs-zk.jpg)
+
+Ein [Optimistic Rollup](/de/glossary/optimistic-rollup/) „geht davon aus, dass Off-Chain-Transaktionen gültig sind, und veröffentlicht keine Gültigkeitsnachweise für Transaktions-Batches“ ([ethereum.org](https://ethereum.org/en/developers/docs/scaling/optimistic-rollups/#:~:text=Optimistic%20rollups%20assume%20offchain%20transactions%20are%20valid%20and%20don%27t%20publish%20proofs%20of%20validity)). Betreiber bündeln Transaktionen, führen sie Off-Chain aus und veröffentlichen die komprimierten Daten auf Ethereum. Danach beginnt eine Anfechtungsfrist, in der jeder mit einem Full Node den Batch mit einem Fraud Proof bestreiten kann. Die Auszahlung von Geldern aus L2 nach L1 muss warten, bis „die ungefähr sieben Tage dauernde Anfechtungsfrist abläuft“ ([ethereum.org](https://ethereum.org/en/developers/docs/scaling/optimistic-rollups/#:~:text=the%20challenge%20period%E2%80%94lasting%20roughly%20seven%20days%E2%80%94elapses)). Deshalb dauert eine einfache Auszahlung aus einem Optimistic Rollup etwa eine Woche, sofern nicht ein externer Liquiditätsanbieter für einen schnelleren, gebührenpflichtigen Ausstieg eingesetzt wird.
+
+Optimistic Rollups benötigen nur ein Fraud-Proof-System statt einer vollständigen kryptografischen Beweis-Pipeline. Das machte es historisch einfacher, allgemeine Smart Contracts darauf zu unterstützen. **Arbitrum**, **Optimism** und **Base** — das Rollup von Coinbase, auf ethereum.org als „ein mit dem OP Stack gebautes Optimistic Rollup“ beschrieben ([ethereum.org](https://ethereum.org/en/layer-2/#:~:text=Base%20is%20an%20Optimistic%20Rollup%20built%20with%20the%20OP%20Stack)) — sind heute gemessen an der Nutzung die größten Optimistic Rollups.
+
+### ZK Rollups
+
+Ein [ZK Rollup](/de/glossary/zk-rollup/) verfolgt den gegenteiligen Ansatz: Statt Gültigkeit anzunehmen und eine Anfechtungsfrist zuzulassen, übermittelt es zusammen mit jedem Batch einen Validity Proof — einen kryptografischen Nachweis, dass der Zustandsübergang des Batches korrekt ist. Weil Ethereum diesen Nachweis On-Chain überprüft, „gibt es keine Verzögerungen beim Verschieben von Geldern aus einem ZK-Rollup zu Ethereum ... da Ausstiegstransaktionen ausgeführt werden, sobald der ZK-Rollup-Contract den Validity Proof verifiziert“ ([ethereum.org](https://ethereum.org/en/developers/docs/scaling/zk-rollups/#:~:text=There%20are%20no%20delays%20when%20moving%20funds%20from%20a%20ZK%2Drollup%20to%20Ethereum)). ZK-Rollups „können Tausende Transaktionen in einem Batch verarbeiten und dann nur minimale Zusammenfassungsdaten an das Mainnet übermitteln“ ([ethereum.org](https://ethereum.org/en/developers/docs/scaling/zk-rollups/#:~:text=ZK%2Drollups%20can%20process%20thousands%20of%20transactions%20in%20a%20batch)). Sie verwenden Beweissysteme wie zk-SNARKs (kleine Beweise, schnelle Verifikation) oder zk-STARKs (transparent, kein vertrauenswürdiges Setup erforderlich). **zkSync Era**, **Starknet** — „ein allgemeines ZK Rollup auf Basis von STARKs und der Cairo VM“ ([ethereum.org](https://ethereum.org/en/layer-2/#:~:text=Starknet%20is%20a%20general%20purpose%20ZK%20Rollup%20based%20on%20STARKs%20and%20the%20Cairo%20VM)) — und **Linea** sind prominente ZK Rollups. Polygon zkEVM und Scroll implementieren ebenfalls eine zkEVM, um bestehende Ethereum Smart Contracts in einer ZK-beweisbaren Umgebung auszuführen.
+
+Der Nachteil: Validity Proofs zu erzeugen ist rechenintensiv und für vollständige EVM-Äquivalenz technisch schwieriger zu bauen als ein Fraud-Proof-System. Das ist ein Teil des Grundes, warum Optimistic Rollups die breite Akzeptanz früher erreichten, obwohl ZK Rollups eine schnellere Finalität bieten.
+
+## Sidechains
+
+Eine **Sidechain** „ist eine separate Blockchain, die unabhängig von Ethereum läuft und über eine bidirektionale Bridge mit dem Ethereum Mainnet verbunden ist“. Anders als ein Rollup „verwendet eine Sidechain einen separaten Konsensmechanismus und profitiert nicht von Ethereums Sicherheitsgarantien“ ([ethereum.org](https://ethereum.org/en/developers/docs/scaling/sidechains/#:~:text=A%20sidechain%20uses%20a%20separate%20consensus%20mechanism%20and%20doesn%27t%20benefit%20from%20Ethereum%27s%20security%20guarantees)). Das ist der zentrale Unterschied zu Layer 2: Eine Sidechain tauscht geerbte Sicherheit gegen unabhängige Gestaltungsfreiheit und in der Regel niedrigere Gebühren sowie schnellere Blöcke, weil sie ihrer eigenen Validator-Gruppe und nicht Ethereum unterliegt.
+
+**Polygon PoS** ist das bekannteste Beispiel. Die eigene Produktseite von Polygon beschreibt es als „die meistgenutzte Sidechain von Ethereum — in der Praxis mit Milliarden an gesichertem Wert erprobt, mit nahezu sofortigen Transaktionen und Gebühren unter einem Cent“ ([polygon.technology](https://polygon.technology/polygon-pos)). Sie wird durch ihre eigene Proof-of-Stake-Validator-Gruppe und nicht durch die von Ethereum abgesichert. **Gnosis Chain** (früher xDai) ist neben Skale und Metis Andromeda eine weitere weit verbreitete Sidechain. Da Nutzer einer anderen, meist kleineren Validator-Gruppe vertrauen, ist die Sicherheit einer Sidechain nur so stark wie diese Gruppe. Das ist eine wesentlich andere Garantie als bei einem Rollup, bei dem ungültige Zustände grundsätzlich anhand auf L1 verankerter Daten erkannt und zurückgesetzt werden können.
+
+## State- und Payment-Channels
+
+Ein **State Channel** ermöglicht es zwei oder mehr Parteien, Off-Chain zu handeln, indem sie Gelder in einem gemeinsamen Contract sperren und signierte Aktualisierungen direkt austauschen. Dadurch können „Channel-Partner beliebig viele Off-Chain-Transaktionen durchführen und dabei nur zwei On-Chain-Transaktionen zum Öffnen und Schließen des Channels übermitteln“ ([ethereum.org](https://ethereum.org/en/developers/docs/scaling/state-channels/#:~:text=Channel%20peers%20can%20conduct%20an%20arbitrary%20number%20of%20offchain%20transactions%20while%20only%20submitting%20two%20onchain%20transactions)). Ein Payment Channel spezialisiert dieses Muster auf einfache Saldenübertragungen und „lässt sich am besten als ein gemeinsam von zwei Nutzern geführtes Zweiwege-Ledger beschreiben“ ([ethereum.org](https://ethereum.org/en/developers/docs/scaling/state-channels/#:~:text=A%20payment%20channel%20is%20best%20described%20as%20a%20%E2%80%9Ctwo%2Dway%20ledger%E2%80%9D%20collectively%20maintained%20by%20two%20users)). Teilnehmende können beliebig oft untereinander, Off-Chain und sofort handeln; die Basischain wird nur berührt, um den Channel zu öffnen (Sicherheiten zu sperren) und ihn zu schließen (den Endsaldo abzurechnen).
+
+Die bekannteste Implementierung ist das **Lightning Network**, das auf seiner eigenen Website als „dezentralisiertes Netzwerk beschrieben wird, das Smart-Contract-Funktionalität in der Blockchain nutzt, um sofortige Zahlungen über ein Netzwerk von Teilnehmenden zu ermöglichen“, aufgebaut aus „bidirektionalen Payment Channels“, die Zahlungen so weiterleiten, wie Datenpakete über das Internet geroutet werden ([lightning.network](https://lightning.network/)). Der Haken: Channels skalieren Transaktionen nur *zwischen Parteien, die einen Pfad offener Channels zueinander haben*. Gelder müssen vorab gebunden werden, um einen Channel zu öffnen, und Channel-Netzwerke benötigen Liquiditätsrouting, um in großem Maßstab gut zu funktionieren. Nichts davon gilt für ein allgemeines Rollup, das beliebige Smart Contracts für jeden ausführen kann.
+
+## Sharding und Datenverfügbarkeitsschichten
+
+![Flaches Vektordiagramm: Transaktionen sind auf vier parallele Shard-Spuren (Shard 1 bis Shard 4) aufgeteilt, die jeweils ihre eigene Block-Chain unabhängig verarbeiten und alle in eine darunterliegende Datenverfügbarkeitsschicht münden](../../assets/blockchain-scaling-approaches-03-sharding.jpg)
+
+**Sharding** teilt die Validierungsarbeit einer Blockchain auf mehrere parallele Teilmengen („Shards“) von Nodes auf, sodass kein einzelner Node die gesamte Transaktionslast des Netzwerks verarbeiten muss. Vitalik Buterin argumentiert, dass „Sharding alle drei“ Ecken des Trilemmas zugleich erreicht ([vitalik.eth.limo](https://vitalik.eth.limo/general/2021/04/07/sharding.html#:~:text=Sharding%20is%20a%20technique%20that%20gets%20you%20all%20three)), indem zufällig zusammengestellte Validator-Komitees unterschiedliche Shards parallel verifizieren. Die Technologie, die Sharding sicher macht, ohne jeden Node zum Herunterladen der vollständigen Daten jedes Shards zu zwingen, ist [Datenverfügbarkeit](/de/glossary/data-availability/)-Sampling (DAS) — „eine Möglichkeit für das Netzwerk zu prüfen, ob Daten verfügbar sind, ohne einen einzelnen Node übermäßig zu belasten“ ([ethereum.org](https://ethereum.org/en/developers/docs/data-availability/#:~:text=Data%20availability%20sampling%20is%20a%20way%20for%20the%20network%20to%20check%20that%20data%20is%20available%20without%20putting%20too%20much%20strain%20on%20any%20individual%20node)). Ein Light Node lädt nur kleine, zufällig ausgewählte Teile der Daten eines Blocks herunter und kann dank Erasure Coding dennoch darauf vertrauen, dass die vollständigen Daten veröffentlicht wurden.
+
+Dasselbe Datenverfügbarkeitsproblem gilt unmittelbar für Rollups. Deshalb sind dedizierte Datenverfügbarkeitsschichten als eigene Infrastrukturkategorie entstanden. **Celestia** ist eine modulare Blockchain, die speziell dafür gebaut wurde, dass „Rollups und L2s Celestia als Netzwerk nutzen, um Transaktionsdaten zu veröffentlichen und für jeden zum Herunterladen verfügbar zu machen“ ([celestia.org](https://celestia.org/what-is-celestia/#:~:text=Rollups%20and%20L2s%20use%20Celestia%20as%20a%20network%20for%20publishing%20and%20making%20transaction%20data%20available%20for%20anyone%20to%20download)). Ein Rollup kann seine Daten dadurch auf einer günstigeren, speziell entwickelten DA-Schicht statt im Ethereum-Mainnet veröffentlichen. **EigenDA**, aufgebaut auf der Restaking-Infrastruktur von EigenLayer, bietet einen vergleichbaren Dienst, der durch Ethereum-Staker abgesichert wird, die sich dafür entscheiden, auch die DA-Schicht abzusichern. Rollups, die Daten bei einer externen DA-Schicht statt bei Ethereum L1 veröffentlichen, werden manchmal *Validiums* oder *Optimiums* statt „reiner“ Rollups genannt. L2BEAT führt sie als eigene Kategorie neben Rollups und anderen L2-Lösungen ([l2beat.com](https://l2beat.com/scaling/summary)); sie tauschen einen Teil dieser an L1 verankerten Sicherheitsgarantie gegen niedrigere Kosten für die Datenveröffentlichung ein.
+
+## Vergleich der Ansätze
+
+| Ansatz | Ort der Berechnung | Erbt L1-Sicherheit? | Datenverfügbarkeit | Wichtigste Abwägung | Beispiele |
+|---|---|---|---|---|---|
+| Optimistic Rollup | Off-Chain (L2) | Ja — Daten + Fraud Proof auf L1 | Vollständige Daten auf L1 veröffentlicht | ~7-tägige Anfechtungsfrist für Auszahlungen | Arbitrum, Optimism, Base |
+| ZK Rollup | Off-Chain (L2) | Ja — Daten + Validity Proof auf L1 | Vollständige Daten auf L1 veröffentlicht | Teure Beweiserzeugung; vollständige EVM-Äquivalenz schwieriger | zkSync, Starknet, Linea |
+| Sidechain | Unabhängige Chain | Nein — eigener Konsens/eigene Validatoren | Eigene Chain, nicht auf L1 veröffentlicht | Sicherheit nur so stark wie die eigene Validator-Gruppe | Polygon PoS, Gnosis Chain |
+| State-/Payment-Channel | Off-Chain, zwischen Teilnehmenden | Indirekt — Gelder auf L1 gesperrt | Nicht veröffentlicht; nur Endzustand On-Chain | Skaliert nur Transaktionen zwischen über Channels verbundenen Parteien; Gelder müssen vorab gesperrt werden | Lightning Network |
+| Sharding / DA-Schicht | Parallele Shards oder separates DA-Netzwerk | Unterschiedlich — L1-Sharding erbt sie; externe DA-Schichten fügen eine neue Vertrauensannahme hinzu | Durch Datenverfügbarkeits-Sampling verifiziert | Externe DA senkt Kosten, schafft aber eine Abhängigkeit außerhalb von L1 | Ethereums Sharding-Roadmap, Celestia, EigenDA |
+
+Kein einzelner Ansatz gewinnt auf jeder Achse. Deshalb kombinieren Produktionssysteme zunehmend mehrere davon: Ein ZK Rollup, das seine Daten beispielsweise bei Celestia statt bei Ethereum veröffentlicht, kombiniert die Sicherheit eines Validity Proofs aus einer Schicht mit günstiger Datenverfügbarkeit aus einer anderen.
+
+---
+
+## Wie dies mit tokenisierten Domains zusammenhängt
+
+Skalierungsentscheidungen sind für [tokenisierte Domains](/de/glossary/tokenized-domain/) wichtig, weil jedes Minting, jede Übertragung, jedes DNS-Update oder jede Besicherungsaktion eine On-Chain-Transaktion ist und ihre Kosten sowie die Zeit bis zur Finalität davon abhängen, wo sie abgerechnet wird. Eine tokenisierte `.com`-Übertragung, die auf einem Optimistic Rollup bestätigt wird, ist für Nutzer günstig und schnell, aber gegenüber L1 etwa eine Woche lang nicht vollständig final, sofern keine Fast-Exit-Bridge verwendet wird. Dieselbe Übertragung auf einem ZK Rollup ist gegenüber L1 final, sobald der Validity Proof eintrifft. Sidechains können noch günstiger sein, aber eine Domain-NFT, die ausschließlich auf einer Sidechain liegt, übernimmt die Sicherheit der kleineren Validator-Gruppe dieser Sidechain statt der von Ethereum. Diese Abwägungen zu verstehen, gehört dazu zu verstehen, was man tatsächlich besitzt, wenn eine Domain On-Chain repräsentiert wird — dieselbe Due-Diligence-Gewohnheit, die generell für [Web3-Grundlagen](/de/topics/web3-foundations/) relevant ist.
+
+---
+
+## Quellen und weiterführende Lektüre
+
+- [Die Grenzen der Blockchain-Skalierbarkeit — Vitalik Buterin](https://vitalik.eth.limo/general/2021/04/07/sharding.html)
+- [Layer 2 — ethereum.org](https://ethereum.org/en/layer-2/)
+- [Optimistic Rollups — ethereum.org](https://ethereum.org/en/developers/docs/scaling/optimistic-rollups/)
+- [ZK-Rollups — ethereum.org](https://ethereum.org/en/developers/docs/scaling/zk-rollups/)
+- [Sidechains — ethereum.org](https://ethereum.org/en/developers/docs/scaling/sidechains/)
+- [State Channels — ethereum.org](https://ethereum.org/en/developers/docs/scaling/state-channels/)
+- [Datenverfügbarkeit — ethereum.org](https://ethereum.org/en/developers/docs/data-availability/)
+- [L2BEAT-Skalierungsübersicht](https://l2beat.com/scaling/summary)
+- [Was ist Celestia? — celestia.org](https://celestia.org/what-is-celestia/)
+- [Lightning Network](https://lightning.network/)
+- [Polygon PoS — polygon.technology](https://polygon.technology/polygon-pos)

--- a/content/blog/de/blockchain-virtual-machines.md
+++ b/content/blog/de/blockchain-virtual-machines.md
@@ -1,0 +1,151 @@
+---
+title: "Die wichtigsten virtuellen Maschinen für Blockchains: EVM, SVM, MoveVM, WASM und CairoVM"
+date: '2026-07-02'
+language: de
+tags: ['guide']
+authors: ['namefiteam']
+draft: false
+cluster: web3-foundations
+series: blockchain-concepts
+seriesOrder: 30
+format: roundup
+description: "Ein Leitfaden zu den wichtigsten virtuellen Maschinen für Blockchains — EVM, SVM, MoveVM, WASM-basierten VMs und CairoVM — mit einem Vergleich von Sprachen, Ausführungsmodellen und Ökosystemen."
+ogImage: ../../assets/blockchain-virtual-machines-og.jpg
+keywords: ['virtuelle maschine blockchain', 'virtuelle maschinen blockchain', 'evm', 'ethereum virtual machine', 'svm', 'solana virtual machine', 'sealevel', 'movevm', 'move-sprache', 'wasm blockchain', 'cosmwasm', 'polkavm', 'cairovm', 'cairo-sprache', 'starknet', 'smart-contract-sprache', 'parallele ausführung blockchain', 'evm-kompatibel', 'ausführungsumgebung blockchain', 'blockchain-zustandsmaschine']
+relatedArticles:
+  - /de/blog/blockchain-consensus-mechanisms/
+  - /de/blog/blockchain-scaling-approaches/
+  - /de/blog/blockchain-cryptographic-primitives/
+  - /de/blog/blockchain-privacy-technologies/
+  - /de/blog/what-are-tokenized-domains/
+relatedTopics:
+  - /de/topics/web3-foundations/
+  - /de/topics/domain-tokenization/
+relatedSeries:
+  - /de/series/tokenize-your-com/
+  - /de/series/domain-flipping-skills/
+relatedGlossary:
+  - /de/glossary/ethereum-virtual-machine/
+  - /de/glossary/webassembly/
+  - /de/glossary/smart-contract/
+  - /de/glossary/ethereum/
+  - /de/glossary/gas/
+---
+
+Jeder [Smart Contract](/de/glossary/smart-contract/) muss irgendwo ausgeführt werden. Dieses „irgendwo“ ist eine virtuelle Maschine (VM) für Blockchains — das abgeschottete Programm, das jeder Node im Netzwerk identisch ausführt, sodass dieselbe Eingabe unabhängig davon, wer sie ausführt, immer dieselbe Ausgabe erzeugt. Die VM, auf der Sie aufbauen, prägt fast alles an einer Chain: in welchen Sprachen Sie schreiben können, ob Transaktionen gleichzeitig oder nur nacheinander laufen und wie viel vom bestehenden Entwicklerökosystem Sie vom ersten Tag an nutzen können.
+
+Dieser Leitfaden führt durch fünf VM-Designs, die zusammen den Großteil der Smart-Contract-Aktivität im heutigen [Web3](/de/glossary/web3/) antreiben: die [Ethereum Virtual Machine](/de/glossary/ethereum-virtual-machine/) (EVM), Solanas SVM, die von Aptos und Sui verwendete MoveVM, auf [WebAssembly](/de/glossary/webassembly/) (WASM) basierende VMs wie CosmWasm und PolkaVM sowie Starknets CairoVM.
+
+---
+
+## Was ist eine virtuelle Maschine für Blockchains, und warum ist sie wichtig?
+
+Eine Blockchain-VM ist eine deterministische, abgeschottete Ausführungsumgebung: Jeder Full Node lädt dieselben Transaktionen herunter, führt sie durch dieselbe VM und erhält denselben resultierenden [On-Chain](/de/glossary/on-chain/)-Zustand. Die Ethereum-Dokumentation beschreibt die EVM als „eine dezentrale virtuelle Umgebung, die Code konsistent und sicher über alle Ethereum-Nodes hinweg ausführt“ ([ethereum.org](https://ethereum.org/en/developers/docs/evm/#:~:text=The%20EVM%20is%20a%20decentralized,mechanics%20of%20how%20they%20work)) — eine Beschreibung, die sich auf jede VM in diesem Leitfaden übertragen lässt.
+
+Zwei Eigenschaften bestimmen die Design-Abwägungen einer VM:
+
+- **Sprache und Toolchain.** In welchen Sprachen können Entwickler Contracts schreiben, und wie groß ist die vorhandene Bibliothek aus geprüftem Code, Werkzeugen und Fachkräften, die sie bereits beherrschen?
+- **Ausführungsmodell.** Verarbeitet die VM Transaktionen strikt einzeln (sequenziell), oder können unabhängige Transaktionen gleichzeitig auf mehreren CPU-Kernen laufen (parallele Ausführung)? Über sequenzielle Ausführung lässt sich einfacher nachdenken; parallele Ausführung steigert den theoretischen Durchsatz, erhöht aber die Planungs-Komplexität.
+
+Diese Entscheidungen wirken sich auf Gaskosten, das Verhalten bei Überlastung und darauf aus, welche bestehenden Contracts und Tools ohne Neuschreibung portiert werden können. Deshalb ist die Frage „Welche VM?“ eine der ersten, die jede neue Chain oder jedes darauf aufgebaute [tokenisierte](/de/glossary/tokenize/) Asset beantworten muss.
+
+---
+
+## EVM (Ethereum Virtual Machine)
+
+![Flachvektordiagramm der EVM als Stack-Maschine mit einer Ausführungsspur: Ein Befehlszeiger legt Werte auf einem vertikalen Stack ab und nimmt sie herunter, während eine Gasanzeige die Ausführungskosten verfolgt](../../assets/blockchain-virtual-machines-01-evm-stack.jpg)
+
+Die EVM ist die älteste und am weitesten verbreitete VM für Smart Contracts; sie wurde 2015 mit [Ethereum](/de/glossary/ethereum/) eingeführt. Sie ist eine **Stack-basierte** Maschine: Laut Ethereum-Dokumentation arbeitet sie als „Stack-Maschine mit einer Tiefe von 1024 Einträgen“, wobei jeder Eintrag ein 256-Bit-Wort ist ([ethereum.org](https://ethereum.org/en/developers/docs/evm/#:~:text=The%20EVM%20executes%20as%20a,256%2Dbit%20word)). Der Contract-Zustand liegt in einem Merkle-Patricia-Trie, der jedem Konto zugeordnet ist; auch der globale Chain-Zustand ist als modifizierter Merkle-Patricia-Trie organisiert, der alle Konten per Hash verknüpft ([ethereum.org](https://ethereum.org/en/developers/docs/evm/#:~:text=Ethereum%20uses%20a%20modified%20Merkle,linked%20by%20hashes)).
+
+**Sprache.** Contracts werden fast immer in **Solidity** geschrieben, das Ethereums eigene Dokumentation als „objektorientierte Hochsprache für die Implementierung von Smart Contracts“ beschreibt und dessen Syntax stark von C++ beeinflusst ist ([ethereum.org](https://ethereum.org/en/developers/docs/smart-contracts/languages/#:~:text=Solidity)). **Vyper**, eine „Python-artige“ Sprache, die bewusst Funktionen reduziert, um Contracts leichter prüfbar zu machen, ist die wichtigste Alternative ([ethereum.org](https://ethereum.org/en/developers/docs/smart-contracts/languages/#:~:text=Vyper)).
+
+**Ausführungsmodell.** Die EVM verarbeitet Transaktionen innerhalb eines Blocks **sequenziell** — eine nach der anderen in fester Reihenfolge. Das hält die Zustandsübergangslogik einfach und gut prüfbar, begrenzt aber den Durchsatz auf der Basisschicht.
+
+**Gas.** Jede Operation kostet [Gas](/de/glossary/gas/), Ethereums Einheit für „den für Operationen erforderlichen Rechenaufwand“. Das bepreist die Ausführung und schützt das Netzwerk vor Spam oder Endlosschleifen ([ethereum.org](https://ethereum.org/en/developers/docs/evm/#:~:text=Since%20each%20transaction%20is%20broadcast,uses%20gas)).
+
+**Besondere Stärke und Reichweite.** Der eigentliche Burggraben der EVM ist ihr Ökosystem: Sie ist die in Krypto am häufigsten implementierte VM, und Dutzende Layer 2s sowie unabhängige Chains (Arbitrum, Optimism, Base, Polygon, BNB Chain, Avalanche C-Chain) liefern **EVM-kompatible** oder **EVM-äquivalente** Umgebungen aus. Dadurch lassen sich bestehende Solidity-Contracts, Wallets und Tools mit wenigen oder ganz ohne Änderungen bereitstellen.
+
+---
+
+## SVM (Solana / Sealevel)
+
+![Flachvektordiagramm mit dem Kontrast einer mehrspurigen Autobahn voller parallel fahrender Transaktionsautos und einer einspurigen Straße mit wartenden Autos; es veranschaulicht Solanas parallele Sealevel-Ausführung gegenüber sequenzieller Ausführung](../../assets/blockchain-virtual-machines-02-parallel-execution.jpg)
+
+Solanas Laufzeitumgebung **Sealevel** beruht auf einer bestimmten Annahme: Die meisten Transaktionen berühren getrennte Teile des Zustands und können daher gleichzeitig statt einzeln ausgeführt werden. Solanas eigene Ankündigung beschreibt Sealevel als „Solanas Laufzeitumgebung für parallele Smart Contracts“, die „Tausende Contracts parallel verarbeiten kann und dabei so viele Kerne verwendet, wie dem Validator zur Verfügung stehen“ ([solana.com](https://solana.com/news/sealevel---parallel-processing-thousands-of-smart-contracts#:~:text=Sealevel%E2%80%94Parallel%20Smart%20Contracts%20Runtime)).
+
+**Wie Parallelität funktioniert.** Solana-Transaktionen müssen im Voraus jedes Konto angeben, das sie lesen oder schreiben werden. Diese Angabe ermöglicht die Planung: Die Laufzeit kann „Millionen ausstehender Transaktionen sortieren“ und „alle sich nicht überschneidenden Transaktionen parallel einplanen“, einschließlich mehrerer Transaktionen, die dasselbe Konto nur *lesen* ([solana.com](https://solana.com/news/sealevel---parallel-processing-thousands-of-smart-contracts#:~:text=Sort%20millions%20of%20pending%20transactions)). Zwei Transaktionen werden nur dann zueinander sequenziell ausgeführt, wenn beide in dasselbe Konto schreiben.
+
+**Sprache und VM-Interna.** Solana-Programme — so nennt Solana Smart Contracts — werden in eine Variante des Berkeley-Packet-Filter-Bytecodes kompiliert. Solana Labs beschreibt die On-Chain-VM als eine Wahl für „eine Variante des Berkeley Packet Filter (BPF)-Bytecodes“ ([solana.com](https://solana.com/news/sealevel---parallel-processing-thousands-of-smart-contracts#:~:text=Berkeley%20Packet%20Filter)). Programme werden am häufigsten in **Rust** geschrieben, unterstützt werden auch C und C++.
+
+**Besondere Stärke.** Weil die Parallelität auf Kontoebene eine Eigenschaft der Laufzeit ist und nicht von jedem Contract-Autor von Hand umgesetzt werden muss, kann Solana hohen Durchsatz aufrechterhalten, ohne die Ausführung Off-Chain zu verlagern. Der Preis ist ein strengeres Modell für die Kontendeklaration, das die Art verändert, wie Contracts im Vergleich zum frei gestaltbaren Speicher der EVM geschrieben werden.
+
+---
+
+## MoveVM (Aptos & Sui)
+
+![Flachvektordiagramm einer Münze als physischer Ressource, die von Hand zu Hand zwischen zwei Kontoboxen gereicht wird; Schutzsymbole „kann nicht kopiert werden“ und „kann nicht verloren gehen“ veranschaulichen Moves Ressourcenmodell](../../assets/blockchain-virtual-machines-03-move-resource.jpg)
+
+**Move** ist eine Smart-Contract-Sprache, die ursprünglich für Metas Diem-Projekt entwickelt wurde und heute die Basisschicht für **Aptos** und **Sui** bildet, die jeweils eine eigene MoveVM-Variante betreiben. Die Dokumentation von Aptos beschreibt Move als „eine sichere Programmiersprache für Web3, die Knappheit und Zugriffskontrolle in den Mittelpunkt stellt“ ([aptos.dev](https://aptos.dev/en/network/blockchain/move#:~:text=Move%20is%20a%20safe%20and,scarcity%20and%20access%20control)).
+
+**Das Ressourcenmodell.** Die prägende Idee von Move ist, digitale Assets als **Ressourcen** zu behandeln — spezielle Struct-Typen, bei denen das Typsystem der Sprache garantiert, dass sie „nicht versehentlich dupliziert oder verworfen werden können“ ([aptos.dev](https://aptos.dev/en/network/blockchain/move#:~:text=Resources%20cannot%20be%20copied%2C%20they,structs%20cannot%20be%20accidentally%20duplicated)). Ein als Move-Ressource modellierter Token oder NFT kann nicht wie ein naiver Ganzzahl-Kontostand durch einen fehlerhaften Contract kopiert oder doppelt ausgegeben werden; der Compiler weist das Programm zurück. Nur Structs, die ausdrücklich als kopierbar oder verwerfbar markiert sind, können dupliziert oder verworfen werden.
+
+**Parallele Ausführung.** Aptos führt Move-Contracts über **Block-STM** aus, das laut Dokumentation „die gleichzeitige Ausführung von Transaktionen ohne Eingaben des Nutzers“ ermöglicht. Die Laufzeit leitet also während der Ausführung ab, welche Transaktionen unabhängig sind, statt die von Solana verwendeten deklarierten Kontolisten zu verlangen ([aptos.dev](https://aptos.dev/en/network/blockchain/move#:~:text=Parallelism%20via%20Block,input%20from%20the%20user)).
+
+**Suis Objektmodell.** Sui führt Moves Ressourcenidee mit einer objektzentrierten Speicherschicht weiter: „Ein Objekt ist eine grundlegende Speichereinheit im Netzwerk. Jede Ressource, jedes Asset und jedes Datenelement On-Chain ist ein Objekt“, das über eine eindeutige ID adressierbar ist, statt im Key-Value-Store eines Kontos zu liegen ([docs.sui.io](https://docs.sui.io/concepts/object-model#:~:text=An%20object%20is%20a%20fundamental,piece%20of%20data%20onchain%20is%20an%20object)). Objekte haben entweder einen einzelnen Eigentümer (**owned objects**, die parallel ohne Konsensreihenfolge ausgeführt werden können, da keine andere Transaktion sie berühren kann) oder sind **shared objects**, auf die mehrere Parteien zugreifen können und die eine Konsensreihenfolge benötigen.
+
+**Besondere Stärke.** Moves Ressourcentypen machen ganze Klassen von Asset-Fehlern — Doppelausgaben und versehentliche Verbrennungen — zur Compile-Zeit nicht darstellbar. Zudem kombinieren Aptos und Sui dieses Sicherheitsmodell mit paralleler Ausführung, die von Anfang an eingeplant und nicht nachträglich ergänzt wurde.
+
+---
+
+## WASM-basierte VMs (CosmWasm, PolkaVM)
+
+Statt ein eigenes Bytecode-Format zu definieren, führt eine zweite Chain-Familie Smart Contracts über **WebAssembly** aus, ein allgemeines Binärformat, das ursprünglich für den Browser entwickelt wurde. Der WebAssembly-Standard beschreibt Wasm als „binäres Befehlsformat für eine Stack-basierte virtuelle Maschine“, das als „portables Kompilierungsziel für Programmiersprachen“ konzipiert ist und „nahezu mit nativer Geschwindigkeit“ ausgeführt werden soll ([webassembly.org](https://webassembly.org/#:~:text=WebAssembly%20(abbreviated%20Wasm)%20is%20a,wide%20range%20of%20platforms)). Wenn Wasm die Contract-VM bildet, kann jede Sprache mit einem Wasm-Kompilierungsziel — Rust, C, C++, Go — grundsätzlich einen bereitstellbaren Contract erzeugen.
+
+**CosmWasm.** Als führende Wasm-basierte Smart-Contract-Plattform im Cosmos-Ökosystem bezeichnet sich CosmWasm selbst als „sichere, leistungsfähige und interoperable Smart-Contract-Plattform für die Multi-Chain-Welt“ ([cosmwasm.com](https://www.cosmwasm.com/#:~:text=Secure%2C%20performant%2C%20interoperable%20smart%20contract,platform%20for%20the%20multi%2Dchain%20world)). Contracts werden in **Rust** geschrieben und laufen auf „einer hochoptimierten Web-Assembly-Laufzeit“ ([cosmwasm.com](https://www.cosmwasm.com/#:~:text=highly%20optimized%20Web%20Assembly%20runtime)). CosmWasm ist auf Dutzenden Cosmos-SDK-Chains bereitgestellt, darunter Osmosis, Neutron, Injective, Secret Network und Terra, und übernimmt Cosmos' natives IBC-Cross-Chain-Messaging.
+
+**PolkaVM.** Polkadots neuere Smart-Contract-VM geht einen anderen Weg: Statt rohes Wasm auszuführen, hat Parity PolkaVM in der eigenen Repository-Beschreibung als „allgemeine virtuelle Maschine auf Nutzerebene, die auf RISC-V basiert“ gebaut ([github.com/paritytech/polkavm](https://github.com/paritytech/polkavm#:~:text=PolkaVM%20is%20a%20general%20purpose,level%20RISC%2DV%20based%20virtual%20machine)). Die Begründung in der ink!-Dokumentation ist Leistung: RISC-V-Ausführung „hängt mit Transaktionsdurchsatz und Transaktionskosten zusammen“ und ermöglicht eine schnellere, günstigere Ausführung als der zuvor von ink! verwendete Wasm-Interpreter ([use.ink](https://use.ink/docs/v6/background/why-riscv-and-polkavm-for-smart-contracts/#:~:text=performance%20correlates%20with%20transaction%20throughput)). Bemerkenswert ist, dass Polkadots PolkaVM-Stack (unter dem Namen „Revive“) auch eine EVM-Interpreterebene bereitstellt, sodass Solidity-Contracts auf demselben RISC-V-Backend laufen können.
+
+**Besondere Stärke.** WASM-basierte VMs tauschen ein speziell gebautes Bytecode-Format gegen ein ausgereiftes, weit verbreitetes Kompilierungsziel. Insbesondere Rust bringt starke Garantien für Speichersicherheit in Contract-Code, und die zugrunde liegenden Wasm-/RISC-V-Laufzeiten profitieren von Tools, die für wesentlich größere Anwendungsfälle außerhalb der Blockchain entwickelt wurden.
+
+---
+
+## CairoVM (Starknet)
+
+**Cairo** ist die speziell für die Erzeugung von Zero-Knowledge-Proofs entwickelte Smart-Contract-Sprache und VM, die **Starknet**, ein Ethereum-[Layer 2](/de/glossary/layer-2/), zugrunde liegt. Starknets Dokumentation formuliert das Designziel ausdrücklich: „Cairo ist eine STARK-freundliche Von-Neumann-Architektur, die Gültigkeitsbeweise für beliebige Berechnungen erzeugen kann“ ([starknet.io](https://www.starknet.io/cairo-book/ch201-architecture.html#:~:text=Cairo%20is%20a%20STARK,for%20arbitrary%20computations)). „STARK-freundlich“ bedeutet, dass der Befehlssatz „für das STARK-Beweissystem optimiert ist und zugleich mit anderen Backends für Beweissysteme kompatibel bleibt“ ([starknet.io](https://www.starknet.io/cairo-book/ch201-architecture.html#:~:text=Being%20STARK,other%20proof%20system%20backends)). Das ist die entgegengesetzte Priorität zur EVM oder SVM, die zunächst für Ausführung entworfen und erst später für Skalierung mit Beweissystemen ergänzt wurden.
+
+**Ausführungsmodell.** Cairo kompiliert zu einem Turing-vollständigen Befehlssatz (der „Cairo-Maschine“), der als Satz algebraischer Zwischendarstellungen spezifiziert ist. Dadurch lässt sich die Ausführungsspur jedes Cairo-Programms in einen kompakten, auf Ethereum L1 überprüfbaren STARK-Proof umwandeln ([starknet.io](https://www.starknet.io/cairo-book/ch201-architecture.html#:~:text=At%20its%20core%2C%20Cairo%20is,arbitrary%20code%29%20through%20the%20Cairo%20machine)). So kann Starknet Tausende Transaktionen Off-Chain bündeln und einen kompakten Korrektheitsbeweis zurück auf Ethereum posten, statt jede Transaktion erneut auszuführen.
+
+**Besondere Stärke.** Da die Beweisfreundlichkeit der ursprüngliche Designzwang und kein Nachgedanke war, lassen sich Cairo-Programme günstiger beweisen als eine gleichwertige Berechnung in einer Allzweck-VM, die nachträglich mit einem zk-Prover ausgestattet wurde (einer „zkEVM“). Der Nachteil ist ein neueres, kleineres Sprachökosystem und für Entwickler aus Ethereum eine steilere Lernkurve als bei Solidity.
+
+---
+
+## Vergleichstabelle
+
+| VM | Contract-Sprache(n) | Ausführungs- / Zustandsmodell | Parallele Ausführung | Größe des Ökosystems | EVM-kompatibel |
+|---|---|---|---|---|---|
+| **EVM** | Solidity, Vyper | Stack-Maschine; Konto-/Speicherzustand in einem Merkle-Patricia-Trie | Nein — sequenziell innerhalb eines Blocks | Am größten; das Standardziel für L2s und App-Chains | Nativ |
+| **SVM (Solana)** | Rust, C, C++ | Von BPF abgeleiteter Bytecode; kontobasierter Zustand mit deklarierten Lese-/Schreibmengen | Ja — Sealevel plant sich nicht überschneidende Transaktionen gleichzeitig | Groß, schnell wachsend, überwiegend Solana-nativ | Nein (eigenes Ökosystem) |
+| **MoveVM (Aptos/Sui)** | Move | Ressourcen-typisierte Objekte; Aptos verwendet Block-STM, Sui ein Modell mit eigenen/geteilten Objekten | Ja — zur Laufzeit abgeleitet (Aptos) oder über Objekteigentum (Sui) | Kleiner, wachsend; zwei unabhängige Move-Ökosysteme | Nein |
+| **WASM-basiert (CosmWasm, PolkaVM)** | Rust (CosmWasm); Rust-/C-/RISC-V-Toolchains (PolkaVM) | Wasm-Bytecode (CosmWasm) oder RISC-V-Bytecode (PolkaVM) | Chain-abhängig; keine universelle Eigenschaft der Wasm-Ausführung | Mittelgroß; über viele Cosmos-Chains und die Polkadot-Parachains verteilt | PolkaVM/Revive ergänzt eine EVM-Interpreterebene; CosmWasm ist nicht EVM-kompatibel |
+| **CairoVM (Starknet)** | Cairo | Turing-vollständige, AIR-basierte Maschine für STARK-Proofs | Nicht das primäre Designziel — auf Beweisbarkeit, nicht Parallelität optimiert | Die kleinste der fünf, wächst aber mit Starknets L2-Aktivität | Nein (zkEVM-Projekte binden Solidity-Contracts separat ein) |
+
+---
+
+## Verbindung zu tokenisierten Domains
+
+Welche VM eine Chain ausführt, ist für die Infrastruktur [tokenisierter Domains](/de/glossary/tokenized-domain/) unmittelbar relevant. Eine als [NFT](/de/glossary/nft/) dargestellte Domain ist im Kern ein Smart Contract, der durchsetzt, wem ein Token gehört und was damit geschehen darf. Das ist genau jene Logik, die Moves Ressourcenmodell nachweisbar sicher machen soll und die sich mit dem ausgereiften Tooling der EVM einfach prüfen und in bestehende Wallets und Marktplätze integrieren lässt. Namefis Tokenisierungsmodell zielt bewusst auf das EVM-Ökosystem: EVM-Kompatibilität bedeutet, dass das Eigentums-NFT einer tokenisierten `.com`- oder `.ai`-Domain direkt mit dem bestehenden Universum aus EVM-Wallets, Marktplätzen und DeFi-Protokollen funktioniert, statt für jede neue VM eine individuelle Integration zu benötigen. Entdecken Sie tokenisierte Domains auf [namefi.io](https://namefi.io).
+
+---
+
+## Quellen und weiterführende Lektüre
+
+- [Die Ethereum Virtual Machine (EVM) — ethereum.org](https://ethereum.org/en/developers/docs/evm/)
+- [Smart-Contract-Sprachen — ethereum.org](https://ethereum.org/en/developers/docs/smart-contracts/languages/)
+- [Sealevel — parallele Verarbeitung Tausender Smart Contracts — Solana](https://solana.com/news/sealevel---parallel-processing-thousands-of-smart-contracts)
+- [Move — Aptos-Dokumentation](https://aptos.dev/en/network/blockchain/move)
+- [Objektmodell — Sui-Dokumentation](https://docs.sui.io/concepts/object-model)
+- [CosmWasm](https://www.cosmwasm.com/)
+- [PolkaVM — GitHub (paritytech)](https://github.com/paritytech/polkavm)
+- [Warum RISC-V und PolkaVM für Smart Contracts — ink!-Dokumentation](https://use.ink/docs/v6/background/why-riscv-and-polkavm-for-smart-contracts/)
+- [Cairo-Architektur — Die Programmiersprache Cairo / Starknet](https://www.starknet.io/cairo-book/ch201-architecture.html)
+- [WebAssembly](https://webassembly.org/)

--- a/content/blog/de/cf-namecom-namefi.md
+++ b/content/blog/de/cf-namecom-namefi.md
@@ -1,0 +1,122 @@
+---
+title: "Cloudflare vs. Name.com vs. Namefi: Agent-native Registrare"
+date: '2026-07-10'
+language: 'de'
+tags: ['ai-agents', 'comparison']
+authors: ['namefiteam']
+draft: false
+format: comparison
+ogImage: ../../assets/cf-namecom-namefi-og.jpg
+description: "Funktionsvergleich der drei agent-nativen Registrare: Preise, MCP-Unterstützung, Krypto-Checkout, tokenisierte Eigentümerschaft und wann welcher die richtige Wahl ist."
+keywords: ["cloudflare registrar api", "name.com ki api", "namefi mcp", "agent-nativer registrar", "ki-registrar vergleich", "krypto-domain-checkout", "tokenisierte domain", "mcp-domain-registrierung", "ki-agent domain kaufen", "cloudflare vs namefi", "name.com vs namefi", "domain-preise zum selbstkostenpreis", "wallet-checkout domain"]
+relatedArticles:
+  - /de/blog/ai-domain-platforms/
+  - /de/blog/agent-native/
+  - /de/blog/airo-vs-namefi/
+  - /de/blog/claude-mcp-domains/
+  - /de/blog/ai-agent-register/
+relatedTopics:
+  - /de/topics/domain-tokenization/
+  - /de/topics/choosing-a-tld/
+relatedSeries:
+  - /de/series/tokenize-your-com/
+  - /de/series/best-tlds-by-industry/
+relatedGlossary:
+  - /de/glossary/ai-agent/
+  - /de/glossary/registrar/
+  - /de/glossary/tokenized-domain/
+  - /de/glossary/dnssec/
+  - /de/glossary/wallet/
+---
+
+Drei [Registrare](/de/glossary/registrar/) ermöglichen es inzwischen etwas anderem als einem Menschen, ein Checkout-Formular auszufüllen. Cloudflare eröffnete im April 2026 eine Beta-API, mit der ein [KI-Agent](/de/glossary/ai-agent/) eine Domain ohne Browser-Sitzung registrieren kann. Name.com hat seine API rund um dieselbe Idee neu aufgebaut und bezeichnet sich als erste KI-native Domain-Plattform. Namefi hat einen Model Context Protocol (MCP)-Server und einen per Wallet-Signatur autorisierten Checkout entwickelt, der die Kontoerstellung vollständig überspringt. Alle drei zielen auf denselben Wandel: Domain-Registrierung wird von etwas, das eine Person im Browser erledigt, zu etwas, das ein Agent über einen API-Aufruf erledigt.
+
+Sie sind jedoch nicht dasselbe Produkt mit unterschiedlichen Logos. Jedes setzt andere Schwerpunkte bei der Preisgestaltung, bei der Frage, was „agent-native“ tatsächlich erfordert, und dabei, wie ein Käufer seine Zahlungsfähigkeit nachweist. Dies ist ein Funktionsvergleich der drei — einschließlich der Punkte, an denen Cloudflares Preisgestaltung wirklich schwer zu übertreffen ist, und der Punkte, an denen die Positionierung von Name.com dem ausgelieferten Produkt voraus ist.
+
+## Was „agent-native“ tatsächlich erfordert
+
+Eine API zu haben ist nicht dasselbe, wie von einem Agenten nutzbar zu sein. Die meisten Registrare bieten seit Jahren programmatische Registrierung an — doch diese Schnittstellen wurden für Reseller und Entwickler entwickelt, die Dokumentation lesen, nicht für einen autonomen Prozess, der herausfinden muss, was möglich ist, sich ohne von einem Menschen eingegebenes Passwort authentifizieren und eine Fehlermeldung ohne menschliche Lektüre auswerten muss. Eine ausführlichere Checkliste dessen, was einen Registrar mit API von einem agent-nativen Registrar unterscheidet, findet sich in [Was ist ein agent-nativer Domain-Registrar?](/de/blog/agent-native/). Kurz gesagt geht es um Auffindbarkeit (kann ein Agent die API selbst finden?), maschinenlesbare Antworten und einen Zahlungsweg, der nicht voraussetzt, dass ein Mensch eine Kreditkarte in der Hand hält. Die drei folgenden Registrare erfüllen diese Anforderungen in unterschiedlichem Maß.
+
+## Cloudflare Registrar API: Zum Selbstkostenpreis, als Beta und bereits in deinem Editor
+
+Die Registrar API von Cloudflare ging am April 15, 2026 während der Ankündigungen zur „Agents Week“ des Unternehmens in die Beta. Laut einem Branchenbericht zur Einführung [ermöglicht die API einem KI-Agenten, die Verfügbarkeit einer Domain zu suchen, Preise zu prüfen und die Registrierung programmatisch ohne Browser-Interaktion oder manuelle Freigabe abzuschließen](https://webhosting.today/2026/04/22/ai-agents-can-now-register-domains-no-human-required/#:~:text=lets%20an%20AI%20agent%20search%20for%20domain%20availability%2C%20check%20pricing%2C%20and%20complete%20registration%20programmatically%20without%20any%20browser%20interaction%20or%20manual%20approval). Die Registrierung wird bei Standard-Domains innerhalb von Sekunden synchron abgeschlossen, und die API ist dafür ausgelegt, in [Code-Editoren mit MCP-Unterstützung wie Cursor und Claude Code](https://webhosting.today/2026/04/22/ai-agents-can-now-register-domains-no-human-required/#:~:text=code%20editors%20with%20MCP%20support%20such%20as%20Cursor%20and%20Claude%20Code) zu laufen. Ein Entwickler kann eine Domain für das Projekt registrieren, das er baut, ohne das Werkzeug zu verlassen, in dem er es baut.
+
+Der stärkste Teil von Cloudflares Angebot ist die Preisgestaltung, und hier verlangt Glaubwürdigkeit, einen echten starken Punkt anzuerkennen: Cloudflare [bietet Registrierungen und Verlängerungen von .ai-Domains zu Großhandelspreisen ohne zusätzliche Aufschläge](https://www.cloudflare.com/application-services/products/registrar/buy-ai-domains/#:~:text=Cloudflare%20offers%20.ai%20domain%20registrations%20and%20renewals%20at%20wholesale%20prices%2C%20with%20no%20additional%20markups). Jede registrierte Domain enthält [kostenlos DNSSEC, SSL, Zwei-Faktor-Authentifizierung und eine standardmäßig aktivierte Domain-Sperre](https://www.cloudflare.com/application-services/products/registrar/buy-ai-domains/#:~:text=free%20DNSSEC%2C%20free%20SSL%2C%20two-factor%20authentication%2C%20and%20a%20domain%20lock%20enabled%20by%20default), außerdem eine [kostenlose WHOIS-Schwärzung](https://www.cloudflare.com/application-services/products/registrar/buy-ai-domains/#:~:text=every%20.ai%20domain%20comes%20with%20free%20WHOIS%20redaction) — für den [WHOIS-Datenschutz](/de/glossary/whois-privacy/), den andere Registrare als Zusatzleistung verkaufen, fällt kein Aufpreis an. Eine separate Übersicht über Registrare bestätigt das Preismodell unabhängig: Bei Cloudflares [Preisgestaltung zum Selbstkostenpreis zahlst du nur, was Cloudflare zahlt, ohne Aufschlag bei Registrierung oder Verlängerung](https://www.hostinger.com/tutorials/best-domain-registrars/#:~:text=At-cost%20pricing%20charges%20you%20only%20what%20Cloudflare%20pays%2C%20with%20no%20markup%20at%20registration%20or%20renewal). Wenn der Preis entscheidend ist und du über „registrieren und absichern“ hinaus nichts brauchst, ist Cloudflare schwer zu übertreffen.
+
+Der Haken ist der Umfang. Die Beta umfasst Suche, Preisprüfung und Registrierung. [Cloudflare hat erklärt, dass das Lebenszyklusmanagement in Entwicklung ist und später 2026 veröffentlicht werden soll](https://webhosting.today/2026/04/22/ai-agents-can-now-register-domains-no-human-required/#:~:text=Cloudflare%20has%20stated%20that%20lifecycle%20management%20is%20in%20development%20and%20is%20planned%20for%20release%20later%20in%202026), sodass Transfers, Verlängerungen und Kontaktaktualisierungen noch nicht Teil der agentengerichteten API sind. Es gibt keine Krypto-Zahlungsoption und keine tokenisierte Eigentümerschaft: Eine über Cloudflare registrierte Domain ist ein konventionelles Asset in einem Registrar-Konto und kein Vermögenswert, den eine Wallet direkt halten kann.
+
+## Die KI-native API von Name.com: Von natürlicher Sprache zu funktionierendem Code
+
+Die Positionierung von Name.com unterscheidet sich von der von Cloudflare. Statt mit dem Preis zu beginnen, hat Name.com seine Entwickler-API rund um [die Einführung der neuen name.com API, unserer KI-nativen Plattform, die Domains für das Zeitalter agentischer KI modernisiert](https://www.name.com/blog/the-first-ai-native-domain-platform#:~:text=the%20launch%20of%20the%20new%20name.com%20API%2C%20our%20AI-native%20platform%20that%20modernizes%20domains%20for%20the%20age%20of%20agentic%20AI), aufgebaut. Diese beruht auf der [Model Context Protocol (MCP)- und OpenAPI-Spezifikation, die KI-Agenten die direkte Interaktion mit Domain-Vorgängen ermöglicht](https://www.name.com/blog/the-first-ai-native-domain-platform#:~:text=supported%20by%20modern%20standards%20like%20Model%20Context%20Protocol%20%28MCP%29%20and%20OpenAPI%20specification%2C%20which%20enable%20AI%20agents%20to%20interact%20directly%20with%20domain). Auch dies vermarktet das Unternehmen ausdrücklich als Workflow im Editor: Es sagt, Entwickler könnten [KI-Tools wie Claude und Cursor dank MCP-Unterstützung über einfache Prompts für Domain-Vorgänge einsetzen](https://www.name.com/blog/the-first-ai-native-domain-platform#:~:text=Leverage%20AI%20tools%20like%20Claude%20and%20Cursor%20to%20handle%20domain%20operations%20through%20simple%20prompts%2C%20thanks%20to%20MCP%20support).
+
+Das klarste Unterscheidungsmerkmal in der Ankündigung von Name.com ist die Einordnung als Weg von natürlicher Sprache zu Code. Statt dass ein Agent einen festen Satz von Endpoints aufruft, lautet das Versprechen: Du sagst einem Agenten „Füge meiner App Domain-Registrierung hinzu“, und der Agent schreibt mithilfe der API-Dokumentation selbst den Integrationscode. Name.com stützt das Argument „die Welt bewegt sich in diese Richtung“ mit eigener Kundenforschung und berichtet, dass [91% der Befragten erwarten, dass KI-Agenten in den nächsten zwei Jahren zumindest einen Teil ihrer Domain-Verwaltung übernehmen](https://www.name.com/blog/the-first-ai-native-domain-platform#:~:text=a%20remarkable%2091%25%20of%20respondents%20envision%20AI%20agents%20handling%20at%20least%20some%20of%20their%20domain%20management%20in%20the%20next%20two%20years). Da diese Statistik unmittelbar aus der Ankündigung von Name.com und nicht von Dritten stammt, sollte sie als vom Unternehmen berichtete Marktstimmung und nicht als unabhängige Umfrage behandelt werden.
+
+Zwei Punkte sollten ehrlich hervorgehoben werden. Erstens ist der Blogbeitrag von Name.com ein Text zu Positionierung und Vision; er veröffentlicht nicht die detaillierte Fähigkeitstabelle, die die Dokumentation von Cloudflare und Namefi bietet. Mehrere Zellen der folgenden Matrix spiegeln daher wider, was die Ankündigung behauptet, und nicht eine getestete Spezifikation. Zweitens spricht der eigene Beitrag von Name.com bei der Preisgestaltung über Flexibilität auf Reseller-Seite — [die Möglichkeit, eigene Aufschläge festzulegen](https://www.name.com/blog/the-first-ai-native-domain-platform#:~:text=the%20ability%20to%20set%20your%20own%20markups). Das ist eine Funktion für Reseller-Partner, nicht das Versprechen von Preisen zum Selbstkostenpreis für Endnutzer wie bei Cloudflare. Auch einen Krypto-Zahlungsweg oder tokenisierte Eigentümerschaft nennt die Ankündigung nicht.
+
+## Namefi: MCP-Server, Wallet-Checkout und tokenisierte Eigentümerschaft
+
+Der Ansatz von Namefi beginnt mit einer anderen Annahme: Der Käufer ist möglicherweise kein Mensch mit Browser-Sitzung oder Kreditkarte und möchte möglicherweise kein Namefi-Konto anlegen, bevor er handeln kann. Laut der eigenen maschinenlesbaren API-Dokumentation von Namefi — der einzigen Quelle der Wahrheit für die Produktbehauptungen — betreibt Namefi einen MCP-Server unter `https://api.namefi.io/mcp` über Streamable-HTTP-Transport. Er stellt „jeden `/v-next`-Vorgang als typisiertes Tool bereit (Suche, Registrierung, DNS, Domain-Konfiguration, Outbound)“, ist unter `https://namefi.io/.well-known/mcp/servers.json` auffindbar und dokumentiert einen einzeiligen Einrichtungsbefehl für Claude Code (`claude mcp add --transport http namefi https://api.namefi.io/mcp --header "x-api-key: YOUR_KEY"`). Die REST API verwendet zur Authentifizierung einen `x-api-key`-Header, der an die Wallet gebunden ist, welche die Domain besitzt; schreibgeschützte Tools benötigen überhaupt keinen Schlüssel.
+
+Das charakteristische Merkmal ist die Zahlung. Namefi dokumentiert einen [x402](https://x402.org)-Zahlungsfluss, mit dem ein Agent eine Domain mit dem Stablecoin USDC kaufen kann, ohne zunächst ein Namefi-Konto anzulegen. Die Wallet des Käufers signiert ein EIP-3009-`transferWithAuthorization`, die API gibt ohne beigefügte Zahlung eine `402 Payment Required`-Antwort mit dem Preis zurück und führt die Registrierung durch, sobald ein gültiger Payment-Header eintrifft. Ein separater Machine Payable Protocol (MPP)-Fluss bietet ein ähnliches Challenge-and-Sign-Muster. Weder Cloudflare noch Name.com dokumentieren etwas Vergleichbares; das ist der schärfste Unterschied in diesem Vergleich. Wie dieser Checkout-Fluss Ende zu Ende funktioniert, zeigt [Domains mit einer Krypto-Wallet bezahlen: Kein Konto nötig](/de/blog/wallet-checkout/).
+
+Namefi registriert Domains außerdem als [NFTs](/de/glossary/nft/) — [tokenisierte Domains](/de/glossary/tokenized-domain/), deren Eigentümerschaft On-Chain und nicht nur in der internen Datenbank eines Registrars verifiziert wird. Seine DNS-Schalter umfassen automatische [ENS](/de/glossary/ens/)-Einträge und [DNSSEC](/de/glossary/dnssec/) sowie vollständige CRUD-Verwaltung von DNS-Einträgen (einzeln und im Batch), automatische Verlängerung, Domain-Parking und Weiterleitung. Was die llms.txt von Namefi nicht veröffentlicht, ist eine festgelegte Preisrichtlinie: Es gibt keinen „zum Selbstkostenpreis“-Anspruch wie bei Cloudflare und keine sichtbare veröffentlichte Preisliste in der für diesen Beitrag geprüften Dokumentation. Prüfe daher die aktuellen Preise direkt auf namefi.io, statt Preisgleichheit mit Cloudflare anzunehmen. <!-- TODO: confirm with team — Namefi's published pricing/markup policy relative to registry cost -->
+
+## Die Funktionsmatrix
+
+| Funktion | Cloudflare Registrar API | Name.com KI-native API | Namefi |
+|---|---|---|---|
+| Verfügbarkeitssuche | Ja | Ja | Ja (`search/availability`, im Batch) |
+| Preisabfrage | Ja | Ja (dokumentiert, nicht detailliert aufgeschlüsselt) | Ja (in der x402-`402`-Antwort; auch über API) |
+| Kauf / Registrierung | Ja, synchron, Sekunden | Ja (vom Agenten erzeugter Integrationscode) | Ja — API-Key oder per Wallet-Signatur autorisiertes USDC über x402/MPP |
+| DNS-Verwaltung | Nicht in der aktuellen Beta | In der Ankündigung nicht detailliert | Ja — vollständiges CRUD, Batch-Vorgänge, A/CNAME/TXT/MX und mehr |
+| Automatisierte Verlängerung | Nicht in der aktuellen Beta (später 2026 geplant) | In der Ankündigung nicht detailliert | Ja — Auto-Renew-Schalter pro Domain |
+| Krypto-Zahlung | Nein | Nein | Ja — USDC über x402, kein Konto erforderlich |
+| Tokenisierte Eigentümerschaft | Nein | Nein | Ja — Domain als NFT registriert, On-Chain-Verifizierung |
+| Konto erforderlich | Ja (Cloudflare-Konto) | Ja (Entwickler-/API-Zugang) | Nein beim x402-Wallet-Checkout; der API-Key-Weg ist an eine Wallet gebunden |
+| MCP-Unterstützung | Ja (im Editor, laut Drittanbieterbericht) | Ja (dokumentiert) | Ja — dedizierter MCP-Server, Discovery-Deskriptor |
+| Editor-Integration | Cursor, Claude Code (laut Bericht) | Claude, Cursor (laut Ankündigung) | Claude Code (dokumentierter Einrichtungsbefehl); offenes MCP-Protokoll |
+| Selbstkostenpreis / keine Aufschläge | Ja, ausdrücklich genannt | Nicht genannt (Aufschläge von Resellern erwähnt) | Nicht veröffentlicht — aktuelle Preise prüfen |
+
+## Wann welcher gewinnt
+
+Wähle **Cloudflare**, wenn Preis und Einfachheit ausschlaggebend sind und du über die Registrierung eines Namens und dessen Absicherung hinaus nichts brauchst. Die Preise zum Selbstkostenpreis und die integrierten Sicherheitsstandards (DNSSEC, WHOIS-Schwärzung, Zwei-Faktor-Authentifizierung) sind tatsächlich besser als das, was die meisten etablierten Anbieter für denselben Schutz verlangen. Wenn du bereits in Cursor oder Claude Code auf dem Stack von Cloudflare arbeitest, ist der Workflow reibungslos. Die ehrliche Abwägung ist der Umfang: Noch keine DNS-Verwaltung, keine automatisierten Verlängerungen und keine Krypto- oder tokenisierten Optionen, denn die Beta beschränkt sich auf Registrierung.
+
+Wähle **Name.com**, wenn ein Agent den Integrationscode für dich schreiben soll, statt eine feste API aufzurufen, oder wenn du bereits Name.com-Reseller bist und auf einer modernisierten, MCP-kompatiblen Plattform flexible Aufschläge möchtest. Die Dokumentation ist bei der Frage, was genau ausgeliefert ist und was auf der Roadmap steht, dünner als bei Cloudflare oder Namefi. Plane daher Zeit ein, die tatsächliche API-Oberfläche gegen das Marketing zu testen.
+
+Wähle **Namefi**, wenn der Käufer wirklich agent-first ist: kein menschliches Konto, eine Zahlung, die durch Wallet-Signatur statt durch eine gespeicherte Karte autorisiert wird, und Eigentümerschaft, die als übertragbarer On-Chain-Token statt nur als Zeile in der Datenbank eines Registrars dargestellt werden soll. Diese Kombination — MCP-Server, vollständige DNS-Kontrolle, automatisches ENS und Wallet-nativer Checkout — bieten die Beta von Cloudflare und die Ankündigung von Name.com derzeit nicht. Der Nachteil ist, dass Namefi keine Selbstkostenpreis-Zusage wie Cloudflare veröffentlicht hat. Wenn Großhandelspreise deine höchste Priorität sind, prüfe die aktuellen Namefi-Preise direkt, bevor du annimmst, sie seien niedriger als bei Cloudflare.
+
+Viele Teams werden am Ende mehr als einen Anbieter nutzen: Cloudflare oder Name.com für die Domain vor Infrastruktur, die sie dort bereits betreiben, und einen Wallet-nativen Registrar wie Namefi für alles, was On-Chain besessen und gehandelt werden muss — sei es ein Name, der auf einem Marketplace gehandelt werden soll, oder einer, der der eigenen Wallet eines Agenten statt dem Konto einer Person gehört. Was „Eigentümerschaft“ überhaupt bedeutet, sobald der [Registrant](/de/glossary/registrant/) ein Agent statt einer Person ist, ist eine Frage, die tief genug für einen eigenen Beitrag ist — siehe [Kann ein KI-Agent eine Domain besitzen? WHOIS, Verwahrung & Token](/de/blog/agent-own-domain/).
+
+## Häufig gestellte Fragen
+
+### Welcher Registrar ist für einen KI-Agenten am günstigsten?
+Cloudflare ist der einzige der drei, der eine ausdrückliche Preiszusage zum Selbstkostenpreis ohne Aufschlag veröffentlicht und diese durch eine unabhängige Registrar-Übersicht bestätigt sieht. Die Ankündigung von Name.com behandelt Aufschlagsflexibilität für Reseller statt einer Selbstkostenpreis-Zusage für Endnutzer. Namefi hat in seiner API-Dokumentation keine Preisrichtlinie veröffentlicht; ein direkter Preisvergleich ist daher derzeit nicht möglich, ohne die aktuellen Preise auf jeder Plattform zu prüfen.
+
+### Ermöglicht einer davon einem Agenten zu zahlen, ohne dass ein Mensch eine Kreditkarte hält?
+Namefi ist der einzige der drei mit einem dokumentierten Krypto-nativen Zahlungsfluss: Die Wallet eines Agenten kann über das x402-Protokoll in USDC zahlen, ohne ein Namefi-Konto anzulegen, oder über einen separaten Machine Payable Protocol Challenge-and-Sign-Fluss. Weder die Beta von Cloudflare noch die API von Name.com dokumentieren einen vergleichbaren Zahlungsweg ohne Konto.
+
+### Kann ich DNS-Einträge über diese APIs verwalten und nicht nur die Domain registrieren?
+Die Dokumentation von Namefi deckt vollständiges CRUD für DNS-Einträge ab, einschließlich Erstellung, Aktualisierung und Löschung im Batch sowie Schalter für Parking, Weiterleitung, automatisches ENS und Vercel-Anycast-Einträge. Die Beta der Registrar API von Cloudflare ist zum Zeitpunkt dieses Beitrags auf Registrierung beschränkt; Lebenszyklus- und Verwaltung nach der Registrierung (einschließlich DNS) sollen später veröffentlicht werden. Die Ankündigung von Name.com schlüsselt DNS-Verwaltungsfähigkeiten nicht auf.
+
+### Ist die Registrar API von Cloudflare bereits allgemein verfügbar?
+Nein. Sie ging am April 15, 2026 während der „Agents Week“ von Cloudflare in die Beta. Cloudflare hat erklärt, dass ein breiteres Lebenszyklusmanagement (Transfers, Verlängerungen, Kontaktaktualisierungen) noch in Entwicklung und für später 2026 geplant ist. Fähigkeiten in der Beta können sich ändern; überprüfe sie erneut, bevor du dich in der Produktion darauf verlässt.
+
+### Was bedeutet „agent-native“, und erfüllen alle drei diesen Anspruch?
+Agent-native bedeutet, dass ein Agent die API finden, sich authentifizieren und einen Kauf abschließen kann, ohne dass ein Mensch ein Browser-Formular ausfüllt. Die vollständige Checkliste steht in [Was ist ein agent-nativer Domain-Registrar?](/de/blog/agent-native/). Alle drei Registrare erfüllen die grundlegende Voraussetzung (programmatische Suche bis zum Kauf, MCP- oder MCP-nahe Tools), unterscheiden sich aber stark darin, wie weit dieses agent-native Design über die Registrierung hinausgeht — DNS, Verlängerungen, Zahlungsmethode und Eigentumsmodell.
+
+## Domains bei Namefi kaufen und tokenisieren
+
+Wenn du Wallet-nativen Checkout und tokenisierte Eigentümerschaft brauchst, registriert [Namefi](https://namefi.io) echte ICANN-Domains wie jeder akkreditierte Registrar — mit der Option, die Domain als NFT zu halten, das deine Wallet kontrolliert. [KI-agentische Domain-Plattformen: Der Leitfaden für 2026](/de/blog/ai-domain-platforms/) zeigt die gesamte Landschaft über diese drei hinaus; direkt zur praktischen Einrichtung geht es in [Wie du mit deinem KI-Agenten eine Domain bei Namefi registrierst](/de/blog/ai-agent-register/). Die Mechanik, mit der ein Agent diesen Kauf selbstständig abschließt, erklärt [Wie KI-Agenten Domains ohne Menschen kaufen (2026)](/de/blog/agents-buy-domains/).
+
+**[Eine Domain bei Namefi suchen und registrieren](https://namefi.io).**
+
+## Quellen und weiterführende Lektüre
+
+- webhosting.today — [KI-Agenten können jetzt Domains registrieren, kein Mensch erforderlich (Cloudflare Registrar API Beta, April 2026)](https://webhosting.today/2026/04/22/ai-agents-can-now-register-domains-no-human-required/#:~:text=lets%20an%20AI%20agent%20search%20for%20domain%20availability%2C%20check%20pricing%2C%20and%20complete%20registration%20programmatically%20without%20any%20browser%20interaction%20or%20manual%20approval)
+- Cloudflare — [.ai-Domains kaufen: Preise zum Selbstkostenpreis und enthaltene Sicherheitsfunktionen](https://www.cloudflare.com/application-services/products/registrar/buy-ai-domains/#:~:text=Cloudflare%20offers%20.ai%20domain%20registrations%20and%20renewals%20at%20wholesale%20prices%2C%20with%20no%20additional%20markups)
+- Name.com — [Die erste KI-native Domain-Plattform](https://www.name.com/blog/the-first-ai-native-domain-platform#:~:text=the%20launch%20of%20the%20new%20name.com%20API%2C%20our%20AI-native%20platform%20that%20modernizes%20domains%20for%20the%20age%20of%20agentic%20AI)
+- Hostinger — [Die besten Domain-Registrare im Vergleich, einschließlich der Selbstkostenpreise von Cloudflare](https://www.hostinger.com/tutorials/best-domain-registrars/#:~:text=At-cost%20pricing%20charges%20you%20only%20what%20Cloudflare%20pays%2C%20with%20no%20markup%20at%20registration%20or%20renewal)
+- llmstxt.org — [Die llms.txt-Spezifikation](https://llmstxt.org/#:~:text=context%20windows%20are%20too%20small%20to%20handle%20most%20websites%20in%20their%20entirety)
+- Model Context Protocol — [Was ist MCP?](https://modelcontextprotocol.io/#:~:text=MCP%20%28Model%20Context%20Protocol%29%20is%20an%20open-source%20standard%20for%20connecting%20AI%20applications%20to%20external%20systems)
+- Namefi — [namefi.io/llms.txt (Referenz für MCP-Server, API und Authentifizierung)](https://namefi.io/llms.txt)
+- Namefi — [namefi.io/web3/llms.txt (Referenz für Wallet-signierte und x402-Krypto-Zahlungen)](https://namefi.io/web3/llms.txt)

--- a/content/blog/de/claude-mcp-domains.md
+++ b/content/blog/de/claude-mcp-domains.md
@@ -1,0 +1,163 @@
+---
+title: "Eine Domain mit Claude kaufen: Schritt-für-Schritt-Anleitung für Namefi MCP"
+date: '2026-07-10'
+language: 'de'
+tags: ['ai-agents', 'domains', 'guide']
+authors: ['namefiteam']
+draft: false
+format: guide
+ogImage: ../../assets/claude-mcp-domains-og.jpg
+description: "Verbinden Sie Claude mit dem Namefi-MCP-Server und registrieren Sie eine echte Domain aus einem einzigen Gespräch. Mit exakter Konfiguration, kommentiertem Transkript und Fehlerbehebung."
+keywords: ["namefi mcp", "claude mcp domain", "mcp-server einrichten", "domain kaufen claude", "x-api-key", "schritt-für-schritt-anleitung", "namefi mcp domainregistrierung", "claude desktop domain registrieren", "claude code domain kaufen", "namefi claude integration", "mcp-domain-registrar", "ki-agent kauft domain claude", "streamable http mcp"]
+relatedArticles:
+  - /de/blog/ai-agent-register/
+  - /de/blog/cf-namecom-namefi/
+  - /de/blog/ai-domain-platforms/
+  - /de/blog/agent-native/
+  - /de/blog/airo-vs-namefi/
+relatedTopics:
+  - /de/topics/domain-tokenization/
+  - /de/topics/domain-basics/
+relatedSeries:
+  - /de/series/tokenize-your-com/
+  - /de/series/blockchain-concepts/
+relatedGlossary:
+  - /de/glossary/ai-agent/
+  - /de/glossary/registrar/
+  - /de/glossary/dns-record-types/
+  - /de/glossary/tokenized-domain/
+  - /de/glossary/x402/
+---
+
+Am Ende dieses Leitfadens haben Sie eine echte, bei [ICANN](/de/glossary/icann/) registrierte Domain, deren DNS auf Ihr Projekt verweist — vollständig aus einem Gespräch mit Claude heraus, ohne Browser-Checkout, Warenkorb oder CAPTCHA. Dies ist die eigene Einrichtungsanleitung des Namefi-Teams für den [Namefi](https://namefi.io)-MCP-Server — die menschenlesbare Erläuterung derselben API, die wir für Agenten unter [namefi.io/llms.txt](https://namefi.io/llms.txt) und [docs.namefi.io](https://docs.namefi.io) veröffentlichen. Wo ein Detail noch nicht finalisiert oder veröffentlicht ist, sagt dieser Leitfaden es ausdrücklich, statt zu raten.
+
+Es gibt Anleitungen von Drittanbietern zum Thema „eine Domain mit Ihrem [KI-Agenten](/de/glossary/ai-agent/) registrieren“ — [ein beliebtes Beispiel](https://dev.to/marsheer/how-to-register-a-domain-name-with-your-ai-agent-no-human-needed-h26) demonstriert das Muster mit einem anderen MCP-Server, der als Reseller auf Cloudflares Registrar-API aufsetzt. Die Mechanik von MCP selbst folgt bei allen Anbietern derselben Idee; dieser Leitfaden bezieht sich konkret auf Namefis eigenen MCP-Server, dessen eigenes Authentifizierungsmodell und dessen Option für [tokenisierte Domains](/de/glossary/tokenized-domain/). Er wurde anhand der Namefi-Dokumentation geprüft, nicht anhand der Beschreibung eines Dritten.
+
+## Was ist MCP, kurz erklärt?
+
+Das [Model Context Protocol](https://modelcontextprotocol.io) (MCP) ist ein offener Standard, der eine KI-Anwendung — hier Claude — mit externen Tools und Datenquellen verbindet. Die Dokumentation des Protokolls selbst beschreibt es als [USB-C-Anschluss für KI-Anwendungen](https://modelcontextprotocol.io/docs/getting-started/intro#:~:text=Think%20of%20MCP%20like%20a%20USB%2DC%20port%20for%20AI%20applications): ein standardisierter Anschluss statt einer individuellen Integration pro Tool. Sobald Claude mit Namefis MCP-Server verbunden ist, erhält es einen definierten Satz aufrufbarer Operationen — Verfügbarkeit prüfen, eine Domain registrieren sowie DNS-Einträge lesen und schreiben — statt eine REST-API aus in den Chat kopierter Dokumentation rekonstruieren zu müssen.
+
+## Voraussetzungen
+
+- **Ein MCP-fähiger Claude-Client.** Dieser Leitfaden behandelt Claude Code (Kommandozeile) mit konkreten, getesteten Befehlen sowie Claude Desktop / claude.ai (über Custom Connectors) mit dem dokumentierten allgemeinen Ablauf. Andere MCP-Clients wie Cursor oder Windsurf verbinden sich mit demselben Server; die Abschnitte je Agent in [Eine Domain mit Ihrem KI-Agenten bei Namefi registrieren](/de/blog/ai-agent-register/) behandeln diese Clients. Wenn Sie nur die Verbindungsbefehle brauchen, nutzen Sie den kompakten [Namefi MCP Quickstart: Claude Code, Cursor & Windsurf](/de/blog/mcp-quickstart/).
+- **Ein Namefi-API-Schlüssel**, erzeugt unter [namefi.io/api-key](https://namefi.io/api-key), *oder* eine Krypto-[Wallet](/de/glossary/wallet/), wenn Sie lieber pro Transaktion ganz ohne API-Schlüssel zahlen möchten (siehe den Wallet-Abschnitt weiter unten).
+- **Ein aufgeladenes NFSC-Guthaben**, wenn Sie sich in Namefis Produktionsumgebung registrieren. NFSC (Namefi Service Credits) ist das Guthaben, gegen das die Domainregistrierung abgerechnet wird. Die Namefi-Dokumentation beschreibt das Aufladen über das Namefi-Dashboard in Produktion und das Anfordern kostenloser Testguthaben von einem Faucet-Endpunkt in Entwicklungsumgebungen.
+
+## Schritt 1: Einen Namefi-API-Schlüssel abrufen
+
+Der [API-Schlüssel](https://namefi.io/api-key) ist der einfachste Authentifizierungsweg und wird in diesem Leitfaden durchgehend verwendet: Ein einzelner Header deckt jede Operation ab — Registrierung, Erstellung, Aktualisierung und Löschung von DNS-Einträgen. Ein Detail sollten Sie verinnerlichen, bevor Sie einen Schlüssel erzeugen: **Der Schlüssel übernimmt die Berechtigungen der Wallet, die ihn erzeugt hat.** Wenn Sie DNS für eine bereits bestehende Domain verwalten möchten, erzeugen Sie den Schlüssel mit der Wallet, der das NFT dieser Domain gehört. Ein Schlüssel aus einer anderen Wallet hat keinen Schreibzugriff auf eine Domain, deren [Registrierungsinhaber](/de/glossary/registrant/) jemand anderes ist.
+
+Nach der Erzeugung ist der Schlüssel ein mit `nfk_` beginnender String. Bei jeder Schreiboperation übergeben Sie ihn im Header `x-api-key`; schreibgeschützte Operationen wie eine Verfügbarkeitsprüfung benötigen ihn überhaupt nicht.
+
+## Schritt 2: Claude mit dem Namefi-MCP-Server verbinden
+
+Namefi, ein von ICANN akkreditierter [Registrar](/de/glossary/registrar/), betreibt für seine gesamte API-Oberfläche einen einzigen MCP-Server unter `https://api.namefi.io/mcp`, erreichbar über den Streamable-HTTP-Transport. Der Server stellt jede `/v-next`-Operation als typisiertes Tool bereit — Suche, Registrierung, DNS, Domainkonfiguration, Outbound — und seine Existenz sowie Verbindungsdetails sind selbst als Discovery-Deskriptor unter [namefi.io/.well-known/mcp/servers.json](https://namefi.io/.well-known/mcp/servers.json) veröffentlicht. Dieser ist maschinenlesbar, damit ein Agent den Server finden kann, ohne dass ein Mensch ihm zuerst die URL einfügt.
+
+### Claude Code
+
+Das Hinzufügen des Servers zu Claude Code ist ein Befehl:
+
+```bash
+claude mcp add --transport http namefi https://api.namefi.io/mcp --header "x-api-key: YOUR_KEY"
+```
+
+Das entspricht der [dokumentierten Syntax von Claude Code](https://code.claude.com/docs/en/mcp) für das Hinzufügen eines entfernten HTTP-MCP-Servers mit einem benutzerdefinierten Authentifizierungs-Header. Das allgemeine Muster lautet `claude mcp add --transport http <name> <url> --header "<Header-Name>: <value>"`. Führen Sie den Befehl einmal im Terminal aus (ersetzen Sie `YOUR_KEY` durch den Schlüssel aus Schritt 1); Claude Code schreibt den Server dann in die MCP-Konfiguration Ihres Projekts oder Benutzers. Standardmäßig registriert der Befehl den Server nur für das aktuelle Projekt. Ergänzen Sie `--scope user`, wenn er in jedem Projekt verfügbar sein soll, oder lassen Sie den Schlüssel zunächst ganz weg, falls Sie nur schreibgeschützte Tools wie die Verfügbarkeitssuche benötigen.
+
+Bestätigen Sie die Verbindung mit `claude mcp list`; dort sollte `namefi` als verbunden erscheinen. Innerhalb einer Claude-Code-Sitzung zeigt Ihnen `/mcp`, wie viele Tools der Namefi-Server bereitstellt.
+
+### Claude Desktop und claude.ai
+
+Claude Desktop und claude.ai verbinden sich über **Custom Connectors** mit entfernten MCP-Servern. Der Ablauf ist unter [modelcontextprotocol.io](https://modelcontextprotocol.io/docs/develop/connect-remote-servers) dokumentiert: Öffnen Sie Settings, wechseln Sie zu Connectors, wählen Sie „Add custom connector“ und geben Sie die Server-URL `https://api.namefi.io/mcp` ein. Nach dem Klick auf Add fordert der Ablauf Sie zum Abschluss der Authentifizierung auf; laut Anthropic-Dokumentation umfasst dieser Schritt „üblicherweise OAuth, API-Schlüssel oder Kombinationen aus Benutzername und Passwort“, abhängig von den Anforderungen des konkreten Servers. Claude zeigt den jeweiligen vom Server angeforderten Dialog an.
+
+<!-- TODO: Mit dem Team bestätigen — welches genaue Feld der Custom-Connector-Authentifizierungsdialog von Claude Desktop für einen Header im Stil von x-api-key anzeigt; die öffentlichen Anthropic-Dokumente beschreiben den allgemeinen Authentifizierungsschritt, zeigen aber nicht speziell den Namefi-Server. --> Falls Ihr Desktop-Connector-Setup keinen offensichtlichen Ort zur Eingabe des Schlüssels zeigt, ist Claude Code derzeit der geprüfte Weg. Schreibgeschützte Tools (Verfügbarkeitssuche) funktionieren über den Connector auch ganz ohne Schlüssel.
+
+## Schritt 3: NFSC-Guthaben aufladen
+
+Eine Domainregistrierung ist eine kostenpflichtige Operation: Sie benötigt NFSC (Namefi Service Credits) in der zahlenden Wallet. In einer Entwicklungs- oder Testumgebung gibt ein Faucet (`POST /v-next/user/faucet` oder `client.user.requestNfscFaucet()` im SDK) kostenlose Testguthaben aus, begrenzt pro Wallet. In Produktion wird NFSC über das Namefi-Dashboard aufgeladen. <!-- TODO: Mit dem Team bestätigen — den genauen Produktionsablauf zum Aufladen: akzeptierte Zahlungsmethoden und ob der Kauf direkt im Chat oder nur über die Dashboard-Oberfläche möglich ist. --> Sie können Ihr aktuelles Guthaben jederzeit prüfen: Fragen Sie Claude nach der Verbindung „Wie hoch ist mein Namefi-Guthaben?“ oder rufen Sie direkt `GET /v-next/balance` auf.
+
+## Schritt 4: Das Kaufgespräch
+
+Bei verbundenem MCP-Server und aufgeladenem Guthaben läuft der Rest in natürlicher Sprache. Hier sehen Sie eine kommentierte Version dieses Gesprächs, die jedem Schritt die zugehörige Operation aus der Namefi-API-Dokumentation zuordnet.
+
+**1. Sie bitten Claude, einen Namen zu prüfen.**
+
+> „Ist `example.com` für eine Registrierung verfügbar?“
+
+Claude ruft die Verfügbarkeitsprüfung auf (die Operation `checkAvailability`, direkt erreichbar unter `GET /v-next/search/availability?domain=example.com`; Authentifizierung ist nicht erforderlich). Claude meldet zurück, ob der Name frei ist, und kann über die Bulk-Variante der Verfügbarkeitsprüfung mehrere Kandidaten gleichzeitig prüfen, wenn Sie mehrere Namen zum Vergleich angeben.
+
+**2. Sie bestätigen und registrieren.**
+
+> „Registriere die Domain für ein Jahr und richte DNS so ein, dass `@` auf 203.0.113.10 zeigt.“
+
+Claude übermittelt eine Registrierungsbestellung (`registerDomain`, `POST /v-next/orders/register-domain`) — oder, falls Sie auch DNS-Einträge angefordert haben, die kombinierte Variante `register-domain/records`. Diese wendet den gewünschten [A-Eintrag](/de/glossary/dns-record-types/) an, sobald die Bestellung abgeschlossen ist. Der Request-Body nimmt einen `normalizedDomainName` entgegen (Kleinschreibung, kein abschließender Punkt; jede [TLD](/de/glossary/tld/), die `search/availability` als registrierbar meldet) sowie `durationInYears` (0–10, Standardwert 1). Optional steuert `nftReceivingWallet` die Tokenisierung: Wenn Sie das Feld weglassen, wird die Domain als NFT auf Base für die mit Ihrem API-Schlüssel verbundene Wallet registriert. Ein Objekt `domainSetupOptions` dokumentiert weitere Überschreibungen pro Domain, darunter `autoRenew`, `dnssec` und `keepExistingNameservers`. Letzteres erlaubt Claude, die Domain zu registrieren, ohne die [Nameserver](/de/glossary/nameserver/)-Delegierung von ihrem derzeitigen Ziel weg umzuleiten.
+
+**3. Claude fragt den Status ab, bis die Bestellung fertig ist.**
+
+Die Registrierung erfolgt asynchron. Claude (oder Sie, wenn Sie den Status beobachten) fragt `getOrder` (`GET /v-next/orders/{orderId}`) ab, bis die Bestellung einen endgültigen Status erreicht: `SUCCEEDED`, `FAILED`, `CANCELLED` oder `PARTIALLY_COMPLETED`. Eine typische Registrierung ist nach wenigen Abfragezyklen fertig; Claude meldet sich dann zurück, statt Sie auf einen Ladeindikator starren zu lassen.
+
+**4. Sie fordern weitere DNS-Einträge an, falls Sie nicht alle im Voraus eingerichtet haben.**
+
+> „Füge außerdem einen CNAME für `www` hinzu, der auf `cname.vercel-dns.com.` zeigt, sowie einen TXT-Eintrag unter `_verify` mit diesem Token.“
+
+Claude ruft für jeden Eintrag `createDnsRecord` (`POST /v-next/dns/records`) auf. Bevor Sie danach fragen, sind zwei Formatierungsregeln wichtig: `rdata` für [CNAME](/de/glossary/dns-record-types/) und ähnliche Eintragstypen muss mit einem abschließenden Punkt enden (`cname.vercel-dns.com.`), während `zoneName` — die Domain selbst — keinen solchen Punkt haben darf. Die Verwechslung dieser beiden Regeln ist die häufigste Ursache eines Validierungsfehlers in diesem Ablauf.
+
+**5. Optional: automatische Verlängerung einschalten.**
+
+> „Schalte die automatische Verlängerung für diese Domain ein.“
+
+Claude schaltet die [automatische Verlängerung](/de/glossary/domain-renewal/) über `PUT /v-next/domain-config/auto-renew` ein oder aus. Wenn sie aktiviert ist, verlängert sich die Domain vor dem Ablauf automatisch über die in der Eigentümer-Wallet verfügbaren Zahlungsarten. Das sollten Sie wissen, bevor Sie sie einschalten, denn es handelt sich um eine fortlaufende Autorisierung und nicht um eine einmalige Bestätigung.
+
+## Schritt 5: Auflösung prüfen
+
+[DNS-Propagation](/de/glossary/dns-propagation/) erfolgt nicht sofort; warten Sie daher vor der Prüfung einige Minuten. DNS-Lesevorgänge benötigen keine Authentifizierung. Sie (oder Claude) können deshalb mit `GET /v-next/dns/records?zoneName=example.com` oder einem öffentlichen DNS-Lookup-Tool bestätigen, was live ist. Wenn Sie die Domain auf eine Deployment-Plattform gerichtet haben, ist deren eigener Domain-Verifizierungsschritt — die Prüfung des angeforderten TXT-Eintrags — ebenfalls eine separate, sinnvolle Bestätigung.
+
+## Mit einer Wallet statt mit einem API-Schlüssel bezahlen
+
+Alles oben nutzt den Weg über den API-Schlüssel. Namefi unterstützt auch die Registrierung einer Domain mit einer Krypto-Wallet und ganz ohne Namefi-Konto über das [x402](/de/glossary/x402/)-Protokoll: Die Wallet des Käufers signiert eine EIP-3009-Autorisierung, die API antwortet ohne beigefügte Zahlung mit `402 Payment Required` samt Preis und führt die Registrierung aus, sobald eine gültige Zahlung eingeht. Dieser Ablauf verdient einen eigenen Leitfaden statt einer Fußnote. Alle Details finden Sie in [Domains mit einer Krypto-Wallet bezahlen: Kein Konto nötig](/de/blog/wallet-checkout/) oder im Zahlungsabschnitt von [Eine Domain mit Ihrem KI-Agenten bei Namefi registrieren](/de/blog/ai-agent-register/).
+
+## Fehlerbehebung
+
+| Symptom | Wahrscheinliche Ursache | Lösung |
+| --- | --- | --- |
+| `401 UNAUTHORIZED` bei jedem Schreibaufruf | API-Schlüssel ungültig, abgelaufen oder von einer Wallet erzeugt, der die Domain nicht gehört | Erzeugen Sie einen neuen Schlüssel unter [namefi.io/api-key](https://namefi.io/api-key) mit der Wallet, der die Domain gehört (oder gehören wird) |
+| `403 FORBIDDEN` | Schlüssel ist gültig, aber die zugehörige Wallet besitzt diese konkrete Domain nicht | Prüfen Sie die Eigentümerschaft anhand Ihres Namefi-Kontos, bevor Sie es erneut versuchen |
+| Registrierungsbestellung verbleibt in einem nicht endgültigen Status | Normal — die Registrierung erfolgt asynchron | Fragen Sie `getOrder` weiter ab; Namefis eigene Beispiele fragen alle 5 Sekunden ab. Betrachten Sie die Bestellung erst als festgefahren, wenn sie nie `SUCCEEDED`, `FAILED`, `CANCELLED` oder `PARTIALLY_COMPLETED` erreicht |
+| Erstellung/Aktualisierung eines DNS-Eintrags wird mit einem Validierungsfehler abgelehnt | `zoneName` hat einen abschließenden Punkt oder bei einem CNAME-/MX-/NS-`rdata`-Wert fehlt der abschließende Punkt | `zoneName` = kein abschließender Punkt; `rdata`-Werte vom FQDN-Typ = abschließender Punkt erforderlich |
+| Registrierung schlägt vollständig fehl | Unzureichendes NFSC-Guthaben in der zahlenden Wallet | Guthaben prüfen (`GET /v-next/balance`), über den Faucet aufladen (Test) oder über das Namefi-Dashboard (Produktion) |
+| Claude sagt, es seien keine Domain-Tools verfügbar | MCP-Server nicht verbunden oder ohne den für Schreiboperationen erforderlichen Header verbunden | `claude mcp add` erneut mit dem Flag `--header` ausführen oder `/mcp` / `claude mcp list` auf den Verbindungsstatus prüfen |
+
+## Häufig gestellte Fragen
+
+### Muss ich dafür Namefis REST-API kennen, oder kann ich einfach mit Claude in natürlicher Sprache sprechen?
+Natürliche Sprache reicht für den gesamten oben beschriebenen Ablauf aus: „Ist diese Domain verfügbar?“, „Registriere sie“ und „Richte sie auf diese IP-Adresse“ funktionieren als direkte Anfragen. Die Endpunkte und Request-Felder in diesem Leitfaden sind dokumentiert, damit Sie überprüfen können, was Claude im Hintergrund tut, oder sie selbst direkt aufrufen können, wenn Sie statt eines Gesprächs ein Skript verwenden.
+
+### Kostet die Registrierung über Claude mehr als die Registrierung auf Namefis Website?
+Dieser Leitfaden stellt keine Preisbehauptung in die eine oder andere Richtung auf. <!-- TODO: Mit dem Team bestätigen — ob die MCP-/API-Preise von Namefi den Standardpreisen für die Registrierung entsprechen oder abweichen. --> In jedem Fall wird die Registrierung gegen dasselbe NFSC-Guthaben abgerechnet, unabhängig davon, ob die Anfrage aus einem Browser, Skript oder MCP-Tool-Aufruf kam.
+
+### Wird meine Domain bei dieser Registrierung automatisch als NFT tokenisiert?
+Ja, standardmäßig. Wenn Sie in der Registrierungsanfrage keine `nftReceivingWallet` angeben, wird die Domain auf Base als NFT für die mit Ihrem API-Schlüssel verbundene Wallet registriert. Bei der Registrierung können Sie sie auf eine andere Wallet oder Chain umleiten.
+
+### Was passiert, wenn Claudes DNS-Eintragsanfrage einen Tippfehler enthält — kann sie meine Domain unbemerkt beschädigen?
+DNS-Schreibvorgänge durchlaufen vor der Anwendung die Namefi-Validierung. Fehlerhafte `rdata` (etwa ein fehlender abschließender Punkt bei einem CNAME-Ziel) werden mit einem Fehler abgelehnt, statt stillschweigend akzeptiert zu werden — siehe die Tabelle zur Fehlerbehebung oben. Behandeln Sie DNS-Änderungen an einer Live-Domain dennoch wie jede Infrastrukturänderung: Prüfen Sie, was Claude senden wird, bevor Sie bestätigen.
+
+### Kann ich diesen MCP-Server statt mit Claude auch mit Cursor oder Windsurf verwenden?
+Ja — der Namefi-Server spricht dasselbe offene MCP-Protokoll, unabhängig davon, welcher Client ihn verbindet; auf Serverseite ändert sich also nichts. Die Verbindungsbefehle auf Clientseite unterscheiden sich je Editor. Siehe die Konfigurationsabschnitte nach Client in [Eine Domain mit Ihrem KI-Agenten bei Namefi registrieren](/de/blog/ai-agent-register/) oder den kürzeren [Namefi MCP Quickstart: Claude Code, Cursor & Windsurf](/de/blog/mcp-quickstart/).
+
+## Ihre nächste Domain aus einem Gespräch kaufen
+
+Dies ist die Einrichtung, die Namefi heute konkret unterstützt, keine Hypothese. Sobald der MCP-Server verbunden ist, geschieht alles vom Suchen eines Namens über die Registrierung und DNS-Konfiguration bis zur optionalen Umwandlung in einen in einer Wallet gehaltenen Token, ohne den Chat zu verlassen. Der MCP-Server stellt mehr als die Registrierung bereit — Outbound-Lead-Finding, DNS-Operationen im Batch, Domainkonfiguration — und alles ist nach der Einrichtung über dieselbe Verbindung auffindbar. Den vollständigen Tool-Katalog finden Sie unter [Namefi MCP Server: Domain-Tools für KI-Agenten](/de/blog/namefi-mcp/).
+
+**[Einen Namefi-API-Schlüssel erzeugen und Claude verbinden](https://namefi.io/api-key).**
+
+## Quellen und weiterführende Lektüre
+
+- Namefi — [namefi.io/llms.txt](https://namefi.io/llms.txt) (MCP-Server-URL, Transport, Authentifizierung, Registrierungs- und DNS-Endpunkte — Primärquelle für diesen Leitfaden)
+- Namefi — [docs.namefi.io: Authentifizierung](https://docs.namefi.io/docs/02-authentication.mdx) (API-Schlüssel, EIP-712- und SIWE-Authentifizierungsmodi; Authentifizierungsanforderungen je Operation)
+- Namefi — [docs.namefi.io: Eine Domain registrieren](https://docs.namefi.io/docs/03-getting-started/01-your-first-domain.mdx) (ausgearbeitete Registrierungs- und Abfragebeispiele in SDK, fetch, cURL und Python)
+- Namefi — [docs.namefi.io: Guthaben verwalten](https://docs.namefi.io/docs/03-getting-started/02-your-balance.mdx) (NFSC-Faucet- und Guthabenprüf-Endpunkte)
+- Namefi — [namefi.io/.well-known/mcp/servers.json](https://namefi.io/.well-known/mcp/servers.json) (MCP-Discovery-Deskriptor)
+- Anthropic / Claude Code — [Claude Code über MCP mit Tools verbinden](https://code.claude.com/docs/en/mcp#:~:text=claude%20mcp%20add%20%2D%2Dtransport%20http) (Syntax für `claude mcp add --transport http`, Header-Authentifizierung, Scope-Flags)
+- Model Context Protocol — [Mit entfernten MCP-Servern verbinden](https://modelcontextprotocol.io/docs/develop/connect-remote-servers#:~:text=Most%20remote%20MCP%20servers%20require%20authentication) (Ablauf für Custom Connectors in Claude Desktop und claude.ai)
+- Model Context Protocol — [Was ist das Model Context Protocol?](https://modelcontextprotocol.io/docs/getting-started/intro#:~:text=Think%20of%20MCP%20like%20a%20USB%2DC%20port%20for%20AI%20applications) (Überblick über das Protokoll)
+- llmstxt.org — [Die Datei /llms.txt](https://llmstxt.org) (Spezifikation und Begründung für den Namen der Discovery-Datei namefi.io/llms.txt)
+- dev.to — [Eine Domain mit Ihrem KI-Agenten registrieren, kein Mensch erforderlich](https://dev.to/marsheer/how-to-register-a-domain-name-with-your-ai-agent-no-human-needed-h26) (MCP-Anleitung eines Drittanbieters auf Basis eines anderen, von Cloudflare unterstützten Registrar-Resellers)

--- a/content/blog/de/how-much-is-a-domain-understanding-holding-cost.md
+++ b/content/blog/de/how-much-is-a-domain-understanding-holding-cost.md
@@ -1,0 +1,156 @@
+---
+title: "Was kostet eine Domain? Die Haltekosten verstehen"
+date: '2026-06-29'
+language: de
+tags: ['domains', 'domain-investing', 'domain-pricing', 'guide']
+authors: ['namefiteam']
+draft: false
+cluster: domain-investing
+series: domain-flipping-skills
+seriesOrder: 41
+format: guide
+description: "Ein praxisnaher Leitfaden zu den Haltekosten einer Domain: Preis im ersten Jahr, Verlängerung, Transfer- und Wiederherstellungsgebühren, Datenschutz, Steuern, Zahlungsmethoden und Preismodelle von Registraren."
+keywords: ['was kostet eine domain', 'domain-haltekosten', 'kosten domain-verlängerung', 'preis domain-registrierung', 'domain-transfergebühr', 'domain-wiederherstellungsgebühr', 'kosten domain-datenschutz', 'registrar-preise', 'preis domain erstes jahr', 'preis domain-verlängerung', 'domain-redemption-gebühr', 'preismodell für domains', 'gesamtpreis domain', 'kosten domain-eigentum', 'domain-laufende-kosten']
+relatedArticles:
+  - /de/blog/domain-renewal-costs-and-sell-through-rate/
+  - /de/blog/domain-portfolio-management/
+  - /de/blog/when-to-drop-a-domain/
+  - /de/blog/domain-flipping/
+  - /de/blog/taxes-and-accounting-for-domain-investors/
+relatedTopics:
+  - /de/topics/domain-investing/
+  - /de/topics/domain-basics/
+relatedSeries:
+  - /de/series/domain-flipping-skills/
+  - /de/series/domain-investor-field-guide/
+relatedGlossary:
+  - /de/glossary/holding-cost/
+  - /de/glossary/domain-renewal/
+  - /de/glossary/registrar/
+  - /de/glossary/registry/
+  - /de/glossary/retail-pricing/
+---
+
+Die günstigste Domain ist selten auch die günstigste Domain zum *Halten*.
+
+Das ist das Erste, was du verstehen solltest, bevor du einen Namen registrierst. Der Preis im Checkout ist nur eine Zeile in der Rechnung. Zu einer Domain gehören ein Registrierungspreis im ersten Jahr, ein Verlängerungspreis, ein Transferpreis, mögliche Wiederherstellungs- oder Redemption-Gebühren, Datenschutzeinstellungen, Steuern, Kosten der Zahlungsmethode und manchmal Gebühren für begleitende Produkte wie DNS, E-Mail, Hosting oder Kontodienste.
+
+Deshalb kann eine Domain für $1 im ersten Jahr völlig seriös sein und später dennoch eine jährliche Verpflichtung von $30, $60 oder $80 werden. Der Preis im ersten Jahr verschafft dir den Einstieg. Der Verlängerungspreis bestimmt die langfristigen [Haltekosten](/de/glossary/holding-cost/).
+
+## Die Zahl, die du zuerst siehst, ist nicht der Preis
+
+Die meisten Menschen fragen: „Was kostet eine Domain?“ und erwarten eine einzige Antwort. Die bessere Frage lautet: „Was kostet mich dieser Name, wenn ich ihn drei Jahre behalte und einmal etwas schiefgeht?“
+
+Hier ist die Kostenstruktur.
+
+| Kosten | Was sie bedeuten | Warum sie wichtig sind |
+| --- | --- | --- |
+| Registrierung im ersten Jahr | Der Preis, einen verfügbaren Namen für die erste Laufzeit zu registrieren | Hier erscheinen üblicherweise Sonderangebote |
+| Verlängerung | Der wiederkehrende Preis, um die Domain nach der ersten Laufzeit zu behalten | Das sind die tatsächlichen langfristigen Kosten |
+| Transfer | Der Preis, den Namen zu einem anderen Registrar zu verschieben | Er kann vom Verlängerungspreis abweichen und die Laufzeit verlängern |
+| Wiederherstellung / Redemption | Die Gebühr, um einen Namen zurückzuholen, nachdem er abgelaufen ist und ein Wiederherstellungsfenster erreicht hat | Sie kann ein Vielfaches der jährlichen Verlängerung betragen |
+| WHOIS-Datenschutz | Datenschutz für Kontaktdaten oder ein Proxy-Dienst | Er kann eingeschlossen, kostenpflichtig, nicht verfügbar oder je nach TLD anders geregelt sein |
+| Steuern und regulatorische Gebühren | Umsatzsteuer, Mehrwertsteuer, GST, lokale Gebühren, ICANN-Gebühren oder weitere Zuschläge im Checkout | Sie hängen von Rechtsraum, Währung und Registrar ab |
+| Zahlungskosten | Wechselkursaufschlag bei Karten, Kosten für Überweisungen, Krypto-Netzwerkgebühren, verzögerte Zahlungsmethoden, Reibung bei Rückerstattungen | Der Registrar-Preis muss nicht dem Betrag entsprechen, der dein Konto tatsächlich verlässt |
+| DNS- / Produktgebühren | Kosten für Hosted Zones, Abfragen, E-Mail, Weiterleitung, SSL oder gebündelte Dienste | Eine Domain kann günstig sein, während das zugehörige Konto es nicht ist |
+
+Die Zeile, über die Menschen am häufigsten stolpern, ist die Verlängerung. Die Expired Registration Recovery Policy von ICANN verpflichtet Registrare, [Gebühren für Verlängerung, Verlängerung nach Ablauf sowie Redemption/Wiederherstellung angemessen verfügbar zu machen](https://www.icann.org/resources/pages/errp-2013-02-28-en#Notice). Käufer müssen sie jedoch vor dem Checkout weiterhin vergleichen. Ein niedriger Preis im ersten Jahr ist für sich genommen nicht irreführend. Er wird zum Problem, wenn der Käufer ihn mit den jährlichen Kosten verwechselt.
+
+## Warum eine $1-Domain mit $30 bis $80 verlängert werden kann
+
+Einführungspreise sind verbreitet, weil das erste Jahr und das Verlängerungsjahr wirtschaftlich unterschiedliche Ereignisse sind.
+
+Das erste Jahr kann rabattiert sein, weil die Registry oder der Registrar Akzeptanz fördern will, weil gerade eine Aktion läuft oder weil der Registrar erwartet, dass viele Kunden die Domain mehrere Jahre behalten. Das Verlängerungsjahr erfüllt eine andere Aufgabe. Es muss die laufende Registry-Gebühr, die Marge des Registrars, Zahlungsabwicklung, Betrugsschutz, Support, Compliance, Verlängerungsbenachrichtigungen und die Produkt-Schicht rund um den Namen tragen.
+
+Das ist in vielen Branchen normal: Der Preis für die Gewinnung eines Kunden ist oft niedriger als der Preis für dessen Bindung. Das domainspezifische Risiko besteht darin, dass Verlängerungen nicht optional sind, wenn der Name wichtig ist. Wenn deine Website, E-Mail, Marke, App oder dein Portfolio von einer Domain abhängt, ist die Verlängerungsrechnung der Preis dafür, die Kontrolle zu behalten.
+
+Die praktische Gewohnheit ist einfach: Notiere vor der Registrierung beide Zahlen. Wenn der Preis im ersten Jahr $1 und die Verlängerung $40 beträgt, betrachte die Domain als Asset für $40 pro Jahr mit einem rabattierten ersten Jahr, nicht als $1-Asset.
+
+## Registrierung, Verlängerung, Transfer, Wiederherstellung
+
+Die vier Domain-Vorgänge, die du vergleichen solltest, sind Registrierung, Verlängerung, Transfer und Wiederherstellung.
+
+**Registrierung** ist die erste Laufzeit. Sie ist die Zahl, die Marketingseiten betonen, weil sie am einfachsten zu verstehen ist. Ein rabattiertes erstes Jahr kann nützlich sein, wenn du eine Idee testest, ist aber nicht die richtige Zahl für die langfristige Planung.
+
+**Verlängerung** sind die Kosten für die weitere Kontrolle. Wenn du eine Domain für ein Nebenprojekt registrierst, mag der Unterschied zwischen $15 und $30 erträglich sein. Wenn du 200 Namen hältst, werden aus $15 Unterschied bei der Verlängerung $3,000 pro Jahr. Deshalb beschäftigen sich Domain-Investoren so intensiv mit [Verlängerungskosten und Sell-through-Rate](/de/blog/domain-renewal-costs-and-sell-through-rate/).
+
+**Transfer** ist, was du bezahlst, um die Domain zu einem anderen Registrar zu verschieben. Ein Transfer kann eine Verlängerung der Laufzeit um ein Jahr einschließen, aber das ist keine allgemeingültige Abkürzung, die du ohne Prüfung annehmen solltest. Achte außerdem auf Transfer-Sperren, Beschränkungen nach einer kürzlichen Registrierung, den Umgang mit Auth-Codes und darauf, ob der Transfer deine DNS- oder Datenschutzeinstellungen verändert.
+
+**Wiederherstellung oder Redemption** ist der teure Panikknopf. Die Wiederherstellungsrichtlinie von ICANN besagt, dass gTLD-Registries nach der Löschung im Allgemeinen eine [30-tägige Redemption Grace Period](https://www.icann.org/resources/pages/errp-2013-02-28-en#Redemption) anbieten müssen, während der die gelöschte Registrierung über den löschenden Registrar wiederhergestellt werden kann. In diesem Zeitraum kann die Wiederherstellung deutlich mehr kosten als eine normale Verlängerung. Die Lehre ist einfach: Auto-Renew ist günstiger als Rettung.
+
+## Datenschutz, Steuern und Kosten der Zahlungsmethode
+
+WHOIS-Datenschutz gehört in den Kostenvergleich, weil er den praktischen Wert des Pakets verändert. Manche Domains enthalten Datenschutz standardmäßig. Manche machen ihn optional. Bei manchen TLDs oder Registrant-Typen wird mit öffentlichen Kontaktdaten anders umgegangen. Wenn Datenschutz für dich wichtig ist, vergleiche ihn als Teil der Domain-Kosten und nicht als Nachgedanken.
+
+Steuern und regulatorische Gebühren sind weniger übersichtlich. Umsatzsteuer, Mehrwertsteuer, GST und lokale Regeln hängen davon ab, wo du dich befindest, wo der Registrar verkauft und wie der Dienst klassifiziert wird. Eine Checkout-Summe kann vom beworbenen Grundpreis abweichen, besonders über Währungen oder Rechtsräume hinweg.
+
+Auch die Zahlungsmethode kann die tatsächlichen Kosten verändern. Eine Karte kann einen Wechselkursaufschlag verursachen. Eine Banküberweisung kann Bankgebühren oder Mindestbeträge mit sich bringen. Eine lokale Überweisung kann die Aktivierung verzögern. Bei einer Krypto-Zahlung können Netzwerkgebühren, Bestätigungszeit und Einschränkungen bei Erstattungen anfallen. Wenn du einen günstigen einzelnen Namen kaufst, mag das geringfügig sein. Wenn du ein Portfolio kaufst oder verlängerst, werden Zahlungswege Teil des Betriebsmodells.
+
+## Preismodelle von Registraren
+
+Registrare verkaufen dasselbe allgemeine Objekt, aber nicht dasselbe Erlebnis. Sie nur anhand des Preises einer TLD im ersten Jahr zu vergleichen, verfehlt das Geschäftsmodell.
+
+### Modell mit Kostenweitergabe
+
+Einige Registrare positionieren sich mit minimalen Aufschlägen. Der Reiz ist offensichtlich: Kann ein Registrar die zugrunde liegenden Registry-Kosten mit geringer zusätzlicher Marge weitergeben, erhält der Käufer möglicherweise einen niedrigeren Verlängerungspreis. Dieses Modell eignet sich tendenziell am besten für Käufer, die bereits wissen, was sie brauchen, und nicht viel Support oder Bündelung benötigen.
+
+Die Abwägung besteht darin, dass ein niedriger Aufschlag nicht die einzige Variable ist. Unterstützte TLDs, Kontowiederherstellung, DNSSEC, Bulk-Kontrollen, Abrechnungskontrollen, Transfer-Workflows, Reaktionsgeschwindigkeit des Supports und die Passung des Registrars zu deinem Sicherheitsmodell bleiben wichtig.
+
+### Infrastrukturorientierter Registrar
+
+Einige Registrare sind an eine breitere Cloud- oder Infrastrukturplattform angebunden. In diesem Modell ist die Domain ein Teil eines größeren Systems, das gehostetes DNS, Gebühren pro Abfrage, Zugriffskontrollen, Audit-Logs, Infrastrukturautomatisierung, Health Checks und andere operative Dienste umfassen kann.
+
+Das kann für technische Teams attraktiv sein, die Domains nah an Infrastruktur und Abrechnung halten möchten. Für Gelegenheitskäufer, die nur eine einfache Domain und eine Verlängerungserinnerung wünschen, kann es überdimensioniert sein. Der Domain-Preis kann angemessen aussehen, während die Kosten für die umgebenden Produkte die Gesamtrechnung schwerer vergleichbar machen.
+
+### Investororientierter Registrar
+
+Einige Registrare sind auf Domain-Investoren und aktive Händler optimiert. Dort zählen Funktionen wie Bulk-Suche, Bulk-Verlängerungen, Portfolio-Exporte, übersichtliche Verlängerungsspalten, Transfer-Tools, Zugang zum Aftermarket, Ablaufkontrollen und Berichte auf Kontoebene.
+
+Für Investoren summiert sich ein kleiner Unterschied bei der Verlängerung schnell. Ein Portfolio von Namen wird jedes Jahr verlängert, unabhängig davon, ob die Namen verkauft werden oder nicht. Deshalb sind die Verlängerungstabelle, Wiederherstellungsgebühren, Bulk-Tools und der Zahlungs-Workflow eines Registrars wichtiger als ein angenehmer Checkout für einen einzelnen Namen.
+
+### Verbraucherorientierter Einzelhandels-Registrar
+
+Verbraucherorientierte Einzelhandels-Registrare optimieren für ein breiteres Käuferpublikum: kleine Unternehmen, Kreative, lokale Dienste, Nebenprojekte, Erstbesitzer von Domains und Teams, die Support sowie ergänzende Produkte möchten. Der Wert kann ein einfacherer Suchablauf, Erinnerungen, Kundensupport, der Umgang mit Datenschutz, E-Mail- oder Hosting-Integrationen, Website-Tools oder eine leichtere Kontowiederherstellung sein.
+
+Einzelhandelspreise sind nicht automatisch schlecht. Der faire Vergleich lautet nicht: „Wer hat den niedrigsten Preis im ersten Jahr für eine TLD?“ Sondern: „Was kostet mich dieser Registrar über die gesamte Laufzeit der Domain, und rechtfertigt die Service-Schicht den Unterschied?“
+
+### Marketplace- und produktisierte Registrar-Erfahrung
+
+Manche Registrar-Erfahrungen sind um Domains als Assets herum gebaut, nicht nur um Domains als Checkout-Artikel. Dazu können Listings, Transfers, Eigentumsverifizierung, Finanzierung, Portfolioansichten, tokenisierte Eigentümerschaft, Marketplace-Abwicklung oder Domain-Übergabe-Workflows gehören.
+
+Die Produkt-Schicht kann nützlich sein, ersetzt aber nicht die grundlegende Kostenprüfung. Auch eine produktisierte Erfahrung hat Preise im ersten Jahr, Verlängerungspreise, Transferregeln, Wiederherstellungsrisiko, Datenschutzeinstellungen, Steuern und Zahlungsflüsse. Die Zusatzfunktionen sind nur dann wertvoll, wenn die gesamten Haltekosten für den Namen weiterhin sinnvoll sind.
+
+## Was du vor der Wahl eines Registrars vergleichen solltest
+
+Nutze diese Checkliste, bevor du einen Namen registrierst, den du behalten möchtest.
+
+1. Wie hoch ist der Preis im ersten Jahr?
+2. Wie hoch ist der Verlängerungspreis nach der ersten Laufzeit?
+3. Hat der Name Standardpreis oder Premium-Preis?
+4. Ist WHOIS-Datenschutz eingeschlossen, optional oder nicht verfügbar?
+5. Wie hoch ist der Preis für einen eingehenden Transfer, und verlängert er die Laufzeit?
+6. Wie hoch ist die Wiederherstellungs- oder Redemption-Gebühr, wenn die Domain abläuft?
+7. Was passiert nach dem Ablauf: Benachrichtigungen, Grace Period, DNS-Unterbrechung, Auktion, Redemption, Pending Delete?
+8. Werden im Checkout Steuern oder lokale regulatorische Gebühren hinzugefügt?
+9. Welche Zahlungsmethoden werden unterstützt, und verursachen sie zusätzliche Kosten, Verzögerung oder Reibung bei Rückerstattungen?
+10. Sind DNS, Hosted Zones, E-Mail, Weiterleitung, SSL oder Sicherheitsprodukte separate Kosten?
+11. Wie leicht lässt sich die Domain exportieren, transferieren, wiederherstellen oder übergeben?
+12. Kannst du bei vielen Domains das Portfolio gesammelt verlängern, taggen, filtern, exportieren und prognostizieren?
+
+Für ein persönliches Projekt kann die Antwort lauten: „Wähle den Registrar, dem du vertraust, und lasse Auto-Renew aktiviert.“ Für eine Marke kann sie lauten: „Zahle mehr für besseren Support und Kontosicherheit.“ Für einen Investor kann sie lauten: „Optimiere die Verlängerungskosten kompromisslos, weil das Portfolio verlängert wird, unabhängig davon, ob es verkauft wird oder nicht.“
+
+## Die praktische Antwort
+
+Was kostet also eine Domain?
+
+Bei einer verbreiteten TLD kann sie im ersten Jahr ungefähr so viel kosten wie ein Mittagessen. Bei einer beworbenen neuen gTLD kann sie heute $1 und im nächsten Jahr $30 bis $80 kosten. Bei einer hochpreisigen ccTLD oder einer Premium-Stufe der Registry kann sie deutlich mehr kosten. Verpasst du die Verlängerung und musst die Domain wiederherstellen, kann die Rechnung in die Hunderte gehen.
+
+Die praktische Antwort ist nicht der Preis im ersten Jahr. Sie lautet:
+
+> **Domain-Haltekosten = Registrierung + Verlängerungen + Transfers + Wiederherstellungsrisiko + Datenschutz + Steuern + Zahlungskosten + Gebühren für begleitende Produkte.**
+
+Das ist die Zahl, die du vergleichen solltest. Eine Domain ist nicht teuer, weil das erste Jahr $60 kostet, und nicht günstig, weil das erste Jahr $1 kostet. Ob sie günstig oder teuer ist, hängt von den Kosten ab, die Kontrolle so lange zu behalten, wie der Name wichtig ist.
+
+## Quellen und weiterführende Lektüre
+
+- ICANN — [Expired Registration Recovery Policy](https://www.icann.org/resources/pages/errp-2013-02-28-en)

--- a/content/blog/de/llms-txt.md
+++ b/content/blog/de/llms-txt.md
@@ -1,0 +1,154 @@
+---
+title: "llms.txt für Domains: Eine API, die jeder KI-Agent lesen kann"
+date: '2026-07-10'
+language: 'de'
+tags: ['ai-agents', 'domains', 'explainer']
+authors: ['namefiteam']
+draft: false
+format: explainer
+ogImage: ../../assets/llms-txt-og.jpg
+description: "Eine Erläuterung von namefi.io/llms.txt: Wie eine Klartextdatei jedem KI-Agenten ermöglicht, die vollständige API eines Registrars zu entdecken und zu nutzen, und wie sie mit MCP zusammenspielt."
+keywords: ["llms.txt", "llms.txt beispiel", "was ist llms.txt", "ki-lesbare api-dokumentation", "api-auffindbarkeit", "robots.txt für ki", "llms.txt vs mcp", "namefi.io/llms.txt", "maschinenlesbare api-referenz", "agent-native api", "strukturierte dokumentation für llms", "api-entdeckung per klartext", "mcp-discovery-deskriptor", "ki-agent domainregistrierung"]
+relatedArticles:
+  - /de/blog/ai-agent-register/
+  - /de/blog/claude-mcp-domains/
+  - /de/blog/namefi-mcp/
+  - /de/blog/mcp-quickstart/
+  - /de/blog/agent-native/
+relatedTopics:
+  - /de/topics/web3-foundations/
+  - /de/topics/domain-basics/
+relatedSeries:
+  - /de/series/blockchain-concepts/
+  - /de/series/tokenize-your-com/
+relatedGlossary:
+  - /de/glossary/ai-agent/
+  - /de/glossary/registrar/
+  - /de/glossary/epp/
+  - /de/glossary/dns/
+  - /de/glossary/seo/
+---
+
+Jeder [Registrar](/de/glossary/registrar/) mit einer [API](/de/glossary/epp/) hat seine Dokumentation irgendwo: auf einer Dokumentationsseite, einer Referenzseite, vielleicht als OpenAPI-Spezifikation hinter einer Anmeldebarriere. Zwei Jahrzehnte lang genügte das, denn der Leser war ein menschlicher Entwickler, der klicken und die Navigationsleisten überfliegen konnte, um den einen relevanten Absatz zu finden. Ein [KI-Agent](/de/glossary/ai-agent/), der dieselbe Seite zur Inferenzzeit liest, hat diesen Luxus nicht — ein festes Kontextbudget, keine Geduld für ein per JavaScript gerendertes Dokumentationsportal und nur einen Versuch herauszufinden, was eine API tut, bevor er aufgibt oder einen nicht existierenden Endpunkt halluziniert.
+
+`llms.txt` löst dieses Problem, und Namefi veröffentlicht eine solche Datei unter [namefi.io/llms.txt](https://namefi.io/llms.txt). Dieser Beitrag erklärt die Konvention, ihren Zweck, den Inhalt unserer eigenen Datei Abschnitt für Abschnitt, ihre bewusst gesetzten Grenzen und wie sie neben dem [Model Context Protocol](https://modelcontextprotocol.io) (MCP) passt, statt mit ihm zu konkurrieren. Er ist außerdem absichtlich ein Beispiel für das, was er beschreibt: ein öffentlicher API-Anbieter, der seine eigene maschinenlesbare Discovery-Datei in verständlicher Prosa erläutert.
+
+## Warum Agenten nicht einfach Ihre Dokumentationsseite crawlen können
+
+Die Begründung für `llms.txt` ist nicht spekulativ — sie steht direkt im Vorschlag. [Jeremy Howards ursprüngliche Erläuterung](https://llmstxt.org) beginnt mit der Einschränkung, die den Vorschlag motivierte: „Große Sprachmodelle stützen sich zunehmend auf Informationen von Websites, stoßen jedoch auf eine kritische Begrenzung: Kontextfenster sind zu klein, um die meisten Websites vollständig zu verarbeiten. Die Umwandlung komplexer HTML-Seiten mit Navigation, Werbung und JavaScript in LLM-freundlichen Klartext ist schwierig und unpräzise.“
+
+Das sind zwei übereinandergestapelte Probleme. Eine echte Dokumentationsseite — Navigation, Changelog, Marketingtexte, Cookie-Banner — besteht größtenteils aus Rauschen im Verhältnis zu den wenigen Absätzen, die ein Agent für eine Aufgabe benötigt. Viel von diesem Rauschen liegt außerdem hinter JavaScript, das ein Headless-Fetch nie ausführt; was der HTTP-Client eines Agenten sieht, ist daher nicht einmal die Seite, die ein Mensch sieht. `llms.txt` umgeht beides: eine einzige Klartext-Markdown-Datei, die vollständig gelesen und nicht gecrawlt und verdichtet werden soll.
+
+## Die `robots.txt`-Analogie — und wo sie nicht mehr trägt
+
+Der Vergleich mit [`robots.txt`](https://www.robotstxt.org) ist der schnellste Weg, `llms.txt` für Menschen mit Web-Infrastrukturwissen einzuordnen, und er ist so weit zutreffend. `robots.txt` existiert, um Web-Crawlern Anweisungen zu geben — in den Worten der Website selbst: „Website-Eigentümer verwenden die Datei /robots.txt, um Web-Robotern Anweisungen zu ihrer Website zu geben; dies wird *Robots Exclusion Protocol* genannt.“ Beide Dateien liegen an einem vorhersehbaren Root-Pfad, beide sind Klartext, beide richten sich an automatisierte Leser statt an Menschen.
+
+Bei der Absicht bricht die Analogie. `robots.txt` ist fast ausschließlich eine **negative** Anweisung — `Disallow: /some-path` sagt einem Crawler, was er *nicht* berühren soll. `llms.txt` ist **positiv**: Hier ist, was diese Website ist, und hier liegen die lesenswerten Teile. Weniger ein Zaun als ein Inhaltsverzeichnis für einen Leser, der nicht das ganze Buch überfliegen kann. Die beiden ergänzen sich, und die Namefi-Website nutzt beide.
+
+## Was die Spezifikation tatsächlich verlangt
+
+`llms.txt` ist nicht formfrei; der Vorschlag definiert eine bestimmte Markdown-Struktur in dieser Reihenfolge: eine optionale Byte-Order-Mark, eine erforderliche H1 mit dem Namen der Website, eine Blockquote-Zusammenfassung, null oder mehr Detailabschnitte ohne Überschrift und null oder mehr H2-getrennte Abschnitte mit Dateilisten aus Links im Format `[name](url): notes`. Eine H2-Überschrift trägt eine besondere Bedeutung: Ein Abschnitt namens **Optional** signalisiert „Die URLs hier können übersprungen werden, wenn Sie einen kürzeren Kontext benötigen.“ Namefis Datei verwendet genau diese Überschrift und tut genau das, was die Spezifikation beschreibt.
+
+## Rundgang durch namefi.io/llms.txt
+
+Hier ist die Live-Datei, Abschnitt für Abschnitt kommentiert — was tatsächlich darin steht, direkt zitiert und warum jeder Teil für einen Agenten, der sie ohne Vorwissen liest, so gestaltet ist.
+
+| Abschnitt (wie in der Datei) | Was er sagt | Warum er so gestaltet ist |
+| --- | --- | --- |
+| H1 + Blockquote | `# Namefi API` / `> Namefi lets you register traditional domains as NFTs and manage their DNS records via API.` | Der von der Spezifikation verlangte Einstieg: eine Zeile, mit der ein Agent handeln kann, selbst wenn er nichts Weiteres liest. |
+| MCP-Hinweis, inline in der Zusammenfassung | `MCP server (every operation below as MCP tools): https://api.namefi.io/mcp — discovery descriptor at https://namefi.io/.well-known/mcp/servers.json` | Setzt den schnellsten Weg — eine aktive Protokollverbindung — in den ersten drei Zeilen vor den Klartextweg. |
+| `## Base URLs` | `https://api.namefi.io/v-next/` | Eine Zeile, keine Prosa — genau das, was ein Agent braucht, der rohe HTTP-Aufrufe zusammenstellt. |
+| `## MCP Server (for AI agents)` | „MCP bevorzugen, wenn Ihr Client es unterstützt … In Claude Code hinzufügen: `claude mcp add --transport http namefi https://api.namefi.io/mcp --header "x-api-key: YOUR_KEY"`“ | Nennt eine Präferenz und belegt sie mit einem kopierbaren Befehl statt mit einem Absatz. |
+| `## Authentication` | „Einen Schlüssel unter https://namefi.io/api-key erzeugen … Funktioniert für **alle Operationen** … **Direkte HTTP-Nutzung (für KI-Agenten empfohlen):** Den Header direkt übergeben — kein SDK erforderlich“ | Sagt dem Leser klar, dass kein SDK, OAuth-Tanz oder Browser-Sitzung nötig ist, um einen Schreibaufruf zu authentifizieren. |
+| `## Domain Registration` | Eine dreistufige `curl`-Sequenz: Verfügbarkeit prüfen, `POST /v-next/orders/register-domain` senden, `GET /v-next/orders/{orderId}` bis zu einem endgültigen Status abfragen | Die Kerntransaktion als ausführbare Befehle, nicht als Prosa über die Form eines Requests und einer Response. |
+| `## DNS Record Management` | Eine Tabelle mit elf Endpunkten (`GET`/`POST`/`PUT`/`DELETE` für `/v-next/dns/records`, `/v-next/dns/park`, `/v-next/dns/forwarding` usw.), jeweils mit Methode, Pfad, Authentifizierung und Kurzbeschreibung | Referenzdaten — viele ähnliche Endpunkte — gehören in eine Tabelle statt in elf Absätze. |
+| Hinweis zur Fehlerbehebung | „**UNAUTHORIZED (401):** Ihr API-Schlüssel ist ungültig, abgelaufen oder nicht mit der Wallet des Domaininhabers verknüpft … **Fehler bei der Eintragsvalidierung:** Prüfen Sie, dass `zoneName` keinen abschließenden Punkt hat und `rdata` für die Typen CNAME/MX/NS einen abschließenden Punkt hat …“ | Antizipiert die Fehlerarten, auf die ein Agent zuerst stößt, als Ursache und Lösung statt als generische Statustabelle. |
+| `## Optional` | Verlinkt die TypeScript-SDK-Dokumentation, das npm-Paket `@namefi/api-client`, eine maschinenlesbare OpenAPI-3-Spezifikation, den Outbound-Agent-Leitfaden und ein GitHub-Repository mit signer-neutralen Hilfsskripten | Der eigene Abschnitt der Spezifikation für „kann bei kürzerem Kontext übersprungen werden“ — vertiefende Ressourcen, keine Voraussetzungen für den oben beschriebenen Kernablauf. |
+
+Die Datei schließt mit einem Verweis auf `namefi.io/llms-full.txt`, denselben Inhalt als ein Dokument eingebunden, einschließlich der Web3-Zahlungsabläufe und des Outbound-Leitfadens, auf die die Root-Datei nur verlinkt. Diese Aufteilung spiegelt das zweistufige Muster der Spezifikation: Der Einstiegspunkt bleibt kurz genug, um komfortabel in den Kontext zu passen, und ein Agent, der mehr braucht, folgt einem Link.
+
+## Begleitdateien: Web3- und MCP-Discovery
+
+Die Root-Datei verlinkt auf Nachbardateien für Teile der API, die nicht in einen allgemeinen Einstiegspunkt gehören. [namefi.io/web3/llms.txt](https://namefi.io/web3/llms.txt) dokumentiert Zahlungswege, die ein Wallet-haltender Agent anstelle eines API-Schlüssels benötigt: einen [x402](/de/glossary/x402/)-Ablauf, bei dem `GET /x402/domain/{domainName}` bis zum Anhängen eines signierten `X-PAYMENT`-Headers mit Preisangabe `402 Payment Required` zurückgibt, eine per `mppx`-CLI signierte MPP-Variante mit Challenge-Response und einen manuellen EIP-712-Signaturweg für Smart-Contract-Wallets. Die Datei erklärt klar, dass eine x402-Registrierung „Kein Namefi-Konto und keine EIP-712-Signatur erfordert — die Wallet des Käufers signiert eine EIP-3009-`transferWithAuthorization`.“ Ein Agent, der nur einen API-Schlüssel benötigt, muss nichts davon laden.
+
+Die MCP-Seite besitzt eine eigene Discovery-Datei, vollständig getrennt von `llms.txt`: [namefi.io/.well-known/mcp/servers.json](https://namefi.io/.well-known/mcp/servers.json), ein kleiner JSON-Deskriptor statt Markdown:
+
+```json
+{
+  "servers": [
+    {
+      "name": "namefi-api",
+      "transport": "streamable-http",
+      "url": "https://api.namefi.io/mcp",
+      "authentication": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-api-key"
+      },
+      "documentation": "https://namefi.io/llms.txt"
+    }
+  ]
+}
+```
+
+Dieser Deskriptor liegt unter `.well-known/`, derselben Konvention, die `/.well-known/security.txt` für maschinell auffindbare Metadaten verwendet — ein engerer, JSON-typisierter Begleiter zu `llms.txt` mit seinem Markdown-Prosa-Ansatz. Sein letztes Feld verweist wieder auf `llms.txt`, sodass ein Agent, der zuerst den MCP-Server findet, dennoch einen Weg zur Klartext-Erklärung dieser Tools hat.
+
+## Was enthalten ist, was fehlt und warum
+
+Einige Entscheidungen wirken bewusst. Fast jede Operation ist ein ausführbarer `curl`-Aufruf statt eines Absatzes, der ein Request-Schema beschreibt — die Datei wurde für etwas geschrieben, das Code ausführt, nicht für etwas, das seine eigene Zusammenfassung schreibt. Die Root-Datei verlinkt, statt alles einzubetten, und `llms-full.txt` bindet ein, worauf sie nur verweist — das Größenmanagementmuster der Spezifikation, wörtlich angewandt. Der Abschnitt `## Optional` verlinkt neben dem Markdown auf eine vollständige OpenAPI-3-Spezifikation, sodass ein Tool, das ein strikt typisiertes Schema benötigt, eines erhält, ohne den primären Lesepfad zu überladen. Wallet-basierte Zahlungen — x402, MPP, EIP-712 — leben in ihrer eigenen Datei; dadurch sind API-Key-Authentifizierung und eine Registrierung das Erste, was jeder Agent liest.
+
+<!-- TODO: Mit dem Team bestätigen — ob es ein Zielbudget für Tokens/Zeichen gibt, auf das die Root-Datei llms.txt geschrieben ist, und wie die Aufteilung zwischen llms.txt / llms-full.txt / web3/llms.txt / outbound/llms.txt mit dem Wachstum der API überprüft wird. -->
+
+## llms.txt und MCP: Discovery versus Verbindung
+
+Es lohnt sich, genau zu unterscheiden, was die beiden leisten. `llms.txt` ist ein Dokument — ein Agent ruft es einmal ab und weiß, was die API ist und wo vertiefende Ressourcen liegen; es bleibt träger Text, bis etwas nach seinen Anweisungen handelt. [MCP](https://modelcontextprotocol.io) ist laut seiner eigenen Protokollbeschreibung „ein Open-Source-Standard, um KI-Anwendungen mit externen Systemen zu verbinden“ — eine aktive Sitzung, die ein Client zu einem Server öffnet und über die er aufrufbare Tools auflistet und ausführt.
+
+Namefis Datei zeigt die Beziehung unmittelbar: `llms.txt` teilt einem Agenten mit, dass unter `api.namefi.io/mcp` ein MCP-Server existiert, und gibt ihm den Befehl `claude mcp add` zum Verbinden. Datei lesen, lernen, dass es eine aktive Toolschnittstelle gibt, verbinden, handeln. Ein Agent, der direkt zu MCP springt, kann den Server auch über `.well-known/mcp/servers.json` finden — doch das Feld `documentation` dieses Deskriptors verweist zurück auf `llms.txt`; daher arbeiten die beiden selten völlig isoliert.
+
+## Hinweise für andere API-Anbieter
+
+Die Veröffentlichung einer funktionierenden `llms.txt` erfordert keinen Neuaufbau Ihrer Dokumentation:
+
+1. **Stellen Sie H1, Zusammenfassung und die schnellste Verbindungsmethode an den Anfang** — ein Agent mit wenig Kontext liest möglicherweise nie über die ersten Zeilen hinaus.
+2. **Zeigen Sie ausführbare Requests, keine Schema-Prosa.** Ein `curl`-Befehl mit echten Feldnamen ist besser als ein Absatz, der einen JSON-Body beschreibt.
+3. **Teilen Sie nach Größe, nicht nach Teamstruktur.** Eine kurze Root-Datei plus eine umfassendere Erweiterung und separate Dateien für Bereiche wie Zahlungen halten den häufigen Pfad kurz.
+4. **Dokumentieren Sie reale Fehlerarten**, nicht nur Statuscodes — warum ein Aufruf 401 statt 403 zurückgibt, ist wichtiger als die Zahlen selbst.
+5. **Verwenden Sie die Überschrift `## Optional` für alles Überspringbare**, entsprechend der Konvention der Spezifikation.
+6. **Veröffentlichen Sie neben llms.txt einen MCP-Discovery-Deskriptor, wenn Sie einen MCP-Server betreiben** — das eine beantwortet „Was ist das?“, das andere „Wie verbinde ich mich?“
+
+## Häufig gestellte Fragen
+
+### Was ist llms.txt?
+
+Eine vorgeschlagene Konvention — kein formaler IETF- oder W3C-Standard — zur Veröffentlichung einer Klartext-Markdown-Datei im Root einer Website. Sie teilt einem KI-Agenten mit, was die Website oder API ist und wo weitere Details zu finden sind. Sie definiert eine bestimmte Reihenfolge: einen H1-Titel, eine Blockquote-Zusammenfassung, optionale Detailabsätze und H2-getrennte Linklisten; die Überschrift „Optional“ ist für überspringbares Material reserviert.
+
+### Wie unterscheidet sich llms.txt von robots.txt?
+
+`robots.txt` ist eine negative Anweisung an Web-Crawler — was sie nach dem Robots Exclusion Protocol nicht indexieren sollen. `llms.txt` ist positiv — was eine Website ist und was sich zu lesen lohnt. Sie bedienen unterschiedliche automatisierte Leser und existieren typischerweise auf derselben Website.
+
+### Ersetzt llms.txt MCP?
+
+Nein. `llms.txt` ist ein Dokument, das ein Agent einmal liest, um zu verstehen, was eine API tut; MCP ist eine aktive Protokollverbindung, die sein Client öffnet, um die Operationen dieser API tatsächlich aufzurufen. Namefi veröffentlicht beides, und `llms.txt` informiert den Agenten überhaupt erst darüber, dass der MCP-Server existiert.
+
+### Was steht in Namefis Datei llms.txt?
+
+Die Basis-URL, ein Hinweis auf den MCP-Server, ein Abschnitt zur API-Key-Authentifizierung, ein dreistufiger Ablauf zur Domainregistrierung mit ausführbaren `curl`-Beispielen, eine Endpunkttabelle für DNS-Eintragsverwaltung, Endpunkte zur Domainkonfiguration, ein Abschnitt zur Fehlerbehebung und ein Abschnitt „Optional“ mit Links zum SDK, zur OpenAPI-Spezifikation sowie zu Begleitdateien für Wallet-Zahlungen und Outbound-Workflows.
+
+### Kann ich llms.txt ohne KI-Agenten selbst lesen?
+
+Ja — es ist schlichtes Markdown, das für Menschen ebenso lesbar ist wie für ein Modell. [namefi.io/llms.txt](https://namefi.io/llms.txt) liest sich wie eine knappe API-Kurzreferenz; dieselbe Klarheit, die einem Menschen beim Überfliegen hilft, erleichtert auch einem Modell das korrekte Parsen.
+
+## Quellen und weiterführende Lektüre
+
+- llmstxt.org — [Die Datei /llms.txt: Hintergrund, Vorschlag und Formatspezifikation](https://llmstxt.org/#:~:text=Large%20language%20models%20increasingly%20rely%20on%20website%20information%2C%20but%20face%20a%20critical%20limitation)
+- robotstxt.org — [Über /robots.txt: „Kurz gesagt“](https://www.robotstxt.org/robotstxt.html#:~:text=Web%20site%20owners%20use%20the%20/robots.txt%20file%20to%20give%20instructions%20about%20their%20site%20to%20web%20robots%3B%20this%20is%20called%20The%20Robots%20Exclusion%20Protocol)
+- modelcontextprotocol.io — [Was ist das Model Context Protocol (MCP)?](https://modelcontextprotocol.io/#:~:text=MCP%20%28Model%20Context%20Protocol%29%20is%20an%20open-source%20standard%20for%20connecting%20AI%20applications%20to%20external%20systems)
+- Namefi — [namefi.io/llms.txt](https://namefi.io/llms.txt) (Primärquelle für jeden kommentierten Auszug in diesem Artikel)
+- Namefi — [namefi.io/web3/llms.txt](https://namefi.io/web3/llms.txt) (x402-, MPP- und EIP-712-Abläufe für Wallet-Zahlungen)
+- Namefi — [namefi.io/.well-known/mcp/servers.json](https://namefi.io/.well-known/mcp/servers.json) (MCP-Discovery-Deskriptor)
+- Namefi — [namefi.io/llms-full.txt](https://namefi.io/llms-full.txt) (Erweiterung in einer Datei, die die Web3- und Outbound-Begleitdateien einbindet)
+- IETF — [RFC 8615, Well-Known Uniform Resource Identifiers (die Konvention `.well-known/`)](https://datatracker.ietf.org/doc/html/rfc8615)
+
+## Lesen Sie die Datei selbst
+
+Der schnellste Weg, `llms.txt` zu verstehen, ist, eine Datei zu öffnen. [namefi.io/llms.txt](https://namefi.io/llms.txt) ist öffentlich, nicht authentifiziert und kurz genug, um sie in der Zeit zu lesen, die Sie für diesen Artikel gebraucht haben — dieselbe Datei, die jeder KI-Agent liest, der sich erstmals mit Namefi verbindet. Welche Aufgaben die dahinterliegenden MCP-Tools tatsächlich erledigen, erläutert [Namefi MCP Server: Domain-Tools für KI-Agenten](/de/blog/namefi-mcp/). Für die Verbindung aus einem Editor gibt es den [MCP Quickstart](/de/blog/mcp-quickstart/); um einen Agenten beim gesamten Ablauf zu beobachten, lesen Sie [Eine Domain mit Ihrem KI-Agenten bei Namefi registrieren](/de/blog/ai-agent-register/).

--- a/content/blog/de/mcp-quickstart.md
+++ b/content/blog/de/mcp-quickstart.md
@@ -1,0 +1,169 @@
+---
+title: "Namefi MCP-Schnellstart: Claude Code, Cursor & Windsurf"
+date: '2026-07-10'
+language: 'de'
+tags: ['ai-agents', 'guide']
+authors: ['namefiteam']
+draft: false
+format: guide
+ogImage: ../../assets/mcp-quickstart-og.jpg
+description: "MCP-Einrichtung je Editor für Claude Code, Cursor und Windsurf, gefolgt von einem 5-Schritte-Schnellstart von einer neuen App bis zu einer live geschalteten benutzerdefinierten Domain — ohne den Editor zu verlassen."
+keywords: ["claude code mcp domain", "cursor mcp domain", "windsurf mcp domain", "domain-registrierung im editor", "domain-registrierung programmieragent", "domain im editor registrieren", "mcp schnellstart", "namefi mcp konfiguration", "vercel custom domain namefi", "cloudflare pages custom domain namefi", "custom domain mit ki-agent deployen", "schnellstart domain-registrierung", "x-api-key mcp konfiguration", "domain auf deployment zeigen"]
+relatedArticles:
+  - /de/blog/ai-agent-register/
+  - /de/blog/claude-mcp-domains/
+  - /de/blog/namefi-mcp/
+  - /de/blog/wallet-checkout/
+  - /de/blog/vibe-coding-domain/
+relatedTopics:
+  - /de/topics/domain-tokenization/
+  - /de/topics/domain-basics/
+relatedSeries:
+  - /de/series/tokenize-your-com/
+  - /de/series/blockchain-concepts/
+relatedGlossary:
+  - /de/glossary/ai-agent/
+  - /de/glossary/registrar/
+  - /de/glossary/dns-record-types/
+  - /de/glossary/nameserver/
+  - /de/glossary/domain-renewal/
+---
+
+Du bist bereits im Editor. Die App ist eingerichtet, das erste Deployment ist gerade auf einer Plattform-Subdomain live gegangen, und bevor du Menschen darauf verweisen kannst, fehlt nur noch eine echte Domain. Dieser Schnellstart zeigt, wie du diesen Registrierungsschritt erledigst, ohne einen Browser-Tab zu öffnen, ein Checkout-Formular auszufüllen oder dieselbe [KI-Agent](/de/glossary/ai-agent/)-Sitzung zu verlassen, die die App erstellt hat: die exakte [MCP](https://modelcontextprotocol.io)-Verbindungskonfiguration für Claude Code, Cursor und Windsurf, ein komprimierter Ablauf in fünf Schritten und — der Teil, den die meisten Domain-Leitfäden überspringen — wie du die gerade registrierte Domain tatsächlich auf das gerade ausgelieferte Deployment zeigst.
+
+Dieser Leitfaden behandelt bewusst drei Editoren. Falls du stattdessen OpenAI Codex, Gemini CLI oder Claude Desktop nutzt, ist [Wie du mit deinem KI-Agenten eine Domain bei Namefi registrierst](/de/blog/ai-agent-register/) der zentrale Leitfaden mit einer verifizierten Einrichtung für alle sechs Clients sowie dem direkten REST-Weg für alles, was nicht MCP-nativ ist. Alles hier verbindet sich mit demselben [Namefi](https://namefi.io)-MCP-Server, den dieser zentrale Leitfaden dokumentiert. Daher widerspricht nichts weiter unten ihm — diese Seite ist lediglich die verdichtete, auf Entwicklertools ausgerichtete Fassung mit einem Deployment-Schritt, den der zentrale Leitfaden nicht behandelt.
+
+## Warum die Domain im Editor registrieren
+
+„Registriere eine Domain“ ist für eine Fünf-Minuten-Aufgabe ein Kontextwechsel mit ungewöhnlich hohen Kosten: Du verlässt den Editor, öffnest die Website eines Registrars, suchst einen Namen, durchläufst einen Upsell-Funnel für Datenschutz und E-Mail-Hosting, nach denen du nicht gefragt hast, bezahlst und kommst dann zurück, um herauszufinden, welche DNS-Einträge du hinzufügen musst.
+
+Die Alternative ist, denselben Agenten, der das Projekt eingerichtet und das Deployment aufgesetzt hat, auch die letzte Meile erledigen zu lassen: den Namen prüfen, registrieren und DNS einrichten — alles als Tool-Aufrufe in der Unterhaltung, die du bereits führst. [Cloudflare vermarktet eine Variante derselben Idee für seine eigene Registrar API](https://webhosting.today/2026/04/22/ai-agents-can-now-register-domains-no-human-required/#:~:text=An%20agent%20using%20the%20API%20can%20suggest%20domain%20names%2C%20check%20registrability%2C%20and%20complete%20the%20purchase%20without%20the%20user%20leaving%20their%20current%20context) — ein Beleg dafür, dass dies keine Nischenpräferenz, sondern ein Workflow ist, auf den mehr als ein Registrar hinarbeitet. Der Vergleichsabschnitt gegen Ende behandelt speziell den Cloudflare-Ansatz; die Version von Namefi ergänzt eine Option für [tokenisierte Domains](/de/glossary/tokenized-domain/) und einen per Wallet-Signatur autorisierten Zahlungsweg ganz ohne Konto, erläutert in [Domains mit einer Krypto-Wallet bezahlen](/de/blog/wallet-checkout/).
+
+## Die Verbindung einrichten: drei Editoren, drei Konfigurationsdateien
+
+Alle drei nachstehenden Editoren verbinden sich über Streamable HTTP mit demselben Endpoint, `https://api.namefi.io/mcp`. Dein Namefi-[API-Key](https://namefi.io/api-key) wird dabei als `x-api-key`-Header gesendet. Je Editor unterscheiden sich nur das Dateiformat und der Befehl, der es schreibt.
+
+### Claude Code
+
+Die eigene Dokumentation von Claude Code enthält einen direkten CLI-Befehl, um einen Remote-HTTP-Server mit einem benutzerdefinierten Header hinzuzufügen:
+
+```bash
+claude mcp add --transport http namefi https://api.namefi.io/mcp --header "x-api-key: YOUR_KEY"
+```
+
+Führe ihn einmal aus einem Terminal in deinem Projekt aus und ersetze den Platzhalter durch deinen echten Schlüssel. Standardmäßig schreibt er den Server im **lokalen** Scope — nur für dich und nur in diesem Projekt verfügbar. Füge `--scope user` hinzu, um ihn stattdessen für jedes Projekt auf deinem Rechner verfügbar zu machen, und bestätige die Verbindung mit `claude mcp list`.
+
+### Cursor
+
+Cursor liest MCP-Server aus `mcp.json` — einer Projektkopie unter `.cursor/mcp.json` oder einer globalen Kopie unter `~/.cursor/mcp.json`. Das dokumentierte Format für Remote-Server unterstützt Header-basierte Authentifizierung mit Umgebungsvariablen-Interpolation, sodass der Schlüssel selbst nicht in der Datei stehen muss:
+
+```json
+{
+  "mcpServers": {
+    "namefi": {
+      "url": "https://api.namefi.io/mcp",
+      "headers": {
+        "x-api-key": "${env:NAMEFI_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+`${env:NAMEFI_API_KEY}` wird aus dem Wert aufgelöst, den diese Variable in der Shell hat, die Cursor gestartet hat — exportiere sie, bevor du den Editor öffnest.
+
+### Windsurf (Cascade)
+
+Die MCP-Integration von Windsurf — als Cascade vermarktet — liest `~/.codeium/windsurf/mcp_config.json`. Remote-Server verwenden dort statt `url` ein Feld `serverUrl`, mit demselben Muster aus `headers` und `${env:VAR}` wie bei Cursor:
+
+```json
+{
+  "mcpServers": {
+    "namefi": {
+      "serverUrl": "https://api.namefi.io/mcp",
+      "headers": {
+        "x-api-key": "${env:NAMEFI_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+Ein wichtiger Hinweis: Zum Veröffentlichungsdatum dieses Leitfadens leitet `docs.windsurf.com/windsurf/cascade/mcp` auf `docs.devin.ai/desktop/cascade/mcp` weiter. Die Windsurf-Dokumentation liegt nun unter der Produktdokumentationsdomain von Cognition Devin, und das obige Konfigurationsformat ist das, was die aktuelle Seite dokumentiert. Falls du einen älteren Build nutzt, überprüfe die Feldnamen anhand des Dokumentationslinks, auf den die In-App-Hilfe deiner Version verweist.
+
+## Der Schnellstart in fünf Schritten: von einer neuen App zu live geschaltetem DNS
+
+Sobald eine der obigen Verbindungen aktiv ist, bleibt der restliche Ablauf gleich, unabhängig vom verwendeten Editor.
+
+1. **Besorge einen API-Key** über [namefi.io/api-key](https://namefi.io/api-key), erzeugt aus der Wallet, der die neue Domain gehören soll.
+2. **Verbinde dich** mit der Konfiguration für deinen Editor und führe dann einen Plausibilitätscheck durch: Frage „Prüfe, ob `<yourapp>.com` auf Namefi verfügbar ist, und sage mir, welches Tool du aufgerufen hast.“ Das ist ein schreibgeschützter `checkAvailability`-Aufruf und funktioniert daher, bevor du etwas finanziert hast.
+3. **Registriere.** Bestätige Name und Laufzeit in natürlicher Sprache — „Registriere sie für ein Jahr.“ Der Agent sendet `registerDomain` und fragt die Bestellung ab, bis sie `SUCCEEDED` erreicht (oder einen terminalen Fehlerzustand); eine typische Registrierung wird nach einer Handvoll Abfragezyklen abgeschlossen.
+4. **Zeige die Domain auf dein Deployment.** Dieser Schritt wird im nächsten Abschnitt ausführlich behandelt — füge die DNS-Einträge hinzu, die deine Hosting-Plattform verlangt, über dieselbe Unterhaltung.
+5. **Prüfe die Auflösung.** [DNS-Propagierung](/de/glossary/dns-propagation/) erfolgt nicht sofort. Warte daher ein paar Minuten und bestätige sie dann mit einer öffentlichen DNS-Abfrage oder indem du die Domain einfach im Browser lädst.
+
+## Die neue Domain auf das gerade ausgelieferte Deployment zeigen
+
+Hierauf kommt ein allgemeiner Leitfaden zu „Wie registriere ich eine Domain?“ nie, weil es nach der Registrierung auf Seiten der Hosting-Plattform geschieht. Es ist jedoch der eigentliche Sinn, dies im Editor zu erledigen: Dein Agent weiß bereits, auf welcher Plattform er deployed hat, und kann das DNS im selben Atemzug wie die Registrierung einrichten.
+
+### Vercel
+
+Die eigene Domain-Dokumentation von Vercel führt durch den Ablauf über **Settings → Domains** im Projekt-Dashboard: Füge die Domain hinzu, und Vercel zeigt dir, welchen Eintrag du erstellen musst, je nachdem, ob es sich um eine Apex-Domain oder eine Subdomain handelt. Für eine **Apex-Domain** (`yourapp.com`) verlangt Vercel einen **A-Eintrag**, der auf seine Serving-IP zeigt; für eine **Subdomain** (`www.yourapp.com`) verlangt es einen **CNAME**. Bevor du ein Beispiel aus einem älteren Leitfaden übernimmst, solltest du wissen: [Die Vercel-Dokumentation stellt ausdrücklich klar, dass dieses CNAME-Ziel für jedes Projekt eindeutig ist](https://vercel.com/docs/domains/working-with-domains/add-a-domain#:~:text=Each%20project%20has%20a%20unique%20CNAME%20record). Es wird im Dashboard angezeigt, statt dass es einen einzelnen festen Hostnamen gibt, den alle Projekte teilen.
+
+Sobald du diesen Wert hast, ist die DNS-Seite eine weitere Anfrage an den Agenten:
+
+> „Füge einen A-Eintrag für `@` hinzu, der auf `76.76.21.21` zeigt, und einen CNAME für `www`, der auf das CNAME-Ziel zeigt, das Vercel mir gegeben hat.“
+
+Das ruft `createDnsRecord` zweimal auf — einmal pro Eintrag —, dasselbe [DNS-Eintrag](/de/glossary/dns-record-types/)-Tool, das für jeden DNS-Schreibvorgang auf Namefi verwendet wird. Die Regel zum abschließenden Punkt gilt hier wie überall: `rdata` für ein CNAME-Ziel benötigt einen abschließenden Punkt, `zoneName` (deine Domain) nicht.
+
+### Cloudflare Pages
+
+Wenn dein Deployment-Ziel stattdessen Cloudflare Pages ist und das DNS deiner Domain nicht bereits auf Cloudflare verwaltet wird, verlangt [die eigene Dokumentation von Cloudflare zu Custom Domains](https://developers.cloudflare.com/pages/configuration/custom-domains/#:~:text=This%20record%20should%20point%20to%20your%20custom%20Pages%20subdomain) einen einzelnen **CNAME**-Eintrag, der auf die `.pages.dev`-Subdomain deines Projekts zeigt. Ein A-Eintrag ist nicht nötig, da Pages alles über dieses CNAME-Ziel ausliefert. Der Schritt im Cloudflare-Dashboard (Workers & Pages → dein Projekt → Custom domains → Set up a domain) muss zuerst erfolgen; erst dann löst das CNAME-Ziel korrekt auf.
+
+> „Füge einen CNAME für `app` hinzu, der auf `my-project.pages.dev.` zeigt.“
+
+Derselbe Tool-Aufruf, dieselbe Regel zum abschließenden Punkt beim Ziel, andere Plattform.
+
+<!-- TODO: verify — Vercel and Cloudflare Pages exact steps for issuing/renewing the TLS certificate on a newly attached custom domain, to state confidently whether it's automatic on both or needs a manual trigger -->
+
+## Wie dies mit der Registrierung im Editor bei Cloudflare verglichen werden kann
+
+Cloudflare ist der andere Registrar, der einen Ansatz im Editor aktiv vermarktet, und verdient eine direkte Erwähnung. Seine Registrar API, [die laut Bericht seit April 2026 in der Beta ist](https://webhosting.today/2026/04/22/ai-agents-can-now-register-domains-no-human-required/), integriert sich ebenfalls mit MCP-fähigen Editoren einschließlich Cursor und Claude Code. Damit kann ein Agent eine Domain suchen, bepreisen und synchron registrieren, ohne den aktuellen Kontext zu verlassen — dieselbe Kernidee, die dieser Leitfaden für Namefi durchgeht. Derselbe Bericht weist darauf hin, dass die API von Cloudflare in der Beta die Verwaltung nach der Registrierung wie Transfers und Verlängerungen noch nicht abdeckt; sie ist für später 2026 geplant.
+
+Der MCP-Server von Namefi deckt heute den gesamten Lebenszyklus ab — Registrierung, DNS, [Auto-Renew](/de/glossary/domain-renewal/) — sowie zwei Dinge, die der Weg über Cloudflare nicht bietet: Die Domain wird standardmäßig als NFT registriert und damit zu einer [tokenisierten Domain](/de/glossary/tokenized-domain/) (auf jede Wallet umleitbar), und er unterstützt einen per Wallet-Signatur autorisierten Checkout ganz ohne Namefi-Konto, ausführlich beschrieben in [Domains mit einer Krypto-Wallet bezahlen](/de/blog/wallet-checkout/). Beide bauen auf denselben „Editor nicht verlassen“-Workflow hin; welcher passt, hängt davon ab, ob du eine Standardregistrierung oder eine Registrierung möchtest, die zugleich ein On-Chain-Asset ist.
+
+## Häufig gestellte Fragen
+
+### Deckt dies auch Codex oder Gemini CLI ab?
+Nicht hier — dieser Leitfaden beschränkt sich bewusst auf Claude Code, Cursor und Windsurf. [Wie du mit deinem KI-Agenten eine Domain bei Namefi registrierst](/de/blog/ai-agent-register/) enthält dieselbe exakte, verifizierte Konfiguration für Codex CLI, Gemini CLI und Claude Desktop.
+
+### Benötige ich ein Namefi-Konto, bevor ich dies ausprobieren kann?
+Nein. Eine schreibgeschützte Verfügbarkeitsabfrage benötigt keine Authentifizierung. Du kannst daher jeden der obigen Editoren verbinden und den Test-Prompt aus Schritt 2 ausführen, bevor du einen API-Key erzeugst oder etwas finanzierst.
+
+### Was ist, wenn meine Deployment-Plattform nicht Vercel oder Cloudflare Pages ist?
+Das Muster gilt überall: Das Dashboard deiner Plattform sagt dir, welchen DNS-Eintragstyp es benötigt — fast immer einen A-Eintrag für eine Apex-Domain oder einen CNAME für eine Subdomain — und du gibst diesen Wert an deinen Agenten weiter, damit er ihn über `createDnsRecord` schreibt.
+
+### Wird die Domain bei dieser Registrierung automatisch tokenisiert?
+Ja, standardmäßig — die Domain wird als NFT auf Base in die an deinen API-Key gebundene Wallet registriert, sofern du in der Anfrage keine andere `nftReceivingWallet` angibst. Wenn das neu für dich ist, lies [Was sind tokenisierte Domains?](/de/blog/what-are-tokenized-domains/).
+
+### Kann ich den API-Key vollständig überspringen?
+Ja, mit einer Einschränkung: Der per Wallet-Signatur autorisierte [x402](/de/glossary/x402/)-Checkout-Weg von Namefi ermöglicht es einer finanzierten Wallet, eine Registrierung ganz ohne Konto oder API-Key zu bezahlen. Er braucht eine eigene Erklärung; diese findest du in [Domains mit einer Krypto-Wallet bezahlen](/de/blog/wallet-checkout/).
+
+## Den Namen mit der App ausliefern
+
+Die Domain ist Infrastruktur, genauso wie das Deployment-Ziel und die Datenbank. Es gibt keinen überzeugenden Grund, warum sie das eine Teil beim Ausliefern einer App sein sollte, das weiterhin verlangt, deine Tools zu verlassen und ein Webformular auszufüllen. Verbinde eine der drei obigen Konfigurationen, führe den Ablauf in fünf Schritten aus, und die Domain geht live, auf dasselbe Deployment gerichtet, das dein Agent gerade erstellt hat — ohne einen einzigen Browser-Tab.
+
+**[Einen Namefi API-Key erzeugen](https://namefi.io/api-key)** — und probiere den Prompt zur Verfügbarkeitsabfrage in dem Editor aus, den du bereits geöffnet hast. Wenn du jeden Schritt im Detail sehen möchtest, lies die [vollständige Claude-Code-Anleitung mit kommentiertem Transkript](/de/blog/claude-mcp-domains/).
+
+## Quellen und weiterführende Lektüre
+
+- Namefi — [namefi.io/llms.txt](https://namefi.io/llms.txt) (MCP-Server-URL, Transport, Authentifizierung, Referenz für die Registrierungs-/DNS-Endpoints — Primärquelle für jede Namefi-spezifische Behauptung in diesem Leitfaden)
+- Namefi — [docs.namefi.io: Eine Domain registrieren](https://docs.namefi.io/docs/03-getting-started/01-your-first-domain.mdx) (Felder der Registrierungsanfrage, Abfrageablauf, Statuswerte der Bestellung)
+- Namefi — [namefi.io/.well-known/mcp/servers.json](https://namefi.io/.well-known/mcp/servers.json) (MCP-Discovery-Deskriptor)
+- Anthropic / Claude Code — [Claude Code über MCP mit Tools verbinden](https://code.claude.com/docs/en/mcp#:~:text=claude%20mcp%20add%20%2D%2Dtransport%20http) (`claude mcp add --transport http`-Syntax, Flags `--header`, `--scope`)
+- Cursor — [cursor.com/docs/mcp](https://cursor.com/docs/mcp) (Remote-Server-Format in `mcp.json`, `headers`, `${env:VAR}`-Interpolation, Konfigurationsorte für Projekt und global)
+- Windsurf / Cascade — [docs.windsurf.com/windsurf/cascade/mcp](https://docs.windsurf.com/windsurf/cascade/mcp) (leitet zum Veröffentlichungsdatum dieses Leitfadens auf [docs.devin.ai/desktop/cascade/mcp](https://docs.devin.ai/desktop/cascade/mcp) weiter; Format von `mcp_config.json`, `serverUrl`, `headers`)
+- Vercel — [Eine Custom Domain hinzufügen und konfigurieren](https://vercel.com/docs/domains/working-with-domains/add-a-domain#:~:text=Each%20project%20has%20a%20unique%20CNAME%20record) (A-Eintrag für Apex-Domains, projektspezifisches CNAME-Ziel für Subdomains, Nameserver-Methode)
+- Vercel — [Domains-Übersicht](https://vercel.com/docs/domains#:~:text=76.76.21.21) (die für Apex-A-Einträge verwendete Serving-IP `76.76.21.21`)
+- Cloudflare — [Custom Domains für Pages](https://developers.cloudflare.com/pages/configuration/custom-domains/#:~:text=This%20record%20should%20point%20to%20your%20custom%20Pages%20subdomain) (CNAME-zu-`.pages.dev`-Ablauf für Domains, die nicht auf Cloudflare verwaltet werden)
+- webhosting.today — [KI-Agenten können jetzt Domains registrieren, kein Mensch erforderlich](https://webhosting.today/2026/04/22/ai-agents-can-now-register-domains-no-human-required/) (Bericht zur Cloudflare Registrar API Beta: Editor-Integrationen, Einschränkungen der Beta)
+- Model Context Protocol — [modelcontextprotocol.io](https://modelcontextprotocol.io) (Protokollübersicht)

--- a/content/blog/de/namefi-mcp.md
+++ b/content/blog/de/namefi-mcp.md
@@ -1,0 +1,201 @@
+---
+title: "Namefi-MCP-Server: Domain-Tools für KI-Agenten"
+date: '2026-07-10'
+language: 'de'
+tags: ['ai-agents', 'domains', 'web3']
+authors: ['namefiteam']
+draft: false
+format: explainer
+ogImage: ../../assets/namefi-mcp-og.jpg
+description: "Jedes Tool, das der Namefi-MCP-Server KI-Agenten bereitstellt: Suche, Registrierung, DNS, Verlängerungen, Tokenisierung sowie das Authentifizierungsmodell und Beispielabläufe."
+keywords: ["namefi mcp server", "mcp-tools liste", "namefi mcp-fähigkeiten", "mcp-server domainverwaltung", "domain-registrar mcp-server", "namefi api-key berechtigungen", "dns mcp-tools", "domain registrieren mcp", "domain tokenisieren mcp", "x402 domainzahlung", "siwe authentifizierung domains", "eip-712 domainsignatur", "outbound lead-finding domains", "namefi openapi", "ki-agent domain-tools"]
+relatedArticles:
+  - /de/blog/claude-mcp-domains/
+  - /de/blog/ai-agent-register/
+  - /de/blog/wallet-checkout/
+  - /de/blog/llms-txt/
+  - /de/blog/mcp-quickstart/
+relatedTopics:
+  - /de/topics/domain-tokenization/
+  - /de/topics/web3-foundations/
+relatedSeries:
+  - /de/series/blockchain-concepts/
+  - /de/series/tokenize-your-com/
+relatedGlossary:
+  - /de/glossary/ai-agent/
+  - /de/glossary/registrar/
+  - /de/glossary/tokenized-domain/
+  - /de/glossary/dnssec/
+  - /de/glossary/ens/
+---
+
+Jeder [KI-Agent](/de/glossary/ai-agent/), der sich mit dem Namefi-MCP-Server verbindet, sieht dieselbe Liste aufrufbarer Tools — eines für jede von der API definierte Operation. Sie decken Suche, Registrierung, DNS, Domain-Konfiguration, Outbound-Lead-Findung und Zahlung ab. Diese Seite ist der Katalog: jedes Tool, seine Funktion, seine erforderliche Authentifizierung sowie drei ausgearbeitete Beispiele, die mehrere Tools zu einem echten Workflow kombinieren.
+
+Wenn Sie noch keinen Agenten mit Namefi verbunden haben, beginnen Sie mit [Eine Domain mit Ihrem KI-Agenten bei Namefi registrieren](/de/blog/ai-agent-register/) für die Einrichtung je Client oder [Eine Domain mit Claude kaufen: Schritt-für-Schritt-Anleitung für Namefi MCP](/de/blog/claude-mcp-domains/) für ein vollständiges Transkript. Diese Seite setzt voraus, dass die Verbindung bereits besteht.
+
+## Was der Namefi-MCP-Server ist
+
+Namefi betreibt für seine gesamte API einen einzigen MCP-Server unter `https://api.namefi.io/mcp` über den Streamable-HTTP-Transport. Statt dass ein Agent REST-Aufrufe aus in einen Chat kopierter Dokumentation von Hand zusammensetzt, verbindet er sich einmal und erhält für jede von der API definierte Operation ein typisiertes Tool. Diese werden direkt aus Namefis eigener OpenAPI-3-Spezifikation unter [api.namefi.io/v-next/openapi/doc.json](https://api.namefi.io/v-next/openapi/doc.json) generiert, sodass MCP-Katalog und REST-API nicht auseinanderlaufen können.
+
+Ein maschinenlesbarer Discovery-Deskriptor unter [namefi.io/.well-known/mcp/servers.json](https://namefi.io/.well-known/mcp/servers.json) ermöglicht einem Agenten, den Server zu finden, ohne dass ein Mensch eine URL manuell in eine Konfigurationsdatei einfügt: Er nennt den Server `namefi-api`, meldet den Transport `streamable-http` und erklärt `apiKey`/`x-api-key` zur Verbindungs-Authentifizierung. Namefi, ein von [ICANN](/de/glossary/icann/) akkreditierter [Registrar](/de/glossary/registrar/), veröffentlicht dieselben Operationen außerdem als einfache HTTPS-Endpunkte unter [namefi.io/llms.txt](https://namefi.io/llms.txt), für Agenten und Skripte, die kein MCP sprechen.
+
+## Der vollständige Funktionskatalog
+
+Im Folgenden stehen alle zum Veröffentlichungszeitpunkt von der API definierten Operationen, gruppiert wie in Namefis eigener Referenz. Die Spalte **Operation** enthält die `operationId` aus der OpenAPI-Spezifikation — den Namen, aus dem die Tool-Liste eines MCP-Clients aufgebaut wird. Die Spalte **Authentifizierung** zeigt den einfachsten Weg (ein API-Schlüssel deckt fast alles ab); das vollständige Authentifizierungsmodell einschließlich der Alternativen zum API-Schlüssel folgt im nächsten Abschnitt.
+
+### Suche und Discovery
+
+| Operation | Endpunkt | Funktion | Authentifizierung |
+| --- | --- | --- | --- |
+| `checkAvailability` | `GET /v-next/search/availability` | Prüft, ob ein einzelner Domainname zur Registrierung frei ist | Keine |
+| `checkBulkAvailability` | `GET /v-next/search/bulk-availability` | Prüft in einem Aufruf einen Stapel möglicher Namen | Keine |
+| `getSuggestions` | `GET /v-next/search/suggestions` | Liefert algorithmische Namensvorschläge zu einer Suchanfrage | Keine |
+
+### Registrierung und Bestellungen
+
+| Operation | Endpunkt | Funktion | Authentifizierung |
+| --- | --- | --- | --- |
+| `registerDomain` | `POST /v-next/orders/register-domain` | Registriert eine Domain für 0–10 Jahre. Akzeptiert ein Objekt `domainSetupOptions` (`autoPark`, `autoEns`, `autoRenew`, `dnssec`, `keepExistingNameservers`) und optional `nftReceivingWallet` | API-Schlüssel |
+| `registerWithRecords` | `POST /v-next/orders/register-domain/records` | Registriert eine Domain und legt im selben Aufruf einen ersten Satz DNS-Einträge an | API-Schlüssel |
+| `getOrder` | `GET /v-next/orders/{orderId}` | Fragt eine Bestellung ab, bis sie einen endgültigen Status erreicht: `SUCCEEDED`, `FAILED`, `CANCELLED` oder `PARTIALLY_COMPLETED` | API-Schlüssel |
+
+Die Registrierung erfolgt asynchron: `registerDomain` gibt sofort eine Bestell-`id` zurück, und der Agent fragt `getOrder` ab, bis die Bestellung abgeschlossen ist. Sowohl die [Claude-Anleitung](/de/blog/claude-mcp-domains/) als auch der [Einrichtungsleitfaden für mehrere Agenten](/de/blog/ai-agent-register/) zeigen dieses Muster als vollständiges Transkript.
+
+### Verwaltung von DNS-Einträgen
+
+Vollständiges CRUD, einzeln oder im Batch, plus ein Lesezugriff, der überhaupt keine Authentifizierung benötigt:
+
+| Operation | Endpunkt | Funktion | Authentifizierung |
+| --- | --- | --- | --- |
+| `getDnsRecords` | `GET /v-next/dns/records` | Listet jeden Eintrag in einer Zone auf | Keine |
+| `createDnsRecord` | `POST /v-next/dns/records` | Erstellt einen Eintrag | API-Schlüssel |
+| `updateDnsRecord` | `PUT /v-next/dns/record` | Aktualisiert einen Eintrag anhand seiner ID | API-Schlüssel |
+| `deleteDnsRecord` | `DELETE /v-next/dns/record` | Löscht einen Eintrag anhand seiner ID | API-Schlüssel |
+| `batchCreateDnsRecords` | `POST /v-next/dns/records/batch` | Erstellt viele Einträge in einem Aufruf | API-Schlüssel |
+| `batchUpdateDnsRecords` | `PUT /v-next/dns/records/batch` | Aktualisiert viele Einträge in einem Aufruf | API-Schlüssel |
+| `batchDeleteDnsRecords` | `DELETE /v-next/dns/records/batch` | Löscht viele Einträge in einem Aufruf | API-Schlüssel |
+
+Unterstützte [Eintragstypen](/de/glossary/dns-record-types/): A, AAAA, CNAME, MX, TXT, NS, SOA, PTR, SRV, CAA, DS, TLSA, SSHFP, HTTPS, SVCB, NAPTR, SPF. Zwei Formatierungsregeln bringen die meisten ersten Versuche zu Fall: `zoneName` darf keinen abschließenden Punkt haben; `rdata`-Werte für CNAME-, MX- und NS-Einträge müssen einen haben.
+
+### Umschalter auf Domain-Ebene
+
+Diese schalten eine vollständige Funktion ein oder aus und sind von einem einzelnen DNS-Eintrag zu unterscheiden:
+
+| Operation | Endpunkt | Funktion | Authentifizierung |
+| --- | --- | --- | --- |
+| `toggleDomainParking` / `parkDomain` | `PUT` / `POST /v-next/dns/park` | Schaltet [Domain-Parking](/de/glossary/domain-parking/) ein oder aus | API-Schlüssel |
+| `isDomainParked` | `GET /v-next/dns/parked` | Prüft, ob eine Domain derzeit geparkt ist | Keine |
+| `toggleForwarding` | `PUT /v-next/dns/forwarding` | Schaltet [Domain-Weiterleitung](/de/glossary/domain-forwarding/) ein oder aus | API-Schlüssel |
+| `toggleAutoEns` | `PUT /v-next/dns/auto-ens` | Schaltet die automatische Veröffentlichung von [ENS](/de/glossary/ens/)-Einträgen ein oder aus | API-Schlüssel |
+| `toggleVercelAnyCastRecords` | `PUT /v-next/dns/vercel-anycast` | Schaltet Vercel-Anycast-DNS-Einträge ein oder aus | API-Schlüssel |
+
+Beachten Sie, dass [DNSSEC](/de/glossary/dnssec/) nicht zu diesen Umschaltern gehört: Es wird bei der Registrierung gesetzt, als eines der oben genannten `domainSetupOptions`-Felder von `registerDomain`, nicht über einen separaten Endpunkt, den ein Agent anschließend aufruft.
+
+### Domain-Konfiguration
+
+| Operation | Endpunkt | Funktion | Authentifizierung |
+| --- | --- | --- | --- |
+| `getAutoRenew` | `GET /v-next/domain-config/auto-renew` | Prüft, ob die automatische Verlängerung aktiviert ist | API-Schlüssel |
+| `toggleAutoRenew` | `PUT /v-next/domain-config/auto-renew` | Schaltet die automatische Verlängerung ein oder aus | API-Schlüssel |
+
+Wenn die [automatische Verlängerung](/de/glossary/domain-renewal/) aktiv ist, verlängert sich die Domain vor Ablauf automatisch mit den in der Eigentümer-Wallet hinterlegten Zahlungsarten. Das ist eine fortlaufende Autorisierung, die Sie bewusst für jede Domain entscheiden sollten, statt sie standardmäßig für ein ganzes Portfolio aktiviert zu lassen.
+
+### Outbound-Lead-Findung
+
+Die neueste Oberfläche verwandelt gehaltene Domains aus einer statischen Asset-Liste in eine Vertriebspipeline:
+
+| Operation | Endpunkt | Funktion | Authentifizierung |
+| --- | --- | --- | --- |
+| `getUserDomains` | `GET /v-next/user/domains` | Listet Domains auf, die der authentifizierten Wallet gehören | API-Schlüssel |
+| `startOutboundRun` | `POST /v-next/outbound/runs` | Startet für eine gehaltene Domain einen KI-Lead-Finding-Lauf mit `reasoningEffort` von `low`, `medium` oder `high` | API-Schlüssel |
+| `listOutboundRuns` | `GET /v-next/outbound/runs` | Listet vergangene und aktive Läufe auf | API-Schlüssel |
+| `getOutboundRun` | `GET /v-next/outbound/runs/{runId}` | Fragt den Status eines Laufs ab: `QUEUED`, `RUNNING`, `SUCCEEDED`, `FAILED` oder `CANCELED` | API-Schlüssel |
+| `listOutboundLeads` | `GET /v-next/outbound/runs/{runId}/leads` | Listet priorisierte Käufer-Leads auf, jeweils mit Begründung, gefundenen Kontakten und vorhandenem Outreach-Entwurf | API-Schlüssel |
+| `prepareOutboundOutreach` | `POST /v-next/outbound/runs/{runId}/leads/{leadId}/outreach` | Erzeugt für einen Lead einen Outreach-Entwurf oder gibt den bestehenden ohne zusätzliche Generierungskosten zurück | API-Schlüssel |
+
+Die Antwort lässt interne Ranking-Mechanismen aus — Score, Modelldetails und Status unterdrückter Leads. Ein Agent, der Ergebnisse für einen Menschen zusammenfasst, sieht daher nur die öffentliche Begründung, den gefundenen Kontakt und ob ein Entwurf existiert.
+
+### Zahlungen und Konto
+
+| Operation | Endpunkt | Funktion | Authentifizierung |
+| --- | --- | --- | --- |
+| `getBalance` | `GET /v-next/balance` | Prüft das NFSC-Guthaben (Namefi Service Credit), das Registrierungen finanziert | API-Schlüssel |
+| `requestNfscFaucet` | `POST /v-next/user/faucet` | Fordert kostenlose NFSC-Testguthaben an (nur Entwicklungsumgebungen) | API-Schlüssel |
+| `registerDomainX402` | `GET /x402/domain/{domainName}` | Registriert und bezahlt in einem Stablecoin-signierten HTTP-402-Ablauf, ohne Namefi-Konto | Wallet-Signatur |
+| — | `GET /x402/purchase/{purchaseId}` | Fragt den Status eines x402-Kaufs ab | Keine |
+| `registerDomainMPP` | `GET /mpp/domain/{domainName}` | Registriert und bezahlt über den Challenge-Response-Ablauf des MPP (Machine Payable Protocol) | Wallet-Signatur |
+
+Damit sind alle Operationen für Suche, Registrierung, DNS, Domainkonfiguration, Outbound und Zahlung abgedeckt — jede ist über die einzelne Serververbindung als MCP-Tool oder als einfacher HTTPS-Aufruf für Agenten erreichbar, die kein MCP sprechen. (Namefis API stellt außerhalb dieser Liste auch einige Hilfsoperationen für Kontoverwaltung und EIP-712/SIWE bereit; den stets aktuellen vollständigen Satz finden Sie in der unten verlinkten OpenAPI-Spezifikation.)
+
+## Das Authentifizierungsmodell: drei Zugangswege, eine Wallet dahinter
+
+Jede obige Schreiboperation prüft über einen von drei Wegen dasselbe: Kontrolliert der Aufrufer die Wallet, die die Domain besitzt oder besitzen wird? Welcher Weg gilt, hängt von der Operation ab, nicht von einer einzelnen Einstellung auf Kontoebene.
+
+**API-Schlüssel (`x-api-key`).** Die einfachste Option und diejenige, die jedes ausgearbeitete Beispiel in diesem Cluster verwendet. Erzeugen Sie einen Schlüssel unter [namefi.io/api-key](https://namefi.io/api-key). Er funktioniert für jede obige Operation, einschließlich DNS-Schreibvorgängen, Parking und Registrierung, weil der Schlüssel die Berechtigungen der Wallet übernimmt, die ihn erzeugt hat. Übergeben Sie ihn als einfachen HTTP-Header; ein SDK ist nicht erforderlich.
+
+**EIP-712-Signatur typisierter Daten.** Für den programmatischen Einsatz ohne gespeicherten Schlüssel signieren Sie jede Anfrage mit einer Ethereum-[Wallet](/de/glossary/wallet/): Die Header `x-namefi-signer`, `x-namefi-signature` und `x-namefi-eip712-type` verpacken den Payload mit Zeitstempel und einmaligem Nonce, der nach 300 Sekunden abläuft. So führen Sie Operationen wie `toggleDomainParking`, `createDnsRecord` und `registerDomain` ohne API-Schlüssel aus. Domain und Typdefinitionen kommen von Live-Endpunkten (`GET /v-next/eip712/domain`, `/eip712/types`) und nicht aus einer hartcodierten Konstante, da die Namefi-Dokumentation darauf hinweist, dass sie sich ändern können. Smart-Contract-Wallets können nicht direkt signieren; daher signiert ein zugelassenes externes Konto im Namen des Contracts, während `x-namefi-erc1271-account` oder `x-namefi-eip7702-account` den Contract benennen, der die Anfrage autorisiert.
+
+**SIWE (Sign-In with Ethereum).** Ein Session-Token (`x-namefi-siwe-token`) für geschützte Lesezugriffe, die nicht bei jedem Aufruf eine neue Signatur benötigen, etwa das Auflisten gehaltener Domains oder Bestellungen: Nonce abrufen, zu signierende Nachricht abrufen, mit `personal_sign` signieren, verifizieren und den Token dann wiederverwenden.
+
+Eine Handvoll Operationen benötigen keine Authentifizierung — `checkAvailability`, `getSuggestions`, `getDnsRecords`, `isDomainParked` und die EIP-712-Metadatenendpunkte —, weil sie schreibgeschützt sind und nichts offenlegen, was das öffentliche DNS einer Domain nicht ohnehin in einem Browser zeigen würde.
+
+Darüber liegt die Zahlung. `registerDomainX402` wickelt einen Kauf über das [x402-Protokoll](https://x402.org) ab: Die Wallet des Käufers signiert eine EIP-3009-`transferWithAuthorization` für einen [Stablecoin](/de/glossary/stablecoin/) wie USDC, ohne dass ein Namefi-Konto beteiligt ist. `registerDomainMPP` erreicht dasselbe Ergebnis stattdessen über einen signierten Challenge-Response. Beide erlauben es einem Agenten, die Kontoerstellung zu überspringen und pro Transaktion zu zahlen — [Domains mit einer Krypto-Wallet bezahlen: Kein Konto nötig](/de/blog/wallet-checkout/) beschreibt diesen Weg vollständig.
+
+## Die Tokenisierung läuft durch den Katalog, nicht daneben
+
+`registerDomain` mintet die Domain standardmäßig auf Base als [NFT](/de/glossary/nft/) — einen [ERC-721](/de/glossary/erc-721/)-Token, [die Standardschnittstelle](https://eips.ethereum.org/EIPS/eip-721), die die meisten Marktplätze und Wallets bereits lesen — für die Wallet, die an den API-Schlüssel des Aufrufers gebunden ist. `nftReceivingWallet` leitet das bei der Registrierung an eine andere Wallet oder Chain weiter, und alles danach — DNS-Schreibvorgänge, Parking, automatische Verlängerung, Outbound-Lead-Findung — prüft denselben On-Chain-Eigentumsnachweis statt einer separaten Kontodatenbank. Eine auf einem Marktplatz wie [OpenSea](https://opensea.io) gehandelte [tokenisierte Domain](/de/glossary/tokenized-domain/) trägt DNS-Kontrolle und ERC-721-Eigentümerschaft als ein Objekt, nicht als zwei Systeme, die man von Hand synchron halten muss.
+
+## Drei Agenten, drei Wege, dasselbe Toolset zu nutzen
+
+**Ein Builder registriert eine Domain und stellt DNS in einem Gespräch bereit.** `checkAvailability` bestätigt, dass der Name frei ist; `registerDomain` übermittelt ihn mit `domainSetupOptions`, die für `autoRenew` und `dnssec` gesetzt sind; und sobald die Bestellung `SUCCEEDED` erreicht, schreibt `batchCreateDnsRecords` die CNAME- und TXT-Einträge, auf die der Verifizierungsschritt einer Deployment-Plattform wartet. Der [Namefi-MCP-Quickstart für Programmieragenten](/de/blog/mcp-quickstart/) führt durch diese Abfolge in einem Editor.
+
+**Ein Domain-Händler verwaltet ein Portfolio.** `getUserDomains` lädt die aktuellen Bestände, `checkBulkAvailability` prüft neue Kandidaten in einem Aufruf und `registerDomain` nimmt die kaufwürdigen Namen auf. Für weiterverkaufte Namen stellt `toggleDomainParking` eine Landingpage bereit und `isDomainParked` bestätigt, dass sie live ist; im gesamten Portfolio entscheiden `getAutoRenew` und `toggleAutoRenew`, welche Namen eine fortlaufende Verlängerungsautorisierung wert sind und welche spekulativ genug sind, um sie auslaufen zu lassen.
+
+**Ein Unternehmen betreibt Outbound-Lead-Findung für bereits gehaltene Namen.** `getUserDomains` identifiziert eine ungenutzte Domain, `startOutboundRun` startet die Recherche und `getOutboundRun` fragt ab, bis der Lauf `SUCCEEDED` erreicht. `listOutboundLeads` liefert priorisierte Unternehmen, deren Profil darauf hinweist, dass sie den Namen wünschen könnten, und `prepareOutboundOutreach` entwirft eine E-Mail pro Lead — einmal erzeugt und bei wiederholten Aufrufen kostenlos zurückgegeben.
+
+## Bevor ein Agent all dies unbeaufsichtigt ausführt
+
+Namefis eigene Outbound-Dokumentation kennzeichnet vier Operationen als **folgenreich** — `registerDomain`, `registerWithRecords`, `startOutboundRun`, `prepareOutboundOutreach` —, weil jede Guthaben ausgibt oder eine nach außen sichtbare Handlung ausführt. Schreibgeschützte Tools wie `checkAvailability` lassen sich risikolos autonom ausführen; alles, was eine Bestellung, einen DNS-Eintrag auf einer Live-Domain oder einen Outreach-Entwurf schreibt, verdient einen Bestätigungsschritt. [Was ist ein agent-nativer Domain-Registrar?](/de/blog/agent-native/) bietet eine ausführlichere Checkliste, um die Agentenschnittstelle jedes Registrars so zu bewerten.
+
+## Diesen Katalog aktuell halten
+
+Diese Tabelle spiegelt Namefis Live-OpenAPI-Spezifikation zum oben genannten Veröffentlichungsdatum wider, keine feste Roadmap. Neue Operationen erscheinen in [namefi.io/llms.txt](https://namefi.io/llms.txt) und [namefi.io/llms-full.txt](https://namefi.io/llms-full.txt), bevor sie in einer Tabelle eines Blogbeitrags landen.
+
+## Häufig gestellte Fragen
+
+### Brauche ich einen API-Schlüssel, nur um zu prüfen, ob ein Name verfügbar ist?
+
+Nein. `checkAvailability`, `checkBulkAvailability` und `getSuggestions` benötigen keine Authentifizierung und funktionieren daher gegen einen frisch verbundenen Agenten, bevor irgendein Guthaben aufgeladen ist.
+
+### Kann ein Agent diesen gesamten Katalog nutzen, ohne dass ich jemals einen Namefi-API-Schlüssel halte?
+
+Ja. `registerDomainX402` und `registerDomainMPP` wickeln beide eine Registrierung über eine Wallet-Signatur ohne Namefi-Konto ab, und die EIP-712-Signatur deckt die übrigen Schreiboperationen direkt aus einer Wallet.
+
+### Wird eine Domain automatisch tokenisiert, wenn ich sie über einen dieser Wege registriere?
+
+Ja, standardmäßig über jeden Registrierungsweg. Wenn `nftReceivingWallet` nicht angegeben ist, wird die Domain auf Base als ERC-721-NFT für die an den API-Schlüssel des Aufrufers gebundene Wallet registriert.
+
+### Welche Operationen sollte ein Mensch bestätigen, bevor ein autonomer Agent sie ausführt?
+
+Mindestens die vier in Namefis Dokumentation als folgenreich markierten — `registerDomain`, `registerWithRecords`, `startOutboundRun`, `prepareOutboundOutreach` — sowie jeden DNS-Schreibvorgang auf einer Domain, die bereits Live-Traffic bedient.
+
+## Verbinden Sie Ihren Agenten mit dem vollständigen Katalog
+
+Jedes obige Tool ist über eine Verbindung live: `https://api.namefi.io/mcp`. Falls Sie diese noch nicht eingerichtet haben, erläutert [Eine Domain mit Ihrem KI-Agenten bei Namefi registrieren](/de/blog/ai-agent-register/) die genaue Konfiguration für sechs verschiedene Clients, und [llms.txt für Domains](/de/blog/llms-txt/) erklärt die darunterliegende Discovery-Schicht.
+
+**[Einen Namefi-API-Schlüssel erzeugen](https://namefi.io/api-key)** und Ihren Agenten auf den Server richten — dort warten die oben genannten Tools auf ihn.
+
+## Quellen und weiterführende Lektüre
+
+- Namefi — [namefi.io/llms.txt](https://namefi.io/llms.txt) (MCP-Server-URL, Transport, Authentifizierung, Referenz der Kernoperationen — Primärquelle für diesen Katalog)
+- Namefi — [namefi.io/llms-full.txt](https://namefi.io/llms-full.txt) (Referenz in einer Datei, die Web3-Zahlungen und Outbound-Lead-Findung einbettet)
+- Namefi — [namefi.io/web3/llms.txt](https://namefi.io/web3/llms.txt) (x402-, MPP-, EIP-712- und SIWE-Abläufe im Detail)
+- Namefi — [namefi.io/.well-known/mcp/servers.json](https://namefi.io/.well-known/mcp/servers.json) (MCP-Discovery-Deskriptor: Servername, URL, Transport, Authentifizierungstyp)
+- Namefi — [api.namefi.io/v-next/openapi/doc.json](https://api.namefi.io/v-next/openapi/doc.json) (maschinenlesbare OpenAPI-3-Spezifikation — Quelle jeder `operationId` und jedes Endpunkts im obigen Funktionskatalog)
+- Namefi — [docs.namefi.io: Authentifizierung](https://docs.namefi.io/docs/02-authentication.mdx#:~:text=The%20Namefi%20API%20supports%20three%20authentication%20methods) (API-Schlüssel, EIP-712- und SIWE-Authentifizierungsmodi; Authentifizierungsanforderungen je Operation; ERC-1271-/EIP-7702-Delegierung)
+- Namefi — [docs.namefi.io: Eine Domain registrieren](https://docs.namefi.io/docs/03-getting-started/01-your-first-domain.mdx) (Felder des Registrierungsrequests, Abfrageablauf, Statuswerte der Bestellung)
+- Namefi — [docs.namefi.io: Guthaben verwalten](https://docs.namefi.io/docs/03-getting-started/02-your-balance.mdx) (NFSC-Guthaben- und Faucet-Endpunkte)
+- Model Context Protocol — [Was ist das Model Context Protocol?](https://modelcontextprotocol.io/docs/getting-started/intro#:~:text=Think%20of%20MCP%20like%20a%20USB%2DC%20port%20for%20AI%20applications) (Überblick über das Protokoll)
+- llmstxt.org — [Die Datei /llms.txt](https://llmstxt.org) (Spezifikation und Begründung für die Discovery-Konvention, der Namefis Datei folgt)
+- x402.org — [x402-Protokoll](https://x402.org) (auf HTTP 402 basierender Stablecoin-Zahlungsstandard, der `registerDomainX402` zugrunde liegt)
+- Ethereum Improvement Proposals — [ERC-721: Non-Fungible-Token-Standard](https://eips.ethereum.org/EIPS/eip-721) (der Token-Standard, den Namefis Domain-NFTs implementieren)

--- a/content/blog/de/nl-domain-purchase.md
+++ b/content/blog/de/nl-domain-purchase.md
@@ -1,0 +1,152 @@
+---
+title: "Wie man eine Domain mit natürlicher Sprache kauft (2026)"
+date: '2026-07-10'
+language: 'de'
+tags: ['ai-agents', 'guide']
+authors: ['namefiteam']
+draft: false
+format: guide
+ogImage: ../../assets/nl-domain-purchase-og.jpg
+description: "Eine Schritt-für-Schritt-Anleitung vom Prompt in natürlicher Sprache bis zur registrierten und DNS-konfigurierten Domain — ohne Browser-Checkout, mit Leitplanken, die Sie kontrollieren."
+keywords: ["domainkauf natürliche sprache", "domainregistrierung im gespräch", "domain mit ki kaufen", "domain mit natürlicher sprache registrieren", "ki-domain-checkout", "vom prompt zur registrierten domain", "mit ki sprechen domain kaufen", "mcp-domain-tutorial", "conversational commerce domain", "namefi mcp-gespräch", "mensch in der schleife domainkauf", "ausgabenlimit ki-agent domain", "ki-agent domain kaufen"]
+relatedArticles:
+  - /de/blog/ai-agent-register/
+  - /de/blog/claude-mcp-domains/
+  - /de/blog/cf-namecom-namefi/
+  - /de/blog/agent-native/
+  - /de/blog/ai-domain-platforms/
+relatedTopics:
+  - /de/topics/domain-tokenization/
+  - /de/topics/domain-basics/
+relatedSeries:
+  - /de/series/tokenize-your-com/
+  - /de/series/blockchain-concepts/
+relatedGlossary:
+  - /de/glossary/ai-agent/
+  - /de/glossary/registrar/
+  - /de/glossary/wallet/
+  - /de/glossary/x402/
+  - /de/glossary/tokenized-domain/
+---
+
+„Kauf mir eine Domain“ bedeutete früher, einen Browser zu öffnen, einen Namen in ein Suchfeld einzutippen, sich durch eine Upsell-Seite für Datenschutz und E-Mail-Hosting zu klicken und eine Kartennummer einzugeben. Für eine wachsende Zahl von Käufern bedeutet es 2026, einen Satz in ein Chatfenster zu schreiben und zuzusehen, wie der Rest geschieht. Das meinen Menschen mit „Domainkauf in natürlicher Sprache“ — doch der Ausdruck wird so locker verwendet, dass es sich lohnt, genau zu bestimmen, was er tatsächlich voraussetzt.
+
+Dieser Leitfaden geht ein vollständiges Beispiel Zug um Zug durch: auf der einen Seite die Klartextanfragen eines Menschen, auf der anderen, was ein [KI-Agent](/de/glossary/ai-agent/) tatsächlich tut, und — der Teil, den die meisten Anleitungen auslassen — wo der Agent selbst abwägen muss, statt Ihre Worte nur an eine API weiterzugeben. Als ausgearbeitetes Beispiel dient [Namefi](https://namefi.io), doch der Weg vom Prompt zur registrierten Domain ist nicht auf einen Anbieter beschränkt; der ehrliche Vergleich gegen Ende sagt das auch.
+
+## Was „Kauf in natürlicher Sprache“ tatsächlich bedeutet
+
+Zwei sehr unterschiedliche Dinge werden beide „eine Domain mit KI kaufen“ genannt; die meisten Missverständnisse beginnen damit, sie zu vermischen.
+
+Das erste ist ein **Namensgenerator mit Chat-Oberfläche**. Sie beschreiben Ihr Unternehmen, das Tool schlägt verfügbare Namen vor, und ein Klick auf einen davon bringt Sie zu einer normalen Checkout-Seite eines Registrars — derselbe Warenkorb, dieselbe Kontoerstellung, derselbe Upsell „Datenschutz für $9.99/Jahr hinzufügen“, den Sie auch beim manuellen Browsen sehen würden. Die KI verkürzt den Brainstorming-Schritt. Sie verkürzt nicht den Kauf.
+
+Das zweite ist ein Agent, der **den Kauf als Teil des Gesprächs ausführt** — die Verfügbarkeit prüft, einen echten Preis gegenüber Ihrem Kontoguthaben nennt, die Domain nach Ihrer Bestätigung registriert und DNS konfiguriert, ohne dass Sie den Chat verlassen. Das setzt voraus, dass der Agent eine echte API aufrufen kann, nicht bloß Wörter erzeugen kann: Der Client, mit dem Sie sprechen, ist mit einem [Model Context Protocol](https://modelcontextprotocol.io)-Server (MCP) verbunden oder gegen eine einfache REST-API geskriptet, die echte Domain-Registrar-Operationen als Tools bereitstellt, die er mitten im Gespräch aufrufen kann.
+
+Das verrät es: Sagt die KI Ihnen jemals, dass eine Domain *registriert* ist, mit einer Bestellung, deren Status Sie prüfen können — oder bringt sie Sie nur bis zu einem Button „Weiter zum Checkout“?
+
+## Was Sie vor dem Start benötigen
+
+Sie brauchen zwei Dinge: einen Agenten, der mit der API eines Domain-Registrars verbunden ist, und eine Zahlungsmöglichkeit. Bei Namefi bedeutet das einen MCP-fähigen Client — Claude, Cursor, Windsurf und mehrere andere funktionieren —, der auf Namefis MCP-Server zeigt und mit einem API-Schlüssel oder einer Krypto-[Wallet](/de/glossary/wallet/) authentifiziert ist. Die genaue Konfiguration hängt vom Client ab und würde hier zu weit führen. [Eine Domain mit Ihrem KI-Agenten bei Namefi registrieren](/de/blog/ai-agent-register/) ist die maßgebliche Einrichtungsanleitung; [Eine Domain mit Claude kaufen: Schritt-für-Schritt-Anleitung für Namefi MCP](/de/blog/claude-mcp-domains/) zeigt die Befehle speziell für Claude. Dieser Artikel setzt voraus, dass dieser Teil erledigt ist, und beginnt dort, wo jene Leitfäden enden: beim Gespräch selbst.
+
+## Das vollständige Gespräch, Schritt für Schritt
+
+Hier ist ein vollständiger, kommentierter Durchlauf. Die zitierten Zeilen könnten von einem Menschen eingegeben werden; die Erläuterung zeigt, was darunter geschieht und wo der Agent eine Entscheidung treffen muss, statt Ihre Anfrage nur weiterzuleiten.
+
+**1. Sie beschreiben, was Sie wollen, nicht ein Formularfeld.**
+
+> „Ich möchte eine Domain für ein neues Projekt namens Aurorafield. Versuche zuerst aurorafield.com; falls sie vergeben ist, schlage einige nahe Alternativen vor.“
+
+Beachten Sie: Das ist nicht „suche nach aurorafield.com“, sondern ein Ziel mit eingebautem Fallback. Der Agent muss es in etwas zerlegen, das er prüfen kann: eine Verfügbarkeitsabfrage für den exakten Namen, mit einer Batch-Abfrage für Alternativen in Reserve, falls der erste vergeben ist. Ein wörtlich denkender Agent bittet Sie, die Anfrage einzeln für jede Suchabfrage zu wiederholen; ein hilfreicher Agent leitet die von Ihnen gemeinte Reihenfolge ab.
+
+**2. Der Agent prüft und antwortet mit mehr als Ja oder Nein.**
+
+> „aurorafield.com ist für eine Registrierung verfügbar. Alternativen musste ich nicht prüfen.“
+
+Technisch ist das eine Domain-Verfügbarkeitsprüfung — eine schreibgeschützte Abfrage, die weder Authentifizierung noch Ausgabenfreigabe benötigt und deshalb sicher ist, bevor Sie sich zu etwas verpflichtet haben. Ein sorgfältiger Agent sagt auch, *was* er geprüft hat, damit Sie einen falsch verstandenen oder vertippten Namen erkennen können, bevor etwas Geld kostet.
+
+**3. Sie bestätigen — die eine bewusste Kaufentscheidung im gesamten Ablauf.**
+
+> „Ja, registriere sie für ein Jahr. Sobald sie live ist, soll die Domain selbst auf 203.0.113.10 zeigen, und füge `www` als Weiterleitung auf dasselbe Ziel hinzu.“
+
+Diese einzelne Nachricht erledigt drei Dinge: Sie autorisiert eine Ausgabe, setzt eine Registrierungsdauer und bestimmt DNS. Ein guter Agent trennt „das, was Geld kostet und nicht unbemerkt rückgängig gemacht werden kann“ von „dem, was nur Konfiguration ist“ — er nennt die genauen Kosten gegenüber Ihrem Guthaben erneut, damit „ja, registriere sie“ eine informierte und keine blinde Bestätigung ist.
+
+**4. Der Agent sendet die Registrierung ab und behauptet nicht, sie sei sofort fertig.**
+
+> „Registrierung eingereicht. Sie wird asynchron verarbeitet; ich prüfe nach, bis sie abgeschlossen ist, statt einfach anzunehmen, dass sie durchgegangen ist — einen Moment.“
+
+Eine Domainregistrierung ist kein einzelner Roundtrip, sondern eine Bestellung, die die Registry verarbeiten muss. Der Agent übermittelt die Registrierung und fragt dann den Status der Bestellung ab, bis sie einen endgültigen Zustand erreicht: `SUCCEEDED`, `FAILED`, `CANCELLED` oder `PARTIALLY_COMPLETED`. Ein Agent, der Erfolg meldet, sobald er die Anfrage übermittelt, beschreibt, was er *angefordert* hat, nicht was *geschehen* ist. Die ehrliche Variante wartet auf einen endgültigen Status, bevor sie die Domain als Ihre bezeichnet.
+
+**5. Sobald die Bestellung gelingt, setzt der Agent DNS — und trifft ohne Nachfrage das richtige Format.**
+
+> „aurorafield.com ist registriert. Ich setze einen A-Eintrag an der Root auf 203.0.113.10 und einen CNAME, sodass `www` auf dasselbe Ziel verweist — fertig, beide Einträge sind live.“
+
+Dieser Schritt hat eine Formatierungsfalle, die die natürliche Sprachschicht abfangen sollte, damit Sie nie darüber nachdenken müssen: Der `rdata`-Wert eines DNS-Eintrags braucht einen abschließenden Punkt, wenn er ein Hostname ist (ein CNAME-Ziel wie `aurorafield.com.`), während der Zonenname selbst *keinen* haben darf. Die Verwechslung ist eine häufige Ursache für einen abgelehnten DNS-Schreibvorgang. Sie haben nie einen abschließenden Punkt eingegeben; „www auf dasselbe Ziel verweisen lassen“ in zwei korrekt formatierte Eintragstypen zu übersetzen, ist genau die Abwägung, die das Gespräch für Sie übernehmen soll.
+
+**6. Eine Folgeanfrage in natürlicher Sprache funktioniert genauso.**
+
+> „Schalte außerdem die automatische Verlängerung ein, damit ich die Domain nicht versehentlich verliere.“
+
+Keine neue Einrichtung, kein neues Tool zum Lernen — dasselbe Gespräch läuft weiter. Das ist der eigentliche Gewinn: Nicht, dass ein einzelner Schritt manuell unmöglich wäre, sondern dass Prüfen, Preis ermitteln, bestätigen, registrieren, warten, konfigurieren und anpassen in einem Austausch stattfinden statt auf sechs getrennten Bildschirmen.
+
+Am Ende haben Sie eine echte, von [ICANN](/de/glossary/icann/) akkreditierte Registrierung, DNS am gewünschten Ziel und — bei Namefi standardmäßig — ein [tokenisiertes](/de/glossary/tokenized-domain/), in einer Wallet gehaltenes NFT statt nur einer Datenbankzeile. Nichts davon erforderte eine Checkout-Seite.
+
+## Wo Sie in der Schleife bleiben sollten
+
+Beim Lesen dieses Transkripts liegt die Versuchung nahe, zu schließen, die Aufgabe des Menschen bestehe nur darin, die erste Nachricht zu tippen und die letzte zu lesen. Das wäre die falsche Schlussfolgerung.
+
+Ein Agent, der eine Domain registrieren kann, kann auch echtes Geld ausgeben und DNS einer Domain umschreiben, die bereits Live-Traffic bedient. Das obige Gespräch lief sauber, weil eine Bestätigung genau an einem Punkt stattfand — Schritt 3, bevor etwas gekauft wurde — und alles davor oder danach entweder keine Kosten verursachte oder ausdrücklich angefordert war. Das ist kein Zufall; Sie sollten diese Richtlinie bewusst festlegen:
+
+- **Entscheiden Sie, was Ihre ausdrückliche Bestätigung braucht.** Eine schreibgeschützte Abfrage wie die Verfügbarkeitsprüfung trägt kein Risiko und benötigt keine; sobald eine Handlung Geld ausgibt oder etwas bereits Live-Geschaltetes verändert, ist das die Grenze für „zuerst fragen“.
+- **Begrenzen Sie, was der Agent ausgeben darf, bevor das Gespräch beginnt.** Bei Namefi ist das so einfach wie die Höhe des Guthabens, das Sie für den von einem API-Schlüssel genutzten Saldo aufladen — finanzieren Sie es nur mit so viel, wie Sie einem unbeaufsichtigten Agenten zu verwenden erlauben möchten.
+- **Beschränken Sie Zugangsdaten eng** auf die Wallet, die neue Registrierungen besitzen soll, statt auf eine, die Assets hält, die Sie mitten im Gespräch nicht offenlegen möchten.
+- **Lesen Sie DNS-Änderungen, bevor Sie sie genehmigen**, so wie Sie jede Infrastrukturänderung prüfen würden. Ein Agent kann die *Syntax* richtig verstehen (die oben genannte Regel zum abschließenden Punkt) und trotzdem einen Eintrag auf das falsche Ziel zeigen lassen, wenn er missverstanden hat, welches „dasselbe Ziel“ Sie meinten.
+
+[Was ist ein agent-nativer Domain-Registrar?](/de/blog/agent-native/) behandelt dies ausführlicher als allgemeine Checkliste für die Agentenschnittstelle jedes Registrars; der Abschnitt zu Leitplanken in [Eine Domain mit Ihrem KI-Agenten bei Namefi registrieren](/de/blog/ai-agent-register/) behandelt dasselbe speziell für Namefis Einrichtung.
+
+## Dieselbe Idee bei Cloudflare und Name.com
+
+Namefi ist nicht der einzige Registrar, der in diese Richtung baut. Die Registrar-API von Cloudflare, seit April 2026 in Beta, [ermöglicht einem KI-Agenten, die Domainverfügbarkeit zu suchen, Preise zu prüfen und die Registrierung programmgesteuert ohne Browserinteraktion oder manuelle Genehmigung abzuschließen](https://webhosting.today/2026/04/22/ai-agents-can-now-register-domains-no-human-required/#:~:text=lets%20an%20AI%20agent%20search%20for%20domain%20availability%2C%20check%20pricing%2C%20and%20complete%20registration%20programmatically%20without%20any%20browser%20interaction%20or%20manual%20approval) — ein Gespräch, das ähnlich wie das obige aussieht, aber gegen die API eines anderen Anbieters geführt wird. Name.com hat seine API um einen ähnlichen „KI-nativen“ Anspruch herum neu aufgebaut, der auf denselben Wandel zielt.
+
+Es lohnt sich, ehrlich zu bleiben, denn die obigen Leitplanken sind wichtig, unabhängig davon, auf welchen Registrar Sie zeigen: Eine Branchenanalyse zu Cloudflares Beta merkte offen an, dass [die Beta-Ankündigung keine Ausgabenlimits pro Agent oder Workflows zur Registrierungsfreigabe beschreibt](https://webhosting.today/2026/04/22/ai-agents-can-now-register-domains-no-human-required/#:~:text=The%20beta%20announcement%20does%20not%20describe%20per-agent%20spending%20limits%20or%20registration%20approval%20workflows) — dieselbe Empfehlung „vor dem Start entscheiden“, als Lücke statt als eingebaute Funktion formuliert. Und das Muster „vorschlagen, nicht kaufen“ ist anderswo weiterhin verbreitet: Wix veröffentlicht beispielsweise seinen eigenen Leitfaden „[Wie man KI nutzt, um einen Domainnamen zu kaufen](https://www.wix.com/blog/buy-a-domain-name-with-ai)“ über KI-gestützte Namensvorschläge innerhalb seines Website-Builders — die erste Art von „KI kauft eine Domain“, die dieser Artikel von der zweiten unterscheidet.
+
+Eine vollständige Aufschlüsselung dessen, was jeder agent-native Registrar tatsächlich unterstützt — Preise, Zahlung, DNS-Verwaltung, tokenisierte Eigentümerschaft — finden Sie unter [Cloudflare vs. Name.com vs. Namefi: Agent-Native Registrare](/de/blog/cf-namecom-namefi/).
+
+## Häufig gestellte Fragen
+
+### Unterscheidet sich das tatsächlich von einem Chatbot, der Domainnamen vorschlägt?
+
+Ja — der Unterschied ist der Kauf, nicht der Vorschlag. Ein Chatbot für Namensvorschläge endet bei „Hier sind einige verfügbare Namen, klicken Sie auf einen zum Checkout“. Ein Kaufablauf in natürlicher Sprache endet bei einer registrierten Domain mit einer Bestellung, deren Status Sie prüfen können, ohne das Gespräch zu verlassen.
+
+### Gibt der Agent jemals Geld aus, ohne mich vorher zu fragen?
+
+Er sollte es nicht, wenn Sie ihn wie oben empfohlen eingerichtet haben. Schreibgeschützte Abfragen kosten nichts und benötigen keine Bestätigung; alles, was Ihr Guthaben belastet, sollte so konfiguriert sein, dass es auf ein ausdrückliches Ja wartet. Das ist eine von Ihnen festgelegte Richtlinie, keine der Technologie innewohnende Eigenschaft.
+
+### Was passiert, wenn ich dem Agenten keinen exakten Domainnamen gebe?
+
+Ein fähiger Agent behandelt eine vage Anfrage — „etwas für mein Café, möglichst kurz“ — zunächst als Suchen-und-Vorschlagen-Schritt. Der Kauf geschieht weiterhin erst, wenn Sie einen konkreten Namen bestätigt haben.
+
+### Kann ich eine Registrierung rückgängig machen, sobald sie erteilt wurde?
+
+Sobald eine Bestellung einen erfolgreichen endgültigen Status erreicht, ist sie eine echte Domain wie jede andere — es gelten die normalen Kündigungs- und Erstattungsrichtlinien des Registrars, ohne besonderes „Rückgängig“ dafür, dass Sie einen Agenten verwendet haben. Deshalb ist der Bestätigungsschritt vor der Registrierung wichtiger als jeder andere Punkt im Gespräch.
+
+### Wird die Domain bei dieser Registrierung automatisch tokenisiert?
+
+Bei Namefi standardmäßig ja: Wenn Sie keine andere Wallet angeben, wird eine neu registrierte Domain auf Base als NFT für die an Ihren API-Schlüssel gebundene Wallet ausgegeben. Das schafft neben der Standardregistrierung bei ICANN On-Chain- und übertragbares Eigentum. Mehr dazu unter [Was sind tokenisierte Domains?](/de/glossary/tokenized-domain/).
+
+### Muss ich die API von Namefi lernen, um auf diese Weise mit ihr zu sprechen?
+
+Nein — das ist der Punkt. Alles im obigen Transkript geschieht in einfachen Sätzen; die API und ihre exakten Request-Formate liegen darunter, damit der Agent sie aufruft, nicht damit Sie sie lesen müssen. Um die Mechanik direkt zu sehen, zeigt [Eine Domain mit Claude kaufen: Schritt-für-Schritt-Anleitung für Namefi MCP](/de/blog/claude-mcp-domains/) denselben Ablauf mit den zugrunde liegenden Operationen in jedem Schritt.
+
+## Das Gespräch beginnen
+
+Der Unterschied zwischen „einer KI, die Ihnen beim Finden eines Namens hilft“ und „einer KI, die Ihnen eine registrierte Domain verschafft“, ist nicht die KI — sondern ob am anderen Ende eine echte Registrar-API steht und ob Sie vernünftige Grenzen für die Handlungen ohne Rückfrage gesetzt haben. Namefis MCP-Server ist diese API für Namefi; die Einrichtung dauert wenige Minuten, danach besteht der gesamte obige Ablauf nur noch aus Tippen.
+
+**[Einen Namefi-API-Schlüssel erzeugen und das Gespräch beginnen](https://namefi.io/api-key).**
+
+## Quellen und weiterführende Lektüre
+
+- webhosting.today — [KI-Agenten können jetzt Domains registrieren, kein Mensch erforderlich](https://webhosting.today/2026/04/22/ai-agents-can-now-register-domains-no-human-required/#:~:text=lets%20an%20AI%20agent%20search%20for%20domain%20availability%2C%20check%20pricing%2C%20and%20complete%20registration%20programmatically%20without%20any%20browser%20interaction%20or%20manual%20approval) (Cloudflare-Registrar-API-Beta und das erwähnte Fehlen eingebauter Leitplanken für Ausgaben und Freigaben)
+- Wix — [Wie man KI nutzt, um einen Domainnamen zu kaufen](https://www.wix.com/blog/buy-a-domain-name-with-ai) (die Einordnung als Namensvorschlag, die dieser Artikel mit einem kaufabschließenden Ablauf kontrastiert)
+- Model Context Protocol — [Was ist MCP?](https://modelcontextprotocol.io/#:~:text=MCP%20%28Model%20Context%20Protocol%29%20is%20an%20open-source%20standard%20for%20connecting%20AI%20applications%20to%20external%20systems) (der Verbindungsstandard unter diesem Gesprächsablauf)
+- Namefi — [namefi.io/llms.txt](https://namefi.io/llms.txt) (Operationsnamen, Bestellstatus und DNS-Regel für abschließende Punkte — Primärquelle für alle Namefi-spezifischen Aussagen hier)
+- Namefi — [Eine Domain mit Ihrem KI-Agenten bei Namefi registrieren](/de/blog/ai-agent-register/) (die Einrichtung, die dieser Artikel voraussetzt)
+- Namefi — [Cloudflare vs. Name.com vs. Namefi: Agent-Native Registrare](/de/blog/cf-namecom-namefi/) (vollständiger Vergleich der drei oben genannten Registrare)

--- a/content/blog/de/state-of-agentic.md
+++ b/content/blog/de/state-of-agentic.md
@@ -1,0 +1,147 @@
+---
+title: "Der Stand des agentischen Domain-Managements, 2026"
+date: '2026-07-10'
+language: 'de'
+tags: ['ai-agents', 'domains', 'analysis']
+authors: ['namefiteam']
+draft: false
+format: analysis
+ogImage: ../../assets/state-of-agentic-og.jpg
+description: "Der Wandel der Domain-Registrierung in die Agentenschicht: eine belegte Zeitleiste, ein Audit von Ausgeliefertem gegenüber Angekündigtem einschließlich Namefi und falsifizierbare Prognosen für 2027."
+keywords: ["stand des agentischen domain-managements", "agentisches domain-management 2026", "ki-trends in der domain-branche", "ki-adoption in der domain-branche", "zeitleiste der agentenschicht", "prognosen für domain-registrare 2027", "mcp-adoption bei domain-registrierung", ".ai domain-registrierungen 2026", "cloudflare registrar api beta", "name.com ki-native api", "these agenten als reseller", "verisign domain name industry brief", "dns-verankerte identität für ki-agenten"]
+relatedArticles:
+  - /de/blog/agents-buy-domains/
+  - /de/blog/cf-namecom-namefi/
+  - /de/blog/ai-domain-platforms/
+  - /de/blog/agent-native/
+  - /de/blog/ai-agent-register/
+relatedTopics:
+  - /de/topics/domain-basics/
+  - /de/topics/web3-foundations/
+relatedSeries:
+  - /de/series/blockchain-concepts/
+  - /de/series/domain-apocalypse/
+relatedGlossary:
+  - /de/glossary/ai-agent/
+  - /de/glossary/epp/
+  - /de/glossary/registrar/
+  - /de/glossary/registry/
+  - /de/glossary/reseller/
+---
+
+Zur Mitte des Jahres 2026 lässt sich die Erzählung „KI-Agenten werden verändern, wie Domains registriert werden“ an realen Ereignissen statt an Prognosen messen. Ein Teil davon geschah an einem konkreten, überprüfbaren Datum. Ein anderer Teil ist noch ein Beta-Label, ein Positionierungsbeitrag oder ein Entwurf in der Warteschlange eines Standardisierungsgremiums. Dieser Beitrag hält diese beiden Kategorien getrennt: eine belegte Zeitleiste dessen, was die Domain-Registrierung in Richtung [Agentenschicht](/de/blog/agents-buy-domains/) bewegte, ein ehrliches Audit dessen, was tatsächlich ausgeliefert und was lediglich angekündigt wurde (einschließlich Namefi, mit allen Lücken), die in der Fachpresse kursierende These „Agenten als Reseller“ sowie Prognosen für 2027, die so formuliert sind, dass Leser sie ohne unsere Interpretation als wahr oder falsch bewerten können.
+
+## Die Adoptionszahlen und woher sie tatsächlich stammen
+
+Zwei Zahlen werden in der Berichterstattung über „KI und Domains“ in diesem Jahr ständig zitiert; sie verdienen unterschiedlich viel Vertrauen.
+
+Die erste ist die eigene Behauptung von Name.com, dass [„91% der Befragten erwarten, dass KI-Agenten in den nächsten zwei Jahren zumindest einen Teil ihrer Domain-Verwaltung übernehmen“](https://www.name.com/blog/the-first-ai-native-domain-platform#:~:text=a%20remarkable%2091%25%20of%20respondents%20envision%20AI%20agents%20handling%20at%20least%20some%20of%20their%20domain%20management%20in%20the%20next%20two%20years). Sie stammt aus einem Blogbeitrag, den das Unternehmen am **July 10, 2025** veröffentlichte. Name.com schreibt die Zahl „unserer jüngsten Kundenumfrage“ zu, veröffentlicht aber weder Stichprobengröße noch Methodik oder unabhängige Überprüfung. Behandle sie daher als das, was sie ist: **Name.com berichtet**, dass die eigenen, von Name.com befragten Kunden dies gesagt haben — vom Unternehmen berichtete Stimmung, keine unabhängige Branchenstatistik.
+
+Die zweite Zahl ist überprüfbar und unabhängig bestätigt. Am **January 28, 2026** gab die Regierung von Anguilla bekannt, dass die `.ai`-[ccTLD](/de/glossary/cctld/) eine Million registrierte Domains überschritten hatte. [Domain Name Wire berichtete direkt über diesen Meilenstein](https://domainnamewire.com/2026/01/28/ai-namespace-hits-1-million-domain-names/): zu Beginn von 2025 gab es ungefähr 598,000 `.ai`-Domains; etwa dreizehn Monate später wurde die Marke von einer Million überschritten. Ausgehend von rund 40,000 Registrierungen in 2020 dauerte dieser Anstieg fünf Jahre. Die Berichterstattung von CircleID über die Domain-Branche nennt denselben Meilenstein unabhängig, und die Branchenanalyse von Hogan Lovells zu `.ai` bestätigt die Entwicklung — eine mehrfach bestätigte Zahl und keine einzelne Selbstauskunft.
+
+Als Größenordnung gegenüber dem gesamten Domain-Markt: Der [Domain Name Industry Brief](https://www.dnib.com) von Verisign für Q1 2026 meldete 392.5 million Domain-Registrierungen über alle TLDs hinweg, 1.4% mehr gegenüber dem Vorquartal und 6.5% mehr gegenüber dem Vorjahr. Die [Berichterstattung von CircleID über die Veröffentlichung](https://circleid.com/posts/dnib-reports-392.5-million-domain-name-registrations-in-q1-2026#:~:text=The%20first%20quarter%20of%202026%20closed%20with%20392.5%20million%20domain%20name%20registrations%20across%20all%20top-level%20domains%20%28TLDs%29) zitiert diese Zahl direkt. Die ungefähr eine Million `.ai`-Registrierungen sind innerhalb der 392.5 million ein kleiner, schnell wachsender Anteil — echte Dynamik, aber noch kein marktverändernder Anteil. Weder DNIB noch die öffentlichen Materialien von Identity Digital weisen aus, welcher Anteil der Registrierungen über einen Agenten statt über einen Browser-Checkout fließt. Genau diese Lücke umgeht der Rest dieses Beitrags: Wir können überprüfen, *dass* agentengerichtete Infrastruktur gestartet wurde und ungefähr wann, aber noch nicht, *wie viel* Volumen darüber fließt.
+
+## Zeitleiste: der Wandel zur Agentenschicht
+
+Jedes nachstehende Datum ist gegen eine Primärankündigung, offizielle Dokumentation oder einen direkt abgerufenen Fachpressebericht verifiziert, nicht gegen einen Sekundäraggregator, der eine unbelegte Zahl wiederholt.
+
+| Datum | Ereignis | Quelle |
+| --- | --- | --- |
+| 2004-03 | [EPP](/de/glossary/epp/) (Extensible Provisioning Protocol) — die Maschine-zu-Maschine-Sprache, mit der Registrare noch immer mit Registries kommunizieren — erhält den Status Proposed Standard | [RFCs 3730–3734, veröffentlicht March 2004](https://en.wikipedia.org/wiki/Extensible_Provisioning_Protocol#:~:text=Proposed%20Standard%20documents%20%28RFCs%203730%20-%203734%29%20were%20published%20by%20the%20RFC%20Editor%20in%20March%202004) |
+| 2024-09-03 | Der Dateivorschlag `/llms.txt` wird veröffentlicht und gibt Websites eine Standardmethode, sich Sprachmodellen zur Inferenzzeit zu beschreiben | [llmstxt.org, veröffentlicht von Jeremy Howard](https://llmstxt.org/#:~:text=A%20proposal%20to%20standardise%20on%20using%20an%20/llms.txt%20file%20to%20provide%20information%20to%20help%20LLMs%20use%20a%20website%20at%20inference%20time) |
+| 2024-11-25 | Anthropic veröffentlicht das [Model Context Protocol](https://modelcontextprotocol.io), einen offenen Standard zum Verbinden von KI-Anwendungen mit externen Tool-Servern | [Ankündigung von Anthropic zu MCP](https://www.anthropic.com/news/model-context-protocol) |
+| 2025-07-10 | Name.com veröffentlicht seinen Positionierungsbeitrag zur „ersten KI-nativen Domain-Plattform“, aufgebaut auf MCP und OpenAPI, einschließlich der oben genannten selbst berichteten 91%-Zahl | [Name.com-Blog](https://www.name.com/blog/the-first-ai-native-domain-platform#:~:text=the%20launch%20of%20the%20new%20name.com%20API%2C%20our%20AI-native%20platform%20that%20modernizes%20domains%20for%20the%20age%20of%20agentic%20AI) |
+| 2026-01-28 | `.ai` überschreitet laut einer Regierungsankündigung aus Anguilla eine Million registrierte Domains | [Domain Name Wire](https://domainnamewire.com/2026/01/28/ai-namespace-hits-1-million-domain-names/) |
+| 2026-04-15 | Cloudflare stellt seine Registrar API während der „Agents Week“ in die öffentliche Beta und bindet Registrierung, Suche und Preisabfrage in die MCP-Schicht ein | [Ankündigung der Cloudflare Registrar API Beta](https://blog.cloudflare.com/registrar-api-beta/); [Branchenberichterstattung](https://webhosting.today/2026/04/22/ai-agents-can-now-register-domains-no-human-required/#:~:text=On%20April%2015%2C%202026%2C%20Cloudflare%20moved%20that%20transaction%20into%20the%20agent%20layer) |
+| 2026-04-20 | CircleID veröffentlicht seine Analyse „Agenten als Domain-Reseller“ | [CircleID, Simone Catania](https://circleid.com/posts/the-domain-universe-in-2026-ai-security-market-maturity-and-the-new-gtld-frontier#:~:text=AI%20agents%20are%20increasingly%20acting%20as%20domain%20resellers%20checking%20availability%2C%20registering%20names%2C%20and%20configuring%20DNS%20without%20human%20intervention) |
+| 2026-04-24 | Der Domain Name Industry Brief von Verisign für Q1 2026 meldet 392.5 million Domain-Registrierungen insgesamt — Markt-Kontext für jede der obigen Zahlen | [DNIB.com](https://www.dnib.com); [CircleID-Berichterstattung](https://circleid.com/posts/dnib-reports-392.5-million-domain-name-registrations-in-q1-2026#:~:text=The%20first%20quarter%20of%202026%20closed%20with%20392.5%20million%20domain%20name%20registrations%20across%20all%20top-level%20domains%20%28TLDs%29) |
+| 2026-04-27 | Identity Digital — Muttergesellschaft der `.ai`-Registry und von [Name.com](https://www.name.com) — startet einen „neutralen, DNS-verankerten Identitätsstandard für KI-Agenten“ und schlägt DNS-Einträge als Ort vor, an dem der verantwortliche Eigentümer eines Agenten festgehalten wird | [Newsroom von Identity Digital](https://www.globenewswire.com/news-release/2026/04/27/3281553/0/en/identity-digital-launches-neutral-dns-anchored-identity-standard-for-ai-agents.html) |
+| 2026-06-04 | Innovation Labs von Identity Digital formalisiert diesen Vorschlag als IETF Internet-Draft „DNS-Anchored Durable Identity for AI Agents (DNSid)“ | [GlobeNewswire](https://www.globenewswire.com/news-release/2026/06/04/3306702/0/en/innovation-labs-by-identity-digital-submits-dns-anchored-durable-identity-proposal-for-ai-agents-to-the-ietf.html#:~:text=Which%20accountable%20entity%20is%20responsible%20for%20this%20agent%2C%20and%20can%20that%20be%20verified%20independently%20across%20systems); [IETF-Datatracker-Entwurf](https://datatracker.ietf.org/doc/draft-ihsanullah-dnsid/) |
+
+In dieser Reihenfolge gelesen ergibt sich folgendes Muster: ein zwanzig Jahre altes Bereitstellungsprotokoll, dann zwei allgemeine KI-Agentenstandards, die gar nicht für Domains entwickelt wurden (llms.txt, MCP), dann Registrare, die diese Standards nacheinander in Checkout-Flüsse nachrüsten, und schließlich dieselbe Registry-Familie (Identity Digital), die über den eigenen Registrar hinausgreift und DNS als Infrastruktur für die *Identität* eines Agenten vorschlägt, nicht nur für dessen *Kauf*. Dieser letzte Schritt ist der neueste und am wenigsten gefestigte: Ein Internet-Draft ist ein zur Diskussion eingereichter Vorschlag, kein ratifizierter Standard.
+
+## Was tatsächlich ausgeliefert ist und was angekündigt wurde
+
+„Agent-native“ wird in Marketingtexten locker verwendet. Hier ist, was jede Position tatsächlich ausgeliefert hat — gegen die jeweils eigene Live-Dokumentation der Plattform verifiziert — im Vergleich zu dem, was noch ein Beta-Label, eine Positionierungsbehauptung oder ein Standard-Track-Vorschlag ohne laufenden Code dahinter ist.
+
+| Plattform | Fähigkeit | Status | Nachweis |
+| --- | --- | --- | --- |
+| Namefi | MCP-Server (`api.namefi.io/mcp`, Streamable HTTP, auffindbar unter `/.well-known/mcp/servers.json`) | **Ausgeliefert** | [namefi.io/llms.txt](https://namefi.io/llms.txt) |
+| Namefi | Per Wallet-Signatur autorisierter USDC-Checkout über [x402](/de/glossary/x402/) (EIP-3009 `transferWithAuthorization`, kein Konto erforderlich) | **Ausgeliefert** | [namefi.io/web3/llms.txt](https://namefi.io/web3/llms.txt) |
+| Namefi | `llms.txt`-basierte Auffindbarkeit für Agenten-Tools und REST-Referenz | **Ausgeliefert** | [namefi.io/llms.txt](https://namefi.io/llms.txt) |
+| Namefi | Primitive für Ausgabenlimit oder Kaufbestätigung auf der API-Schicht | **Nicht ausgeliefert** — zum Zeitpunkt dieses Beitrags gibt es keine dokumentierte Schranke; die Leitplanke liegt derzeit beim MCP-Client, nicht beim Server | Unsere eigene [Analyse der agent-nativen Checkliste](/de/blog/agent-native/), für diesen Beitrag direkt gegen `namefi.io/llms.txt` und `namefi.io/web3/llms.txt` gegengeprüft |
+| Cloudflare | Registrar API: Suche, Verfügbarkeit, Preisabfrage, synchrone Registrierung | **Ausgeliefert, in öffentlicher Beta** seit 2026-04-15 | [Ankündigung der Cloudflare Registrar API Beta](https://blog.cloudflare.com/registrar-api-beta/) |
+| Cloudflare | DNS-Eintragsverwaltung, Transfers, Verlängerungen, Kontaktaktualisierungen über dieselbe API | **Angekündigt, in Entwicklung** — der eigene Beitrag von Cloudflare sagt, das Unternehmen arbeite „aktiv daran, die API auf weitere Teile des grundlegenden Registrar-Erlebnisses auszuweiten“, vorgesehen für später 2026 | [Ankündigung der Cloudflare Registrar API Beta](https://blog.cloudflare.com/registrar-api-beta/) |
+| Name.com | KI-native Positionierung mit MCP und OpenAPI, Einordnung von natürlicher Sprache zu Integrationscode | **Angekündigt** — ein Positionierungsbeitrag, keine detaillierte Fähigkeitsspezifikation | [Name.com-Blog](https://www.name.com/blog/the-first-ai-native-domain-platform) |
+| Name.com | Auffindbare `llms.txt` oder dedizierter MCP-Server, direkt an der Domain-Root geprüft | **Nicht gefunden** zum Zeitpunkt unserer Prüfung | Direkte Prüfung von `name.com`, abgeglichen in [Cloudflare vs. Name.com vs. Namefi](/de/blog/cf-namecom-namefi/) |
+| Identity Digital | DNSid: ein DNS-verankerter, kryptografisch überprüfbarer Eintrag zum verantwortlichen Eigentümer für KI-Agenten | **Vorgeschlagen** — ein zur Diskussion eingereichter IETF Internet-Draft, kein ratifizierter Standard und in keinen Live-Registrar-Checkout integriert | [IETF-Datatracker: draft-ihsanullah-dnsid](https://datatracker.ietf.org/doc/draft-ihsanullah-dnsid/) |
+
+In dieser Tabelle stecken zwei Erkenntnisse. Erstens hat keine der von uns geprüften Plattformen — einschließlich Namefi — ein dokumentiertes, von der API erzwungenes Ausgabenlimit ausgeliefert; jede Leitplanke liegt eine Schicht höher, in der clientseitig von Menschen festgelegten Richtlinie. Zu demselben Ergebnis kam unsere [agent-native Checkliste](/de/blog/agent-native/) bei der Bewertung dieser Kategorie. Zweitens befindet sich DNS als Identitätsanker für den Agenten selbst, nicht nur für die Domain, die er kauft, noch im Stadium „zur IETF-Diskussion eingereicht“ — selbst bei positiver Aufnahme noch Monate davon entfernt, dass ein Registrar es in einen Live-Checkout einbauen könnte.
+
+## Die Reseller-These
+
+Die in der Berichterstattung der Domain-Branche 2026 wiederholte Aussage lautet, dass KI-Agenten zu *Resellern* werden. Die Analyse von CircleID vom April 20, 2026 formuliert es direkt: [„KI-Agenten agieren zunehmend als Domain-Reseller, prüfen die Verfügbarkeit, registrieren Namen und konfigurieren DNS ohne menschliches Eingreifen.“](https://circleid.com/posts/the-domain-universe-in-2026-ai-security-market-maturity-and-the-new-gtld-frontier#:~:text=AI%20agents%20are%20increasingly%20acting%20as%20domain%20resellers%20checking%20availability%2C%20registering%20names%2C%20and%20configuring%20DNS%20without%20human%20intervention)
+
+Die Wortwahl sollte von ihren Implikationen getrennt werden. Ein [Reseller](/de/glossary/reseller/) ist im eigenen Vokabular der Domain-Branche etwas Bestimmtes und Formelles: eine Partei, die Domains im Rahmen der [ICANN](/de/glossary/icann/)-Akkreditierungsvereinbarung eines Registrars verkauft oder bereitstellt und vertragliche Pflichten gegenüber dem Registrar und mittelbar gegenüber ICANN hat. Ein Agent, der heute eine Registrierungs-API aufruft, schafft diese Beziehung nicht. Der Agent handelt als Delegierter des Endkunden, authentifiziert durch dessen eigenen API-Key oder dessen Wallet, nicht als eigenständig akkreditierte Partei. Die Einordnung von CircleID ist beschreibend, keine Behauptung über einen Akkreditierungsstatus: Das *Verhaltensmuster* eines Resellers — suchen, bepreisen, registrieren, DNS konfigurieren, in großer Menge und im Auftrag anderer wiederholt — erscheint nun in Agenten-Workflows, obwohl der Betreiber kein Unternehmen mit einer unterzeichneten Reseller-Vereinbarung ist.
+
+Ob sich dieses Verhalten zu etwas verdichtet, das Registries formell anerkennen, ist eine offene Frage. Dafür müssten Registries und Registrare entscheiden, ob Agentenaktivität mit hohem Volumen und klaren Richtlinien eine eigene Akkreditierungsstufe, Haltung zur Ratenbegrenzung oder Kategorie für Missbrauchsüberwachung braucht, die sich von der eines menschlichen Resellers unterscheidet. Nichts in der obigen Zeitleiste — die Beta von Cloudflare, der Beitrag von Name.com, der DNSid-Entwurf von Identity Digital — schlägt diese Stufe bislang vor. DNSid kommt dem am nächsten, weil es ausdrücklich darum geht zu überprüfen, wer für die Handlungen eines Agenten verantwortlich ist. Doch „wer ist verantwortlich“ und „ist formell als Reseller akkreditiert“ sind unterschiedliche Fragen, und der Entwurf beantwortet nur die erste. Die Mechanik eines einzelnen Kaufs erklärt [Wie KI-Agenten Domains ohne Menschen kaufen](/de/blog/agents-buy-domains/).
+
+## Prognosen für 2027
+
+Jede der folgenden Aussagen ist so formuliert, dass sie anhand öffentlicher Belege überprüfbar ist — eine konkrete Behauptung, keine Stimmung. Leser, die Mitte 2027 zurückkehren, können sie daher ohne unsere Interpretation als wahr, falsch oder ungelöst markieren.
+
+1. **Mindestens einer von Cloudflare, Name.com oder ein vergleichbarer Mainstream-Registrar wird bis July 2027 eine dokumentierte, von der API erzwungene Primitive für Ausgabenlimit oder Kaufbestätigung veröffentlichen** (nicht nur clientseitige Anleitung). Zum Zeitpunkt dieses Beitrags ist diese Zeile bei jeder von uns geprüften Plattform leer, einschließlich Namefi.
+2. **Die Registrar API von Cloudflare wird bis Ende 2027 ihr „Beta“-Label ablegen und mindestens eine von DNS-Eintragsverwaltung, automatisierter Verlängerung oder Transferunterstützung ausliefern** — entsprechend der Formulierung „später 2026“ in der eigenen Beta-Ankündigung, mit einem zusätzlichen Jahr Spielraum.
+3. **Der DNSid Internet-Draft (oder ein direkter Nachfolger zur Frage „wer ist für diesen Agenten verantwortlich?“) wird bis July 2027 weiterhin IETF-Entwurfsstatus und keinen genehmigten RFC haben**, denn Standard-Track-Dokumente brauchen üblicherweise Jahre über die Einreichung hinaus und dieser wurde im June 2026 eingereicht.
+4. **`.ai`-Registrierungen werden bis July 2027 1.5 million überschreiten** und damit die von Domain Name Wire und Identity Digital dokumentierte Wachstumskurve fortsetzen, statt nahe der im January 2026 überschrittenen Marke von einer Million zu stagnieren.
+5. **Mindestens eine hier verglichene Plattform wird in eigenem Marketing oder eigener Dokumentation öffentlich das Wort „Reseller“ oder „Agent-Reseller“** für agentengesteuerte Registrierungsaktivitäten verwenden und damit die von CircleID im April 2026 verwendete Einordnung formalisieren, statt sie als Sprache der Fachpresse zu belassen.
+
+## Häufig gestellte Fragen
+
+### Wie viele Domains werden derzeit tatsächlich von KI-Agenten registriert?
+
+Keine von uns geprüfte Registry oder kein Registrar — DNIB, Identity Digital, Cloudflare, Name.com — veröffentlicht eine Zahl, die von Agenten initiierte Registrierungen von menschlichen trennt. Überprüfbar ist die Infrastruktur: welche Plattformen einen von Agenten aufrufbaren Registrierungspfad ausgeliefert haben (Namefi, Cloudflare in der Beta, Name.com über Positionierung) und wann. Ein Agenten zurechenbares Adoptionsvolumen ist zum Zeitpunkt dieses Beitrags keine öffentliche Datenquelle.
+
+### Ist die 91%-Statistik von Name.com eine verlässliche Branchenzahl?
+
+Behandle sie als vom Unternehmen berichtete Stimmung, nicht als unabhängige Umfrage. Der Beitrag von Name.com aus July 2025 schreibt die Zahl „unserer jüngsten Kundenumfrage“ zu, ohne Methodik, Stichprobengröße oder externen Prüfer zu veröffentlichen — ein Signal dafür, was die Kunden von Name.com dem Unternehmen mitgeteilt haben, keine zitierfähige marktweite Statistik.
+
+### Hat `.ai` wirklich eine Million Registrierungen erreicht, und wer hat dies bestätigt?
+
+Ja — unabhängig bestätigt. Die Regierung von Anguilla, die die `.ai`-[ccTLD](/de/glossary/cctld/) verwaltet, gab den Meilenstein direkt bekannt, und Domain Name Wire berichtete die Wachstumszahlen mit einem konkreten Datum (January 28, 2026). CircleID und eine Branchenanalyse von Hogan Lovells zitieren denselben Meilenstein jeweils unabhängig — eine andere Belegschwelle als bei einer vom Unternehmen selbst berichteten Statistik.
+
+### Was ist DNSid, und verändert es die Registrierung von Domains?
+
+DNSid ist ein Internet-Draft — ein formeller Vorschlag, kein ratifizierter Standard —, den Innovation Labs von Identity Digital im June 2026 bei der IETF eingereicht hat. Er schlägt DNS-Einträge als dauerhaften, überprüfbaren Eintrag „wer ist für diesen KI-Agenten verantwortlich?“ vor. Das ist ein anderes Problem als die Registrierung selbst: Es geht um die Identifizierung des Agenten, nicht um den Kauf einer Domain. Zum Zeitpunkt dieses Beitrags ist DNSid in keinen Live-Registrar-Checkout integriert.
+
+### Hat ein Registrar tatsächlich ein Ausgabenlimit oder eine „Lass den Agenten nicht zu viel ausgeben“-Kontrolle ausgeliefert?
+
+Nicht auf API-Ebene, soweit wir durch direkte Prüfung der Dokumentation jeder Plattform überprüfen konnten. Namefi, Cloudflare und Name.com überlassen diese Leitplanke alle der Richtlinie, die ein Mensch clientseitig festlegt — dem MCP-Client, dem Agenten-Framework, dem Finanzierungslimit des API-Keys — statt einer Bestätigungsschranke, die der Registrar selbst erzwingt. Es ist die eine Zeile, die jede „agent-native“ Scorecard in diesem Bereich, einschließlich unserer, weiterhin als unvollständig markiert.
+
+### Wo kann ich die Mechanik eines einzelnen Agentenkaufs statt der branchenweiten Perspektive nachlesen?
+
+[Wie KI-Agenten Domains ohne Menschen kaufen](/de/blog/agents-buy-domains/) führt Schritt für Schritt durch die Abfolge Suche–Preis–Authentifizierung–Registrierung–Konfiguration. [Cloudflare vs. Name.com vs. Namefi](/de/blog/cf-namecom-namefi/) vergleicht die drei Plattformen Funktion für Funktion, und [Was ist ein agent-nativer Domain-Registrar?](/de/blog/agent-native/) beschreibt die Checkliste hinter der Tabelle dieses Beitrags zu ausgeliefert gegenüber angekündigt.
+
+## Mit einem Agenten registrieren, der bereits den gesamten Stack ausliefert
+
+Die meisten Lücken, die dieser Beitrag dokumentiert — undokumentierte Ausgabenlimits, Beta-Labels, Positionierungsbeiträge ohne detaillierte Spezifikation — sind nicht einzigartig für eine Plattform. Sie beschreiben, wo die Kategorie Mitte 2026 steht. [Namefi](https://namefi.io) liefert, was heute ausgeliefert ist: einen MCP-Server, mit dem sich dein Agent direkt verbindet, eine über `llms.txt` auffindbare REST API und einen per Wallet-Signatur autorisierten [x402](/de/glossary/x402/)-Checkout in USDC ganz ohne Konto, dazu [tokenisierte](/de/glossary/tokenized-domain/) Eigentümerschaft, falls die Domain in der Wallet eines Agenten liegen soll.
+
+**[Eine Domain bei Namefi suchen und registrieren](https://namefi.io).**
+
+## Quellen und weiterführende Lektüre
+
+- Domain Name Wire — [.AI-Namespace erreicht 1 Million Domainnamen (January 28, 2026)](https://domainnamewire.com/2026/01/28/ai-namespace-hits-1-million-domain-names/)
+- CircleID — [Das Domain-Universum 2026: KI, Sicherheit, Marktreife und die New-gTLD-Grenze (April 20, 2026)](https://circleid.com/posts/the-domain-universe-in-2026-ai-security-market-maturity-and-the-new-gtld-frontier#:~:text=AI%20agents%20are%20increasingly%20acting%20as%20domain%20resellers%20checking%20availability%2C%20registering%20names%2C%20and%20configuring%20DNS%20without%20human%20intervention)
+- CircleID — [DNIB meldet 392.5 Million Domain-Registrierungen in Q1 2026](https://circleid.com/posts/dnib-reports-392.5-million-domain-name-registrations-in-q1-2026#:~:text=The%20first%20quarter%20of%202026%20closed%20with%20392.5%20million%20domain%20name%20registrations%20across%20all%20top-level%20domains%20%28TLDs%29)
+- Verisign / DNIB.com — [Domain Name Industry Brief](https://www.dnib.com)
+- Cloudflare — [Ankündigung der Registrar API Beta (April 15, 2026)](https://blog.cloudflare.com/registrar-api-beta/)
+- webhosting.today — [KI-Agenten können jetzt Domains registrieren, kein Mensch erforderlich](https://webhosting.today/2026/04/22/ai-agents-can-now-register-domains-no-human-required/#:~:text=On%20April%2015%2C%202026%2C%20Cloudflare%20moved%20that%20transaction%20into%20the%20agent%20layer)
+- Name.com — [Die erste KI-native Domain-Plattform (July 10, 2025)](https://www.name.com/blog/the-first-ai-native-domain-platform#:~:text=a%20remarkable%2091%25%20of%20respondents%20envision%20AI%20agents%20handling%20at%20least%20some%20of%20their%20domain%20management%20in%20the%20next%20two%20years)
+- Identity Digital — [Identity Digital startet neutralen DNS-verankerten Identitätsstandard für KI-Agenten (April 27, 2026)](https://www.globenewswire.com/news-release/2026/04/27/3281553/0/en/identity-digital-launches-neutral-dns-anchored-identity-standard-for-ai-agents.html)
+- Identity Digital / GlobeNewswire — [Innovation Labs von Identity Digital reicht DNS-verankerten Vorschlag für eine dauerhafte KI-Agentenidentität bei der IETF ein (June 4, 2026)](https://www.globenewswire.com/news-release/2026/06/04/3306702/0/en/innovation-labs-by-identity-digital-submits-dns-anchored-durable-identity-proposal-for-ai-agents-to-the-ietf.html#:~:text=Which%20accountable%20entity%20is%20responsible%20for%20this%20agent%2C%20and%20can%20that%20be%20verified%20independently%20across%20systems)
+- IETF Datatracker — [draft-ihsanullah-dnsid: DNS-verankerte dauerhafte Identität für KI-Agenten](https://datatracker.ietf.org/doc/draft-ihsanullah-dnsid/)
+- llmstxt.org — [Der /llms.txt-Dateivorschlag (veröffentlicht September 3, 2024)](https://llmstxt.org/#:~:text=A%20proposal%20to%20standardise%20on%20using%20an%20/llms.txt%20file%20to%20provide%20information%20to%20help%20LLMs%20use%20a%20website%20at%20inference%20time)
+- Anthropic — [Einführung des Model Context Protocol (November 25, 2024)](https://www.anthropic.com/news/model-context-protocol)
+- Wikipedia — [Extensible Provisioning Protocol (Proposed Standard, March 2004)](https://en.wikipedia.org/wiki/Extensible_Provisioning_Protocol#:~:text=Proposed%20Standard%20documents%20%28RFCs%203730%20-%203734%29%20were%20published%20by%20the%20RFC%20Editor%20in%20March%202004)
+- Namefi — [namefi.io/llms.txt (Referenz für MCP-Server und REST API)](https://namefi.io/llms.txt)
+- Namefi — [namefi.io/web3/llms.txt (Referenz für x402-Checkout per Wallet-Signatur)](https://namefi.io/web3/llms.txt)

--- a/content/blog/de/vibe-coding-domain.md
+++ b/content/blog/de/vibe-coding-domain.md
@@ -1,0 +1,110 @@
+---
+title: "Vibe Coding braucht eine Domain: Registrieren, ohne den Flow zu verlassen"
+date: '2026-07-10'
+language: 'de'
+tags: ['ai-agents', 'domains', 'guide']
+authors: ['namefiteam']
+draft: false
+format: opinion
+ogImage: ../../assets/vibe-coding-domain-og.jpg
+description: "Vibe-Coding-Apps werden auf Subdomains von Plattformen bereitgestellt. Wie derselbe Agent, der Ihre App gebaut hat, sie benennen und die Domain registrieren kann, ohne den Flow zu unterbrechen."
+keywords: ["vibe coding domain", "vibe coding eigene domain", "domain aus cursor registrieren", "ki hat meine app gebaut jetzt brauche ich eine domain", "eigene domain für ki-generierte app", "vibe-coded app domainname", "plattform-subdomain", "domainregistrierung ohne editor zu verlassen", "coding-agent domainregistrierung", "namefi mcp vibe coding", "ki-agent registriert domain", "domainregistrierung im kontext", "eigene domain ki-app bereitstellen", "verfügbarkeitsbewusstes domain-brainstorming"]
+relatedArticles:
+  - /de/blog/mcp-quickstart/
+  - /de/blog/ai-agent-register/
+  - /de/blog/claude-mcp-domains/
+  - /de/blog/nl-domain-purchase/
+  - /de/blog/best-ai-tools-2026/
+relatedTopics:
+  - /de/topics/domain-tokenization/
+  - /de/topics/domain-basics/
+relatedSeries:
+  - /de/series/tokenize-your-com/
+  - /de/series/blockchain-concepts/
+relatedGlossary:
+  - /de/glossary/subdomain/
+  - /de/glossary/nameserver/
+  - /de/glossary/dns/
+  - /de/glossary/tld/
+  - /de/glossary/registrar/
+---
+
+Sie haben einen Prompt eingegeben, zugesehen, wie sich der Dateibaum füllt, und dreißig Sekunden später erschien eine Live-URL im Chat. Das ist der ganze Reiz von Vibe Coding: Die Lücke zwischen „Ich habe eine Idee“ und „da ist etwas Funktionierendes im Internet“ ist auf ungefähr die Dauer einer Kaffeepause geschrumpft. Nur endet die URL, die Sie ansehen, auf etwas wie `my-app-a3f9.vercel.app` oder `my-app.lovable.app` — einer Plattform-Subdomain, nicht einem Namen für Ihre Visitenkarte. Von dort zu einer Domain zu gelangen, die Ihnen tatsächlich gehört, ist der Punkt, an dem der Flow gewöhnlich bricht. Er muss es nicht.
+
+## Was „Vibe Coding“ tatsächlich bedeutet
+
+Falls Ihnen der Begriff noch nicht geläufig ist: [Wikipedia definiert Vibe Coding](https://en.wikipedia.org/wiki/Vibe_coding) als „eine durch künstliche Intelligenz (KI) unterstützte Praxis der Softwareentwicklung, bei der ein Entwickler ein Projekt oder eine Aufgabe in einem Prompt an ein großes Sprachmodell (LLM) beschreibt, das automatisch Quellcode erzeugt.“ Das definierende Merkmal ist nicht nur, dass KI den Code schreibt — viele ältere Tools taten das bereits mit Autovervollständigung —, sondern dass Sie das Ergebnis häufig annehmen und durch Beschreiben der nächsten Änderung in natürlicher Sprache iterieren, statt jede vom Modell erzeugte Zeile zu lesen. Der frühere Tesla-AI-Leiter und OpenAI-Mitgründer Andrej Karpathy prägte den Begriff im Februar 2025; er verbreitete sich schnell genug, dass Merriam-Webster ihn innerhalb eines Monats als Trend-Slang markierte und das Collins English Dictionary ihn später zum Wort des Jahres kürte.
+
+Das ist keine Kritik an der Praxis. Zu beschreiben, was Sie wollen, und eine laufende App zurückzubekommen, ist eine wirklich neue Art zu bauen. Die Tools darum herum — Cursor, Lovable, Replit, bolt.new, v0, Claude Code — sind gut genug geworden, dass ein funktionierender Prototyp nicht mehr der schwierige Teil ist. Schwierig ist, oder zumindest weiterhin wie 2015 aussieht, alles nach „es funktioniert“: ihm einen Namen zu geben und ihm eine echte Adresse zuzuweisen.
+
+## Die letzte Meile: von der Plattform-Subdomain zur eigenen Domain
+
+All diese Plattformen lösen dasselbe Problem auf dieselbe Weise: erst bereitstellen, auf einer [Subdomain](/de/glossary/subdomain/) der eigenen Plattform-Domain veröffentlichen und die eigene Domain als späteren, optionalen Schritt in einem Einstellungsbereich konfigurieren. Das ist der richtige Standard — Sie sollten keine Domain besitzen müssen, bevor Sie sehen können, ob Ihre Idee überhaupt funktioniert —, doch es macht die Plattform-Subdomain zu einem Zwischenstopp, nicht zum Ziel. Sie lässt sich langsamer aussprechen, bleibt nicht im Gedächtnis und signalisiert jedem Blick auf die Adressleiste: „Ich nutze noch die kostenlose Stufe eines fremden Tools.“
+
+Die echte Domain zu registrieren ist absolut gesehen eine kleine Aufgabe — eine Namenssuche, ein Kauf, ein paar DNS-Einträge —, aber es ist der eine Schritt in der gesamten Vibe-Coding-Schleife, der traditionell an einem völlig anderen Ort geschieht.
+
+## Warum das Verlassen des Editors den Flow unterbricht
+
+Hier liegt die eigentliche Reibung, und nicht darin, dass eine Domainregistrierung schwierig wäre. Sondern darin, dass sie *woanders* stattfindet. Um eine Domain auf herkömmliche Weise zu registrieren, unterbrechen Sie das Gespräch mit Ihrem Coding-Agenten, öffnen einen Browser-Tab, landen auf der Startseite eines [Registrars](/de/glossary/registrar/), suchen einen Namen, bekommen drei Upsells für Datenschutz, E-Mail-Hosting und einen Website-Builder gezeigt, den Sie nicht brauchen, müssen herausfinden, welches Kontrollkästchen abzuwählen ist, bezahlen und dann — diesen Teil lassen allgemeine Domainleitfäden aus — bestimmen, welchen [DNS](/de/glossary/dns/)-Eintrag Ihre konkrete Hosting-Plattform benötigt, den Wert in einem anderen Dashboard suchen und ihn in einen dritten Tab einfügen.
+
+Das ist keine Aufgabe, sondern fünf, verteilt auf drei verschiedene Produkte, von denen keines weiß, was Sie gerade gebaut haben oder auf welcher Plattform Sie es bereitgestellt haben. Jeder Kontextwechsel kostet wirklich etwas: Sie verlieren den Faden Ihrer Arbeit, und es besteht eine reale Chance, dass Sie eine Stunde später zurückkommen, weil Sie in einem der anderen Tabs abgelenkt wurden. Für eine Fünf-Minuten-Aufgabe ist das viel Overhead.
+
+## Registrieren, ohne den Chat zu verlassen
+
+Die Lösung besteht darin, die Domain genauso zu behandeln wie das Deployment: als weiteren Tool-Aufruf im selben Gespräch, nicht als separaten Botengang. Der Agent, der Ihre App aufgebaut und das Deployment gepusht hat, kennt bereits den Kontext — den Namen der App und die Plattform, auf der sie läuft — und ist deshalb das richtige Tool, um auch einen Namen zu prüfen, ihn zu registrieren und DNS zu verbinden.
+
+Auf das Wesentliche verdichtet, besteht der Ablauf aus drei Schritten:
+
+1. **Bitten Sie den Agenten, den Namen zu prüfen.** „Ist `myapp.com` verfügbar?“ ist ein schreibgeschützter Aufruf und funktioniert deshalb sogar, bevor Sie etwas mit Schreibzugriff verbunden haben.
+2. **Bestätigen und registrieren.** „Registriere sie für ein Jahr“ übermittelt die Bestellung; der Agent überwacht sie, bis sie abgeschlossen ist.
+3. **Auf Ihr Deployment zeigen lassen.** Geben Sie dem Agenten den Eintrag, den Ihre Hosting-Plattform verlangt (einen A-Eintrag für eine Apex-Domain, einen CNAME für eine Subdomain), und er schreibt ihn — oder er richtet die Delegierung auf [Nameserver](/de/glossary/nameserver/)-Ebene der Domain neu aus, wenn Sie DNS vollständig Ihrem Hoster überlassen.
+
+Das ist die Form des Ablaufs. Die exakte Mechanik — welche Konfigurationsdatei jeder Editor liest, die genauen DNS-Werte, die Vercel und Cloudflare Pages verlangen — ist bereits Schritt für Schritt im [Namefi MCP Quickstart: Claude Code, Cursor & Windsurf](/de/blog/mcp-quickstart/) beschrieben; dieser Beitrag wiederholt sie daher nicht. Wenn Sie in einem anderen als diesen drei Editoren programmieren — OpenAI Codex, Gemini CLI, Claude Desktop oder etwas anderem, das [MCP](https://modelcontextprotocol.io) spricht —, ist [Eine Domain mit Ihrem KI-Agenten bei Namefi registrieren](/de/blog/ai-agent-register/) der Knotenpunkt mit geprüfter Einrichtung für jeden davon sowie einem reinen REST-Weg für alles, was überhaupt nicht MCP-nativ ist.
+
+## Lassen Sie den Agenten auch Namen brainstormen
+
+Der Benennungsschritt verdient eine eigene Erwähnung, weil er gewöhnlich ebenso sehr die Schleife unterbricht wie der Checkout. Die traditionelle Version: Einen Namen ausdenken, zu einem Registrar wechseln, entdecken, dass er vergeben ist, einen anderen ausdenken, zurückwechseln, wiederholen, bis etwas hängen bleibt oder Sie aufgeben und eine Zahl ans Ende setzen.
+
+Die API von Namefi stellt eine Massenverfügbarkeitsprüfung bereit. Dieselbe Referenz unter [namefi.io/llms.txt](https://namefi.io/llms.txt#:~:text=or%20screen%20many%20names%20at%20once), die jeder Agent liest, beschreibt sie als Möglichkeit, „viele Namen gleichzeitig zu prüfen“. Anstatt Kandidaten nacheinander zu testen, können Sie Ihrem Agenten eine ganze Vorauswahl geben und in einem einzigen Roundtrip zurückerhalten, welche wirklich frei sind. In der Praxis wird die Namensfindung zu einem Prompt: „Die App ist ein Habit-Tracker namens Streaky — prüfe `streaky.com`, `streaky.app`, `getstreaky.com` und `streaky.io` und sage mir, was verfügbar ist.“ Der Agent führt den Batch aus, berichtet zurück, und Sie wählen aus Namen, die Sie tatsächlich haben können, statt sich in einen Namen zu verlieben, der schon registriert ist.
+
+## Ein ausgearbeitetes Beispiel: vom Prompt zur Live-URL
+
+Nehmen wir an, Sie haben einen Nachmittag lang per Vibe Coding ein kleines Tool gebaut — eine gemeinsame Einkaufslisten-App, weil Sie die bestehenden störten. Es ist auf einer Plattform-Subdomain live, es funktioniert, und ein paar Freunde wollen den Link. Hier ist der ganze Rest der Sitzung im selben Chatfenster:
+
+Sie fragen, ob `cartly.app` frei ist. Sie ist es. Sie sagen: „Registriere sie für ein Jahr und richte sie auf das Deployment, das wir gerade erstellt haben.“ Der Agent übermittelt die Registrierung, fragt ab, bis sie fertig ist, und fragt dann Ihre Hosting-Plattform (durch einen Blick in ihr Dashboard), welchen DNS-Eintrag sie für die gerade gekaufte Domain benötigt — in diesem Fall einen A-Eintrag, weil Sie eine Apex-Domain statt einer `www`-Subdomain verwenden. Sie fügen den Wert zurück ein, der Agent schreibt den Eintrag, und wenige Minuten später — DNS braucht etwas Zeit zur Propagation — löst `cartly.app` auf genau die App auf, die Ihre Freunde bereits in einem anderen Tab geöffnet haben. Gesamte Zeit außerhalb des Editors: null. Insgesamt geöffnete Tabs, die nicht ohnehin zum Bau der App gehörten: null.
+
+## Häufig gestellte Fragen
+
+### Muss ich DNS kennen, um das zu tun?
+
+Nicht mehr, als Sie wissen müssen, wie ein Datenbankindex funktioniert, um einen zu verwenden. Ihr Agent fragt die Hosting-Plattform, welchen Eintrag sie benötigt, und schreibt ihn; Sie bestätigen überwiegend Werte, statt sie selbst von Hand zusammenzusetzen.
+
+### Funktioniert das mit jeder Vibe-Coding-Plattform oder nur mit bestimmten?
+
+Die Registrierungs- und DNS-Seite ist plattformunabhängig — es sind eine Domain und ein DNS-Eintrag, die unabhängig davon gleich funktionieren, wodurch Ihre App gebaut wurde. Unterschiede gibt es beim Eintragstyp, den Ihre Hosting-Plattform verlangt; der [Namefi MCP Quickstart](/de/blog/mcp-quickstart/) behandelt das speziell für Vercel und Cloudflare Pages.
+
+### Wird die Domain, die ich so registriere, tokenisiert?
+
+Ja, standardmäßig. Namefi ist ein von ICANN akkreditierter Registrar und registriert die Domain zusätzlich zur Standardregistrierung auf Base als NFT für die an Ihren API-Schlüssel gebundene Wallet. Sie erhalten eine normale funktionierende Domain und einen On-Chain-Eigentumsnachweis, nicht das eine statt des anderen.
+
+### Was ist, wenn der exakte Name, den ich möchte, schon vergeben ist?
+
+Dafür ist die obige Massenverfügbarkeitsprüfung da: Geben Sie Ihrem Agenten mehrere Kandidaten ([TLD](/de/glossary/tld/)-Varianten, Präfixe, Synonyme), statt sie einzeln zu testen, und lassen Sie ihn berichten, was wirklich frei ist.
+
+### Brauche ich ein Namefi-Konto, bevor ich das ausprobiere?
+
+Nein. Die Verfügbarkeitsprüfung ist schreibgeschützt und benötigt keine Authentifizierung. Sie können die Verbindung also einrichten und einen Namen testen, bevor Sie einen API-Schlüssel erzeugen oder irgendetwas aufladen.
+
+## Den Namen mit dem Flow ausliefern, in dem Sie schon arbeiten
+
+Die Domain ist kein separates Projekt — sie ist dieselbe Art Infrastrukturentscheidung wie die Wahl einer Hosting-Plattform. Es gibt keinen guten Grund, warum sie der eine Teil beim Bereitstellen einer App sein sollte, der weiterhin einen Browser-Tab und ein Checkout-Formular verlangt. Wenn ein Agent Ihnen das nächste Mal eine funktionierende App auf einer Plattform-Subdomain zurückgibt, bleiben Sie im Gespräch und bitten ihn, einen Namen zu prüfen.
+
+**[Einen Namefi-API-Schlüssel erzeugen](https://namefi.io/api-key)** und es mit dem ausprobieren, was Sie gerade bauen, oder mit der vollständigen Anleitung im [Namefi MCP Quickstart: Claude Code, Cursor & Windsurf](/de/blog/mcp-quickstart/) beginnen.
+
+## Quellen und weiterführende Lektüre
+
+- Wikipedia — [Vibe Coding](https://en.wikipedia.org/wiki/Vibe_coding) (Definition, Prägung durch Andrej Karpathy im Februar 2025, zeitlicher Verlauf der Verbreitung)
+- Namefi — [namefi.io/llms.txt](https://namefi.io/llms.txt#:~:text=or%20screen%20many%20names%20at%20once) (Endpunkt für Massenverfügbarkeit, MCP-Server-URL, Referenz für Registrierung und DNS)
+- Namefi — [Namefi MCP Quickstart: Claude Code, Cursor & Windsurf](/de/blog/mcp-quickstart/) (Konfiguration je Editor, der vollständige Ablauf in fünf Schritten, DNS-Schritte für Vercel und Cloudflare Pages)
+- Namefi — [Eine Domain mit Ihrem KI-Agenten bei Namefi registrieren](/de/blog/ai-agent-register/) (Einrichtung für Codex, Gemini CLI, Claude Desktop und den direkten REST-Weg)
+- Model Context Protocol — [modelcontextprotocol.io](https://modelcontextprotocol.io) (Überblick über das Protokoll)

--- a/content/blog/de/wallet-checkout.md
+++ b/content/blog/de/wallet-checkout.md
@@ -1,0 +1,136 @@
+---
+title: "Domains mit einer Krypto-Wallet bezahlen: Kein Konto nötig"
+date: '2026-07-10'
+language: 'de'
+tags: ['ai-agents', 'payments']
+authors: ['namefiteam']
+draft: false
+format: explainer
+ogImage: ../../assets/wallet-checkout-og.jpg
+description: "Wie der per Wallet-Signatur autorisierte Checkout von Namefi einem KI-Agenten ermöglicht, eine Domain mit Krypto zu kaufen — ohne Konto: Ablauf, Sicherheitsmodell und Ausgabenrichtlinien."
+keywords: ["krypto-zahlung für domain", "wallet-checkout domain-registrierung", "domain mit krypto-wallet kaufen ohne konto", "domain mit usdc bezahlen", "ki-agent bezahlt domain mit krypto", "x402 domain-registrierung", "eip-3009 transferwithauthorization", "domain-registrar akzeptiert krypto", "checkout mit wallet-signatur", "namefi x402", "agentische zahlungen", "stablecoin-domainkauf", "domain-registrierung ohne konto", "eip-712 wallet-signatur"]
+relatedArticles:
+  - /de/blog/ai-agent-register/
+  - /de/blog/claude-mcp-domains/
+  - /de/blog/cf-namecom-namefi/
+  - /de/blog/namefi-mcp/
+  - /de/blog/agent-own-domain/
+relatedTopics:
+  - /de/topics/domain-tokenization/
+  - /de/topics/web3-foundations/
+relatedSeries:
+  - /de/series/blockchain-concepts/
+  - /de/series/tokenize-your-com/
+relatedGlossary:
+  - /de/glossary/x402/
+  - /de/glossary/wallet/
+  - /de/glossary/stablecoin/
+  - /de/glossary/private-key/
+  - /de/glossary/tokenized-domain/
+---
+
+Jeder andere Beitrag über „ein KI-Agent kann eine Domain für dich kaufen“ stößt irgendwann auf dieselbe Hürde: Wie bezahlt der Agent tatsächlich? Eine Kreditkarte setzt voraus, dass ein Mensch anwesend ist, Ziffern in ein Formular eingibt, eine Betrugsprüfung besteht und einen einmaligen, an ein Telefon gesendeten Code bestätigt. Ein [KI-Agent](/de/glossary/ai-agent/) kann nichts davon. Die Antwort von Namefi ist ein Checkout-Weg, der keine Karte, keine gespeicherte Zahlungsmethode und überhaupt kein Namefi-Konto braucht — nur eine Krypto-[Wallet](/de/glossary/wallet/), die eine Zahlung im Moment der Transaktion signiert. Dieser Beitrag erklärt ausführlich, wie dieser Ablauf tatsächlich funktioniert, was das Signaturverfahren einem Agenten erlaubt und was nicht, und wann stattdessen Abrechnung über einen API-Key sinnvoll ist.
+
+## Warum die Zahlung der schwierigste Teil des agentischen Handels ist
+
+Suche und Preisabfrage waren nie der schwierige Teil, wenn ein Agent Dinge kaufen soll. Das sind schreibgeschützte Aufrufe — keine Autorisierung nötig, und nichts steht auf dem Spiel, falls ein Agent sich irrt. Bei der Zahlung ist es anders, denn sie ist der eine Schritt, bei dem ein Fehler echtes Geld kostet; jedes heute weit verbreitete Zahlungssystem setzt voraus, dass eine Person die Belastung autorisiert.
+
+Eine gespeicherte Karte ist das deutlichste Beispiel. Die Abrechnung per hinterlegter Karte funktioniert, indem man einem Zahlungsabwickler ein Token übergibt, das später auf Veranlassung des Händlers erneut belastet werden kann, ohne dass der Karteninhaber im Moment der Belastung erneut etwas nachweisen muss. Für ein Abonnement, dem du vertraust und das dich monatlich abrechnet, ist das in Ordnung. Für einen autonomen Prozess passt es schlechter: Wer diesen Token der gespeicherten Karte besitzt, kann ihn belasten. Die einzige echte Verteidigung besteht darin, darauf zu vertrauen, dass die Software ihn nicht missbraucht, oder den Missbrauch später auf dem Kontoauszug zu entdecken. Es gibt keine Möglichkeit, einem Agenten eine gespeicherte Karte zu geben, die nur Domain-Registrierungen bis zu $50 bezahlt — die Karte weiß nicht, wofür sie eingesetzt wird.
+
+[Was ist ein agent-nativer Domain-Registrar?](/de/blog/agent-native/) erläutert, warum Zahlung zu den tragenden Elementen der Nutzbarkeit durch einen Agenten gehört und nicht nur eine API vorhanden sein muss. Der Krypto-Wallet-Checkout von Namefi ist die konkrete Antwort auf diese Anforderung: Statt einer gespeicherten Zugangsinformation, die ein Dienst jederzeit belasten kann, ist jede Zahlung eine Signatur, die die Wallet für genau diese Transaktion, zu genau diesem Preis und für nichts anderes erstellt.
+
+## Die Antwort von Namefi: Checkout per Wallet-Signatur, ohne Kontoerstellung
+
+Die Registrierung einer Domain auf Namefi verwendet normalerweise einen über einen aufgeladenen NFSC- (Namefi Service Credit-)Saldo abgerechneten [API-Key](https://namefi.io/api-key), wie in [Wie du mit deinem KI-Agenten eine Domain bei Namefi registrierst](/de/blog/ai-agent-register/) beschrieben. Dieser Weg erfordert ein Konto: Jemand erzeugt aus einer Wallet einen Key, lädt einen Saldo auf und der Key wird bei jeder Registrierung dagegen abgerechnet.
+
+Der Weg per Wallet-Signatur überspringt all das. Laut der von Namefi veröffentlichten maschinenlesbaren Dokumentation für Wallet-Zahlungen kann die Wallet eines Agenten direkt in [USDC](/de/glossary/stablecoin/) zahlen, ohne dass irgendwo ein Namefi-Konto oder API-Key vorliegt. Die Wallet des Käufers signiert eine Zahlungsautorisierung, und die Registrierung wird abgewickelt, sobald diese Signatur eintrifft. Es muss nichts im Voraus angelegt werden, und es gibt keine dauerhafte Berechtigung, die später missbraucht werden könnte: Die Wallet handelt nur in dem Moment, in dem sie signiert.
+
+Namefi dokumentiert drei Wege, wie eine Wallet diese Signatur erzeugen kann, die unten Schritt für Schritt behandelt werden: das [x402](/de/glossary/x402/)-Protokoll (der primäre Weg und der Fokus dieses Leitfadens), eine Challenge-Response-Variante des Machine Payable Protocol (MPP) sowie einen manuellen EIP-712-Signaturweg für Wallets, die keine der beiden Abkürzungen verwenden.
+
+## Der x402-Ablauf Schritt für Schritt
+
+x402 ist ein offener Standard, der von Unternehmen wie Cloudflare, AWS und Stripe unterstützt wird. Er belebt den lange ungenutzten HTTP-Statuscode `402 Payment Required` als strukturierte Möglichkeit wieder, im Rahmen einer normalen Anfrage nach einer On-Chain-Zahlung zu fragen, statt auf eine separate Checkout-Seite weiterzuleiten. Namefi implementiert ihn auf seinem Endpoint für die Domain-Registrierung:
+
+1. **Anfrage ohne Zahlung.** Der Agent sendet eine einfache `GET`-Anfrage an den Endpoint `/x402/domain/{domainName}` von Namefi — ohne beigefügte Zahlung, denn er kennt den Preis noch nicht.
+2. **HTTP 402 mit Preis.** Namefi antwortet mit `402 Payment Required` und nimmt die Zahlungsoptionen in den Response-Body auf: Netzwerk, akzeptierter Vermögenswert (USDC) und Betrag. Das unterscheidet x402 von einem normalen Fehler: Der Status 402 trägt alles, was der Client zum Konstruieren einer gültigen Zahlung benötigt, statt nur „nein“ zu sagen.
+3. **Die Wallet signiert ein EIP-3009 `transferWithAuthorization`.** Statt eine separate Blockchain-Transaktion zu senden und auf ihre Bestätigung zu warten, erzeugt die Wallet eine Signatur gemäß [EIP-3009](https://eips.ethereum.org/EIPS/eip-3009), einem Ethereum-Standard speziell für per Signatur autorisierte Token-Transfers. Die Funktion `transferWithAuthorization` von EIP-3009 erlaubt einem Token-Inhaber, eine Nachricht zu signieren, die einen Transfer eines bestimmten Betrags an einen bestimmten Empfänger autorisiert, nur innerhalb eines bestimmten Zeitfensters gültig (`validAfter` / `validBefore`), die ein Dritter dann On-Chain einreichen kann. Die Dokumentation von Namefi stellt ausdrücklich klar, dass dieser Schritt weder ein Namefi-Konto noch vorheriges EIP-712-Signieren benötigt — die Wallet signiert schlicht eine eigenständige USDC-Transferautorisierung.
+4. **Die Anfrage mit einem Payment-Header wiederholen.** Der Agent sendet die ursprüngliche Anfrage erneut, diesmal mit einem `X-PAYMENT`-Header, der die signierte Autorisierung trägt.
+5. **Überprüfen, abwickeln, registrieren.** Namefi überprüft die Signatur, startet den Ablauf der Domain-Registrierung und wickelt die Zahlung ab — USDC bewegt sich aus der Wallet des Käufers und die Registrierung läuft wie über den API-Key-Weg weiter, einschließlich der Registrierung der Domain als [NFT](https://eips.ethereum.org/EIPS/eip-721) — einer [tokenisierten Domain](/de/glossary/tokenized-domain/) — standardmäßig für dieselbe zahlende Wallet.
+
+Nichts an dieser Abfolge erfordert, dass der Agent ein Namefi-Konto erstellt, eine Zugangsinformation speichert, die Namefi ohne weitere Nachfrage wiederverwenden könnte, oder die Verwahrung der Mittel vor dem genauen Zeitpunkt der Zahlung aufgibt. Die Signatur beweist nur, dass die Wallet diesen konkreten USDC-Transfer, für diesen Betrag und innerhalb eines begrenzten Zeitfensters autorisiert hat.
+
+## Die MPP-Challenge-Response-Variante
+
+x402 ist der primäre Weg, doch Namefi dokumentiert auch einen zweiten für Wallets oder Agenten-Frameworks, die ein anderes Zahlungsmuster sprechen: das Machine Payable Protocol (MPP). Strukturell ist es das Spiegelbild von x402 — eine Challenge-Response statt einer bloßen 402:
+
+1. Die erste Anfrage an den geschützten Endpoint gibt erneut `402 Payment Required` zurück, diesmal jedoch mit einer **signierten Challenge** statt eines einfachen Preisangebots.
+2. Der Client (typischerweise über das speziell für den Signaturschritt entwickelte Kommandozeilentool `mppx` von Namefi) signiert diese Challenge mit der zahlenden Wallet.
+3. Der Client wiederholt die ursprüngliche Anfrage mit der resultierenden Signatur in einem `Authorization`-Header.
+
+Der Nettoeffekt ist derselbe wie bei x402 — eine von der Wallet signierte Zahlung pro Anfrage ohne gespeicherte Zugangsinformation —, verpackt als signierter Challenge-Handshake statt als bloße Preis-in-402-Antwort. Welchen der beiden Wege ein Agent nutzt, hängt davon ab, welche Zahlungstools er bereits spricht; der Endpoint von Namefi versteht beide.
+
+## Der manuelle EIP-712-Weg
+
+Für Wallets oder Skripte, die keine der beiden Abkürzungen verwenden, stellt Namefi einen niedrigeren, vollständig manuellen Signaturweg bereit, der auf [EIP-712](https://eips.ethereum.org/EIPS/eip-712)-Signieren typisierter Daten aufbaut, demselben Standard, auf dem EIP-3009 selbst aufbaut. Eine so signierte Anfrage trägt drei Header — `x-namefi-signer` (die Adresse der signierenden Wallet), `x-namefi-signature` (die hex-codierte Signatur) und `x-namefi-eip712-type` (gegen welches Schema typisierter Daten die Signatur erstellt wurde) — und verpackt ihren Payload in einen Umschlag mit `payloadType`, dem `payload` selbst, einem `timestamp` und einem `nonce`.
+
+Zwei Details sind für die Sicherheit wichtig: **Signaturen laufen nach 300 seconds ab, und Nonces sind nur einmal verwendbar.** Eine aus dem Netzwerkverkehr abgefangene Signatur oder eine später wiederholte Anfrage funktioniert nicht — sie ist bereits abgelaufen oder ihr Nonce wurde schon verbraucht. Die Dokumentation von Namefi gibt außerdem an, dass die aktuellen EIP-712-Typdefinitionen zur Anfragezeit von den Endpoints `/v-next/eip712/` abgerufen und nicht von einer Integration fest verdrahtet werden müssen, da sich das exakte Schema, dem eine Signatur entsprechen muss, ändern kann.
+
+Namefi dokumentiert auch die Signatur durch Smart-Contract-Wallets auf diesem Weg: Ein genehmigtes externes Konto (EOA) kann gemäß ERC-1271 oder dem neueren EIP-7702 im Namen einer Contract-Wallet signieren, sofern der Contract eine Prüfung `approvedSigners(address)` implementiert, gegen die die API verifizieren kann.<!-- TODO: confirm — how commonly this smart-contract-wallet path is used in practice versus a standard EOA wallet -->
+
+## Das Sicherheitsmodell: Was der Agent kann und nicht kann
+
+Es lohnt sich, genau zu benennen, was dieses Signaturverfahren tatsächlich beschränkt, statt eine stärkere Garantie zu beschreiben, als der Mechanismus liefert.
+
+**Was es beschränkt.** Jede Zahlung — über alle drei oben beschriebenen Varianten — ist eine frische Signatur, die an eine konkrete Transaktion gebunden ist: an einen bestimmten Betrag, an die von Namefi festgelegte Adresse, nur innerhalb eines kurzen Zeitfensters gültig und (im EIP-712-Weg) durch einen nur einmal nutzbaren Nonce verbraucht, der nicht wiederholt werden kann. Die Wallet erteilt Namefi niemals eine dauerhafte Berechtigung, künftige Belastungen selbst auszulösen. Vergleiche das mit einer gespeicherten Karte: Sobald ein Händler deinen Kartentoken besitzt, begrenzt nichts am Token selbst, was er im nächsten Monat belastet oder ob ein kompromittiertes System ihn wiederverwendet. In keinem dieser Abläufe verlässt der private Schlüssel der Wallet die Wallet — der Agent bittet sie, eine Signatur für eine konkrete Anfrage zu erzeugen; das ist der gesamte Umfang des Vorgangs.
+
+**Was es allein nicht beschränkt.** Die Dokumentation von Namefi beschreibt keine eingebaute, pro Transaktion in Dollar festgelegte Ausgabenobergrenze, die vom Protokoll selbst erzwungen wird. Die Sicherheit kommt hier von Ablauf der Signatur und nur einmal verwendbaren Nonces, nicht von einer Obergrenze dafür, wie viel eine einzelne signierte Anfrage autorisieren kann.<!-- TODO: confirm with team — whether Namefi's x402/MPP endpoint enforces any server-side maximum payment amount independent of what the client requests to sign --> In der Praxis kommt die tatsächliche Ausgabendisziplin für einen Agenten von außerhalb dieses Mechanismus: davon, wie viel USDC du in die Wallet einzahlst, und von jeder Richtlinienschicht — etwa einer [Multi-Sig](/de/glossary/multi-sig/)-Wallet, die eine zweite Genehmigung verlangt, oder einem Schritt der menschlichen Bestätigung, bevor der Agent überhaupt signieren darf —, die du zwischen den Agenten und den [privaten Schlüssel](/de/glossary/private-key/) der Wallet setzt. [Was ist ein agent-nativer Domain-Registrar?](/de/blog/agent-native/) und [Wie du mit deinem KI-Agenten eine Domain bei Namefi registrierst](/de/blog/ai-agent-register/) behandeln denselben Punkt aus Sicht der Leitplanken: Fülle die Wallet nur mit dem Betrag, dessen Ausgabe durch einen unbeaufsichtigten Prozess für dich akzeptabel ist, und entscheide im Voraus, wann ein Mensch zustimmen muss.
+
+Diese Kombination — keine dauerhafte Zugangsinformation, eine begrenzte Autorisierung pro Transaktion und die Finanzierung als praktische Ausgabengrenze — schafft ein tatsächlich anderes Risikoprofil als eine hinterlegte Karte, nicht nur eine krypto-gefärbte Variante desselben. Eine geleakte Kartennummer oder ein kompromittiertes Abrechnungs-Token kann wiederholt belastet werden, bis es jemand bemerkt und sperrt. Eine abgefangene x402-Signatur, die bereits 300 seconds alt ist oder deren Nonce schon ausgegeben wurde, ist in dem Moment wertlos, in dem sie abgefangen wird.
+
+## Wann stattdessen API-Key- oder NFSC-Abrechnung verwendet werden sollte
+
+Der Weg per Wallet-Signatur ist das richtige Werkzeug, wenn der Kernpunkt ist, dass vor dem Kauf kein Konto bestehen soll — ein vollständig autonomes Skript, ein Agent, der im Auftrag einer anderen Person ohne gemeinsam genutzte Login-Daten arbeitet, oder die Präferenz, eine Krypto-native Wallet als einzige beteiligte Identität zu behalten. Er ist nicht automatisch für jede Situation das richtige Werkzeug.
+
+Die Abrechnung über einen API-Key gegen einen aufgeladenen NFSC-Saldo, wie in [Wie du mit deinem KI-Agenten eine Domain bei Namefi registrierst](/de/blog/ai-agent-register/) beschrieben, ist sinnvoller, wenn ein Agent wiederholt Domains registriert und ein dauerhafter, überprüfbarer Saldo besser ist als jedes Mal eine neue Zahlung zu signieren; wenn der Betreiber eine einzelne Dashboard-Ansicht der Ausgaben möchte, statt sie aus On-Chain-Transfers zu rekonstruieren; oder wenn der Client bereits eine saubere Möglichkeit hat, einen Header-Wert zu speichern, aber keine einfache Möglichkeit, einen privaten Schlüssel zu halten und damit zu signieren. Beide Wege führen nach der Zahlungsabwicklung zu denselben Registrierungs- und DNS-Vorgängen — die Wahl betrifft die Art der Autorisierung, nicht was du danach registrieren oder verwalten kannst.
+
+## Häufig gestellte Fragen
+
+### Brauche ich ein Namefi-Konto, um mit einer Krypto-Wallet zu bezahlen?
+
+Nein. Sowohl der x402- als auch der MPP-Ablauf wickeln eine Domain-Registrierung aus einer signierten Wallet-Zahlung ab, ohne dass zuvor ein Namefi-Konto oder API-Key erstellt wird. Ein API-Key ist nur für den Abrechnungsweg über den NFSC-Saldo erforderlich.
+
+### Welche Kryptowährung akzeptiert Namefi für den Wallet-Checkout?
+
+USDC. Der x402-Endpoint von Namefi gibt den Preis an und wickelt die Zahlung spezifisch in USDC ab. Dadurch werden die Preisschwankungen vermieden, die ein volatiler Vermögenswert wie ETH zwischen Preisstellung und Zahlungsabwicklung verursachen würde.
+
+### Ist das Signieren einer Wallet-Zahlung dasselbe wie dem Agenten meinen privaten Schlüssel zu geben?
+
+Nein — eine Signatur wird von der Wallet erzeugt, ohne dass der private Schlüssel selbst jemals offengelegt wird. Der Agent (oder die von ihm aufgerufenen Tools) bittet die Wallet, eine konkrete, begrenzte Autorisierung zu signieren; der Schlüssel bleibt die ganze Zeit in der Wallet.
+
+### Kann jemand eine Zahlungs-Signatur wiederverwenden, die ich früher erstellt habe?
+
+Nicht über den manuellen EIP-712-Weg, bei dem Signaturen nach 300 seconds ablaufen und jeder Nonce nur einmal verwendet werden kann. Die EIP-3009-Autorisierung des x402-Ablaufs ist ähnlich durch ihr `validAfter`/`validBefore`-Fenster begrenzt. Eine abgefangene Signatur hat damit eine kurze, endliche Lebensdauer, statt wie ein gespeichertes Karten-Token unbegrenzt fortzubestehen.
+
+### Wird die Domain beim Bezahlen auf diese Weise automatisch tokenisiert?
+
+Ja, standardmäßig — die registrierte Domain wird als NFT für dieselbe Wallet geprägt, die bezahlt hat. Das entspricht demselben Tokenisierungsverhalten wie beim API-Key-Weg, sofern keine andere empfangende Wallet angegeben wird. [Cloudflare vs. Name.com vs. Namefi: Agent-native Registrare](/de/blog/cf-namecom-namefi/) zeigt, wie sich dies von Registraren unterscheidet, die weder Wallet-nativen Checkout noch tokenisierte Eigentümerschaft anbieten.
+
+### Ist Wallet-Checkout sicherer als die Zahlung mit einer gespeicherten Karte?
+
+Er beschränkt andere Risiken, statt Risiken insgesamt zu beseitigen. Es gibt keine dauerhafte Zugangsinformation, die ein kompromittiertes System unbegrenzt wiederverwenden kann, und jede Zahlung ist eine frische, zeitlich begrenzte, nur einmal verwendbare Signatur. Das Protokoll selbst begrenzt jedoch nicht, wie viel eine einzelne signierte Anfrage autorisieren kann. Die praktische Obergrenze dessen, was ein Agent ausgeben kann, ergibt sich daher weiterhin aus dem Betrag, mit dem du die Wallet finanzierst, und aus zusätzlichen Genehmigungsrichtlinien (etwa einer Multi-Sig), die du davor schaltest.
+
+## Eine Domain mit einer Wallet bei Namefi kaufen
+
+Wenn der Sinn der Nutzung eines Agenten darin liegt, dass kein menschliches Konto zwischen Agent und Kauf stehen soll, ist der Checkout von Namefi per Wallet-Signatur genau dafür gebaut: eine echte, ICANN-akkreditierte Domain-Registrierung, bezahlt mit einer einzigen signierten USDC-Autorisierung, wobei die tokenisierte Eigentümerschaft in derselben Wallet landet, die bezahlt hat. Die vollständige Mechanik steht in [namefi.io/web3/llms.txt](https://namefi.io/web3/llms.txt), oder beginne mit der umfassenderen Einrichtung in [Wie du mit deinem KI-Agenten eine Domain bei Namefi registrierst](/de/blog/ai-agent-register/).
+
+**[Eine Domain bei Namefi suchen und registrieren](https://namefi.io).**
+
+## Quellen und weiterführende Lektüre
+
+- Namefi — [namefi.io/web3/llms.txt](https://namefi.io/web3/llms.txt) (Primärquelle für den x402-Ablauf, die MPP-Challenge-Response-Variante, den manuellen EIP-712-Signaturweg, Regeln zu Ablauf/Nonce und die Signatur durch Smart-Contract-Wallets nach ERC-1271/EIP-7702)
+- Namefi — [namefi.io/llms.txt](https://namefi.io/llms.txt) (NFSC-/API-Key-Abrechnungsweg und Verweis auf die obige Referenz für Wallet-Zahlungen)
+- x402.org — [x402: Ein Internet-nativer Zahlungsstandard](https://x402.org) (das offene, auf HTTP 402 beruhende Zahlungsprotokoll, das der Ablauf von Namefi implementiert)
+- Ethereum — [EIP-3009: Transfer With Authorization](https://eips.ethereum.org/EIPS/eip-3009) (der Signaturstandard hinter dem Schritt `transferWithAuthorization`; zeitliche Begrenzung über `validAfter`/`validBefore`, nur einmal verwendbare zufällige Nonces)
+- Ethereum — [EIP-721: Non-Fungible Token Standard](https://eips.ethereum.org/EIPS/eip-721) (der NFT-Standard, auf dem tokenisierte Domain-Eigentümerschaft beruht)
+- Namefi — [Wie du mit deinem KI-Agenten eine Domain bei Namefi registrierst](/de/blog/ai-agent-register/) (der Abrechnungsweg über API-Key/NFSC und weitergehende Leitplanken)
+- Namefi — [Cloudflare vs. Name.com vs. Namefi: Agent-native Registrare](/de/blog/cf-namecom-namefi/) (wie sich Wallet-nativer Checkout bei den drei agentengerichteten Registraren vergleicht)

--- a/content/blog/de/why-a-dao-should-control-the-main-domain.md
+++ b/content/blog/de/why-a-dao-should-control-the-main-domain.md
@@ -1,0 +1,141 @@
+---
+title: 'Warum eine DAO die Hauptdomain kontrollieren sollte'
+date: '2026-06-23'
+language: de
+tags: ['governance', 'dao', 'web3', 'namefi space']
+authors: ['namefiteam']
+draft: false
+format: opinion
+description: "Jedes Land und jede Bewegung erreicht irgendwann einen Moment der Verfassungskrise — wer legitim ist, wer Autorität besitzt, wer im Zentrum der Bühne spricht. Für eine Onlinebewegung konzentriert sich diese Frage auf ein Asset: die Hauptdomain. Darum sollte sie der DAO gehören."
+ogImage: ../../assets/why-a-dao-should-control-the-main-domain-og.jpg
+keywords: ['dao-governance', 'hauptdomain', 'verfassungskrise', 'wer spricht für die dao', 'ens dao', 'aave labs', 'wikipedia-governance', 'ethereum classic', 'bitcoin.org', 'tokenisierte domains', 'digitale souveränität', 'markenkontrolle', 'dezentrale governance', 'domaineigentum', 'namefi']
+relatedArticles:
+  - /de/blog/from-mona-co-to-crypto-com/
+  - /de/blog/from-bufferapp-com-to-buffer-com/
+  - /de/blog/from-del-icio-us-to-delicious-com/
+  - /de/blog/from-discordapp-com-to-discord-com/
+  - /de/blog/from-ctrip-com-to-trip-com/
+relatedTopics:
+  - /de/topics/domain-investing/
+  - /de/topics/domain-basics/
+relatedSeries:
+  - /de/series/name-change-game-change/
+  - /de/series/domain-apocalypse/
+relatedGlossary:
+  - /de/glossary/registrar/
+  - /de/glossary/icann/
+  - /de/glossary/dns/
+  - /de/glossary/web3/
+  - /de/glossary/tld/
+---
+
+Vom Namefi-Team — Juni 2026
+
+Meistens fragt niemand, wer das Sagen hat. Die Arbeit wird erledigt, die Website bleibt online, Abstimmungen gehen durch, und die Frage nach der letzten Autorität bleibt höflich ungeprüft. Dann bricht etwas — eine umstrittene Entscheidung, ein Streit um Geld, eine Spaltung — und plötzlich zählt nur noch die Frage, die niemand laut beantworten wollte: *Wer spricht tatsächlich für dieses Gebilde?*
+
+Das ist ein Moment der Verfassungskrise. Und für jede Onlinebewegung wird er fast nie vor einem Gericht oder in einer Satzung entschieden. Sondern in einem Domainnamen.
+
+## Der Moment der Verfassungskrise
+
+Eine Verfassung ist das Dokument, das bei ruhigem Wetter niemand lesen muss. Sie können ein Land, ein Unternehmen oder eine Gemeinschaft jahrelang führen, ohne dass jemand darin nachschlägt. Ihre Aufgabe ist es, dort zu liegen, langweilig und unbeachtet, bis die normalen Regeln eines Tages nicht mehr reichen — eine umstrittene Wahl, eine angefochtene Nachfolge, ein Anführer, der nicht zurücktritt — und alle zugleich danach greifen, um eine einzige Frage zu beantworten: Wenn wir uns darüber streiten, wer entscheidet, wer entscheidet dann?
+
+Bei der Krise geht es nie wirklich um den unmittelbaren Streit. Es geht um *Legitimität* — wer Autorität hat, wer anerkannt wird, wer im Zentrum der Bühne stehen und sagen darf: „Ich spreche für uns“, während alle anderen es akzeptieren. Staaten beantworten das mit Verfassungen, Gerichten und Wahlen. Die Antwort ist selten sauber, aber der Mechanismus existiert.
+
+Bewegungen, die keine Staaten sind, haben einen solchen Mechanismus nicht standardmäßig. Sie improvisieren ihn — und die Improvisation scheitert meist im denkbar schlechtesten Moment.
+
+![Ein abgenutztes verfassungsähnliches Dokument liegt geschlossen auf einem Podium in der Mitte einer leeren Bühne; ein einzelner Scheinwerfer markiert den Ort, an dem Legitimität beansprucht wird](../../assets/why-a-dao-should-control-the-main-domain-01-crisis-moment.jpg)
+
+## Auch Nichtstaaten haben Verfassungskrisen
+
+Sie brauchen weder Flagge noch Grenze, um eine Nachfolgekrise zu haben. Es reichen genügend Menschen, genügend Wert und ein Moment, in dem zwei Parteien jeweils glauben, die legitime Stimme zu sein.
+
+Wikipedia — eine freiwillig erstellte Enzyklopädie, also ungefähr so weit von einem Nationalstaat entfernt, wie eine Institution nur sein kann — hatte mehrere davon. Die erste kam früh. Im Februar 2002 ging die spanischsprachige Community, angetrieben von der [wahrgenommenen Erwartung, dass Wikipedia bald Werbung hosten werde](https://en.wikipedia.org/wiki/Enciclopedia_Libre_Universal_en_Espa%C3%B1ol#:~:text=soon%20start%20hosting%20advertisements), einfach. [Unter der Führung von Edgar Enyedy verließ sie Wikipedia am 26. Februar 2002 und gründete die neue Website](https://en.wikipedia.org/wiki/Enciclopedia_Libre_Universal_en_Espa%C3%B1ol#:~:text=Led%20by%20Edgar%20Enyedy) Enciclopedia Libre. Der Inhalt der Enzyklopädie war frei kopierbar; nicht kopierbar war die Frage, welches Projekt die *echte* spanische Wikipedia war.
+
+Ein Jahrzehnt später kehrte sich der Konflikt um — Community gegen Foundation. 2014 schuf die Wikimedia Foundation eine neue administrative Befugnis namens „superprotect“ und nutzte sie, um [gegen den Willen der Wikimedia-Community die Installation einer neuen Softwarefunktion in der deutschsprachigen Wikipedia zu erzwingen](https://en.wikipedia.org/wiki/Superprotect#:~:text=force%20the%20installation%20of%20a%20new%20software%20feature). [Dieser Konflikt war beispiellos](https://en.wikipedia.org/wiki/Superprotect#:~:text=This%20conflict%20was%20unprecedented): Zum ersten Mal setzte sich die Foundation, die die Server betrieb, mit technischer Gewalt über die Freiwilligen hinweg, die die Enzyklopädie schrieben. Die bleibende Lehre dieser Episode war, dass [die Wikimedia Foundation die Wikimedia-Community nicht mit technischen Funktionen kontrollieren konnte](https://en.wikipedia.org/wiki/Superprotect#:~:text=unable%20to%20control%20the%20Wikimedia%20community) — superprotect wurde schließlich entfernt.
+
+Dann kam 2019. Als das Trust-&-Safety-Team der Foundation einen etablierten Editor namens Fram aus der englischsprachigen Wikipedia sperrte, richtete sich der Einwand der Community nicht wirklich gegen Fram. Er betraf Zuständigkeit. Wie ein Administrator formulierte, [scheint eine Sperre aus en.wiki nur etwas zu sein, das ArbCom tun darf, nicht die WMF](https://en.wikipedia.org/wiki/Wikipedia:Fram#:~:text=something%20ArbCom%20gets%20to%20do%2C%20not%20WMF) — die klare Behauptung, dass die Foundation ihre Autorität über ein Gebiet ausgedehnt hatte, das die Community regierte. Der Streit beschäftigte das Projekt monatelang.
+
+Drei unterschiedliche Auseinandersetzungen, eine wiederkehrende Frage: Wenn die Menschen, die *die Infrastruktur betreiben*, und die Menschen, die *die Community sind*, darüber streiten, wer das letzte Wort hat — wer gewinnt? Das ist eine Verfassungskrise, mit Flagge oder ohne.
+
+![Eine geteilte redaktionelle Szene: auf der einen Seite ein Server-Stack der Foundation, auf der anderen eine Menge freiwilliger Mitwirkender; dazwischen schwebt ein umstrittenes Siegel](../../assets/why-a-dao-should-control-the-main-domain-02-wikipedia.jpg)
+
+## Auf der Domain landet die Krise
+
+Hier ist der Teil, den man leicht übersieht, bis man ihn erlebt hat: Eine DAO ist kein Gebäude, das Sie besetzen, und kein Marktplatz, auf dem Sie stehen können. Fast alles, was sie tut, geschieht online — die Vorschläge, die Debatte, die Abstimmungen, die Ankündigungen. Deshalb sind die Fragen, die tatsächlich über Macht entscheiden, nie territorial. Sie betreffen Kanäle: *Welcher Account ist der „offizielle“? Wo trifft sich die Community tatsächlich zur Diskussion? Wer kann sich anmelden und unter dem Namen des Projekts posten?* Wer diese drei Fragen zu seinen eigenen Gunsten beantwortet, **ist** das Projekt in der Praxis — unabhängig davon, was irgendeine Abstimmung gesagt hat.
+
+Und alle drei führen auf dasselbe zentrale Asset zurück: die Hauptdomain. Die `.com`, die `.org`, die `.eth`, die Menschen aus dem Gedächtnis eintippen, die Wallets auflösen und die Google an erster Stelle führt — sie ist das Zentrum der Bühne in konkreter Form. Wer sie kontrolliert, muss das Argument über Legitimität nicht *gewinnen*; diese Person wird standardmäßig als legitim *behandelt*, weil es die Adresse ist, der bereits alle vertrauen. Der Fork kann den besseren Anspruch haben, die größere Community, die ursprünglichen Mitwirkenden — und trotzdem verlieren, weil das Publikum weiter durch die Tür geht, die es schon kennt.
+
+Die Domain ist auch nicht bloß die Website. Sie ist die Wurzel von allem, was danach kommt. Die „offizielle“ E-Mail läuft darüber, und diese E-Mail setzt das Passwort für den X-Account, Discord, das Governance-Forum und die Mailingliste zurück. Wer die Domain kontrolliert, kontrolliert das Postfach; wer das Postfach kontrolliert, kontrolliert jeden offiziellen Kanal, der daran hängt. Deshalb greifen in einer Spaltung beide Seiten zuerst nach der Domain. Sie ist das eine Asset, bei dem weiche Fragen der Legitimität auf eine harte Frage der Zugriffskontrolle zusammenschrumpfen — wer hält das Login, wer kann die Nameserver ändern, wessen Signatur bewegt das Asset? Die Verfassung, nach der Sie tatsächlich handeln, ist die Person, die die Domain umleiten kann.
+
+Das macht aus einem schönen Prinzip auch eine harte Anforderung. Eine DAO, die ihre eigene Domain nicht halten kann, kann ihre eigenen Beschlüsse nicht *durchsetzen*. Governance kann über einen Kurswechsel abstimmen, einen Mitwirkenden entfernen oder sich von einem abtrünnigen Frontend distanzieren — doch wenn die Domain und die dadurch geschützten Accounts in den Händen anderer bleiben, ist diese Abstimmung eine Pressemitteilung, keine Anweisung. Die Durchsetzung liegt dort, wo die Domain liegt. Wenn das Wort der DAO endgültig sein soll, muss die DAO die Haustür halten.
+
+![Eine einzelne erleuchtete Tür im Zentrum eines öffentlichen Platzes, zu der eine Menge strömt; kleinere Seitentüren stehen dunkel und unbeachtet](../../assets/why-a-dao-should-control-the-main-domain-03-front-door.jpg)
+
+## Die Krypto-Version: Welches ist das echte?
+
+Krypto hat dieses Experiment offen und mit Geld daran durchgeführt.
+
+2016 führte Ethereum nach dem Diebstahl von Geldern aus „The DAO“ einen Hard Fork aus, um ihn rückgängig zu machen. Nicht alle stimmten zu. Die Chain spaltete sich, und [die veränderte Historie erhielt den Namen [Ethereum](/de/glossary/ethereum/) (ETH), die unveränderte den Namen Ethereum Classic (ETC)](https://en.wikipedia.org/wiki/Ethereum_Classic#:~:text=the%20altered%20history%20was%20named%20Ethereum). Der gesamte Anspruch der Classic-Seite war ein Legitimitätsanspruch — dass sie und nicht der größere Fork [die ursprüngliche, unveränderte Geschichte des Ethereum-Netzwerks bewahrt](https://en.wikipedia.org/wiki/Ethereum_Classic#:~:text=unaltered%20history%20of%20the%20Ethereum%20network). Beide Chains waren technisch real. Nur eine durfte in der Vorstellung der Welt den Namen „Ethereum“ behalten, und es war diejenige, auf die die Eingangstüren des Ökosystems — Börsen, Wallets, die Hauptwebsite — zeigten.
+
+Die mahnende Variante ist `bitcoin.org`, die kanonische Eingangstür, die ursprünglich zu Satoshis Zeit registriert wurde. Bis 2020 lag die tatsächliche Kontrolle bei einem einzigen pseudonymen Eigentümer, „Cobra“, der den langjährigen Betreuer der Website in einem einseitigen Eigentumsstreit entfernte. Die Schilderung des Betreuers war unverblümt: [Cobra hat mir den Zugriff entzogen und die Kontrolle über die Website und die zugehörigen Code-Repositories an sich gerissen](https://decrypt.co/33703/bitcoin-orgs-secret-owner-kicks-out-the-sites-maintainer#:~:text=seized%20control%20of%20the%20site). Eine anonyme Person, die die Schlüssel zur bekanntesten Adresse einer Bewegung hält und niemandem Rechenschaft ablegt. Das ist der Fehlermodus in Reinform: die wichtigste Domain im Raum, regiert von demjenigen, der zufällig den Account beim [Registrar](/de/glossary/registrar/) kontrolliert.
+
+![Zwei fast identische Ladenfronten nebeneinander, eine beleuchtet und belebt, die andere dunkel; ein einzelner Wegweiser zeigt nur auf die beleuchtete](../../assets/why-a-dao-should-control-the-main-domain-04-which-is-real.jpg)
+
+## Aaves Identitätskrise: Spricht „Labs“ für die DAO?
+
+Der klarste jüngere Fall ist Aave, und er ist fast zu treffend: Eine DAO streitet öffentlich darüber, dass sie — nicht das Unternehmen, das die Software baut — ihre eigene Hauptdomain und Marke kontrollieren sollte.
+
+Ende 2025 forderte ein Governance-Vorschlag Aave-Tokenhalter auf, die Marke des Protokolls, Benennungsrechte, Webdomains und Social-Accounts in die DAO zu überführen, nachdem ein Streit über ein Geschäft entstanden war, das Gebühren an Aave Labs statt an die DAO leitete. Beachten Sie, was zusammengebunden wurde — *Webdomains und Social-Accounts* — denn in der realen Welt reisen sie als ein Paket: Die Entität, die die Domain hält, hält die Schlüssel zu den Kanälen. Es ging um die Frage, wem die Eingangstür wirklich gehört. Wie der Vorschlag es formulierte, [sollten wir nicht fürchten müssen, dass der implizite Verwalter der Marke diese Marke jederzeit ohne Zustimmung der DAO zu seinem eigenen Vorteil nutzen könnte](https://www.dlnews.com/articles/defi/aave-dao-proposal-to-take-control-of-brand-from-aave-labs-gains-traction/#:~:text=implicit%20steward%20of%20the%20brand). Der entscheidende Ausdruck darin ist *impliziter Verwalter* — niemand hatte je dafür gestimmt, Labs zur Stimme von Aave zu machen; es war es einfach, weil es die Assets hielt.
+
+Und zu den Assets gehörte die Website. Die eigene Verteidigung von Labs machte die Kontrolle ausdrücklich: Sie argumentierte, dass sie den neuen Einnahmestrom brauche, um die Kosten für den Betrieb der Website des Protokolls zu decken, [die sie kontrolliert](https://www.dlnews.com/articles/defi/aave-dao-proposal-to-take-control-of-brand-from-aave-labs-gains-traction/#:~:text=which%20it%20controls). Kommentatoren auf der Suche nach der richtigen Metapher landeten genau bei derjenigen, auf der dieser Artikel aufbaut: Die DAO ist der Motor, der Upgrades ausliefert und Einnahmen erzielt, während die [Marken-Assets als Ladenfront fungieren](https://www.coindesk.com/tech/2025/12/23/most-important-tokenholder-rights-debate-aave-faces-identity-crisis#:~:text=brand%20assets%20function%20as%20the%20storefront) — und sie nannten es [die heute wichtigste laufende Debatte über Tokenhalterrechte](https://www.coindesk.com/tech/2025/12/23/most-important-tokenholder-rights-debate-aave-faces-identity-crisis#:~:text=the%20most%20important%20live%20debate). Ein Multi-Milliarden-Dollar-Protokoll entdeckte mitten in einem Gebührenstreit, dass es nie geklärt hatte, wem seine eigene Eingangstür gehörte.
+
+![Ein redaktionelles Diagramm eines Protokolls: auf einer Seite ein beschrifteter Motorblock, der Wert erzeugt, auf der anderen eine getrennte helle Ladenfront; ein Tauziehen verbindet ein Firmenbüro mit einer Versammlung von Tokenhaltern](../../assets/why-a-dao-should-control-the-main-domain-05-aave.jpg)
+
+## Die Antwort von ENS: Festhalten, wer Autorität hat
+
+Aave zeigt, wie die Krise unangekündigt eintritt. ENS zeigt eine Bewegung, die versucht, die Frage *vor* der Krise zu beantworten — und genau darum geht es.
+
+ENS trennt die Rollen bereits sauber. [Die ENS DAO regiert das ENS-Protokoll und die Treasury](https://docs.ens.domains/dao#:~:text=governs%20the%20ENS%20protocol%20and%20treasury), während [ENS Labs eine gemeinnützige Organisation ist, die für die Kernsoftwareentwicklung von ENS verantwortlich ist](https://basics.ensdao.org/ens-labs#:~:text=responsible%20for%20the%20core%20software%20development%20of%20ENS). Labs baut; die DAO regiert. Doch ein Temp Check zur „nächsten Ära“ der ENS-Governance aus 2024 ging weiter und versuchte, die Autoritätskarte ausdrücklich festzuschreiben. In der vorgeschlagenen Struktur [bleiben Protokollkontrollen wie Smart-Contract-Upgrades, ENS-Preise und Gebührenstrukturen, Root-Key- und Registry-Kontrolle sowie Verfassungsänderungen ausschließlich bei Tokenhaltern](https://discuss.ens.domains/t/temp-check-next-era-of-ens-dao-empowering-the-ens-foundation/22175#:~:text=remain%20exclusively%20with%20tokenholders), während eine in einer Satzung verankerte Foundation — nicht das operative Unternehmen — die Marken und Marken-Assets hält und [sie an Labs lizenziert](https://discuss.ens.domains/t/temp-check-next-era-of-ens-dao-empowering-the-ens-foundation/22175#:~:text=licenses%20them%20to%20Labs).
+
+Lesen Sie das genau. Das in einer Krise am stärksten umkämpfte Asset — die Marke, der Name, die Identität, um die alle kämpfen — wird einer satzungsmäßigen Körperschaft zugeordnet, die den Tokenhaltern verantwortlich ist, und nur *lizenziert* an das Unternehmen, das die tägliche Arbeit erledigt. So entscheidet eine Bewegung bei ruhigem Wetter, wer im Zentrum der Bühne steht, damit niemand es unter Beschuss improvisieren muss.
+
+![Eine gebundene Satzung liegt geöffnet auf einem Tisch; darauf zeigt ein klares Organigramm eine Tokenhalterversammlung, eine Foundation mit Markensiegel und darunter ein lizenziertes Arbeitsteam](../../assets/why-a-dao-should-control-the-main-domain-06-ens.jpg)
+
+## Warum speziell die DAO?
+
+Angenommen, *jemand* sollte die Hauptdomain absichtlich und nicht zufällig halten — warum die DAO und nicht der Gründer, das Labs-Unternehmen oder ein vertrauenswürdiges Multisig aus Insidern?
+
+Weil die DAO die einzige Kandidatin ist, deren Autorität zugleich ausdrücklich, überprüfbar und überlebensfähig ist.
+
+- **Ausdrücklich.** Eine Tokenhalter-Abstimmung ist das Nächste, was eine dezentrale Bewegung zu einer geschriebenen Verfassung plus einer Wahl hat. Niemand ist der „implizite Verwalter“. Autorität ist ein dokumentiertes Ergebnis, kein geerbter Standard.
+- **Überprüfbar.** Wer das Asset bewegen kann und unter welchem Schwellenwert, ist [On-Chain](/de/glossary/on-chain/) sichtbar. Sie müssen nicht darauf vertrauen, dass die richtigen Personen das Registrar-Passwort halten — Sie können die Regel lesen.
+- **Überlebensfähig.** Gründer gehen, ändern ihre Meinung oder erweisen sich, wie `bitcoin.org` zeigte, als Pseudonym, das niemandem Rechenschaft ablegt. Unternehmen entwickeln Interessen, die von denen ihrer Community abweichen, wie Aave erfahren hat. Die Legitimität einer DAO verschwindet nicht, wenn eine Person geht, weil sie nie in einer einzelnen Person wohnte.
+
+Wenn Sie die Hauptdomain irgendwo anders platzieren, haben Sie genau jenen einzelnen Vereinnahmungspunkt wieder eingeführt, den die Bewegung beseitigen sollte. Die Domain wird zum einen zentralisierten Asset, das eine dezentrale Erzählung stützt — bis zur Krise in Ordnung und während ihr entscheidend. Sie der DAO unterzuordnen bedeutet, dass die Antwort auf „Wer spricht im Zentrum der Bühne?“ von derselben Legitimitätsmaschine erzeugt wird, die alles andere regiert, statt von demjenigen, der das Login hält.
+
+Es gibt einen ehrlichen Einwand: Historisch konnte eine DAO eine `.com` schlicht *nicht* halten. Domains liegen bei Web2-Registraren hinter Benutzername, Passwort und Kreditkarte. Das Beste, was eine DAO tun konnte, war, einem Menschen — oder einem Labs-Unternehmen — zu vertrauen, sich in ihrem Namen einzuloggen. Genau diese Lücke schafft überhaupt erst den „impliziten Verwalter“.
+
+Tokenisierte Domains schließen sie. Wenn eine Domain ein On-Chain-Asset ist, können ein Governance-Contract oder ein von der DAO kontrolliertes Multisig sie halten und per Abstimmung übertragen, nach denselben Regeln und Schwellenwerten wie die Treasury. Die Eingangstür ist dann kein Passwort mehr im persönlichen Tresor von jemandem, sondern ein regierbares Asset unter der tatsächlichen Verfassung der Bewegung. Dieses Problem löst [Namefi](https://namefi.io): reale Domains On-Chain zu bringen, damit das Gremium, das das Protokoll regiert, auch seine Eingangstür nachweisbar halten kann.
+
+![Ein Domainname als On-Chain-Assetkarte in einem transparenten Multisig-Tresor, umgeben von Governance-Signaturen; gehalten von einer Versammlung statt von einer einzelnen Hand](../../assets/why-a-dao-should-control-the-main-domain-07-dao-vault.jpg)
+
+## Vor der Krise entscheiden
+
+An einer Verfassungskrise ist eines sicher: Sie ist ein schrecklicher Zeitpunkt, eine Verfassung zu schreiben. Alle kämpfen bereits, jede Entscheidung wirkt parteiisch, und wer das Asset hält, wenn die Musik aufhört, behält es meist.
+
+Entscheiden Sie also jetzt, während es ruhig und langweilig ist und niemand darum kämpft: Wer kontrolliert die Hauptdomain? Wenn die ehrliche Antwort „der Registrar-Account des Gründers“ oder „das Labs-Unternehmen, das zufällig die Website betreibt“ lautet, dann hat die Bewegung einen impliziten Verwalter und eine ungeschriebene Verfassung — und sie wird beides im schlimmstmöglichen Moment entdecken.
+
+Geben Sie die Eingangstür dem Gremium, das für die gesamte Bewegung sprechen soll. Machen Sie es ausdrücklich, machen Sie es überprüfbar, machen Sie es überlebensfähig für jede einzelne Person. Eine DAO, die ihre eigene Domain hält, kann ihre eigenen Entscheidungen durchsetzen; eine DAO, die das nicht kann, kann nur höflich bitten und hoffen, dass die Person mit dem Login zustimmt. Ordnen Sie die Hauptdomain der DAO unter, bevor Sie es müssen.
+
+## Quellen und weiterführende Lektüre
+
+- Wikipedia — [Enciclopedia Libre Universal en Español](https://en.wikipedia.org/wiki/Enciclopedia_Libre_Universal_en_Espa%C3%B1ol#:~:text=soon%20start%20hosting%20advertisements) (der spanische Wikipedia-Fork von 2002)
+- Wikipedia — [Superprotect](https://en.wikipedia.org/wiki/Superprotect#:~:text=This%20conflict%20was%20unprecedented) (die Übersteuerung der Community durch die Foundation 2014)
+- Wikipedia — [Wikipedia:Fram](https://en.wikipedia.org/wiki/Wikipedia:Fram#:~:text=something%20ArbCom%20gets%20to%20do%2C%20not%20WMF) (der Zuständigkeitsstreit „Framgate“ von 2019)
+- Wikipedia — [Ethereum Classic](https://en.wikipedia.org/wiki/Ethereum_Classic#:~:text=the%20altered%20history%20was%20named%20Ethereum) (die Spaltung von 2016: „Welche Chain ist das echte Ethereum?“)
+- Decrypt — [Der geheime Eigentümer von Bitcoin.org wirft den Betreuer der Website hinaus](https://decrypt.co/33703/bitcoin-orgs-secret-owner-kicks-out-the-sites-maintainer#:~:text=seized%20control%20of%20the%20site) (der Kontrollstreit um `bitcoin.org` 2020)
+- DLNews — [Aave-DAO-Vorschlag zur Übernahme der Markenkontrolle von Aave Labs gewinnt an Fahrt](https://www.dlnews.com/articles/defi/aave-dao-proposal-to-take-control-of-brand-from-aave-labs-gains-traction/#:~:text=implicit%20steward%20of%20the%20brand)
+- CoinDesk — [Die wichtigste Debatte über Tokenhalterrechte: Aave erlebt eine Identitätskrise](https://www.coindesk.com/tech/2025/12/23/most-important-tokenholder-rights-debate-aave-faces-identity-crisis#:~:text=brand%20assets%20function%20as%20the%20storefront)
+- Aave Governance Forum — [Temp Check: The Aave Interface Transparency Act](https://governance.aave.com/t/temp-check-the-aave-interface-transparency-act/23647)
+- ENS — [Temp Check: Nächste Ära der ENS DAO — Stärkung der ENS Foundation](https://discuss.ens.domains/t/temp-check-next-era-of-ens-dao-empowering-the-ens-foundation/22175#:~:text=remain%20exclusively%20with%20tokenholders)
+- ENS Docs — [Die ENS DAO](https://docs.ens.domains/dao#:~:text=governs%20the%20ENS%20protocol%20and%20treasury) · ENS DAO Basics — [ENS Labs](https://basics.ensdao.org/ens-labs#:~:text=responsible%20for%20the%20core%20software%20development%20of%20ENS)


### PR DESCRIPTION
## Summary

- add German translations for all 26 English blog articles previously missing from `content/blog/de`
- localize every internal link to `/de/` while preserving its source slug; external URLs, code, images, dates, and numeric values remain unchanged
- preserve each English article's related-content ordering and slugs

## Quality checks

- `TMPDIR=/private/tmp bun run data:validate` (passes; 29 pre-existing empty-keyword warnings outside this change)
- `bun run lint:mdx`
- `bun run check:termbase` (0 known-variant deviations)
- `bun .agents/skills/cross-link/link-audit.ts <26 target files>` (0 broken, 0 missing-locale, 0 locale-mismatch, 0 relationship-mismatch; 26 intentional runtime fallbacks only for untranslated German glossary entries)
- structural parity scan across all 26 articles: frontmatter language, internal-link locale, no copied English body, external URLs, number tokens, code fences, headings, table lines, and related metadata
- independent bilingual LQA on three samples (`agent-native`, `ai-tld-registrars`, `ai-agent-register`); all S0/S1 findings resolved and suggested German fluency fixes applied

## Notes

- This is content-only. It does not include a production deployment or native-speaker review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only localization with validated MDX/links; no auth, payments, or runtime behavior changes. Residual risk is editorial accuracy and untranslated glossary fallbacks noted in QA, not production defects.
> 
> **Overview**
> Adds **26 new German blog posts** under `content/blog/de/`, closing the gap where English articles had no `de` counterpart.
> 
> Each file mirrors its English sibling: same slug, `format`, dates, assets, code samples, and external links. **Frontmatter and body are translated** (`language: 'de'`, German titles, descriptions, and keywords). **Site-internal links are rewritten to `/de/`** paths (blog, glossary, topics, series) while keeping the same slug ordering in `relatedArticles` / `relatedTopics` / related metadata.
> 
> Topics covered span the existing AI-agent/domain content cluster (agent-native registrars, MCP registration guides, platform comparisons, `.ai` registrar roundups, ownership/UDRP explainers, etc.). No application or routing code changes—MDX content only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0edefd65284a48a21c5f3409d701903a756b669. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive collection of German-language guides and articles on AI agents, domain registration, DNS management, MCP, `llms.txt`, wallet-based checkout, and agent-native registrar platforms.
  - Added comparisons of domain providers, AI domain tools, `.ai` registrars, pricing models, and registration workflows.
  - Added educational blockchain content covering consensus, cryptography, privacy, scaling, and virtual machines.
  - Added articles on domain ownership, custody, tokenization, governance, and lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->