### PR TITLE
fix(content): qualify Compass domain sale claims

### DIFF
--- a/content/blog/en/from-urbancompass-com-to-compass-com.md
+++ b/content/blog/en/from-urbancompass-com-to-compass-com.md
@@ -31,7 +31,7 @@ relatedGlossary:
   - /en/glossary/registry/
 ---
 
-Before Compass became the largest residential brokerage in the United States, it was a more literal, more local thing: **UrbanCompass.com**, an app for finding an apartment to rent in New York City.
+Before Compass became a national residential real-estate brokerage, it was a more literal, more local thing: **UrbanCompass.com**, an app for finding an apartment to rent in New York City.
 
 The original name made sense. When Robert Reffkin and Ori Allon built the service, it did one narrow thing in one narrow place. The Daily Beast described the early product as a service that [launched in beta on May 7 with an endorsement from Mayor Michael Bloomberg](https://www.thedailybeast.com/start-up-urban-compass-aims-to-drive-apartment-rental-online/#:~:text=launched%20in%20beta%20on%20May%207), offering a comprehensive database of available rentals and information about the surrounding neighborhoods. The coverage map was small to start: [Manhattan and parts of Brooklyn, with more New York neighborhoods to come later](https://www.thedailybeast.com/start-up-urban-compass-aims-to-drive-apartment-rental-online/#:~:text=Manhattan%20and%20parts%20of%20Brooklyn). The word "Urban" told you exactly what you were getting: a city tool, for city renters.
 
@@ -65,19 +65,19 @@ Read that quote carefully. The word doing the heavy lifting is *universally*. "U
 
 ![Colorful editorial illustration of the word "Urban" peeling away from a sleek black-and-white compass logo, the compass needle swinging from a tight Manhattan street grid outward toward a wide map of the United States](../../assets/from-urbancompass-com-to-compass-com-01-dropping-urban.jpg)
 
-## The domain that had a price tag before Compass needed it
+## The domain that had an asking price before Compass needed it
 
 Once the name became "Compass," the obvious address was Compass.com. But that domain wasn't a throwaway. Common single-word English nouns are among the most contested real estate on the internet, and "compass" — a word for direction, navigation, and finding your way — is about as on-brand a noun as a real-estate company could ask for.
 
 The market had already put a number on it. Before Compass ever needed the name, [Compass.com was listed in an auction back in 2013 for US$ 1 Million](https://smartbranding.com/urbancompass-com-rebrands-to-compass-com/#:~:text=Compass.com%20was%20listed%20in%20an%20auction%20back%20in%202013%20for%20US%24%201%20Million). What Compass actually paid stayed behind closed doors. As Smart Branding noted, [the transaction was private so we don't know the investment made towards securing the matching domain name](https://smartbranding.com/urbancompass-com-rebrands-to-compass-com/#:~:text=The%20transaction%20was%20private).
 
-That secrecy is itself the norm for premium one-word [.com](/en/tld/com/) deals. The seven-figure [auction](/en/glossary/auction/) listing is the public floor; the closing price is a number both sides usually agree to keep quiet. Either way, the signal is clear: dropping "Urban" wasn't free. The exact-match version of the name cost real money, because the word "Compass" was valuable to the world long before it was valuable to this company.
+The $1 million [auction](/en/glossary/auction/) listing was an asking price, not a sale price, appraisal, or public floor. The private transaction record therefore establishes neither what Compass paid nor whether the seller's earlier ask was met. What it does establish is that the exact-match name was already controlled and publicly marketed before Compass adopted it.
 
 ## The money looked different then
 
-It is tempting to judge a domain purchase from the end of the story, where Compass is a household name and a seven-figure URL looks like a rounding error. But in early 2015, the math looked different.
+It is tempting to judge a domain purchase from the end of the story, where Compass is a well-known brand and a premium URL can look inevitable. But in early 2015, the math looked different.
 
-At that point Compass was a young, venture-funded brokerage that had just changed its business model and was about to bet everything on leaving the one city it understood. It was spending on engineers, on recruiting agents, on opening offices in new markets. Against that backdrop, putting (very plausibly) seven figures into a *domain name* — not technology, not agent recruiting, not a new office — was the kind of line item a finance team would question.
+At that point Compass was a young, venture-funded brokerage that had recently changed its business model and was looking beyond its original rental product. It was spending on engineers, recruiting agents, and expanding operations. Against that backdrop, paying an undisclosed amount for a *domain name* — not technology, agent recruiting, or a new office — was the kind of line item a finance team would examine closely.
 
 The decision only makes sense if you treat the domain as infrastructure rather than decoration. Compass was about to ask the country — not just New York — to remember its name. Every yard sign, every agent's email signature, every listing page, every press mention in a new market was going to carry its web address. Paying to make that address the clean, universal, exact-match version of the brand was a bet that the name would be repeated millions of times across the country — and that each repetition should land on Compass.com, not UrbanCompass.com.
 
@@ -101,11 +101,11 @@ This is the same pattern that shows up again and again in domain upgrades: early
 
 The order of events is what makes this case instructive. The rebrand wasn't cosmetic housekeeping — it was the starting gun for national expansion.
 
-When Urban Compass became Compass in February 2015, it did so explicitly to shed a name that pinned it to dense urban cores. The new identity arrived alongside the company's first moves outside New York, into markets like Washington, D.C. — the beginning of a rollout that would eventually carry Compass into hundreds of cities and, a decade later, make it one of the biggest brokerages in the country. The name and the domain had to change *before* the map could.
+When Urban Compass became Compass in February 2015, its marketing leader described the shorter name as more universally memorable. That supports the geographic logic of removing "Urban," but the cited record here does not establish the exact synchronization between the rebrand and each new-market launch. The defensible point is narrower: the new identity no longer limited the brand to dense urban cores.
 
 ![Colorful editorial illustration of a black Compass yard sign being planted in city after city across a stylized US map — from a Manhattan block to a DC row house to a Sun Belt suburb — each sign reading "Compass.com," a single compass-rose motif tying the cities together](../../assets/from-urbancompass-com-to-compass-com-02-going-national.jpg)
 
-Notice the dependency. Compass couldn't credibly market itself as a national brand while its website lived at UrbanCompass.com. The brand, the logo, and the domain had to move together — and the piece least under Compass's control was the domain, because someone else owned Compass.com and the market had already priced it at a million dollars. Securing the exact-match name was what made "national" sound real instead of aspirational.
+The brand, the logo, and the domain moved together — and the piece least under Compass's control was the domain, because someone else owned Compass.com and had previously listed it at a $1 million ask. The actual transaction price remains unknown. Securing the exact-match name nevertheless removed a visible mismatch between the broader brand and its old, city-qualified address.
 
 Imagine the alternative: a company telling agents and sellers in Texas or Florida that it is a nationwide brokerage, while still sending them to a website with the word "Urban" in it. The mismatch would have undercut the whole point of the rebrand. The domain wasn't decoration on top of the new strategy. It was the load-bearing piece of it.
 
@@ -121,7 +121,7 @@ A real-estate brand's core domain shows up in places the marketing team never di
 - In press headlines as the company enters each new city.
 - In every word-of-mouth referral — "I listed with Compass" — passed from one neighbor to the next.
 
-Every one of those repetitions either adds friction or removes it. UrbanCompass.com made each mention longer, more city-bound, more obviously a New York thing. Compass.com made each mention shorter, cleaner, and geography-free. Multiply that across thousands of agents, hundreds of markets, and a brokerage that grew into one of the largest in the country, and a seven-figure domain stops looking like a luxury and starts looking like the cheapest piece of national infrastructure the company ever bought.
+Every one of those repetitions either adds friction or removes it. UrbanCompass.com made each mention longer, more city-bound, and more obviously a New York thing. Compass.com made each mention shorter, cleaner, and geography-free. Repeated across a growing brokerage, that reduction in friction can make a premium domain function more like durable brand infrastructure than decoration — without telling us what this particular transaction cost.
 
 The domain didn't build Compass's brand. But once Compass.com was the address, every future repetition of the name compounded on a cleaner foundation — one with no "Urban" to explain away in a suburban market.
 
@@ -131,7 +131,7 @@ The easy takeaway — "drop the descriptive word and buy your exact-match .com" 
 
 1. **A descriptive domain is fine to start.** UrbanCompass.com did real work: it made a brand-new company feel local and trustworthy to nervous New York renters. A modifier like "Urban," "App," or "HQ" is a reasonable on-ramp, not a failure.
 2. **Watch for the moment the modifier becomes a ceiling.** For Compass the signal was geographic. The instant the strategy turned national, the word "Urban" stopped describing the company and started shrinking it. When your name describes a smaller territory than the one you're moving into, the upgrade is urgent.
-3. **Expect the exact-match name to have a market price.** Common one-word .coms like Compass.com don't sit around free. This one was [listed at auction for $1 million](https://smartbranding.com/urbancompass-com-rebrands-to-compass-com/#:~:text=Compass.com%20was%20listed%20in%20an%20auction%20back%20in%202013%20for%20US%24%201%20Million) before Compass even needed it. Budget for the domain the way you'd budget for any strategic asset that someone else already controls.
+3. **Expect the exact-match name to carry an asking price.** Common one-word .coms like Compass.com don't sit around free. This one was [listed at auction for $1 million](https://smartbranding.com/urbancompass-com-rebrands-to-compass-com/#:~:text=Compass.com%20was%20listed%20in%20an%20auction%20back%20in%202013%20for%20US%24%201%20Million) before Compass needed it, although the later sale price is unknown. Budget for the domain the way you'd budget for any strategic asset that someone else already controls.
 4. **Secure the domain before the expansion, not after.** The rename and the move to Compass.com came *first*, then the national rollout. The slow, externally-owned, expensive asset — the domain — had to be locked down for the new strategy to mean anything.
 
 The domain upgrade did not make Compass win. Product, capital, agent recruiting, timing, and execution mattered far more. But Compass.com made the company's reinvention — from a New York rental app into a national brokerage — *nameable*, and it had to be secured the moment "Urban" turned from an asset into a fence.
@@ -142,11 +142,11 @@ The domain upgrade did not make Compass win. Product, capital, agent recruiting,
 
 This case is, at its core, a transfer problem wearing a branding costume.
 
-The strategic decision was never really in doubt — of course a company going national should drop the word "Urban" and own Compass.com. The hard part was everything around the asset: finding terms with the owner of a million-dollar one-word .com, agreeing on a price with no public comparables, closing the deal under a non-disclosure agreement so tight that the world still doesn't know what was paid, moving control cleanly, and timing it all to land alongside a coordinated rebrand. Even years later, the most basic question about the deal — what it cost — remains private, exactly the kind of opacity that surrounds most premium one-word domain transfers.
+The strategic appeal is easy to understand — a company expanding beyond one urban market benefits from dropping "Urban" and owning Compass.com. The public record confirms the earlier $1 million auction listing and says the later transaction was private, but it does not disclose the negotiated price, contract terms, transfer mechanics, or seller motivation. Those unknowns should remain unknown rather than being reconstructed as a detailed deal narrative.
 
-[Namefi](https://namefi.io) is built around the idea that domains should behave like internet-native assets. Tokenized ownership can make domain control easier to verify, transfer, and integrate into modern workflows while staying compatible with [DNS](/en/glossary/dns/) — turning the messiest parts of a deal like this (proving who owns what, agreeing on value, and moving it safely) into something closer to a clean, auditable transaction. A future where a one-word .com can be priced, escrowed, and transferred without a multi-year private paper trail is exactly the kind of friction this case spent real money to overcome.
+[Namefi](https://namefi.io) is built around the idea that domains should behave like internet-native assets. Tokenized ownership can make domain control easier to verify, transfer, and integrate into modern workflows while staying compatible with [DNS](/en/glossary/dns/) — turning tasks such as proving control and transferring an asset into something closer to a clean, auditable transaction. That is a general benefit of more transparent domain infrastructure; the private Compass.com record does not show which mechanisms the parties actually used.
 
-Compass.com looks inevitable now because Compass became enormous. But the lesson lands long before that scale: when a name is going to carry the business across an entire country — and especially when the old name quietly fences you into one city — the domain isn't decoration. It's the part of the brand worth paying seven figures to get right.
+Compass.com looks inevitable in hindsight because Compass grew far beyond its original product. But the lesson lands earlier: when a name is meant to carry a business beyond one city, the domain is not merely decoration. It is worth evaluating as part of the rebrand even when the eventual purchase price remains private.
 
 ## Sources and further reading
 


### PR DESCRIPTION
## Summary

- distinguish Compass.com's public $1 million auction asking price from its undisclosed sale price
- remove unsupported seven-figure purchase, market-floor, NDA, transfer, and exact expansion-timing claims
- narrow current-size and geographic claims to what the cited record supports
- preserve the documented February 2015 rename and exact-match domain upgrade

## Validation

- `TMPDIR=/private/tmp bun run data:validate` (29 pre-existing empty-keyword warnings)
- `TMPDIR=/private/tmp bun run lint:mdx`
- `TMPDIR=/private/tmp bun run check:termbase`
- `TMPDIR=/private/tmp bun .agents/skills/cross-link/link-audit.ts content/blog/en/from-urbancompass-com-to-compass-com.md`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial-only changes to one English blog post; no application logic, auth, or data pipelines.
> 
> **Overview**
> Tightens factual claims in the **UrbanCompass.com → Compass.com** case study so they match what cited sources actually say.
> 
> The **$1M figure** is reframed as a **2013 auction asking price**, not a sale price, public floor, or implied seven-figure purchase. Copy no longer infers what Compass paid, whether the ask was met, or NDA/transfer details beyond “transaction was private.”
> 
> **Scale and timing** language is pulled back: opening line drops “largest residential brokerage in the US”; national-expansion sections no longer assert exact sync between the February 2015 rebrand and each market launch unless the record supports it.
> 
> **Founder takeaways and Namefi** sections keep the strategic narrative (exact-match domain, dropping “Urban”) but stop reconstructing a detailed private deal or overstating Namefi’s relevance to this specific transaction.
> 
> Documented facts preserved: February 2015 rename, UrbanCompass.com → Compass.com upgrade, and Smart Branding’s auction listing reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e99fcec68c77fce35842e23843641470d78eade. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->