### PR TITLE
fix(content): correct domain media publishing cadence

### DIFF
--- a/content/blog/en/domain-industry-media.md
+++ b/content/blog/en/domain-industry-media.md
@@ -64,7 +64,7 @@ These are reference works rather than publications, but no media stack is comple
 
 ### DNJournal — [dnjournal.com](https://www.dnjournal.com/)
 
-Edited by Ron Jackson since 2003. Publishes the **weekly Domain Sales Report** every Monday — the canonical record of reported sales for the prior week. Every "top sales of the year" list in the industry derives from DNJournal data. Also runs The Lowdown, a long-form interview column.
+Edited by Ron Jackson, with sales archives reaching back to 2003. The report was weekly for many years, but the [archive labels the 2021-2025 columns as bi-weekly](https://www.dnjournal.com/archive/domainsales-archive.htm), and current 2026 reports generally cover two-week periods. It is a long-running curated record of publicly reported sales, not a complete or audited ledger; DNJournal itself says private deals make a complete list impossible. The site also runs The Lowdown, a long-form interview column.
 
 ### NameBio — [namebio.com](https://namebio.com/)
 
@@ -99,9 +99,14 @@ A few things to keep in mind.
 
 ## Choosing a starting set
 
-If you want a single recommendation: **subscribe to DomainNameWire (RSS or newsletter), check DNJournal every Monday morning, and bookmark NameBio for lookups.** That gives you news, weekly sales context, and a searchable history — enough to follow the industry without needing to refresh ten sites a day.
+If you want a single recommendation: **subscribe to DomainNameWire (RSS or newsletter), check DNJournal when its next sales report lands, and bookmark NameBio for lookups.** That gives you news, recurring sales context, and a searchable history — enough to follow the industry without needing to refresh ten sites a day.
 
 Add DomainSherpa's archive when you want depth on a specific investor, and CircleID when policy issues start affecting your portfolio.
+
+## Sources and further reading
+
+- DNJournal — [Domain Sales Archive](https://www.dnjournal.com/archive/domainsales-archive.htm), including weekly and bi-weekly historical columns.
+- DNJournal — [Latest Domain Sales Report](https://www.dnjournal.com/domainsales.htm), including the report's date range and disclosure limits.
 
 ---
 

--- a/content/blog/en/famous-domainer-blogs-and-newsletters.md
+++ b/content/blog/en/famous-domainer-blogs-and-newsletters.md
@@ -72,7 +72,7 @@ Substack has not produced a dominant *domain-specific* publication yet — most 
 
 - **The DomainInvesting.com daily email** — same content as the blog, delivered to your inbox. The most reliable single feed in the industry.
 - **DomainNameWire newsletter** — see the companion post on [domain industry media](/en/blog/domain-industry-media) for context; the newsletter is the easiest way to follow [DomainNameWire](https://domainnamewire.com/) without checking the site.
-- **DNJournal's weekly sales report** — published every Monday since 2003 at [DNJournal](https://www.dnjournal.com/). Not a personal newsletter, but it is *the* canonical weekly digest of reported domain sales, edited by Ron Jackson. Every other "top sales" list in the industry derives from this one.
+- **DNJournal's recurring sales report** — edited by Ron Jackson, with archives reaching back to 2003. It ran weekly for many years, while the [2021-2025 archives are labeled bi-weekly](https://www.dnjournal.com/archive/domainsales-archive.htm) and current 2026 reports generally cover two-week periods. It is not a personal newsletter, but it remains a useful curated digest of publicly reported sales; it is neither a complete nor an audited ledger.
 - **DomainShane's recap posts** — Shane periodically does week-in-review pieces that are essentially newsletter-style summaries of the market.
 - **Saw.com blog** — [Saw.com](https://saw.com/blog) (the brokerage co-founded by Amanda Waltz and Jeff Gabriel) publishes thoughtful pieces on the brokerage side of the business. More polished than the average personal blog.
 
@@ -92,9 +92,14 @@ A few patterns are worth pointing out.
 
 ## Choosing a starting set
 
-If you want a single recommendation: **subscribe to DomainInvesting.com (daily), DNJournal (weekly), and follow Elliot, Morgan Linton, and one or two brokers on X.** That gives you the daily pulse, the weekly sales digest, and the live feed — without drowning.
+If you want a single recommendation: **subscribe to DomainInvesting.com (daily), follow DNJournal's recurring sales reports, and follow Elliot, Morgan Linton, and one or two brokers on X.** That gives you the daily pulse, periodic sales context, and the live feed — without drowning.
 
 You can add the rest of this list as you figure out which voices you trust.
+
+## Sources and further reading
+
+- DNJournal — [Domain Sales Archive](https://www.dnjournal.com/archive/domainsales-archive.htm), including weekly and bi-weekly historical columns.
+- DNJournal — [Latest Domain Sales Report](https://www.dnjournal.com/domainsales.htm), including the report's date range and disclosure limits.
 
 ---
 


### PR DESCRIPTION
## Summary

- correct DNJournal's historical and current publishing cadence in two English articles
- replace unsupported claims that its report is a complete, canonical ledger
- add direct archive and current-report sources

## Solution

The copy now distinguishes the historically weekly report from the bi-weekly 2021-2025 archive labels and the generally two-week 2026 reports. It also describes DNJournal as a curated record of publicly reported sales and preserves its own limitation that private deals make a complete list impossible.

## Test plan

- `TMPDIR=/private/tmp/namefi-domain-media-bun bun run data:validate`
- `TMPDIR=/private/tmp/namefi-domain-media-bun bun run lint:mdx`
- `TMPDIR=/private/tmp/namefi-domain-media-bun bun run check:termbase`
- `TMPDIR=/private/tmp/namefi-domain-media-bun bun .agents/skills/cross-link/link-audit.ts content/blog/en/domain-industry-media.md content/blog/en/famous-domainer-blogs-and-newsletters.md`
- `git diff --check`

## Agent session

Codex session: redacted (2026-07-14T20:29:01Z)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial-only English blog copy with no application, auth, or data-pipeline changes.
> 
> **Overview**
> Updates **DNJournal** coverage in `domain-industry-media.md` and `famous-domainer-blogs-and-newsletters.md` so cadence and data claims match the source site.
> 
> The copy no longer says the sales report is **weekly every Monday** or the **canonical** record all other top-sales lists derive from. It now describes a long weekly history, **bi-weekly** archive labeling for 2021–2025, and **~two-week** 2026 reports, and frames DNJournal as a **curated, publicly reported** sales digest—not a complete or audited ledger—with a nod to DNJournal’s own private-deal limitation.
> 
> **Choosing a starting set** recommendations shift from “check DNJournal every Monday” / “weekly” to checking when the **next report lands** and following **recurring** reports. Both posts gain a **Sources and further reading** section linking the domain sales archive and latest report pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cf661e83bf49f4e43a97fec6fd95dbaa3c52b68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->