### PR TITLE
fix(content): qualify domain hijacking controls

### DIFF
--- a/content/blog/en/how-domain-hijacking-actually-happens.md
+++ b/content/blog/en/how-domain-hijacking-actually-happens.md
@@ -1,5 +1,5 @@
 ---
-title: 'How Domain Hijacking Actually Happens: Five Attack Paths and the Controls That Stop Them'
+title: 'How Domain Hijacking Actually Happens: Five Attack Paths and Controls That Reduce the Risk'
 date: '2026-05-10'
 language: en
 tags: ['security', 'domains', 'registrar', 'incident-response', 'domain-flipping']
@@ -9,7 +9,7 @@ cluster: domain-security
 series: domain-apocalypse
 seriesOrder: 1
 format: case-study
-description: A practical walk-through of the five ways attackers actually take over domains in the real world—social engineering, registrar account compromise, DNS provider takeover, NS hijacks, and expired-domain reclamation—and the specific controls that block each one.
+description: A practical walk-through of five ways attackers take over domains in the real world—social engineering, registrar account compromise, DNS provider takeover, NS hijacks, and expired-domain reclamation—and controls that prevent, limit, or detect them.
 ogImage: ../../assets/how-domain-hijacking-actually-happens-og.jpg
 keywords: ['domain hijacking', 'domain security', 'registrar lock', 'transfer lock', 'dnssec', 'two factor authentication', 'social engineering', 'dangling dns', 'namefi']
 relatedArticles:
@@ -36,15 +36,15 @@ relatedGlossary:
 
 In every case, the result is the same: someone else is now telling the world where your name points. Email, payments, login flows, and SaaS integrations all start sending traffic to the attacker. Recovery often takes days, sometimes weeks. If the domain was transferred to another registrar, [ICANN](/en/glossary/icann/)'s [Transfer Dispute Resolution Policy (TDRP)](https://www.icann.org/en/contracted-parties/consensus-policies/uniform-domain-name-dispute-resolution-policy/domain-name-dispute-resolution-policies-25-02-2012-en#:~:text=The%20Transfer%20Dispute%20Resolution%20Policy%20(TDRP)%20applies%20to%20transactions%20in%20which%20a%20domain%2Dname%20holder%20transfers%20or%20attempts%20to%20transfer%20a%20domain%20name%20to%20a%20new%20registrar.) may be relevant; other cases often require registrar escalation, [registry](/en/glossary/registry/) escalation, platform recovery, or a court order. The fastest fix is to never get into that position in the first place.
 
-This post walks through the five attack paths we see most often, what each one looks like from the defender's side, and the specific controls that actually stop it.
+This post walks through five recurring attack paths, what each one looks like from the defender's side, and controls that can prevent, limit, or detect them.
 
 ## 1. Social engineering against the registrar's support team
 
-The most common high-profile hijacks of the last decade did not involve any technical exploit. They involved a phone call.
+Many high-profile hijacks have not required a technical exploit. They have relied on a phone call or support request.
 
 The pattern: an attacker collects enough information about a target—[WHOIS](/en/glossary/whois/) history, LinkedIn, leaked password dumps, social media—and then calls or emails the registrar's support team impersonating the owner. They ask for a password reset, an email change, or a transfer [auth code](/en/glossary/auth-code/). If the support agent runs a checklist that the attacker has prepared for, the account changes hands.
 
-This was the mechanism behind several of the most damaging hijacks involving cryptocurrency exchanges, ad platforms, and infrastructure brands. It does not require any vulnerability in the registrar's code; it exploits the human in the loop.
+This path does not require a vulnerability in the registrar's code; it exploits the human in the loop.
 
 **What stops it:**
 
@@ -58,7 +58,7 @@ The technical cousin of social engineering. The attacker phishes the registrar a
 
 **What stops it:**
 
-- **Phishing-resistant 2FA on the registrar account.** TOTP via authenticator app is the floor; hardware keys (WebAuthn / FIDO2) are the ceiling. SMS-based 2FA is not sufficient—SIM-swapping attacks have repeatedly defeated it. The U.S. government's [CISA guidance](https://www.cisa.gov/secure-our-world/turn-mfa) explicitly recommends moving off SMS.
+- **Phishing-resistant 2FA on the registrar account.** TOTP via an authenticator app is stronger than password-only access; hardware keys using WebAuthn/FIDO2 are the strongest widely available option. SMS-based 2FA remains vulnerable to SIM swapping. The U.S. government's [CISA guidance](https://www.cisa.gov/secure-our-world/turn-mfa) recommends phishing-resistant MFA where available.
 - **A registrar that supports per-domain locks** in addition to per-account locks, so a single account compromise cannot unlock everything at once.
 - **Audit trail and alerting** on contact changes, nameserver changes, and transfer requests. The attacker's first move is to silence those alerts; if they fire to a channel the attacker does not control, you get warning time.
 
@@ -83,7 +83,7 @@ Examples:
 - A subdomain CNAMEd to an old Heroku, S3, or Azure asset that has been released. The attacker re-claims that asset name and gets a valid TLS cert.
 - A delegated `NS` record pointing at a DNS provider account that has been deleted. The attacker creates a fresh account using that exact host pattern and serves whatever records they want for the subdomain.
 
-These are catalogued under the umbrella term **dangling DNS**, and they are the most common form of "real" domain hijacks on the open web today because most large organizations have hundreds or thousands of subdomains and only audit a fraction of them.
+These are catalogued under the umbrella term **dangling DNS**. The risk grows with large, poorly inventoried subdomain estates because abandoned third-party mappings can remain live after the underlying resource is removed.
 
 **What stops it:**
 
@@ -100,30 +100,30 @@ This sounds like an operational failure, not a security incident, but the impact
 **What stops it:**
 
 - **Multi-year renewal** (5-10 years) on any domain that touches authentication, payments, or production traffic. The cost is trivial; the protection is significant.
-- **Auto-renewal with a payment method that cannot silently fail.** Card expirations are the single most common cause of accidental expiry.
+- **Auto-renewal with monitored payment and failure alerts.** Cards expire and payment attempts fail, so auto-renewal is only effective when a team watches the failure channel.
 - **Calendar reminders** at 90, 60, 30, and 7 days that fire to a *team* address, not the inbox of one person who might leave the company.
 
 ## What good looks like
 
 Pulling the controls together, the baseline for any domain that matters looks like this:
 
-| Control                                | Blocks attack path                              |
-| -------------------------------------- | ----------------------------------------------- |
-| Hardware-key 2FA on registrar          | Account compromise (path 2)                     |
-| Hardware-key 2FA on DNS provider       | DNS takeover (path 3)                           |
-| Registry lock (where available)        | Social engineering (path 1)                     |
-| DNSSEC signed at the zone              | DNS in-path tampering and forged answers        |
-| Subdomain inventory + dangling scanner | Subdomain hijack (path 4)                       |
-| 5-10 year renewal + auto-renew         | Accidental expiry (path 5)                      |
-| Alerts on contact/NS/transfer changes  | All five (you learn early)                      |
+| Control                                | Primary mitigation or detection role                              |
+| -------------------------------------- | ----------------------------------------------------------------- |
+| Hardware-key 2FA on registrar          | Reduces registrar account compromise risk (path 2)                |
+| Hardware-key 2FA on DNS provider       | Reduces DNS-provider account compromise risk (path 3)             |
+| Registry lock (where available)        | Adds out-of-band approval for covered registry changes (paths 1-2) |
+| DNSSEC signed at the zone              | Rejects in-path tampering and forged DNS answers                  |
+| Subdomain inventory + dangling scanner | Detects and prevents abandoned subdomain mappings (path 4)        |
+| 5-10 year renewal + auto-renew         | Reduces accidental expiry risk (path 5)                           |
+| Alerts on contact/NS/transfer changes  | Detects some registrar and delegation changes (paths 1-3)         |
 
-If you are responsible for a domain and you cannot tick every row, the attacker's job is materially easier.
+Not every control is available for every TLD or provider. The goal is to document which controls apply, identify uncovered paths, and add compensating monitoring rather than treating the table as a universal guarantee.
 
 ## How Namefi changes the picture
 
-Most of the controls above exist as features at one registrar, one DNS provider, or one workflow tool, and the security depends on whichever account is weakest. Namefi tokenizes the registrant relationship [on-chain](/en/glossary/on-chain/), which means the authoritative record of *who owns this name* lives outside any single registrar's customer database. A support agent at any one provider cannot quietly change ownership without a signed transaction the rightful owner has to approve. The registrar still operates the technical delegation, but the *control* layer is moved into a place where social engineering does not work.
+Most of the controls above exist as features at one registrar, one DNS provider, or one workflow tool, and security depends on the weakest relevant account. Namefi adds an [on-chain](/en/glossary/on-chain/) token as a parallel control layer for a traditional DNS registration. As [the two-layer model explains](/en/blog/dns-on-tokenized-domains/), the NFT can become the control point for supported ownership and transfer actions while the registrar and registry layers continue to operate the DNS name.
 
-That is not a complete substitute for the controls in the table above—you still need DNSSEC, you still need 2FA on the DNS provider, you still need to renew. But it removes the single most common high-impact hijack vector (path 1) from the threat model entirely.
+That can reduce exposure to registrar-dashboard credential theft or support-driven changes when the workflow actually requires wallet authorization. It does not make social engineering impossible or remove path 1 entirely: the domain still depends on registrar and registry processes, the wallet introduces its own key-management and recovery risks, and DNS-provider accounts remain separate attack surfaces. DNSSEC, renewal controls, account security, and incident recovery are still required.
 
 ## Sources and further reading
 


### PR DESCRIPTION
## Summary

- replace unsupported “most common” rankings with scoped descriptions of recurring attack paths
- distinguish preventive controls from detection and remove the claim that one alert type covers all five paths
- qualify MFA, registry-lock, dangling-DNS, and renewal guidance so controls are not presented as universal guarantees
- describe Namefi's on-chain layer as an additional control surface without claiming social engineering is impossible or removed from the threat model

## Product/security source checked

- [Namefi: DNS still works on a tokenized domain](https://namefi.io/r/en/blog/dns-on-tokenized-domains)

## Validation

- `TMPDIR=/private/tmp bun run data:validate` (29 pre-existing empty-keyword warnings)
- `TMPDIR=/private/tmp bun run lint:mdx`
- `TMPDIR=/private/tmp bun run check:termbase`
- `TMPDIR=/private/tmp bun .agents/skills/cross-link/link-audit.ts content/blog/en/how-domain-hijacking-actually-happens.md`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to one English blog post; no application logic, auth, or data handling.
> 
> **Overview**
> **Tones down absolute security claims** in `how-domain-hijacking-actually-happens.md` so guidance reads as risk reduction and detection, not guaranteed blocking.
> 
> Title, description, and intro now say controls **prevent, limit, or detect** rather than **stop** attacks. Wording drops unsupported rankings (e.g. “most common” paths) in favor of **recurring** attack paths.
> 
> Per-section edits qualify **MFA** (TOTP vs hardware keys vs SMS), **dangling DNS** (risk tied to large subdomain estates, not “most common” hijacks), and **auto-renewal** (needs monitored payment/failure alerts, not a payment method that “cannot silently fail”).
> 
> The **controls table** is reframed from “Blocks attack path” to **mitigation or detection roles**, with softer verbs (`Reduces`, `Detects`, `Adds out-of-band approval`) and alerts scoped to **some** registrar/delegation changes (paths 1–3), not all five. A new note states controls are **not universal** across TLDs/providers.
> 
> The **Namefi** section is rewritten to describe an **on-chain token as a parallel control layer** (with a link to the two-layer model), and explicitly states it does **not** remove social engineering or path 1, plus wallet and DNS-provider risks remain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e56806d1738ebc8d0917376d699c434ad08d87d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->