### PR TITLE
fix(content): distinguish Drop.com ask from sale price

### DIFF
--- a/content/blog/en/from-massdrop-com-to-drop-com.md
+++ b/content/blog/en/from-massdrop-com-to-drop-com.md
@@ -73,13 +73,13 @@ What Massdrop actually paid is not public. The domain went dark behind privacy p
 
 ## The money looked different then
 
-It is tempting to look at a six-figure (or more) domain purchase and call it an easy decision. Drop went on to ship its own keyboards and headphones, expand internationally, and eventually get [acquired by Corsair in July 2023](https://en.wikipedia.org/wiki/Drop_(company)#:~:text=Corsair%20announced%20it%20had%20acquired%20Drop). Against an exit to a public hardware company, an $800,000-ish domain looks small.
+It is tempting to look at a one-word `.com` acquisition in hindsight and call it an easy decision. Drop went on to ship its own keyboards and headphones, expand internationally, and eventually get [acquired by Corsair in July 2023](https://en.wikipedia.org/wiki/Drop_(company)#:~:text=Corsair%20announced%20it%20had%20acquired%20Drop). But the actual Drop.com purchase price was never disclosed, so the earlier $800,000 asking price cannot be treated as the amount Massdrop paid.
 
 But it should be judged at the moment it was spent, not from the far end of the story.
 
-In 2017 and 2018, Drop was still Massdrop — a venture-backed community-commerce company that lived and died on margins, logistics, and inventory bets on its own first products. A near-million-dollar line item for a *domain name* — not engineering, not inventory, not a keyboard mold — is the kind of spend a CFO questions hard. It only makes sense if you treat the domain as infrastructure for a rename you've already decided is coming.
+In 2017 and 2018, Drop was still Massdrop — a venture-backed community-commerce company that lived and died on margins, logistics, and inventory bets on its own first products. Without a disclosed sale price, we cannot know how large the domain line item was. We can say that negotiating for a one-word `.com` publicly offered at $800,000 required the company to weigh the address against engineering, inventory, and product tooling — and to treat the domain as infrastructure for a rename it had decided was coming.
 
-That is what makes the sequence telling. Drop didn't buy Drop.com because it had spare cash lying around. It bought Drop.com because it had concluded the company needed to stop being "Mass" anything — and the only way to make that real was to own the shorter name first.
+That is what makes the sequence telling. The company secured Drop.com before announcing that it needed to stop being "Mass" anything — and the only way to make that shorter identity real was to own the shorter name first.
 
 ## Why shortening to "Drop" mattered
 


### PR DESCRIPTION
## Summary

- distinguish Drop.com's public $800,000 asking price from its undisclosed sale price
- remove unsupported six-figure and near-million-dollar purchase assertions
- retain the acquisition's strategic lesson without inventing transaction economics

## Test plan

- `TMPDIR=/private/tmp bun run data:validate`
- `TMPDIR=/private/tmp bun run lint:mdx`
- `TMPDIR=/private/tmp bun run check:termbase`
- `TMPDIR=/private/tmp bun .agents/skills/cross-link/link-audit.ts content/blog/en/from-massdrop-com-to-drop-com.md`
- `git diff --check`

Agent session: redacted (UTC)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only factual corrections in one English MDX article; no application or data-handling changes.
> 
> **Overview**
> **Fact-checks the Massdrop → Drop.com case study** so it no longer treats the public **$800,000 asking price** as the acquisition cost.
> 
> In **"The money looked different then"**, the post drops hindsight framing that implied a **six-figure / near-million-dollar** purchase and an **"$800,000-ish"** domain line item against the Corsair exit. It now states that **Massdrop’s actual Drop.com price was never disclosed** and that the **$800,000 figure was only an ask**. The venture-stage spend paragraph is rewritten to say the **domain budget is unknown**, while still arguing that chasing a one-word `.com` at that public ask meant weighing the name against engineering and inventory. The closing beat is toned from **"bought Drop.com"** to **secured the domain before the rename**—same strategic lesson, no invented transaction economics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b07e336651224622df8d861688f6243b42e42da2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->