### PR TITLE
fix(content): correct Jamba founder timeline

### DIFF
--- a/content/blog/en/from-jambajuice-com-to-jamba-com.md
+++ b/content/blog/en/from-jambajuice-com-to-jamba-com.md
@@ -73,7 +73,7 @@ In August 2018, Jamba, Inc. agreed to be acquired by Atlanta-based Focus Brands.
 
 New ownership tends to force the identity question that founders defer for years. Within months of the sale closing, the 29-year-old "Juice" was gone. The rebrand was Focus Brands' first big public statement about what Jamba was going to be — and the simplest, cleanest way to say "we're more than juice now" was to stop saying "Juice."
 
-Kirk Perron, the founder who chose "Jamba" in the first place, didn't live to see the brand fully grow into the single word he'd picked. He [passed away on June 20](https://www.legacy.com/news/kirk-perron-2020-jamba-juice-founder) in 2020, in Palm Springs. The coined identity associated with celebration outlived the descriptive label that had ridden alongside it for a quarter century.
+Kirk Perron, the founder who chose "Jamba" in the first place, lived to see the brand shorten to the single word he'd picked. He [passed away on June 20](https://www.legacy.com/news/kirk-perron-2020-jamba-juice-founder) in 2020, in Palm Springs. The coined identity associated with celebration outlived the descriptive label that had ridden alongside it for a quarter century.
 
 ## The money looked different then
 


### PR DESCRIPTION
## Summary

- correct the Jamba founder timeline after the article incorrectly said Kirk Perron did not live to see the 2019 short-name rebrand
- preserve the surrounding cited 2019 rebrand and 2020 death chronology

## Validation

- `TMPDIR=/private/tmp bun run data:validate` (29 pre-existing empty-keyword warnings)
- `TMPDIR=/private/tmp bun run lint:mdx`
- `TMPDIR=/private/tmp bun run check:termbase`
- `TMPDIR=/private/tmp bun .agents/skills/cross-link/link-audit.ts content/blog/en/from-jambajuice-com-to-jamba-com.md`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial-only change to blog copy with no application logic, auth, or data handling impact.
> 
> **Overview**
> Fixes a **factual error** in the Jamba case-study post: Kirk Perron **did** live through the June 2019 short-name rebrand (he died in June 2020).
> 
> The backstory paragraph now says he **“lived to see the brand shorten to the single word he'd picked”** instead of implying he died before that rebrand. The cited 2019 rebrand → 2020 death sequence is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87ff076cc83906a95945e16123ca170528a41148. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->