### PR TITLE
fix(content): remove remaining Instagram funding contradiction

### DIFF
--- a/content/blog/en/from-instagr-am-to-instagram-com.md
+++ b/content/blog/en/from-instagr-am-to-instagram-com.md
@@ -138,7 +138,7 @@ The hack didn't build Instagram's growth — filters, timing, and the iPhone cam
 
 The easy takeaway — "never use a domain hack" — is wrong. The hack was *good*. The more useful lessons are about how to use one without getting trapped by it:
 
-1. **A domain hack is a great launch front door.** instagr.am was exact, short, shareable, and available when the `.com` wasn't. For a pre-funding launch, that is a real edge, not a failure.
+1. **A domain hack is a great launch front door.** instagr.am was exact, short, shareable, and available when the `.com` wasn't. For an early-stage launch, that is a real edge, not a failure.
 2. **Know what you're borrowing.** A [ccTLD](/en/glossary/cctld/) hack means a foreign registry sets your policies and pricing. That is fine at small scale and a liability once your brand is valuable. Treat the hack as [a secondary URL](https://www.domaingravity.com/instagr.am-Instagram.com.htm#:~:text=secondary%20URLs), not the permanent home.
 3. **Secure the canonical `.com` early — while it can still become the one people remember.** Instagram bought Instagram.com in its first months, not after it was famous. The window to make the clean name canonical is narrow.
 4. **Budget for the transaction, not just the price.** The strategic call is obvious; clean title is not. Instagram paid $100,000 and *still* ended up in a multi-year ownership dispute over who had the authority to sell.


### PR DESCRIPTION
## Summary

- replace the remaining `pre-funding launch` wording with `early-stage launch`
- align the lesson with the article's documented $500,000 Burbn seed round before the Instagram pivot

## Validation

- `TMPDIR=/private/tmp bun run data:validate` (passes; 29 pre-existing empty-keyword warnings)
- `TMPDIR=/private/tmp bun run lint:mdx`
- `TMPDIR=/private/tmp bun run check:termbase`
- `TMPDIR=/private/tmp bun .agents/skills/cross-link/link-audit.ts content/blog/en/from-instagr-am-to-instagram-com.md`
- `git diff --check`

## Access control

No new surface or access-control change; this edits an existing public article.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single phrase change in a public blog post; no code, auth, or access-control impact.
> 
> **Overview**
> Updates one sentence in the **What founders should learn** section of `from-instagr-am-to-instagram-com.md`: the first lesson now says a domain hack is a real edge **for an early-stage launch** instead of **for a pre-funding launch**.
> 
> That wording matches the article’s own sourcing (Burbn’s documented $500,000 seed round before the Instagram pivot), so the takeaway no longer implies Instagram had no funding when it launched on instagr.am.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8ef9ebc570429e79b8e5770b3e1aae0b8f80921. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->