### PR TITLE
fix(content): qualify Chewy domain history

### DIFF
--- a/content/blog/en/from-mrchewy-com-to-chewy-com.md
+++ b/content/blog/en/from-mrchewy-com-to-chewy-com.md
@@ -1,5 +1,5 @@
 ---
-title: 'From MrChewy.com to Chewy.com: How Dropping "Mr." Turned a Pet Startup Into a $3.35B Brand'
+title: 'From Mr. Chewy to Chewy.com: A $3.35B Pet Brand’s One-Word Upgrade'
 date: '2026-06-17'
 language: en
 tags: ['domains', 'branding', 'startups', 'domain-upgrades']
@@ -9,7 +9,7 @@ cluster: domain-investing
 series: name-change-game-change
 seriesOrder: 18
 format: case-study
-description: 'How a 2011 pet startup launched as "Mr. Chewy" on MrChewy.com, dropped the "Mr." to become Chewy on the exact-match Chewy.com, and why that one-word domain upgrade quietly became part of a brand PetSmart bought for $3.35 billion.'
+description: 'How a 2011 pet startup founded as "Mr. Chewy" became Chewy on the exact-match Chewy.com, and why that one-word domain upgrade quietly became part of a company PetSmart bought for $3.35 billion.'
 keywords: ['mrchewy.com', 'chewy.com', 'chewy domain name', 'mr chewy', 'domain upgrade', 'ryan cohen', 'michael day', 'frank schilling', 'exact match domain', 'startup naming', 'brand naming', 'premium domain', 'domain strategy', 'pet ecommerce']
 relatedArticles:
   - /en/blog/from-urbancompass-com-to-compass-com/
@@ -31,11 +31,11 @@ relatedGlossary:
   - /en/glossary/web3/
 ---
 
-Before Chewy was the customer-service legend of pet e-commerce — before the handwritten cards, the condolence flowers, and the $3.35 billion exit — it had a slightly cuddlier, more cautious name. It was **Mr. Chewy**, and it lived at **MrChewy.com**.
+Before Chewy was the customer-service legend of pet e-commerce — before the handwritten cards, the condolence flowers, and the $3.35 billion exit — it had a slightly cuddlier, more cautious name. It was **Mr. Chewy**. Public accounts disagree on whether its early web address was **MrChewy.com** or **MyChewy.com**, but they agree on the original brand and the eventual move to **Chewy.com**.
 
 The honorific made sense at the time. In 2011, two friends in their twenties were asking strangers to buy dog food from a website nobody had heard of, in a category that had already produced one of the most famous failures of the dot-com era. "Mr. Chewy" was friendly. It was approachable. It sounded like a character, not a corporation — a polite, personable shopkeeper for your pet. For a brand-new store trying to feel trustworthy, the "Mr." did real emotional work.
 
-But a name that reads like a mascot is a different thing from a name that reads like a category. As the company grew past its first audience, the "Mr." started to look less like warmth and more like training wheels. The founders dropped it. The store became simply **Chewy**, and the address became the exact-match **Chewy.com** — a one-word domain that had been hand-registered by one of the most famous domain investors in the world years before any pet startup existed.
+But a name that reads like a mascot is a different thing from a name that reads like a category. As the company grew past its first audience, the "Mr." started to look less like warmth and more like training wheels. The founders dropped it. The store became simply **Chewy**, and the address became the exact-match **Chewy.com** — a one-word domain registered years before the pet startup existed.
 
 Six years after launch, [PetSmart's owners paid $3.35 billion for Chewy](https://hbr.org/2020/01/the-founder-of-chewy-com-on-finding-the-financing-to-achieve-scale) — the company, not the domain — in what was then the largest e-commerce acquisition on record. The domain was not the reason. But by then, the clean, one-word name was load-bearing — the address printed on every box, every receipt, and every "we got it from Chewy" recommendation passed from one pet owner to the next.
 
@@ -45,7 +45,7 @@ In the beginning, "Mr. Chewy" was a feature, not a bug.
 
 The company was [founded with the name "Mr. Chewy" in June 2011 by Ryan Cohen and Michael Day](https://en.wikipedia.org/wiki/Chewy_(company)#:~:text=Chewy%20was%20founded%20with%20the%20name%20%22Mr.%20Chewy%22%20in%20June%202011%20by%20Ryan%20Cohen%20and%20Michael%20Day). It almost didn't happen. Cohen and Day were, by their own account, about to launch something else entirely. As the founding story goes, [Cohen and Day were a week away from launching their jewelry business. Instead, they sold the inventory and the safe and immersed themselves in learning about the pet food industry](https://www.businessofbusiness.com/articles/if-you-own-a-pet-youve-heard-of-chewy-heres-why-the-31-billion-site-succeeded-where-petscom-failed/#:~:text=Cohen%20and%20Day%20were%20a%20week%20away%20from%20launching%20their%20jewelry%20business). The pivot came from a small, personal moment: [Cohen was standing in a pet food store with his poodle talking to an employee about food options when he had a revelation](https://www.businessofbusiness.com/articles/if-you-own-a-pet-youve-heard-of-chewy-heres-why-the-31-billion-site-succeeded-where-petscom-failed/#:~:text=co%2Dfounder%20Ryan%20Cohen%20was%20standing%20in%20a%20pet%20food%20store%20with%20his%20poodle).
 
-They [launched Chewy.com in 2011 using their own cash and several small loans](https://www.businessofbusiness.com/articles/if-you-own-a-pet-youve-heard-of-chewy-heres-why-the-31-billion-site-succeeded-where-petscom-failed/#:~:text=Cohen%20and%20Day%20launched%20Chewy.com%20in%202011%20using%20their%20own%20cash%20and%20several%20small%20loans) — but under the "Mr. Chewy" banner, on MrChewy.com. The honorific did exactly what a young brand needs a name to do: it made an unproven website feel like a friendly neighbor instead of a faceless storefront. In a category still haunted by the spectacular collapse of Pets.com, a name that felt warm and human was a deliberate antidote to the cold, sock-puppet memory of the last pet-store gold rush.
+They [launched the online business in 2011 using their own cash and several small loans](https://www.businessofbusiness.com/articles/if-you-own-a-pet-youve-heard-of-chewy-heres-why-the-31-billion-site-succeeded-where-petscom-failed/#:~:text=Cohen%20and%20Day%20launched%20Chewy.com%20in%202011%20using%20their%20own%20cash%20and%20several%20small%20loans) under the "Mr. Chewy" brand. Contemporary reporting identifies the startup as [MrChewy.com](https://www.miamiherald.com/news/business/article231381373.html), while a later domain-industry account says it initially operated on [MyChewy.com](https://smartbranding.com/mychewy-com-upgrade-to-chewy-com/). With that conflict unresolved, the safe conclusion is the brand history — Mr. Chewy became Chewy — rather than a definitive claim about its first domain. The honorific made the unproven store feel like a friendly neighbor instead of a faceless storefront. In a category still haunted by the spectacular collapse of Pets.com, a name that felt warm and human was a deliberate antidote to the cold, sock-puppet memory of the last pet-store gold rush.
 
 The "Mr." was the on-ramp. It was not the destination.
 
@@ -57,7 +57,7 @@ Industry chroniclers of domain upgrades treat the move as a textbook simplificat
 
 ![Colorful editorial illustration in Chewy blue of a friendly "Mr. Chewy" shopkeeper character setting down his top hat and bowtie to step through a clean doorway labeled Chewy.com](../../assets/from-mrchewy-com-to-chewy-com-01-dropping-mr.jpg)
 
-How much did the upgrade cost? Here the public record goes quiet. Multiple accounts agree the company [acquired the name from domain investor Frank Schilling for an undisclosed amount](https://smartbranding.com/mychewy-com-upgrade-to-chewy-com/#:~:text=They%20acquired%20the%20name%20from%20domain%20investor%20Frank%20Schilling%20for%20an%20undisclosed%20amount), and the same chronicles confirm bluntly that [the price of the domain was kept private](https://smartbranding.com/2010-2020-a-decade-in-domains-part-1-brands-simplified-their-names/#:~:text=The%20price%20of%20the%20domain%20was%20kept%20private). So the figure that *is* on the record for this story is not the domain price at all — it's the one at the other end of the arc: [in 2017, PetSmart acquired Chewy.com for $3.35 billion in the largest e-commerce acquisition](https://smartbranding.com/2010-2020-a-decade-in-domains-part-1-brands-simplified-their-names/#:~:text=In%202017%2C%20PetSmart%20acquired%20Chewy.com%20for%20%243.35%20billion%20in%20the%20largest%20e%2Dcommerce%20acquisition) up to that date. The domain that PetSmart bought a stake of was the clean, one-word version — not the honorific.
+How much did the upgrade cost? Here the public record goes quiet. Smart Branding reports that the company [acquired the name from domain investor Frank Schilling for an undisclosed amount](https://smartbranding.com/mychewy-com-upgrade-to-chewy-com/#:~:text=They%20acquired%20the%20name%20from%20domain%20investor%20Frank%20Schilling%20for%20an%20undisclosed%20amount), and its decade review says [the price of the domain was kept private](https://smartbranding.com/2010-2020-a-decade-in-domains-part-1-brands-simplified-their-names/#:~:text=The%20price%20of%20the%20domain%20was%20kept%20private). So the figure that *is* on the record for this story is not the domain price at all — it's the one at the other end of the arc: [PetSmart completed its acquisition of the Chewy company in 2017](https://investor.chewy.com/news-and-events/news/news-details/2017/PetSmart-Completes-Acquisition-of-Chewy/default.aspx), in a deal widely reported at $3.35 billion. PetSmart bought the company, not a domain stake.
 
 ## The backstory: a Java chat room, a jewelry pivot, and 100 rejections
 
@@ -73,19 +73,19 @@ By the time the money arrived, the brand had to be ready to scale — and a bran
 
 It is tempting to look at "Chewy" and "Chewy.com" and assume the one-word name was always obvious, always cheap, always inevitable. It wasn't.
 
-In 2011 and 2012, Chewy was a self-funded startup running on the founders' own cash and small loans, in a category investors actively avoided. A premium, exact-match, one-word [.com](/en/tld/com/) — hand-registered in 2004 and parked inside a top-tier [domain portfolio](/en/glossary/domain-portfolio/) — is not the kind of asset a cash-strapped pet store buys casually. Whatever the undisclosed price was, it was being weighed against payroll, inventory, and the customer-service infrastructure that would actually become the company's moat.
+In 2011 and 2012, Chewy was a self-funded startup running on the founders' own cash and small loans, in a category investors actively avoided. A premium, exact-match, one-word [.com](/en/tld/com/) registered in 2004 is not the kind of asset a cash-strapped pet store buys casually. Whatever the undisclosed price was, it would have competed with payroll, inventory, and the customer-service infrastructure that would actually become the company's moat.
 
-That is the right frame for any domain decision: not "what is this name worth at the end of the story," but "what is it worth to a company that doesn't yet know if it will survive the year." Chewy chose to consolidate on the clean name early, while it was still small enough that the decision was a real cost — and that, more than hindsight, is what made it a strategic choice rather than a vanity one.
+That is the right frame for any domain decision: not "what is this name worth at the end of the story," but "what is it worth to the company at the time of purchase." The public sources do not disclose the exact acquisition or changeover date, so the defensible lesson is about evaluating the upgrade against the company's then-current resources — not claiming a precise stage that the record does not establish.
 
 ## Why dropping "Mr." mattered
 
-The gap between MrChewy.com and Chewy.com is one word — and arguably not even a word, just a title. Strategically, it is the difference between a *character* and a *category*.
+The gap between the **Mr. Chewy** brand and **Chewy.com** is one word — and arguably not even a word, just a title. Strategically, it is the difference between a *character* and a *category*.
 
-**MrChewy.com** sounds like a personality: a single, friendly shopkeeper, charming but small. **Chewy.com** sounds like the place you buy things for your pet, full stop. One is a mascot you visit; the other is a default you reach for. The honorific that made the store feel safe in 2011 became the thing that made it sound smaller than it was becoming.
+**Mr. Chewy** sounds like a personality: a single, friendly shopkeeper, charming but small. **Chewy** sounds like the place you buy things for your pet, full stop. One is a mascot you visit; the other is a default you reach for. The honorific that made the store feel safe in 2011 became the thing that made it sound smaller than it was becoming.
 
 | Before | After |
 | --- | --- |
-| MrChewy.com | Chewy.com |
+| Mr. Chewy | Chewy / Chewy.com |
 | Reads like a mascot / a character | Reads like the category itself |
 | Friendly, but small and personal | Friendly *and* big enough to be the default |
 | Two-token name on every box and receipt | One clean word, easy to say and spell |
@@ -107,9 +107,9 @@ When a company is sending real flowers to grieving pet owners and answering the 
 
 The order of operations is the lesson.
 
-Chewy consolidated on its clean name and [exact-match domain](/en/glossary/exact-match-domain/) *while it was still small* — before the brand was printed on millions of boxes, before the [$15 million](https://www.businessofbusiness.com/articles/if-you-own-a-pet-youve-heard-of-chewy-heres-why-the-31-billion-site-succeeded-where-petscom-failed/#:~:text=immediately%20wrote%20a%20%2415%20million%20check%20to%20Cohen%20and%20Day%20to%20invest%20in%20Chewy) growth round forced it to scale, and long before PetSmart valued the whole thing at [$3.35 billion](https://hbr.org/2020/01/the-founder-of-chewy-com-on-finding-the-financing-to-achieve-scale). That sequencing is what made the upgrade cheap in effort even if it cost real money: changing a name is trivial when a thousand customers know you, and brutal when ten million do.
+Chewy did consolidate on its clean name and [exact-match domain](/en/glossary/exact-match-domain/) before PetSmart valued the whole company at [$3.35 billion](https://hbr.org/2020/01/the-founder-of-chewy-com-on-finding-the-financing-to-achieve-scale). The available sources do not pin down whether the domain change came before or after the [$15 million](https://www.businessofbusiness.com/articles/if-you-own-a-pet-youve-heard-of-chewy-heres-why-the-31-billion-site-succeeded-where-petscom-failed/#:~:text=immediately%20wrote%20a%20%2415%20million%20check%20to%20Cohen%20and%20Day%20to%20invest%20in%20Chewy) growth round, so they cannot support a more exact sequencing claim. The general timing principle still holds: changing a name is easier before it has been taught to millions of customers.
 
-Imagine the alternative. A Chewy that waited — that scaled MrChewy.com to national recognition, printed "Mr. Chewy" on every package, taught a generation of pet owners to say "Mr. Chewy" out loud — and *then* tried to drop the "Mr." That rename would have meant retraining the entire market, reprinting everything, and confusing the exact customers it had spent years winning. By upgrading early, Chewy paid the switching cost once, while it was small.
+Imagine the alternative in general: a company scales a modifier-heavy launch brand to national recognition, prints it on every package, teaches a generation of customers to say it aloud, and only then tries to simplify. That rename means retraining the market and reprinting everything. The Chewy sources do not establish the exact changeover date, but the counterfactual illustrates why founders should investigate an exact-match upgrade before switching costs become entrenched.
 
 ## The domain became part of the operating system
 
@@ -123,7 +123,7 @@ A pet retailer's core domain shows up in places the marketing team never directl
 - In search results and browser bars.
 - In every spoken recommendation — "just get it from Chewy" — passed from one pet owner to the next.
 
-Every one of those repetitions either adds friction or removes it. **MrChewy.com** made each mention a touch longer, a touch cuter, a touch smaller. **Chewy.com** made each mention shorter, plainer, and category-sized. Multiply that across tens of millions of orders and a brand mentioned daily in households with pets, and the one-word upgrade stops looking like a cosmetic choice and starts looking like a permanent reduction in drag.
+Every one of those repetitions either adds friction or removes it. A launch name carrying the **Mr.** modifier makes each mention a touch longer, a touch cuter, and a touch smaller. **Chewy.com** makes each mention shorter, plainer, and category-sized. Multiply that across millions of orders and the one-word upgrade stops looking like a cosmetic choice and starts looking like a permanent reduction in drag.
 
 The domain didn't build Chewy's brand — the service did. But once Chewy.com was the address, every future repetition of the name compounded on a cleaner, confident foundation, with no "Mr." to explain or outgrow.
 
@@ -134,7 +134,7 @@ The easy takeaway — "drop the cute modifier and grab your exact-match .com" �
 1. **A reassuring name is a fine on-ramp.** "Mr. Chewy" wasn't a mistake. In a category scarred by Pets.com, a warm, human, almost-mascot name lowered the trust barrier for a brand-new store. A modifier like "Mr.," "App," or "HQ" can be a smart way to feel approachable on day one.
 2. **Watch for the moment the modifier shrinks you.** The signal to upgrade isn't aesthetic — it's when your name starts describing something smaller than what you're becoming. A mascot name caps you at "charming small business." A category name doesn't.
 3. **Build the substance the name was faking.** "Mr." promised friendliness; Chewy's call center, live chat, and condolence flowers *delivered* it. Once the warmth lives in the company, the name no longer has to costume it — and can afford to be plain and confident.
-4. **Upgrade while you're small.** The switching cost of a rename grows with every customer who has learned the old name. Chewy consolidated on Chewy.com before the brand was printed on millions of boxes. The expensive, externally-owned piece — the exact-match domain, hand-registered in 2004 inside a major portfolio — was worth securing early.
+4. **Upgrade before switching costs compound.** The switching cost of a rename grows with every customer who has learned the old name. Chewy's public record does not disclose the exact date of the domain change, so this case should not be used to claim a precise cutoff; the practical lesson is to weigh the externally owned exact match before the old name becomes harder to replace.
 
 The domain upgrade did not make Chewy win. Service, logistics, capital, and relentless execution mattered far more. But dropping "Mr." and consolidating on Chewy.com made the company's growth *nameable* — and it was done while the cost of doing it was still small.
 
@@ -144,11 +144,11 @@ The domain upgrade did not make Chewy win. Service, logistics, capital, and rele
 
 This case is, at its core, a transfer problem wearing a branding costume.
 
-The strategic decision was never really in doubt — of course a pet store called Chewy should own Chewy.com instead of MrChewy.com. The hard part was everything around the asset: a cash-strapped startup negotiating for a premium one-word .com that had sat in a top-tier domain portfolio since 2004, agreeing on a price that stayed private, and moving control of a name the entire brand would soon depend on — all without breaking the live store. The most consequential parts of this story are the parts the public record can't even see: the undisclosed price, the terms, the proof of clean ownership.
+The strategic appeal is easy to see — a pet store called Chewy benefits from owning Chewy.com instead of a longer launch address. The hard part was everything around the asset: negotiating for a premium one-word .com registered in 2004, agreeing on a price that stayed private, and moving control of a name the brand would depend on — all without breaking the live store. The most consequential parts of this story are the parts the public record can't see: the undisclosed price, the terms, and the transfer process.
 
 [Namefi](https://namefi.io) is built around the idea that domains should behave like internet-native assets. Tokenized ownership can make domain control easier to verify, transfer, and integrate into modern workflows while staying compatible with DNS — turning the messiest parts of a deal like this (proving who owns what, agreeing on value, and moving it safely) into something closer to a clean, auditable transaction. The next founder who needs to graduate from a cute, modifier-laden launch domain to the confident exact-match shouldn't have to do it through a private, unverifiable handshake.
 
-Chewy.com looks inevitable now because Chewy became enormous. But the lesson lands long before that scale: when a name is going to ride on every box you ship, the domain isn't decoration — it's the part of the brand worth simplifying early, and worth securing cleanly, so the company can grow into a name instead of out of one.
+Chewy.com looks inevitable now because Chewy became enormous. But the lesson applies before that scale: when a name is going to ride on every box you ship, the domain isn't decoration. It is worth evaluating and securing cleanly before the company has to grow out of a name already taught to the market.
 
 ## Sources and further reading
 


### PR DESCRIPTION
## Summary

- acknowledge the conflicting public record over whether the early store used MrChewy.com or MyChewy.com
- remove unsupported claims about Chewy.com's original or continuous ownership and the exact timing of the domain upgrade
- clarify that PetSmart acquired the Chewy company, not a stake in the domain
- narrow timing lessons to what the cited record actually establishes

## Sources checked

- [Chewy investor relations: PetSmart completes acquisition of Chewy](https://investor.chewy.com/news-and-events/news/news-details/2017/PetSmart-Completes-Acquisition-of-Chewy/default.aspx)
- [Miami Herald: 2011 retailer described as MrChewy.com](https://www.miamiherald.com/news/business/article231381373.html)
- [Smart Branding: early operation described as MyChewy.com](https://smartbranding.com/mychewy-com-upgrade-to-chewy-com/)

## Validation

- `TMPDIR=/private/tmp bun run data:validate` (29 pre-existing empty-keyword warnings)
- `TMPDIR=/private/tmp bun run lint:mdx`
- `TMPDIR=/private/tmp bun run check:termbase`
- `TMPDIR=/private/tmp bun .agents/skills/cross-link/link-audit.ts content/blog/en/from-mrchewy-com-to-chewy-com.md`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial-only updates to one English MDX article; no application logic, auth, or data pipelines.
> 
> **Overview**
> Fact-checks the English **Mr. Chewy → Chewy.com** case study so claims match what sources actually support.
> 
> The intro and launch section now note **conflicting reports** (**MrChewy.com** vs **MyChewy.com**) and center the verified **Mr. Chewy** brand story instead of asserting a single launch URL. **PetSmart’s $3.35B deal** is described as buying the **company** (with an investor-relations cite), not a stake in the domain. Wording around **Chewy.com** drops overstated ownership/portfolio color and sticks to **2004 registration** and **undisclosed Schilling sale** where cited.
> 
> Sections on **timing**, **early upgrade while small**, and founder takeaway **#4** are hedged where the record does not give a **domain changeover date** (including vs the **$15M** round). The before/after table and repetition examples use **Mr. Chewy** / modifier language rather than assuming **MrChewy.com** everywhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcbcdd64e98551cb03065e8224c094879c3bee98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->