### PR TITLE
fix(content): qualify tokenized marketplace settlement

### DIFF
--- a/content/blog/en/how-tokenized-marketplaces-replace-escrow.md
+++ b/content/blog/en/how-tokenized-marketplaces-replace-escrow.md
@@ -38,9 +38,9 @@ The traditional flow for selling a `.com` looks something like this:
 3. Open an [escrow](/en/glossary/escrow/) at [Escrow.com](https://www.escrow.com/) or similar. Buyer wires funds.
 4. Seller unlocks the domain and provides the [auth code](/en/glossary/auth-code/).
 5. Buyer initiates [cross-registrar transfer](/en/glossary/cross-registrar-transfer/) at their [registrar](/en/glossary/registrar/).
-6. Wait for the [ICANN](/en/glossary/icann/) inter-registrar process. Under ICANN's current policy, the transfer proceeds by default if the registrar of record does not respond to the registry within five calendar days; that is a response window, not a five-day lock.
+6. Wait for the [ICANN](/en/glossary/icann/) inter-registrar process. Under ICANN's current policy, the registry completes the transfer unless it receives a NACK from the registrar of record within five calendar days; that is a response window, not a five-day lock.
 7. Confirm the transfer; escrow releases funds.
-8. Pay the escrow provider's current fee, plus any marketplace charges. [Escrow.com's published standard domain fee schedule](https://www.escrow.com/domains) currently ranges from 2.6% for transactions up to USD 5,000 to 0.7% for transactions above USD 10 million; its optional concierge tier ranges from 5.2% to 1.4% across those bands.
+8. Pay the escrow provider's current fee, plus any marketplace charges. [Escrow.com's published USD fee schedule](https://www.escrow.com/fee-calculator) currently ranges from 2.6% for standard service on transactions up to USD 5,000 to 0.7% above USD 10 million; its optional concierge tier ranges from 5.2% to 1.4% across those bands. Published minimum fees apply in several bands, and eligible credit-card or PayPal payments up to USD 5,000 add a 3.05% payment-processing fee.
 
 It works. It's been the standard for two decades. It is also slow, expensive, and full of moments where one party has to trust the other (or a third-party escrow) to do the right thing.
 
@@ -72,7 +72,7 @@ Compatible venues can add discovery and settlement surfaces. Whether that produc
 
 **Potentially unnecessary for the supported on-chain trade.** Replaced by atomic settlement for the payment and NFT legs.
 
-In the traditional flow, escrow bridges the asynchronous gap between buyer payment and domain transfer. An atomic marketplace contract can remove that gap for the token trade, so a separate fund-holding service may not be needed for that leg. This avoids the selected escrow service's fee, but marketplace fees, network gas, currency conversion, and any registrar-side processing can remain. As of this article's update, [Escrow.com's standard domain schedule](https://www.escrow.com/domains) is 0.7%–2.6% by transaction value, not a universal 3%–6%.
+In the traditional flow, escrow bridges the asynchronous gap between buyer payment and domain transfer. An atomic marketplace contract can remove that gap for the token trade, so a separate fund-holding service may not be needed for that leg. This avoids the selected escrow service's fee, but marketplace fees, network gas, currency conversion, and any registrar-side processing can remain. As of this article's update, [Escrow.com's standard USD domain schedule](https://www.escrow.com/fee-calculator) is 0.7%–2.6% by transaction value, with published minimums in several bands and an additional 3.05% processing fee for eligible credit-card or PayPal payments up to USD 5,000; the percentage range is not the complete effective cost in every case.
 
 ### Auth codes (EPP codes)
 
@@ -82,7 +82,7 @@ In the traditional flow, escrow bridges the asynchronous gap between buyer payme
 
 ### ICANN transfer timing and 60-day restrictions
 
-There is no general "five-day registrar lock." Under the [ICANN Transfer Policy](https://www.icann.org/en/contracted-parties/accredited-registrars/resources/domain-name-transfers/policy), five calendar days is the window in which the registrar of record can respond to the registry before an inter-registrar request receives default approval. Separate rules allow denial within 60 days of initial registration or a previous inter-registrar transfer.
+There is no general "five-day registrar lock." Under the [ICANN Transfer Policy](https://www.icann.org/en/contracted-parties/accredited-registrars/resources/domain-name-transfers/policy), the registry completes an inter-registrar transfer unless it receives a NACK from the registrar of record within five calendar days. Separate rules allow denial within 60 days of initial registration or a previous inter-registrar transfer. A registrar can also impose a 60-day inter-registrar lock after a Change of Registrant when the registered name holder did not opt out before the change; whether that pre-change opt-out is offered depends on the registrar.
 
 An in-protocol NFT transfer may not be an inter-registrar transfer, but that does not make ICANN and registrar policy irrelevant. The platform must still map the buyer to the registered name holder or authorized control record, and a later detokenization or registrar move can encounter transfer restrictions.
 

--- a/content/blog/en/how-tokenized-marketplaces-replace-escrow.md
+++ b/content/blog/en/how-tokenized-marketplaces-replace-escrow.md
@@ -1,5 +1,5 @@
 ---
-title: "From Listing to Settlement: How Tokenized Marketplaces Replace Escrow"
+title: "From Listing to Settlement: How Tokenized Marketplaces Can Replace Escrow"
 date: '2026-05-22'
 language: en
 tags: ['guide']
@@ -9,7 +9,7 @@ cluster: domain-tokenization
 series: tokenize-your-com
 seriesOrder: 3
 format: explainer
-description: How tokenized-domain marketplaces let buyers and sellers settle atomically on-chain — no escrow service, no auth codes, no five-day registrar lock. What replaces each piece of the traditional flow, and what risks shift to other layers.
+description: How tokenized-domain marketplaces can settle payment and an NFT atomically, while registrar claims, record updates, fees, and platform-specific risks may remain.
 keywords: ['domain marketplace blockchain', 'atomic domain transfer', 'tokenized domain marketplace', 'replace domain escrow', 'no escrow domain sale', 'domain sale crypto', 'tokenized domain sale process', 'sell tokenized domain', 'buy tokenized domain', 'on-chain domain sale', 'domain NFT settlement', 'domain marketplace 2026', 'tokenized domain liquidity']
 relatedArticles:
   - /en/blog/domain-escrow-explained/
@@ -33,30 +33,30 @@ relatedGlossary:
 
 The traditional flow for selling a `.com` looks something like this:
 
-1. List on [Sedo](https://sedo.com/), [Afternic](https://www.afternic.com/), or Dan.com.
+1. List on [Sedo](https://sedo.com/), [Afternic](https://www.afternic.com/), or another domain marketplace.
 2. Negotiate.
 3. Open an [escrow](/en/glossary/escrow/) at [Escrow.com](https://www.escrow.com/) or similar. Buyer wires funds.
 4. Seller unlocks the domain and provides the [auth code](/en/glossary/auth-code/).
 5. Buyer initiates [cross-registrar transfer](/en/glossary/cross-registrar-transfer/) at their [registrar](/en/glossary/registrar/).
-6. Wait 5–7 days for the [ICANN](/en/glossary/icann/) transfer to clear.
+6. Wait for the [ICANN](/en/glossary/icann/) inter-registrar process. Under ICANN's current policy, the transfer proceeds by default if the registrar of record does not respond to the registry within five calendar days; that is a response window, not a five-day lock.
 7. Confirm the transfer; escrow releases funds.
-8. Pay 3–6% in escrow fees, plus marketplace cuts.
+8. Pay the escrow provider's current fee, plus any marketplace charges. [Escrow.com's published standard domain fee schedule](https://www.escrow.com/domains) currently ranges from 2.6% for transactions up to USD 5,000 to 0.7% for transactions above USD 10 million; its optional concierge tier ranges from 5.2% to 1.4% across those bands.
 
 It works. It's been the standard for two decades. It is also slow, expensive, and full of moments where one party has to trust the other (or a third-party escrow) to do the right thing.
 
-Tokenized-domain sales compress the whole thing into one transaction. This post explains how, and where the trust actually moves to.
+Tokenized-domain marketplaces can compress the **payment and NFT transfer** into one transaction. Whether that single transaction also completes the registrar-side change depends on the protocol and registrar integration. This post explains what can become atomic, what can remain asynchronous, and where the trust moves.
 
 ---
 
-## The New Flow, End-to-End
+## The New Flow Is Platform-Specific
 
-1. List the [tokenized domain](/en/blog/what-are-tokenized-domains/) on a [marketplace](/en/glossary/marketplace/) (Namefi's own, Doma's, [OpenSea](https://opensea.io/), [Blur](https://blur.io/), etc.).
-2. Buyer pays. The [NFT](/en/glossary/nft/) moves to the buyer's [wallet](/en/glossary/wallet/). The [registrar](/en/glossary/registrar/)-side record is kept in sync by the platform.
-3. Done.
+1. List the [tokenized domain](/en/blog/what-are-tokenized-domains/) on a [marketplace](/en/glossary/marketplace/) that supports its chain and issuing contract.
+2. Buyer pays through the marketplace contract. If the trade is atomic, the [NFT](/en/glossary/nft/) moves to the buyer's [wallet](/en/glossary/wallet/) only when payment succeeds.
+3. Complete any protocol-specific registrar step and verify the [registrar](/en/glossary/registrar/) record. For example, [Doma's documentation](https://docs.doma.xyz/faq) says a marketplace buyer must claim the domain on Doma, provide an email address, and let the registrar finalize its ownership records.
 
-That's it. Two steps. No [auth code](/en/glossary/auth-code/), no [escrow](/en/glossary/escrow/), no 5-day registrar lock, no "I sent the wire, now I'm trusting you" gap.
+The on-chain purchase can remove the "I sent the wire, now I'm trusting you to send the token" gap. It does not guarantee that every platform completes the full domain-ownership workflow in two steps. Some systems synchronize registrar records automatically; others require a claim or verification step after the NFT purchase.
 
-This works because the **NFT is the canonical ownership record**, and [on-chain](/en/glossary/on-chain/) transactions are [atomic](/en/glossary/atomic-transfer/): payment and asset transfer happen in the same block, or neither happens.
+Within a supported protocol, the NFT can be the record that authorizes platform-level control. It is not, by itself, the universal ICANN registration record. The [on-chain](/en/glossary/on-chain/) payment and token transfer can be [atomic](/en/glossary/atomic-transfer/) while a registrar claim or record update still happens afterward.
 
 ---
 
@@ -64,35 +64,35 @@ This works because the **NFT is the canonical ownership record**, and [on-chain]
 
 ### Listing platform
 
-Same idea, different surface. Marketplaces still take a cut and still curate listings. The big change: tokenized listings can show up on **multiple marketplaces at once** because they're standard NFTs. List once on the platform that originated the domain; OpenSea/Blur may aggregate it automatically.
+Same idea, different surface. Marketplaces can take a cut and apply their own listing rules. An NFT standard can make cross-market integration easier, but it does not guarantee aggregation: each marketplace must support the chain and contract, and a stale listing can be dangerous if the asset sells elsewhere.
 
-This is a meaningful [liquidity](/en/glossary/domain-liquidity/) improvement over the legacy domain world, where Sedo and Afternic ran walled gardens.
+Compatible venues can add discovery and settlement surfaces. Whether that produces more [liquidity](/en/glossary/domain-liquidity/) depends on buyer demand, marketplace support, and accurate listing synchronization.
 
 ### Escrow.com
 
-**Gone.** Replaced by on-chain atomic settlement.
+**Potentially unnecessary for the supported on-chain trade.** Replaced by atomic settlement for the payment and NFT legs.
 
-In the traditional flow, escrow exists to bridge the asynchronous gap between buyer paying and seller transferring. In the tokenized flow, that gap doesn't exist — the transaction is atomic, so no third party needs to hold the money in the middle. This eliminates the 3–6% escrow fee and the wait time.
+In the traditional flow, escrow bridges the asynchronous gap between buyer payment and domain transfer. An atomic marketplace contract can remove that gap for the token trade, so a separate fund-holding service may not be needed for that leg. This avoids the selected escrow service's fee, but marketplace fees, network gas, currency conversion, and any registrar-side processing can remain. As of this article's update, [Escrow.com's standard domain schedule](https://www.escrow.com/domains) is 0.7%–2.6% by transaction value, not a universal 3%–6%.
 
 ### Auth codes (EPP codes)
 
-**Not needed for the tokenized half of the transaction.** The on-chain transfer happens immediately. The registrar-side record sync is handled by the protocol; the buyer doesn't need to do anything manual.
+**Usually not needed for an in-protocol NFT sale.** Moving the token does not itself change registrars. However, the buyer may still need to claim the domain or provide information so an integrated registrar can update its records; Doma documents exactly such a post-purchase claim.
 
 (If a buyer later wants to *de-tokenize* the domain and move it to a different registrar entirely, that's a separate flow that would re-engage the traditional registrar transfer mechanism — auth codes and all.)
 
-### ICANN 5-day transfer lock
+### ICANN transfer timing and 60-day restrictions
 
-**Skipped for the tokenized transfer itself.** ICANN's transfer rules apply to inter-registrar transfers, not to ownership changes within a registrar. The tokenized-domain platform handles the on-chain change without triggering a full inter-registrar transfer.
+There is no general "five-day registrar lock." Under the [ICANN Transfer Policy](https://www.icann.org/en/contracted-parties/accredited-registrars/resources/domain-name-transfers/policy), five calendar days is the window in which the registrar of record can respond to the registry before an inter-registrar request receives default approval. Separate rules allow denial within 60 days of initial registration or a previous inter-registrar transfer.
 
-There's a related rule — the 60-day cooldown after a registrar transfer — that still applies if a domain was recently transferred between registrars. That's about registrar transfers, not on-chain transfers, so it doesn't block tokenized sales.
+An in-protocol NFT transfer may not be an inter-registrar transfer, but that does not make ICANN and registrar policy irrelevant. The platform must still map the buyer to the registered name holder or authorized control record, and a later detokenization or registrar move can encounter transfer restrictions.
 
 ### Wire transfers and bank delays
 
-**Replaced by crypto and [stablecoin](/en/glossary/stablecoin/) payments.** USDC, ETH, and other on-chain payments settle in seconds. Wire transfers settle in days. The difference is most stark for international sales.
+**Can be replaced by crypto or [stablecoin](/en/glossary/stablecoin/) payments.** On-chain confirmation time and finality depend on the network, while fiat wires depend on banks, currencies, and jurisdictions. Neither should be described with one universal settlement time.
 
 ### "I'm trusting the other person to do their part"
 
-**Replaced by smart-contract atomicity.** The transaction either fully completes (you get the asset, they get the money) or doesn't happen (no movement on either side). There's no version where one side moves and the other doesn't.
+**Reduced for the atomic legs of the trade.** A correctly implemented marketplace transaction can ensure that the NFT and payment move together or both revert. Trust remains in the contract, marketplace interface, issuing protocol, registrar integration, and any post-sale claim process.
 
 ---
 
@@ -128,9 +128,9 @@ A sale paid in crypto is a different tax event from a sale paid in fiat in some 
 
 ## What This Means for Buyers
 
-- **Speed.** Sales settle in minutes, not days.
-- **Lower fees.** No escrow cut. Marketplace and [gas](/en/glossary/gas/) costs are usually much lower than 3–6%.
-- **Direct ownership.** The NFT is in your wallet, immediately, with no waiting.
+- **Potential speed.** The payment and NFT transfer can settle in one transaction; registrar claims or record updates can take additional time.
+- **Different fees.** A supported atomic trade may avoid a separate escrow charge, but marketplace, [gas](/en/glossary/gas/), payment, and registrar costs remain. Compare the actual all-in totals.
+- **Direct token control.** The NFT can arrive in your wallet immediately, but verify that any required registrar claim and ownership-record update also complete.
 - **Verification.** You can check on-chain history before buying — when the domain was minted, prior transfers, prior listings.
 
 You're trading the comfort of a familiar escrow workflow for the unfamiliar comfort of cryptographic atomicity. For most buyers used to NFTs, this is a net upgrade. For first-timers, it pays to do a small practice transaction first.
@@ -140,36 +140,36 @@ You're trading the comfort of a familiar escrow workflow for the unfamiliar comf
 ## What This Means for Sellers
 
 - **Same upgrades**: faster, cheaper, more transparent.
-- **More venues.** Your listing can appear on multiple NFT marketplaces simultaneously.
+- **Potentially more venues.** A listing can reach multiple compatible NFT marketplaces if each supports the chain and contract and the listings stay synchronized.
 - **Different audience.** NFT-marketplace buyers behave differently from traditional domain buyers. Pricing dynamics may shift in either direction depending on the domain.
-- **No "buyer flake" risk.** Either the transaction completes or it doesn't. No more "buyer paid the escrow and then disappeared."
+- **No partial atomic trade.** The payment-and-NFT transaction either completes or reverts, although post-sale registrar claims and buyer support can still fail or stall.
 
-The flip side: you give up the (sometimes considerable) marketing reach of the traditional domain industry's specialized brokerages. For premium domains, hybrid strategies — list both as a tokenized NFT and through traditional channels — are common.
+The flip side: you may give up the marketing reach of specialized domain brokerages. A hybrid strategy can use both tokenized and traditional channels, but the seller must prevent stale listings and make the delivered ownership form clear.
 
 ---
 
 ## Hybrid Listings
 
-Nothing about a tokenized domain prevents you from also listing it the old-fashioned way. Many owners list:
+Some platforms allow a tokenized domain to be marketed through traditional channels as well. Possible venues include:
 
 - On the platform's own marketplace.
 - On general NFT marketplaces (OpenSea, Blur).
 - On traditional domain marketplaces (Sedo, Afternic), with the caveat that the buyer may want to "de-tokenize" or accept the tokenized form.
 
-This is more work, but for top-tier domains it expands the buyer pool meaningfully.
+This is more work and creates listing-reconciliation risk. It only expands the buyer pool if those venues accept the asset and the seller can complete the ownership form promised in each listing.
 
 ---
 
 ## Where We Think This Goes
 
-Once buyers and sellers are used to atomic settlement, the traditional escrow flow starts to feel like writing a check — workable but archaic. The pieces still needed for tokenized-domain marketplaces to take more of the volume are:
+Atomic settlement can improve the payment-and-token exchange, but broader adoption still depends on the rest of the domain workflow. Remaining constraints include:
 
 - Better domain-specific search and filtering on NFT marketplaces.
 - Better valuation tooling for heterogeneous assets.
 - Wider [TLD](/en/glossary/tld/) coverage across tokenization platforms.
 - Stable, well-audited contracts that haven't introduced any high-profile incidents.
 
-All of these are work-in-progress and visibly improving year over year.
+Progress varies by platform, registrar integration, chain, and jurisdiction.
 
 ---
 
@@ -183,10 +183,11 @@ All of these are work-in-progress and visibly improving year over year.
 
 ## Summary
 
-- Tokenized-domain marketplaces compress the traditional list → negotiate → escrow → transfer → settle flow into a single on-chain transaction.
-- The piece that disappears most clearly is **escrow**: cryptographic atomicity makes a third-party fund-holder unnecessary.
-- Auth codes, registrar locks, and wire transfers all also drop out for the tokenized half of the transaction.
+- Tokenized-domain marketplaces can compress **payment plus NFT transfer** into a single on-chain transaction.
+- Atomicity can make a third-party fund-holder unnecessary for that supported trade, while marketplace, gas, registrar, and claim costs remain.
+- Auth codes are usually absent from an in-protocol NFT sale, but registrar claims or record updates may still follow; Doma requires such a claim after a marketplace purchase.
+- ICANN's five-day rule is an inter-registrar response/default-approval window, not a five-day lock; separate 60-day restrictions can apply to registrar transfers.
 - New risks appear in their place: wallet security, smart-contract bugs, MEV, stolen-asset coordination. They live in different places, not in zero places.
-- Net effect: faster, cheaper, more transparent sales, with a different (and improvable) UX. Hybrid listings remain common for premium domains.
+- Net effect: potentially faster and more transparent token settlement, with total cost and end-to-end completion dependent on the platform and registrar workflow.
 
 If you want to actually try selling a tokenized domain, head to [namefi.io](https://namefi.io). For the broader picture, see [Use Cases for Tokenized Domains in 2026](/en/blog/tokenized-domain-use-cases-2026/).


### PR DESCRIPTION
## Summary

- separate atomic payment-plus-NFT settlement from end-to-end registrar ownership completion
- document Doma's required post-purchase claim and registrar record update
- correct the false `five-day registrar lock` description using ICANN's current transfer policy
- replace the repeated 3%–6% escrow claim with Escrow.com's current standard and concierge fee schedules
- qualify marketplace aggregation, fees, speed, listing synchronization, and hybrid-sale claims

## Sources

- Doma FAQ for marketplace purchase, claim, email, gas, and registrar-finalization behavior
- ICANN Transfer Policy for the five-day response/default-approval window and 60-day restrictions
- Escrow.com domain fee schedule, including USD value bands

## Validation

- `TMPDIR=/private/tmp bun run data:validate`
- `TMPDIR=/private/tmp bun run lint:mdx`
- `TMPDIR=/private/tmp bun run check:termbase`
- target cross-link audit
- `git diff --check`

All checks passed; the validator reported the existing 29 empty-keyword warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only editorial accuracy changes to one English blog post; no application or data-handling code.
> 
> **Overview**
> Revises the **how-tokenized-marketplaces-replace-escrow** explainer so it no longer overstates what tokenized marketplaces replace end-to-end.
> 
> **Title and framing** shift from definitive “replace escrow” to **can** replace escrow, with the description stressing that atomic settlement applies to **payment + NFT**, while registrar claims, fees, and platform risks may still apply.
> 
> **Traditional flow** is tightened: generic marketplace wording, ICANN’s **five-day NACK window** (not a “five-day lock”), and **Escrow.com’s current fee bands** with minimums and card/PayPal processing—replacing repeated **3–6%** escrow claims.
> 
> **Tokenized flow** is reframed as **platform-specific**: atomic payment/NFT only when the contract supports it; **Doma’s post-purchase claim** and registrar finalization called out; NFT as platform control vs universal ICANN record.
> 
> **Comparisons** (listing aggregation, escrow elimination, auth codes, ICANN timing, wires, trust) are qualified with **may/potentially** language, stale-listing risk, and remaining marketplace/gas/registrar costs.
> 
> **Buyer/seller/hybrid/adoption** sections drop absolute speed/fee/venue claims in favor of verification, all-in cost comparison, listing reconciliation, and jurisdiction-dependent completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c37bd4f75d8e50bc9795d8969a0162af1c026d2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the article title and description to better reflect tokenized-domain marketplace workflows.
  * Expanded the explanation of traditional escrow and on-chain transaction flows.
  * Clarified ICANN timing, escrow fees, registrar claims, and post-sale verification requirements.
  * Added more precise guidance for buyers and sellers, including remaining costs, dependencies, and risk considerations.
  * Refined coverage of hybrid listings, adoption challenges, and future marketplace direction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->