### PR TITLE
fix(content): correct ccTLD ranking and counts

### DIFF
--- a/content/blog/en/cctld-market-share-by-registration-volume.md
+++ b/content/blog/en/cctld-market-share-by-registration-volume.md
@@ -34,15 +34,15 @@ When most people picture the internet, they picture `.com`. And in raw numbers, 
 
 This post walks through which ccTLDs lead by registration volume, why the leaders are not who you would guess, and what those numbers reveal about how the internet is *actually used* in different parts of the world.
 
-## The leaders, roughly ordered
+## The leaders as of March 31, 2026
 
-Public registry data (from operators that publish counts, plus aggregator snapshots like [DNIB's Q1 2026 Domain Name Industry Brief](https://www.dnib.com/articles/the-domain-name-industry-brief-q1-2026#:~:text=The%20top%2010%20ccTLDs%2C%20as%20of%20March%2031%2C%202026%2C%20were%20.cn%2C%20.de%2C%20.uk%2C%20.ru%2C%20.nl%2C%20.br%2C%20.fr%2C%20.au%2C%20.in%20and%20.eu.) and [DENIC's .de statistics](https://www.denic.de/en/products/statistics-about-de/)) puts the top tier of ccTLDs in roughly this order:
+Public registry data (from operators that publish counts, plus aggregator snapshots like [DNIB's Q1 2026 Domain Name Industry Brief](https://www.dnib.com/articles/the-domain-name-industry-brief-q1-2026#:~:text=The%20top%2010%20ccTLDs%2C%20as%20of%20March%2031%2C%202026%2C%20were%20.cn%2C%20.de%2C%20.uk%2C%20.ru%2C%20.nl%2C%20.br%2C%20.fr%2C%20.au%2C%20.in%20and%20.eu.) and [DENIC's .de statistics](https://www.denic.de/en/products/statistics-about-de/)) puts the top tier of ccTLDs in this reported order as of March 31, 2026:
 
 - **.cn (China)** — somewhere in the range of 20 million names. Largest [ccTLD](/en/glossary/cctld/) on most days.
 - **.de (Germany)** — around 17 million. Run by DENIC; remarkably stable year over year.
 - **.uk (United Kingdom)** — around 10 million across `.uk` and `.co.uk` combined.
-- **.nl (Netherlands)** — about 6 million. Outsized for a country of 17 million people.
-- **.ru (Russia)** — around 5 million, plus several million on `.рф` (the Cyrillic IDN equivalent).
+- **.ru (Russia)** — about 6.1 million; the official .RU/.РФ Coordination Center reported 6,119,675 `.ru` registrations on April 7, 2026, plus a separate `.рф` Cyrillic IDN zone ([Coordination Center](https://cctld.ru/en/media/news/kc/39938/)).
+- **.nl (Netherlands)** — 6,063,462 registrations on April 1, 2026, according to registry operator SIDN. That is outsized for a country of roughly 18 million people ([SIDN](https://www.sidn.nl/en/news-and-blogs/nl-starts-2026-with-growth)).
 - **.br (Brazil)** and **.fr (France)** — each around the next large tier, with `.br` concentrated heavily under `.com.br`.
 - **.au (Australia)**, **.in (India)**, and **.eu (European Union)** — each in the next tier; `.eu` is technically a regional ccTLD rather than a single-country namespace.
 - **.it, .pl, .ca** — important national namespaces that sit just outside or near the current top-10 band depending on the reporting period and source.
@@ -110,6 +110,8 @@ The deeper point: ccTLD market share is a story about *trust signals* on the ope
 - Verisign — [Domain Name Industry Brief](https://www.verisign.com/en_US/domain-names/dnib/index.xhtml), the most cited quarterly snapshot of the TLD market.
 - DNIB — [Q1 2026 Domain Name Industry Brief](https://www.dnib.com/articles/the-domain-name-industry-brief-q1-2026#:~:text=The%20top%2010%20ccTLDs%2C%20as%20of%20March%2031%2C%202026%2C%20were%20.cn%2C%20.de%2C%20.uk%2C%20.ru%2C%20.nl%2C%20.br%2C%20.fr%2C%20.au%2C%20.in%20and%20.eu.), the current top-10 ccTLD ordering used above.
 - DENIC — [Statistics for .de](https://www.denic.de/en/know-how/statistics/), the German registry's public dashboard.
+- Coordination Center for TLD .RU/.РФ — [.RU registration count on April 7, 2026](https://cctld.ru/en/media/news/kc/39938/).
+- SIDN — [.nl registration count on April 1, 2026](https://www.sidn.nl/en/news-and-blogs/nl-starts-2026-with-growth).
 - Nominet — [Statistics for .uk](https://www.nominet.uk/news/reports-statistics/) and policy.
 - JPRS — [.jp registration eligibility](https://jprs.co.jp/en/jpdomain.html#:~:text=Any%20individual%2C%20group%20or%20organization%20having%20a%20permanent%20postal%20address%20in%20Japan%20is%20eligible%20for%20registration.).
 - Norid — [.no general requirements](https://teknisk.norid.no/en/administrere-domenenavn/generelle-krav/#:~:text=must%20have%20a%20mailing%20address%20in%20Norway).


### PR DESCRIPTION
## Summary

- correct the reported 2026 ordering of the largest ccTLDs
- replace the inverted `.nl` / `.ru` ranking with dated registry counts
- make the article's ranking snapshot explicit instead of presenting it as timeless

## Solution

- anchor the top-ten order to the March 31, 2026 Domain Name Industry Brief
- cite the .RU/.РФ Coordination Center's April 7 count and SIDN's April 1 `.nl` count
- update the sources section with the two registry-operator references

## Test plan

- `TMPDIR=/private/tmp/namefi-cctld-bun bun run data:validate`
- `TMPDIR=/private/tmp/namefi-cctld-bun bun run lint:mdx`
- `TMPDIR=/private/tmp/namefi-cctld-bun bun run check:termbase`
- `TMPDIR=/private/tmp/namefi-cctld-bun bun .agents/skills/cross-link/link-audit.ts content/blog/en/cctld-market-share-by-registration-volume.md`
- `git diff --check`
- pre-push hooks: data validation, full link audit, and MDX lint

## Agent session

- Codex session (redacted) at 2026-07-14T19:57:04Z

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial and citation updates only; no application code, auth, or data pipelines.
> 
> **Overview**
> Updates the **ccTLD market share** article so the leader list matches reported **Q1 2026** data instead of a vague, timeless ordering.
> 
> The section is retitled to **“The leaders as of March 31, 2026”**, and the intro now states the top tier follows DNIB’s reported order on that date. **`.ru` and `.nl` are reordered** (`.ru` before `.nl`) and both bullets get **dated registry counts**—Coordination Center for `.ru` (April 7, 2026) and SIDN for `.nl` (April 1, 2026)—replacing rough “around 5–6 million” figures. The **Sources** section adds links to those two operator publications.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac2da7c58369e24537609d5490d786bdbfb02ec5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->