### PR TITLE
fix(content): qualify Uber domain deal claims

### DIFF
--- a/content/blog/en/from-ubercab-com-to-uber-com.md
+++ b/content/blog/en/from-ubercab-com-to-uber-com.md
@@ -1,5 +1,5 @@
 ---
-title: 'From UberCab.com to Uber.com: How Dropping One Word — and Trading 2% for a Domain — Built a Verb'
+title: 'From UberCab.com to Uber.com: Trading Equity for the Domain Before Uber Became a Verb'
 date: '2026-06-16'
 language: en
 tags: ['domains', 'branding', 'startups', 'domain-upgrades']
@@ -9,7 +9,7 @@ cluster: domain-investing
 series: name-change-game-change
 seriesOrder: 7
 format: case-study
-description: 'How a 2010 cease-and-desist forced UberCab to drop "Cab," how Uber bought Uber.com from Universal Music for 2% equity worth $107K, and why that domain upgrade became one of the most consequential trades in startup history.'
+description: 'How UberCab dropped "Cab" as it faced a 2010 cease-and-desist, how reports say Uber acquired Uber.com from Universal Music for 2% equity, and why the exact historical dollar values remain uncertain.'
 keywords: ['ubercab.com', 'uber.com', 'uber domain name', 'domain upgrade', 'ubercab cease and desist', 'universal music uber domain', 'startup naming', 'brand naming', 'premium domain', 'domain strategy', 'uber history', 'equity for domain', 'domain acquisition', 'category-defining domain']
 relatedArticles:
   - /en/blog/from-urbancompass-com-to-compass-com/
@@ -37,11 +37,11 @@ The original name made sense. When Garrett Camp and Travis Kalanick built the se
 
 For that first audience, UberCab.com was clear. It explained the product.
 
-But the name had a problem the founders didn't choose. In October 2010, San Francisco's transportation regulators read the word "Cab" literally — and decided UberCab was operating an unlicensed taxi company. The startup got a cease-and-desist. And within a day, the logo dropped the word "Cab."
+But the service had a regulatory problem the founders didn't choose. In October 2010, San Francisco and California transportation regulators challenged UberCab's operation. The reported concerns involved taxi licensing, insurance, dispatch, and prebooking rules. The startup got a cease-and-desist, and within days its logo dropped the word "Cab."
 
-That regulatory accident pushed Uber toward a decision it would have had to make anyway: it needed the [exact-match domain](/en/glossary/exact-match-domain/), **Uber.com**. The catch was that Uber.com already belonged to someone else — a music label — and Uber had almost no cash. So it paid in something else.
+The rename created a separate branding requirement: the company needed the [exact-match domain](/en/glossary/exact-match-domain/), **Uber.com**. The catch was that Uber.com already belonged to someone else — a music label — and the young company was short on cash. So reports say it paid in something else.
 
-In a deal that now reads like one of the most lopsided trades in startup history, Uber acquired Uber.com from Universal Music Group [in exchange for a 2% stake in the company](https://www.snagged.com/post/uber-com-the-3-46b-domain-that-universal-music-let-go#:~:text=Uber%20offered%20UMG%202%25%20equity%20in%20the%20company%20in%20exchange%20for%20the%20domain%20name) — a stake [worth just $107,000](https://www.snagged.com/post/uber-com-the-3-46b-domain-that-universal-music-let-go#:~:text=that%20stake%20was%20worth%20just%20%24107%2C000) at the time.
+Multiple secondary accounts say Uber acquired Uber.com from Universal Music Group [in exchange for a 2% stake in the company](https://www.snagged.com/post/uber-com-the-3-46b-domain-that-universal-music-let-go#:~:text=Uber%20offered%20UMG%202%25%20equity%20in%20the%20company%20in%20exchange%20for%20the%20domain%20name). The equity percentage is consistently reported; the exact dollar value and later economics are less certain.
 
 ## 2009–2010: the cab in the name that did real work
 
@@ -61,11 +61,11 @@ The trigger came from the government, not the marketing department.
 
 On October 20, 2010, UberCab was hand-delivered a cease-and-desist order. TechCrunch reported that [the San Francisco Metro Transit Authority & the Public Utilities Commission of California have ordered the startup to cease and desist](https://techcrunch.com/2010/10/24/ubercab-ordered-to-cease-and-desist/#:~:text=the%20San%20Francisco%20Metro%20Transit%20Authority%20%26%20the%20Public%20Utilities%20Commission%20of%20California%20have%20ordered%20the%20startup%20to%20cease%20and%20desist). The stakes were not trivial. The orders carried the threat of [up to $5,000 fee per instance of Ubercab's operation](https://techcrunch.com/2010/10/24/ubercab-ordered-to-cease-and-desist/#:~:text=up%20to%20%245%2C000%20fee%20per%20instance%20of%20Ubercab%E2%80%99s%20operation), and [potentially 90 days in jail per each day the company remains in operation past the orders](https://techcrunch.com/2010/10/24/ubercab-ordered-to-cease-and-desist/#:~:text=potentially%2090%20days%20in%20jail%20per%20each%20day%20the%20company%20remains%20in%20operation%20past%20the%20orders).
 
-A central objection was the word itself. By calling itself a "Cab" company, UberCab invited regulators to treat it like a licensed taxi operator — which it was not. The fastest way to remove that target was to remove the word.
+The cited report does not say the word "Cab" was the legal basis for the order. It lists concrete operating concerns: UberCab acted like a cab company without a taxi license, its cars did not carry taxi-equivalent insurance, the model threatened taxi dispatchers, and it offered immediate pickups despite rules that generally required limousines to be prebooked. The name change happened in the same regulatory window, but removing a word did not resolve those compliance questions.
 
 So Uber did. Almost immediately, the logo changed. TechCrunch noted that [Ubercab's logo now reads simply "Uber,"](https://techcrunch.com/2010/10/24/ubercab-ordered-to-cease-and-desist/#:~:text=Ubercab%E2%80%99s%20logo%20now%20reads%20simply%20%E2%80%9CUber%2C%E2%80%9D) and the company told its own Facebook community, in a line that captured the whole pivot, that it was [more uber than cab](https://techcrunch.com/2010/10/24/ubercab-ordered-to-cease-and-desist/#:~:text=more%20uber%20than%20cab). Smart Branding summarized the sequence: [On the same day, Uber officially changed its name from UberCab to Uber.](https://smartbranding.com/ubercab-com-to-uber-com/#:~:text=On%20the%20same%20day%2C%20Uber%20officially%20changed%20its%20name%20from%20UberCab%20to%20Uber.)
 
-The corporate rename was a forced move. But it pointed at a domain the company didn't yet own.
+The rename came amid that pressure. It also pointed at a domain the company didn't yet own.
 
 ## The domain that belonged to a music label
 
@@ -83,32 +83,32 @@ The reluctant-owner problem that makes most premium-domain deals slow was, in th
 
 This is the part that makes the case unusual. Uber didn't pay cash. It paid in itself.
 
-When [the team behind UberCab reached out in 2010](https://www.snagged.com/post/uber-com-the-3-46b-domain-that-universal-music-let-go#:~:text=the%20team%20behind%20UberCab%20reached%20out%20in%202010), they didn't have much money to offer. Instead, [Uber offered UMG 2% equity in the company in exchange for the domain name](https://www.snagged.com/post/uber-com-the-3-46b-domain-that-universal-music-let-go#:~:text=Uber%20offered%20UMG%202%25%20equity%20in%20the%20company%20in%20exchange%20for%20the%20domain%20name). At the moment of the deal, [that stake was worth just $107,000](https://www.snagged.com/post/uber-com-the-3-46b-domain-that-universal-music-let-go#:~:text=that%20stake%20was%20worth%20just%20%24107%2C000) — a small bet on an unproven company.
+When [the team behind UberCab reached out in 2010](https://www.snagged.com/post/uber-com-the-3-46b-domain-that-universal-music-let-go#:~:text=the%20team%20behind%20UberCab%20reached%20out%20in%202010), they reportedly did not have much cash to offer. Instead, [Uber offered UMG 2% equity in the company in exchange for the domain name](https://www.snagged.com/post/uber-com-the-3-46b-domain-that-universal-music-let-go#:~:text=Uber%20offered%20UMG%202%25%20equity%20in%20the%20company%20in%20exchange%20for%20the%20domain%20name). One later article assigns the stake a $107,000 value at the time, but the cited material does not show the valuation method or primary transaction documents, so that figure should be treated as an estimate rather than a verified purchase price.
 
 The detail was later confirmed in Vanity Fair's reporting by Kara Swisher, which described Uber [buying the Uber.com domain name from Universal Music Group for what was then 2 percent of the company](https://domaininvesting.com/vanity-fair-reveals-cost-uber-com-domain-name/#:~:text=buying%20the%20Uber.com%20domain%20name%20from%20Universal%20Music%20Group%20for%20what%20was%20then%202%20percent%20of%20the%20company). Smart Branding framed the same arrangement plainly: Uber [offered Universal Music 2% of the company in exchange for the domain](https://smartbranding.com/a-creative-approach-to-domain-name-acquisitions-domain-deals-with-equity/#:~:text=it%20offered%20Universal%20Music%202%25%20of%20the%20company%20in%20exchange%20for%20the%20domain).
 
-Equity-for-domain deals are rare for a reason: they ask a seller to take a bet instead of a check. Universal could have demanded cash and walked away. Instead, it accepted a sliver of a tiny startup that called black cars in one city. On the day it closed, that looked like a generous price for a domain. It would not stay that way.
+Equity-for-domain deals ask a seller to take a bet instead of a check. In this account, Universal accepted a stake in a tiny startup that called black cars in one city. Without the transaction documents, the public record cannot establish what cash alternatives were discussed or how either side valued the exchange at closing.
 
 ## The seller's exit — and the cost of cashing out early
 
 Here is where the story turns from clever deal into cautionary tale — for the *seller*.
 
-Universal didn't hold the equity. Somewhere along the way, [Universal Music decided to sell its 2% stake back to Uber — for just $863,000](https://www.snagged.com/post/uber-com-the-3-46b-domain-that-universal-music-let-go#:~:text=Universal%20Music%20decided%20to%20sell%20its%202%25%20stake%20back%20to%20Uber%E2%80%94for%20just%20%24863%2C000). Vanity Fair's account describes the same buyback in round numbers: [Uber bought back the shares, which would now be worth hundreds of millions, for $1 million](https://domaininvesting.com/vanity-fair-reveals-cost-uber-com-domain-name/#:~:text=Uber%20bought%20back%20the%20shares%2C%20which%20would%20now%20be%20worth%20hundreds%20of%20millions%2C%20for%20%241%20million).
+Universal did not hold the equity indefinitely. The secondary accounts disagree on the exact buyback amount: Snagged reports [$863,000](https://www.snagged.com/post/uber-com-the-3-46b-domain-that-universal-music-let-go#:~:text=Universal%20Music%20decided%20to%20sell%20its%202%25%20stake%20back%20to%20Uber%E2%80%94for%20just%20%24863%2C000), while a DomainInvesting summary of Vanity Fair reports [about $1 million](https://domaininvesting.com/vanity-fair-reveals-cost-uber-com-domain-name/#:~:text=Uber%20bought%20back%20the%20shares%2C%20which%20would%20now%20be%20worth%20hundreds%20of%20millions%2C%20for%20%241%20million). In the absence of primary deal records, the defensible statement is that Uber reportedly repurchased the shares for roughly $1 million.
 
-Writing years before Uber reached its peak valuation, domain-watchers already saw the miss coming. By later estimates, the same stake — had it been held — would have been worth [roughly $3.46B at the current stock price](https://www.snagged.com/post/uber-com-the-3-46b-domain-that-universal-music-let-go#:~:text=that%20equity%20would%20be%20worth%20roughly%20%243.46B).
+Later articles estimate very large counterfactual values for the original 2% stake. Those calculations implicitly treat the stake as if it remained an undiluted 2% through later financing and public-market changes, so they should not be presented as a verified value that Universal would actually have held.
 
-That is the unglamorous mirror image of every blockbuster domain story. The buyer had a strategic need and almost no cash, so it paid with the only thing it had in abundance: belief in itself. The seller had a dead startup's leftover asset and chose certainty over conviction. Uber got the domain *and* the equity back. Universal got a domain sale that, on a long enough timeline, cost it billions.
+That is the mirror image of many equity-for-asset stories. The buyer had a strategic need and limited cash, so it reportedly paid with a stake in itself. The seller later chose a reported cash buyback. Uber ended up with both the domain and the repurchased equity, but the surviving public evidence does not support a precise claim that Universal "lost" billions.
 
 ## The money looked different then
 
-It is tempting to judge this deal from the end of the story, where Uber is a global company and the missed stake is worth billions. But every party in 2010 was acting in a fog.
+It is tempting to judge this deal from the end of the story, where Uber is a global company and counterfactual estimates for the repurchased stake can become enormous. But every party in 2010 was acting in a fog, and those estimates depend on assumptions about dilution and holding history.
 
-In 2010, Uber was a single-city black-car app that had just been threatened with daily jail time by its hometown regulators. It had raised $1.25 million. It had no idea whether it would survive the cease-and-desist, let alone whether "Cab" or no "Cab" it would ever be more than a luxury convenience for San Francisco tech workers.
+In 2010, Uber was a single-city black-car app facing an order whose reported penalties included fines and possible jail time for continued operation. It had raised $1.25 million. It had no idea whether it would survive the cease-and-desist, let alone whether "Cab" or no "Cab" it would ever be more than a luxury convenience for San Francisco tech workers.
 
 From *that* vantage point, the math looks different on both sides:
 
-- For **Uber**, paying cash it didn't have was impossible; trading 2% of a company that might be worth nothing was almost free. The downside was a rounding error. The upside was owning its own name.
-- For **Universal**, accepting equity in a tiny, legally-embattled car app instead of cash was the *risky* choice. Taking $107,000 of paper for a domain off a dead startup looked smart. Selling that paper for under a million dollars looked smart too — right up until Uber became Uber.
+- For **Uber**, a cash purchase would have consumed scarce operating capital. Trading 2% of a company that might fail shifted the consideration into uncertain future value, but it was not free: the equity diluted the other owners if the company succeeded. The upside was owning its own name.
+- For **Universal**, accepting equity in a tiny, legally embattled car app instead of cash was the *risky* choice. The later reported buyback around $1 million exchanged uncertain future upside for cash, without giving us enough primary evidence to calculate the exact opportunity cost.
 
 The lesson isn't "Universal was foolish." It's that a domain trade priced in equity is really two bets stacked together: a bet on the name, and a bet on the company. Uber won both. Universal won the first and folded on the second.
 
@@ -125,10 +125,10 @@ The gap between UberCab.com and Uber.com is one word. Strategically, it is the d
 | UberCab.com | Uber.com |
 | Names a taxi-like service | Names a company without a ceiling |
 | Anchored to the "cab" category | Travels across rides, food, freight, and more |
-| Invites taxi regulators by its own name | Sheds the regulatory label baked into the word |
+| Carries a taxi-category label | Removes that category label from the brand |
 | Adds a word to every mention | Reduces the brand to one word — and then to a verb |
 
-This is the same pattern that shows up again and again in domain upgrades: early names *explain*, great names *own*. The descriptive version helps while a company still has to tell you what it does. The exact-match version helps once the company is ready to *be* the thing people reach for by default. Dropping "Cab" didn't just dodge a regulator — it removed the category cap baked into the name.
+This is the same pattern that shows up again and again in domain upgrades: early names *explain*, great names *own*. The descriptive version helps while a company still has to tell you what it does. The exact-match version helps once the company is ready to *be* the thing people reach for by default. Dropping "Cab" did not settle the regulatory dispute, but it removed the category cap baked into the name.
 
 As Smart Branding observed, [Uber really wasn't a taxicab company in the traditional sense, so there was no reason to attach the term "cab" to its name](https://smartbranding.com/ubercab-com-to-uber-com/#:~:text=Uber%20really%20wasn%E2%80%99t%20a%20taxicab%20company%20in%20the%20traditional%20sense).
 
@@ -154,7 +154,7 @@ A company's core domain shows up in places the marketing team never directly con
 - In search results and browser bars.
 - In every spoken recommendation — "just take an Uber" — passed from one person to the next.
 
-Every one of those repetitions either adds friction or removes it. UberCab.com made each mention longer, more taxi-bound, more legally loaded. Uber.com made each mention shorter, cleaner, and category-free. Multiply that across billions of trips and a name that became a literal verb in everyday speech, and the cost of the domain — 2% of a then-tiny company — stops looking like a price and starts looking like the cheapest infrastructure Uber ever bought.
+Every one of those repetitions either adds friction or removes it. UberCab.com made each mention longer, more taxi-bound, and more legally loaded. Uber.com made each mention shorter, cleaner, and category-free. Repeated across a global service and a name that became a verb in everyday speech, the domain starts to look like durable brand infrastructure — even though its equity cost cannot be reduced to a single verified dollar figure.
 
 The domain didn't build Uber's brand. But once Uber.com was the address, every future repetition of the name compounded on a cleaner foundation — one with no "Cab" to explain away.
 
@@ -163,9 +163,9 @@ The domain didn't build Uber's brand. But once Uber.com was the address, every f
 The easy takeaway — "drop the descriptive word and buy your exact-match [.com](/en/tld/com/)" — is too blunt. The more useful lessons are about sequence, leverage, and how you pay:
 
 1. **A descriptive domain is fine to start.** UberCab.com did real work: it made an alien idea — summon a car with your phone — instantly legible. A modifier like "Cab," "App," or "HQ" is a reasonable on-ramp, not a failure.
-2. **Watch for the moment the modifier becomes a liability, not just a ceiling.** For most companies the signal is ambition outgrowing the name. For Uber it was sharper: the word "Cab" literally invited a [cease and desist](https://techcrunch.com/2010/10/24/ubercab-ordered-to-cease-and-desist/#:~:text=cease%20and%20desist). When your name is doing the regulator's targeting for them, the upgrade is urgent.
+2. **Watch for the moment the modifier becomes a mismatch, not just a ceiling.** For Uber, the cease-and-desist made the taxi classification central, while the cited operating concerns went well beyond the brand name. When a modifier describes a narrower regulated category than the business claims to occupy, reassess it — without mistaking a rename for regulatory compliance.
 3. **Secure the exact-match domain before the rename is real.** Uber couldn't be "Uber" while it lived at UberCab.com. The slow, externally-owned asset — the domain — had to be locked down for the corporate rename to mean anything.
-4. **When you have no cash, the domain can still move — if you can structure the trade.** Uber paid in equity because it had to. That creativity got it the name. But the deal also shows the seller's risk: a domain priced in startup equity is a bet on the startup, and Universal cashed out [for just $863,000](https://www.snagged.com/post/uber-com-the-3-46b-domain-that-universal-music-let-go#:~:text=Universal%20Music%20decided%20to%20sell%20its%202%25%20stake%20back%20to%20Uber%E2%80%94for%20just%20%24863%2C000) before the upside arrived.
+4. **When cash is scarce, a domain can still move through a structured trade.** Reports say Uber used equity to acquire the name. The deal also shows the seller's risk: startup equity is volatile consideration, and later accounts place Universal's buyback at roughly $1 million rather than agreeing on an exact figure.
 
 The domain upgrade did not make Uber win. Product, capital, aggression, timing, and execution mattered far more. But Uber.com made the company's reinvention — from "a better cab" into a category — *nameable*, and it had to be secured the moment the old name turned toxic.
 
@@ -175,9 +175,9 @@ The domain upgrade did not make Uber win. Product, capital, aggression, timing, 
 
 This case is, at its core, a transfer problem wearing a branding costume.
 
-The strategic decision was never really in doubt — of course a company called Uber should own Uber.com. The hard part was everything around the asset: finding the unlikely owner (a music label sitting on a dead startup's domain), agreeing on terms when the buyer had no cash, structuring an equity-for-domain trade, moving control cleanly, and doing it all under deadline pressure from regulators. The deal also left a long tail of value questions — what was 2% worth then, what was it worth later, who captured the upside — that took years and a Vanity Fair scoop to fully surface.
+The strategic appeal is easy to understand — a company called Uber benefits from owning Uber.com. Reports describe an unusual owner and an equity-for-domain structure, but they do not expose the complete negotiation, transfer process, valuation method, or capitalization history. Those gaps are why the 2% figure is more defensible than the precise dollar values later attached to it.
 
-[Namefi](https://namefi.io) is built around the idea that domains should behave like internet-native assets. Tokenized ownership can make domain control easier to verify, transfer, and integrate into modern workflows while staying compatible with [DNS](/en/glossary/dns/) — turning the messiest parts of a deal like this (proving who owns what, agreeing on value, and moving it safely) into something closer to a clean, auditable transaction. A future where a domain can be priced, traded, and even partially exchanged for other assets without a multi-year paper trail is exactly the kind of friction this case spent so much effort overcoming.
+[Namefi](https://namefi.io) is built around the idea that domains should behave like internet-native assets. Tokenized ownership can make domain control easier to verify, transfer, and integrate into modern workflows while staying compatible with [DNS](/en/glossary/dns/) — turning tasks such as proving control and moving an asset into something closer to a clean, auditable transaction. That is a general benefit of more transparent domain infrastructure; the public Uber.com record does not show which transfer mechanisms the parties actually used.
 
 Uber.com looks inevitable now because Uber became enormous. But the lesson lands long before that scale: when a name is going to carry the business — and especially when the old name has become a liability — the domain isn't decoration. It's the part of the brand worth trading a slice of the company to get right.
 


### PR DESCRIPTION
## Summary

- describe the 2010 order using the reported licensing, insurance, dispatch, and prebooking concerns instead of claiming the word “Cab” was the legal basis
- keep the consistently reported 2% equity-for-domain structure while qualifying unsupported $107K and $3.46B valuations
- reconcile secondary buyback reports as roughly $1 million rather than presenting $863K as certain
- remove unsupported negotiation, transfer, and counterfactual opportunity-cost claims

## Source checked

- [TechCrunch: UberCab Ordered to Cease And Desist](https://techcrunch.com/2010/10/24/ubercab-ordered-to-cease-and-desist/)

## Validation

- `TMPDIR=/private/tmp bun run data:validate` (29 pre-existing empty-keyword warnings)
- `TMPDIR=/private/tmp bun run lint:mdx`
- `TMPDIR=/private/tmp bun run check:termbase`
- `TMPDIR=/private/tmp bun .agents/skills/cross-link/link-audit.ts content/blog/en/from-ubercab-com-to-uber-com.md`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single English blog post; editorial fact-checking only, no application or data pipeline changes.
> 
> **Overview**
> Tightens factual claims in the **UberCab → Uber.com** case study (`from-ubercab-com-to-uber-com.md`) so the narrative matches what secondary sources actually support.
> 
> The **2010 cease-and-desist** section no longer says the word “Cab” was the legal basis for the order; it now cites TechCrunch’s reported operating issues (licensing, insurance, dispatch, prebooking) and notes that dropping “Cab” did not resolve compliance.
> 
> **Deal economics** are hedged: the **2% equity-for-domain** structure stays, but **$107K** at closing and **$3.46B** counterfactuals are framed as estimates with unstated dilution/valuation assumptions. **Buyback** copy reconciles **$863K vs ~$1M** as “roughly $1 million” without treating either as primary-document fact.
> 
> **Front matter** (title/description) and **founder lessons / Namefi** sections lose unsupported certainty about negotiation, transfer mechanics, and Universal “losing billions,” while keeping the branding and equity-trade story.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b2d50b83cb8239d9a046722c28fce5e4b28c936. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->