### PR TITLE
fix(content): distinguish transfer from atomic settlement

### DIFF
--- a/content/blog/en/dns-on-tokenized-domains.md
+++ b/content/blog/en/dns-on-tokenized-domains.md
@@ -98,7 +98,7 @@ Most owners manage DNS records inside the Namefi dashboard after tokenization �
 ### Transferring the domain
 
 Before: [cross-registrar transfer](/en/glossary/cross-registrar-transfer/) flow, with [auth codes](/en/glossary/auth-code/) and 60-day cooldowns.
-After: [**transfer the NFT**](/en/glossary/atomic-transfer/). A single on-chain transaction moves ownership. The registrar-side record is kept in sync by the protocol. This is dramatically faster — and is why tokenized-domain marketplaces don't need traditional [escrow](/en/glossary/escrow/) (see [From Listing to Settlement](/en/blog/how-tokenized-marketplaces-replace-escrow/)).
+After: [**transfer the NFT**](/en/glossary/atomic-transfer/). A single on-chain transaction moves ownership, and the protocol keeps the registrar-side record in sync. When a marketplace sale contract atomically exchanges the buyer's payment for that NFT, payment and delivery settle together. That atomic sale—not an NFT transfer by itself—is why tokenized-domain marketplaces can avoid traditional [escrow](/en/glossary/escrow/) (see [From Listing to Settlement](/en/blog/how-tokenized-marketplaces-replace-escrow/)).
 
 You can still do a traditional registrar transfer if you want; the on-chain layer doesn't prevent that.
 


### PR DESCRIPTION
## Summary

- distinguish a plain tokenized-domain NFT transfer from an atomic marketplace sale
- explain that escrow can be avoided only when payment and NFT delivery settle together
- preserve the existing ownership-sync and traditional registrar-transfer guidance

## Test plan

- `TMPDIR=/private/tmp bun run data:validate`
- `TMPDIR=/private/tmp bun run lint:mdx`
- `TMPDIR=/private/tmp bun run check:termbase`
- `TMPDIR=/private/tmp bun .agents/skills/cross-link/link-audit.ts content/blog/en/dns-on-tokenized-domains.md`
- `git diff --check`

## Agent session

- Codex session: redacted
- Prepared: 2026-07-14 UTC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change in a blog post with no runtime, security, or data-handling impact.
> 
> **Overview**
> In **DNS Still Works** (`content/blog/en/dns-on-tokenized-domains.md`), the **Transferring the domain** section is tightened so readers don’t conflate a plain on-chain NFT transfer with a marketplace sale.
> 
> The post still says a single transaction moves ownership and the protocol keeps the registrar record in sync. It now adds that **escrow-free marketplaces** depend on a **sale contract** that atomically swaps the buyer’s payment for the NFT—payment and delivery settle together—and explicitly notes that **an NFT transfer alone** is not what replaces traditional escrow (still linked to the escrow article).
> 
> Guidance that you can still do a normal registrar transfer is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02ce4c2b0b390a64a23cfd0c1230fc5a57bf6365. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->