### PR TITLE
fix(content): refresh llms txt authentication

### DIFF
--- a/content/blog/en/llms-txt.md
+++ b/content/blog/en/llms-txt.md
@@ -51,16 +51,17 @@ Where the analogy breaks is intent. `robots.txt` is almost entirely a **negative
 
 ## Walking through namefi.io/llms.txt
 
-Here's the live file, annotated section by section — what's actually in it, quoted directly, and why each piece is shaped the way it is for an agent reading it cold.
+The file changes as Namefi's API and authentication options evolve. The table below is an abridged snapshot checked on **2026-07-14**; agents should fetch the [current live file](https://namefi.io/llms.txt) before acting.
 
 | Section (as it appears in the file) | What it says | Why it's shaped that way |
 | --- | --- | --- |
 | H1 + blockquote | `# Namefi API` / `> Namefi lets you register traditional domains as NFTs and manage their DNS records via API.` | The required opening the spec calls for — one line an agent can act on even if it reads nothing else. |
 | MCP pointer, inline in the summary | `MCP server (every operation below as MCP tools): https://api.namefi.io/mcp — discovery descriptor at https://namefi.io/.well-known/mcp/servers.json` | Puts the fastest path — a live protocol connection — ahead of the plain-text one, in the first three lines. |
 | `## Base URLs` | `https://api.namefi.io/v-next/` | One line, no prose — an agent constructing raw HTTP calls needs exactly this. |
-| `## MCP Server (for AI agents)` | "Prefer MCP if your client supports it… Add in Claude Code: `claude mcp add --transport http namefi https://api.namefi.io/mcp --header "x-api-key: YOUR_KEY"`" | States a preference and backs it with one copy-pasteable command instead of a paragraph. |
-| `## Authentication` | "Generate a key at https://namefi.io/api-key… Works for **all operations**… **Direct HTTP usage (recommended for AI agents):** Pass the header directly — no SDK required" | Tells the reader plainly that no SDK, OAuth dance, or browser session is required to authenticate a write call. |
-| `## Domain Registration` | A three-step `curl` sequence: check availability, submit `POST /v-next/orders/register-domain`, poll `GET /v-next/orders/{orderId}` to a terminal status | The core transaction as runnable commands, not a prose description of a request/response shape. |
+| `## Agent policy (mandatory)` | Prefer MCP when the client can connect it; use REST or `curl` only when MCP is unavailable, installation fails, or the user explicitly requests raw HTTP | Keeps capable agents on the typed MCP path while preserving an explicit REST fallback. |
+| `## MCP Server (for AI agents)` | Connect to `https://api.namefi.io/mcp`; read-only tools need no authentication; use OAuth 2.1 + PKCE when no API key is available, or send an existing key in `x-api-key` | Documents both the browser-authorized OAuth path and the API-key path instead of assuming every agent already has a stored secret. |
+| `## Authentication` | API keys work through `x-api-key`; every `/v-next` endpoint also accepts an OAuth bearer token. The file documents device authorization for headless clients, authorization code + PKCE for redirect-capable apps, dynamic client registration, access-token lifetime, and rotating refresh tokens | Authentication is no longer API-key-only, and direct REST callers can use OAuth without MCP. |
+| `## Buy a domain (MCP-first happy path)` and REST fallback | Connect MCP, search, register, and poll with typed tools; if MCP is unavailable, use the documented three-step `curl` sequence | Separates the preferred tool path from the raw-HTTP fallback without removing either. |
 | `## DNS Record Management` | A table of eleven endpoints (`GET`/`POST`/`PUT`/`DELETE` on `/v-next/dns/records`, `/v-next/dns/park`, `/v-next/dns/forwarding`, etc.) with method, path, auth, and one-line description | Reference data — many similar endpoints — goes in a table rather than eleven paragraphs. |
 | Troubleshooting note | "**UNAUTHORIZED (401):** Your API key is invalid, expired, or not associated with the domain owner's wallet… **Record validation errors:** Check that `zoneName` has no trailing dot, `rdata` for CNAME/MX/NS types has a trailing dot…" | Anticipates the failure modes an agent is most likely to hit first, as cause-and-fix rather than a generic status table. |
 | `## Optional` | Links to the TypeScript SDK docs, the `@namefi/api-client` npm package, a machine-readable OpenAPI 3 spec, the outbound-agent guide, and a GitHub repo of signer-neutral helper scripts | The spec's own "skip this if you need a shorter context" section — deeper resources, not prerequisites for the core flow above. |
@@ -69,21 +70,33 @@ The file closes by pointing to `namefi.io/llms-full.txt`, the same content inlin
 
 ## The companion files: web3 and MCP discovery
 
-The root file links out to siblings for parts of the API that don't belong in a general-purpose entry point. [namefi.io/web3/llms.txt](https://namefi.io/web3/llms.txt) documents payment paths a wallet-holding agent needs instead of an API key: an [x402](/en/glossary/x402/) flow where `GET /x402/domain/{domainName}` returns `402 Payment Required` with pricing until a signed `X-PAYMENT` header is attached, an MPP (Machine Payable Protocol) challenge-response variant signed via the `mppx` CLI, and a manual EIP-712 signing path covering smart-contract wallets. The file states plainly that x402 registration needs "No Namefi account or EIP-712 signing required — the buyer's wallet signs an EIP-3009 `transferWithAuthorization`." An agent that only needs an API key never has to load any of it.
+The root file links out to siblings for parts of the API that don't belong in a general-purpose entry point. [namefi.io/web3/llms.txt](https://namefi.io/web3/llms.txt) documents payment paths a wallet-holding agent needs instead of an API key: an [x402](/en/glossary/x402/) flow where `GET /x402/domain/{domainName}` returns `402 Payment Required` with pricing until a signed `X-PAYMENT` header is attached, an MPP (Machine Payable Protocol) challenge-response variant signed via the `mppx` CLI, and a manual EIP-712 signing path covering smart-contract wallets. The file states plainly that x402 registration needs "No Namefi account or EIP-712 signing required — the buyer's wallet signs an EIP-3009 `transferWithAuthorization`." An agent using the ordinary MCP, OAuth, or API-key path does not need to load that wallet-payment guide.
 
-The MCP side has its own discovery file, separate from `llms.txt` entirely: [namefi.io/.well-known/mcp/servers.json](https://namefi.io/.well-known/mcp/servers.json), a small JSON descriptor rather than Markdown:
+The MCP side has its own discovery file, separate from `llms.txt` entirely: [namefi.io/.well-known/mcp/servers.json](https://namefi.io/.well-known/mcp/servers.json), a JSON descriptor rather than Markdown. This abridged snapshot was checked on **2026-07-14**:
 
 ```json
 {
   "servers": [
     {
       "name": "namefi-api",
+      "description": "Preferred interface for Namefi...",
+      "version": "next",
       "transport": "streamable-http",
       "url": "https://api.namefi.io/mcp",
+      "websiteUrl": "https://namefi.io",
       "authentication": {
         "type": "apiKey",
         "in": "header",
-        "name": "x-api-key"
+        "name": "x-api-key",
+        "description": "Read-only tools need no auth; prefer OAuth when no API key is available."
+      },
+      "oauth": {
+        "type": "oauth2",
+        "protectedResourceMetadata": "https://api.namefi.io/.well-known/oauth-protected-resource",
+        "authorizationServerMetadata": "https://api.namefi.io/.well-known/oauth-authorization-server",
+        "grantTypes": ["authorization_code", "refresh_token", "device_code"],
+        "codeChallengeMethods": ["S256"],
+        "dynamicClientRegistration": true
       },
       "documentation": "https://namefi.io/llms.txt"
     }
@@ -91,13 +104,11 @@ The MCP side has its own discovery file, separate from `llms.txt` entirely: [nam
 }
 ```
 
-That descriptor lives under `.well-known/`, the same convention `/.well-known/security.txt` uses for machine-discoverable metadata — a narrower, JSON-typed sibling to `llms.txt`'s Markdown-prose approach. Its last field points back at `llms.txt`, so an agent that finds the MCP server first still has a path to the plain-text explanation of what those tools do.
+That descriptor lives under `.well-known/`, the same convention `/.well-known/security.txt` uses for machine-discoverable metadata — a narrower, JSON-typed sibling to `llms.txt`'s Markdown-prose approach. It advertises both API-key and OAuth discovery metadata, including PKCE and dynamic client registration, and its `documentation` field points back at `llms.txt`.
 
 ## What's included, what's left out, and why
 
-A few choices look deliberate. Nearly every operation is a runnable `curl` invocation rather than a paragraph describing a request schema — a file written for something that executes code, not something that writes its own summary. The root file links out rather than including everything, and `llms-full.txt` inlines what it only references — the spec's own size-management pattern, applied literally. The `## Optional` section links a full OpenAPI 3 spec alongside the Markdown, so a tool wanting a strictly typed schema has one without cluttering the primary read path. And wallet-based payment — x402, MPP, EIP-712 — lives in its own file, keeping API-key auth and a registration as the first thing any agent reads.
-
-<!-- TODO: confirm with team — whether there's a target token/character budget the root llms.txt is written against, and how the split between llms.txt / llms-full.txt / web3/llms.txt / outbound/llms.txt is revisited as the API grows -->
+A few choices look deliberate. The mandatory agent policy and MCP setup come before the REST recipes, so a capable client discovers the typed tool interface first. Runnable `curl` examples remain as a fallback for clients that cannot connect MCP or for users who explicitly ask for raw HTTP. The root file links out rather than including everything, while `llms-full.txt` inlines the companion material. The `## Optional` section links a full OpenAPI 3 spec alongside the Markdown, and wallet-based payment — x402, MPP, EIP-712 — stays in its own file.
 
 ## llms.txt and MCP: discovery versus connection
 
@@ -110,11 +121,11 @@ Namefi's file demonstrates the relationship directly: `llms.txt` tells an agent 
 Publishing a working `llms.txt` doesn't require rebuilding your documentation:
 
 1. **Front-load the H1, summary, and fastest connection method** — a small-context agent may never read past the first few lines.
-2. **Show runnable requests, not schema prose.** A `curl` command with real field names beats a paragraph describing a JSON body.
+2. **Lead with the fastest supported connection, then show a runnable fallback.** If you offer MCP, document the typed path first; preserve concrete HTTP examples for clients that cannot connect it.
 3. **Split by size, not by team structure.** A short root file plus a fuller expansion, and separate files for concerns like payments, keeps the common path short.
 4. **Document actual failure modes**, not just status codes — why a call returns 401 versus 403 matters more than the numbers.
 5. **Use the `## Optional` heading for anything skippable**, per the spec's own convention.
-6. **Publish an MCP discovery descriptor alongside llms.txt if you run an MCP server** — one answers "what is this," the other "how do I connect."
+6. **Publish an MCP discovery descriptor alongside llms.txt if you run an MCP server** — include current authentication and OAuth-discovery metadata, not only the server URL.
 
 ## Frequently Asked Questions
 
@@ -132,7 +143,7 @@ No. `llms.txt` is a document an agent reads once to understand what an API does;
 
 ### What's in Namefi's llms.txt file?
 
-The base URL, an MCP server pointer, an API-key authentication section, a three-step domain-registration flow with runnable `curl` examples, a DNS record management endpoint table, domain-configuration endpoints, a troubleshooting section, and an "Optional" section linking the SDK, the OpenAPI spec, and companion files for wallet payments and outbound workflows.
+The base URL, a mandatory MCP-first agent policy, MCP installation examples, API-key and OAuth authentication, a typed domain-registration path plus REST fallback, DNS and domain-configuration endpoints, troubleshooting, and an "Optional" section linking the SDK, OpenAPI spec, and companion files.
 
 ### Can I read llms.txt myself, without an AI agent?
 


### PR DESCRIPTION
## Summary

- update the llms.txt walkthrough to reflect the current MCP-first agent policy
- document OAuth 2.1 + PKCE, device authorization, bearer tokens, and rotating refresh tokens alongside API-key authentication
- replace the stale MCP discovery descriptor with an abridged, dated snapshot that includes OAuth metadata
- mark live-file excerpts as a 2026-07-14 snapshot and direct agents to fetch the current file before acting

## Live sources checked

- https://namefi.io/llms.txt
- https://namefi.io/.well-known/mcp/servers.json

## Validation

- `TMPDIR=/private/tmp bun run data:validate`
- `TMPDIR=/private/tmp bun run lint:mdx`
- `TMPDIR=/private/tmp bun run check:termbase`
- `TMPDIR=/private/tmp bun .agents/skills/cross-link/link-audit.ts content/blog/en/llms-txt.md`
- `git diff --check`

All passed. The existing 29 empty-keyword warnings remain unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to a single blog article; no application or API code changes.
> 
> **Overview**
> Updates **`content/blog/en/llms-txt.md`** so the walkthrough matches the current [namefi.io/llms.txt](https://namefi.io/llms.txt) and MCP discovery descriptor, instead of an API-key–first, `curl`-centric picture.
> 
> The section table now covers **`## Agent policy (mandatory)`**, MCP-first domain purchase with REST fallback, and **OAuth 2.1 + PKCE** (device flow, bearer tokens, refresh rotation) alongside **`x-api-key`**. Excerpts are labeled as an abridged **2026-07-14** snapshot with a reminder to fetch the live file before acting.
> 
> The **`.well-known/mcp/servers.json`** example is expanded with OAuth metadata (grant types, S256, dynamic client registration). Narrative sections, vendor guidance, and the FAQ are aligned with MCP-first discovery; the internal TODO about token budgets is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3bc742448e1f235702ee8a160cef1cc4ce055f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->