### PR TITLE
fix(content): qualify domain pricing psychology claims

### DIFF
--- a/content/blog/en/domain-pricing-psychology-buy-now-vs-make-offer.md
+++ b/content/blog/en/domain-pricing-psychology-buy-now-vs-make-offer.md
@@ -9,7 +9,7 @@ cluster: domain-investing
 series: domain-flipping-skills
 seriesOrder: 21
 format: guide
-description: "Why the listing mode and the first number decide your domain sale: anchoring, never naming the price first, price laddering, and buy-now vs make-offer."
+description: "How listing mode and initial numbers can influence a domain sale: anchoring, when to name a price, planned concessions, and buy-now vs make-offer."
 ogImage: ../../assets/domain-pricing-psychology-buy-now-vs-make-offer-og.jpg
 keywords: ['domain pricing psychology', 'buy now vs make offer', 'domain anchoring', 'how to price a domain', 'domain price negotiation', 'make offer domain', 'buy it now domain', 'price laddering domains', 'domain listing format', 'who names the price first', 'domain negotiation tactics', 'charm pricing domains', 'end user domain price', 'domain sale psychology']
 relatedArticles:
@@ -32,29 +32,29 @@ relatedGlossary:
   - /en/glossary/registry/
 ---
 
-The number on your listing is doing more work than you think. Two flippers can own the same name, list it on the same marketplace, and walk away with prices that differ by an order of magnitude — not because one negotiated harder, but because one understood that the *way* a price is presented shapes what a buyer will pay. Pricing a domain is part arithmetic, mostly psychology.
+The number on your listing is doing more work than you think. Comparable domains can produce very different outcomes because buyer need, timing, alternatives, distribution, and negotiation all vary; the *way* a price is presented can be one influence among those factors. Pricing a domain combines valuation evidence, market conditions, and psychology.
 
-This guide is the psychological layer underneath the mechanical choices in [how to sell domains for profit](/en/blog/how-to-sell-domains-for-profit/), the selling pillar of our [domain flipping](/en/blog/domain-flipping/) series. We'll cover what anchoring does to a negotiation, why naming the first number is a two-sided trap, how to ladder a price instead of folding, and how buy-now versus make-offer quietly decides the outcome before a single message is sent.
+This guide is the psychological layer underneath the mechanical choices in [how to sell domains for profit](/en/blog/how-to-sell-domains-for-profit/), the selling pillar of our [domain flipping](/en/blog/domain-flipping/) series. We'll cover how anchoring can affect a negotiation, why naming the first number involves tradeoffs, how to plan concessions, and how buy-now versus make-offer changes the sales process before a single message is sent.
 
-## Anchoring: the first number wins
+## Anchoring: why the first number can matter
 
 ![Editorial illustration of a heavy dropped anchor bending a negotiation line toward it while a small figure is pulled along](../../assets/domain-pricing-psychology-buy-now-vs-make-offer-01-anchoring.jpg)
 
-Start with the one cognitive bias that governs every price negotiation. The anchoring effect is, as Wikipedia defines it, [a psychological phenomenon in which an individual's judgments or decisions are influenced by a reference point or "anchor"](https://en.wikipedia.org/wiki/Anchoring_effect#:~:text=a%20psychological%20phenomenon%20in%20which%20an%20individual%27s%20judgments%20or%20decisions%20are%20influenced%20by%20a%20reference%20point), and that reference point can be almost arbitrary. Once a number is on the table, every figure that follows gets measured against it. The buyer who hears "$25,000" first will treat $12,000 as a win; the buyer who hears "$3,000" first will treat $4,500 as a stretch. Same name, same buyer, different anchor, different ceiling.
+Start with a cognitive bias that can influence price negotiation. The anchoring effect occurs when judgments are pulled toward an initial reference point. Once a number is on the table, later figures may be evaluated relative to it. As a purely illustrative example—not evidence about any specific domain buyer—a $25,000 opening and a $3,000 opening could frame the same later counteroffer very differently.
 
-This is not folklore. As the same article notes, [initial offers have a stronger influence on the outcome of negotiations than subsequent counteroffers](https://en.wikipedia.org/wiki/Anchoring_effect#:~:text=initial%20offers%20have%20a%20stronger%20influence%20on%20the%20outcome%20of%20negotiations%20than%20subsequent%20counteroffers). Whoever sets the anchor bends the conversation toward it. For a seller, that single finding explains most of the tactics below: a price isn't just information, it's the gravity well the negotiation falls into.
+Experimental negotiation research found an advantage to making the first offer in the studied settings, but also found that the effect disappeared when the other negotiator focused on inconsistent information such as the opponent's alternatives, reservation price, or their own target. ([Galinsky and Mussweiler, 2001](https://pubmed.ncbi.nlm.nih.gov/11642352/)) Other experiments found that overly extreme openings can increase impasse risk. ([Schweinsberg et al., 2012](https://www.sciencedirect.com/science/article/pii/S0022103111001880)) A price is therefore more than information, but a credible first number is neither guaranteed to win nor a substitute for valuation evidence.
 
 ## The first-number trap: naming your price
 
 So who should name the first number? The honest answer is that it cuts both ways, and that tension is the entire game.
 
-Name a price that's too low and you've anchored *against yourself*. You can't un-ring the bell: the buyer now knows your floor was below their budget, and no amount of "others are interested" walks it back. Plenty of flippers have quoted $1,500 on a name an [end user](/en/glossary/end-user/) would have happily paid $15,000 for, because they priced it like a fellow investor buying inventory in the [domain trading](/en/glossary/domain-trading/) market rather than a business buying a tool. That [reseller](/en/glossary/reseller/)-versus-end-user gap is the single most expensive thing to misjudge, and we break it down in [how to value a domain name](/en/blog/how-to-value-a-domain-name/) and [inbound vs outbound domain sales](/en/blog/inbound-vs-outbound-domain-sales/).
+Name a price that's too low and you may anchor *against yourself*. You can't un-ring the bell: the buyer now knows you were willing to open below their possible budget. For example, $1,500 versus $15,000 is a hypothetical illustration of the risk, not a documented domain sale. The underlying problem is pricing for a fellow investor buying inventory in the [domain trading](/en/glossary/domain-trading/) market when the actual prospect is an [end user](/en/glossary/end-user/) buying a business tool. That [reseller](/en/glossary/reseller/)-versus-end-user gap is important to estimate, and we break it down in [how to value a domain name](/en/blog/how-to-value-a-domain-name/) and [inbound vs outbound domain sales](/en/blog/inbound-vs-outbound-domain-sales/).
 
 Name a price that's too high for *this* buyer and you may scare off someone who would have made a real offer. The wrong anchor can end a conversation before it starts.
 
-There's a third option the pros lean on: don't name the number first. A simple "what range did you have in mind?" flips the dynamic so their figure becomes the reference point, and you negotiate up from it instead of down from your own. This is the leverage a broker sells: negotiating distance, so the buyer never learns how badly you want the sale. We cover when that's worth a commission in [working with domain brokers](/en/blog/working-with-domain-brokers/).
+There's a third option: ask the buyer to name a range first. A simple "what range did you have in mind?" can reveal information, but it also gives the buyer the first anchor and may produce a low opening. A broker can add negotiating distance and process discipline, although that does not guarantee a higher outcome. We cover when that may be worth a commission in [working with domain brokers](/en/blog/working-with-domain-brokers/).
 
-The catch is that "make them go first" only works when the buyer arrives with real intent. On a cold outbound email, silence reads as no price and no price reads as no deal. So when the buyer is inbound and motivated, let them anchor; when you're the one reaching out, put a credible number on the table to get a response at all.
+There is no universal rule that inbound buyers should always go first or outbound sellers should always quote. Before choosing, estimate your target and reservation price from comparable evidence, consider how much reliable information each side has, and decide whether learning the buyer's range is worth accepting their opening anchor. Cold outreach often benefits from a credible price or range because it reduces uncertainty, while some motivated inbound conversations justify asking for the buyer's budget first.
 
 ## Why sellers overprice: the endowment effect
 
@@ -72,17 +72,17 @@ The listing format is not a checkbox. It's a decision about which buyer you're h
 
 **[Make Offer](/en/glossary/make-offer/) (negotiation)** invites the buyer to reveal intent and lets you capture an end-user price you'd never have guessed. It's the right mode for a genuinely premium name with one or two obvious buyers, where the upside justifies the friction. The cost is real: make-offer attracts lowballers, stalls deals across days of messages, and demands that you actually negotiate.
 
-Here's the part most listicles miss: the mode itself anchors the buyer before you've said a word. A high buy-now price anchors high even for a buyer who intends to haggle down — they start from your number, not from zero. A bare "make offer" with no price anchors *low*, because the buyer's instinct is to test you with a fraction of what they'd actually pay. If you choose make-offer, consider a stated "minimum offer" or a high floor; the absence of any number is itself an anchor, and it usually works against you. For the venues where each format lives, see [where to sell domains: marketplaces compared](/en/blog/where-to-sell-domains-marketplaces-compared/), and for the step-by-step of a single sale, [how to sell a domain name you own](/en/blog/how-to-sell-a-domain-name-you-own/).
+The mode itself also sets expectations before you've exchanged messages. A buy-now price supplies an explicit reference point and a path to immediate purchase. A bare "make offer" listing supplies no seller number, so opening offers can vary widely; it does not mechanically anchor every buyer low. A stated minimum offer may filter unserious inquiries, but it can also deter buyers, so treat it as a marketplace setting to test rather than a universal fix. For the venues where each format lives, see [where to sell domains: marketplaces compared](/en/blog/where-to-sell-domains-marketplaces-compared/), and for the step-by-step of a single sale, [how to sell a domain name you own](/en/blog/how-to-sell-a-domain-name-you-own/).
 
-## Price laddering: never fold to the first counter
+## Planned concessions: avoid improvising under pressure
 
 ![Editorial illustration of a descending staircase of shrinking blocks stepping down toward a floor, with a dashed arrow tracing the smaller and smaller concessions](../../assets/domain-pricing-psychology-buy-now-vs-make-offer-03-laddering.jpg)
 
 When a make-offer negotiation opens, the rookie mistake is to swing straight to your real minimum the moment the buyer pushes back. That hands them the whole spread and teaches them that pressure works. Experienced sellers ladder instead, moving down in shrinking steps that signal the floor is near.
 
-A ladder might look like this. The buyer offers $2,000 on a name you've anchored at $12,000. You come down to $9,500, then $8,000, then settle at $7,000, each step smaller than the last, which says without your saying it that there isn't much room left. Drop from $12,000 straight to $6,500 in one move and you've told the buyer your "$12,000" was theater and the real number is lower still, so they'll keep digging.
+A hypothetical ladder might look like this: the buyer offers $2,000 on a name listed at $12,000; the seller counters at $9,500 and later $8,000 while protecting a pre-decided floor. Those figures are illustrative, not a recommended schedule or evidence that the deal will settle at $7,000. The useful practice is deciding your rationale, target, floor, and concession pattern before the exchange so a counteroffer does not force an improvised collapse.
 
-Two psychological levers ride on top of the ladder. A buyer who extracts a discount feels like they won, and that feeling is often what closes the deal. And patience reads as leverage: a reply that takes a day says "I have other interest and I'm not desperate." Fire back a discount within ninety seconds and you broadcast the opposite.
+Concessions can help a buyer feel that negotiation produced value, but cadence does not carry one reliable meaning. A delayed reply may be read as leverage, disinterest, or poor responsiveness; a quick reply may signal preparedness rather than desperation. Respond on a professional timeline and never imply competing interest that does not exist.
 
 ## Round numbers, charm pricing, and what a figure signals
 
@@ -94,11 +94,11 @@ For domains, the lesson is more nuanced than "always end in 9." The number's sha
 - An oddly precise figure ($24,750) can read as a calculated valuation or, on a cheaper name, a discount cue. Used well, precision implies you've done the math; used carelessly, it looks like a sale rack.
 - A very low, charm-priced number ($299, $499) signals a budget name and invites budget buyers. Fine for velocity, wrong for a name you believe an enterprise will want.
 
-The extension feeds in too: the same word on a [`.com`](/en/tld/com/) carries a different ceiling than on [`.io`](/en/tld/io/) or [`.co`](/en/tld/co/), so match the shape to the name and the buyer. A round premium price filters for end users; a charm price filters for bargain hunters and fellow resellers in the [marketplace](/en/glossary/marketplace/). A mismatch quietly repels the buyer you actually want.
+The extension feeds in too: the same word on a [`.com`](/en/tld/com/) can carry a different valuation range than on [`.io`](/en/tld/io/) or [`.co`](/en/tld/co/), so match the price to the name, evidence, and buyer. Research on left-digit effects comes largely from retail contexts and does not establish that round domain prices reliably attract end users or charm prices reliably attract resellers. Treat number shape as a hypothesis to test, not a buyer-class detector.
 
 ## Putting it together
 
-Pricing a domain is one decision made twice: once when you pick the listing mode, and once on every number you name inside it. Choose buy-now when speed and a clean ceiling beat the hunt for a perfect buyer; choose make-offer when a premium name's upside justifies the friction, and put a floor under it so no number doesn't anchor you down. Let inbound, motivated buyers name the first figure. Ladder your concessions so each step says "almost there." Shape the number to signal the buyer you want. And watch your own endowment effect like the liability it is.
+Pricing a domain is one decision made repeatedly: first when you pick the listing mode, then whenever you name or revise a number. Choose buy-now when speed and a clear ceiling fit the evidence; choose make-offer when uncertainty and possible upside justify the friction. Decide who should open based on information and leverage rather than a blanket inbound/outbound rule. Plan concessions around a defensible target and floor, test how listing settings affect real inquiries, and watch for ownership bias in your own valuation.
 
 The price is a message. Make sure it says what you mean. Once a deal closes, getting paid safely — [escrow](/en/glossary/escrow/), the [auth-code](/en/glossary/auth-code/) handoff, [DNS](/en/glossary/dns/) continuity — is its own discipline; tokenized rails like [Namefi](https://namefi.io) aim to make settlement less nerve-racking so more agreed deals finish. But the money only gets that far if the number on the listing did its job first.
 
@@ -110,6 +110,8 @@ The price is a message. Make sure it says what you mean. Once a deal closes, get
 
 ## Sources and further reading
 
-- Wikipedia — [Anchoring effect](https://en.wikipedia.org/wiki/Anchoring_effect#:~:text=a%20psychological%20phenomenon%20in%20which%20an%20individual%27s%20judgments%20or%20decisions%20are%20influenced%20by%20a%20reference%20point) (definition; initial offers outweigh later counteroffers)
+- Galinsky and Mussweiler — [First offers as anchors: The role of perspective-taking and negotiator focus](https://pubmed.ncbi.nlm.nih.gov/11642352/)
+- Schweinsberg et al. — [Starting high and ending with nothing: The role of anchors and power in negotiations](https://www.sciencedirect.com/science/article/pii/S0022103111001880)
 - Wikipedia — [Endowment effect](https://en.wikipedia.org/wiki/Endowment_effect#:~:text=people%20are%20more%20likely%20to%20retain%20an%20object%20they%20own) (ownership inflates perceived value)
 - Wikipedia — [Psychological pricing](https://en.wikipedia.org/wiki/Psychological_pricing#:~:text=based%20on%20the%20theory%20that%20certain%20prices%20have%20a%20psychological%20impact) (charm pricing, just-below prices, the left-digit effect)
+- Thomas and Morwitz — [Penny Wise and Pound Foolish: The Left-Digit Effect in Price Cognition](https://doi.org/10.1086/429600)


### PR DESCRIPTION
## Summary

- replace deterministic first-offer and anchoring advice with evidence-bounded guidance
- label numeric examples as hypothetical and make opening and concession strategy context-specific
- add primary negotiation and left-digit research while qualifying domain-specific inferences

## Test plan

- `TMPDIR=/private/tmp bun run data:validate`
- `TMPDIR=/private/tmp bun run lint:mdx`
- `TMPDIR=/private/tmp bun run check:termbase`
- `TMPDIR=/private/tmp bun .agents/skills/cross-link/link-audit.ts content/blog/en/domain-pricing-psychology-buy-now-vs-make-offer.md`
- `git diff --check origin/main...HEAD`

## Agent session

- Codex session: redacted
- UTC date: 2026-07-14

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial-only changes to one English blog MDX file; no application logic, auth, or data handling.
> 
> **Overview**
> Revises the **domain pricing psychology** guide so negotiation and listing advice is **evidence-bounded** instead of prescriptive.
> 
> **Anchoring and first offers** now cite negotiation research (limits on first-offer advantage, impasse risk from extreme openings) and frame dollar examples as **illustrative**, not outcomes. **Who names price first** drops blanket inbound/outbound rules in favor of target, reservation price, and information tradeoffs. **Buy-now vs make-offer** softens claims that listing mode mechanically anchors buyers and treats minimum-offer settings as something to **test**. The **price laddering** section is reframed as **planned concessions** with pre-decided floors and qualified guidance on reply timing and competing interest. **Charm/round pricing** for domains is presented as a **hypothesis**, with retail left-digit research cited but not over-applied. Front matter **description** and **sources** are updated accordingly (primary citations added).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aef7cdbcadda49b48ef7b8556838fb1a70a2d51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->