### PR TITLE
fix(content): correct marketplace listing guidance

### DIFF
--- a/content/blog/en/marketplace-seo-for-domain-listings.md
+++ b/content/blog/en/marketplace-seo-for-domain-listings.md
@@ -1,5 +1,5 @@
 ---
-title: "Marketplace SEO: Getting Your Domain Listing Found"
+title: "Marketplace Discoverability for Domain Listings: Afternic and Sedo"
 date: '2026-06-21'
 language: en
 tags: ['domains', 'domain-investing', 'domain-flipping', 'guide']
@@ -9,9 +9,9 @@ cluster: domain-investing
 series: domain-flipping-skills
 seriesOrder: 31
 format: guide
-description: "How to get a domain listing found: titles, keywords, and categories on Afternic and Sedo, plus the discoverability that lands the right buyer."
+description: "How domain listings are discovered on Afternic and Sedo, which seller-controlled fields each platform actually exposes, and how registrar distribution, pricing, landers, and promotion differ."
 ogImage: ../../assets/marketplace-seo-for-domain-listings-og.jpg
-keywords: ['marketplace SEO', 'domain listing SEO', 'how to list a domain on Afternic', 'how to list a domain on Sedo', 'domain listing title', 'domain listing keywords', 'domain marketplace categories', 'get a domain listing found', 'domain aftermarket listing', 'sell a domain online', 'domain listing optimization', 'domain search visibility', 'how buyers find domains', 'domain reseller network']
+keywords: ['marketplace discoverability', 'domain listing visibility', 'how to list a domain on Afternic', 'how to list a domain on Sedo', 'Afternic bulk upload', 'Afternic Search Insights', 'Sedo category showcase', 'SedoMLS', 'domain aftermarket listing', 'sell a domain online', 'domain search visibility', 'how buyers find domains', 'domain reseller network']
 relatedArticles:
   - /en/blog/marketing-your-domains-for-sale/
   - /en/blog/inbound-vs-outbound-domain-sales/
@@ -32,89 +32,80 @@ relatedGlossary:
   - /en/glossary/registry/
 ---
 
-A listing nobody sees is the same as no listing at all. You can price a name perfectly and write a clean for-sale page, but if your listing never surfaces when the right buyer searches, the deal never starts. Most of the inbound demand in this business runs through a handful of marketplaces, and inside those marketplaces your name competes with millions of others for the same scarce thing: a buyer's attention at the moment they're looking.
+A listing cannot produce marketplace inquiries if buyers never encounter it. But "marketplace SEO" is a misleading shorthand: Afternic and Sedo do not expose one shared set of title, description, keyword, and category controls. Each platform has its own listing fields, distribution network, search behavior, sales formats, and paid promotion options.
 
-This guide is about that competition. It covers how a domain listing actually gets found — the title, keywords, and category fields you fill in on marketplaces like Afternic and Sedo, plus the broader discoverability that decides whether your name shows up when someone searches. It sits under the [marketing your domains for sale](/en/blog/marketing-your-domains-for-sale/) pillar and the wider [domain flipping](/en/blog/domain-flipping/) guide, and picks up where they leave off: once your name is parked and your lander is live, the next job is making the listing itself searchable.
+This guide separates those systems. It explains the seller-controlled fields documented by Afternic, what Afternic's exact-match Search Insights measure, how Sedo's marketplace, category promotion, and SedoMLS distribution work, and what your own for-sale lander contributes. It sits under [marketing your domains for sale](/en/blog/marketing-your-domains-for-sale/) and the wider [domain flipping](/en/blog/domain-flipping/) guide.
 
-## Where listings live: the marketplace as a search engine
+## Discovery is platform-specific
 
-When you list a domain for sale, you're publishing into the [domain aftermarket](/en/glossary/marketplace/) — which is, by definition, [the secondary resale market for Internet domain names](https://en.wikipedia.org/wiki/Domain_aftermarket#:~:text=is%20the%20secondary%20resale%20market%20for%20Internet%20domain%20names) where a buyer who wants a name that's already registered negotiates to take it over. Two marketplaces dominate that market for most sellers. Sedo, [an American domain aftermarket company](https://en.wikipedia.org/wiki/Sedo#:~:text=is%20an%20American%20domain%20aftermarket%20company) founded in 2000, runs one of the largest [marketplaces](/en/glossary/domain-trading/) and [auction](/en/glossary/auction/) systems. Afternic, GoDaddy's aftermarket arm, runs the other.
+When you list a domain for sale, you publish into the [domain aftermarket](/en/glossary/marketplace/) — [the secondary resale market for Internet domain names](https://en.wikipedia.org/wiki/Domain_aftermarket#:~:text=is%20the%20secondary%20resale%20market%20for%20Internet%20domain%20names). Marketplaces and registrar partners can expose listings through their own search and purchase flows, but the available seller inputs differ. Do not invent a title, keyword, description, or category strategy until you have confirmed that the platform actually accepts that field and uses it in discovery.
 
-The mental shift that makes a flipper better at this is simple: treat each marketplace as a search engine, not a noticeboard. Buyers don't browse front to back. They search — by keyword, by [TLD](/en/glossary/tld/), by price, by length — and your listing either matches that query or it doesn't. Everything below is about making your name match the searches real buyers run.
-
-There's a second discovery layer most beginners miss. Afternic doesn't just show listings on its own site; it syndicates them. As Afternic's own marketing puts it, [your domains will show up in many of the 125M monthly search queries across leading domain registrars](https://www.afternic.com/#:~:text=125M%20monthly%20search%20queries%20across%20leading%20domain%20registrars) — so a name listed there can appear as a premium result when someone searches to register that exact string at registrars like GoDaddy or Namecheap. That syndication is a strong reason to list a sellable name rather than letting it sit. It's also the main lever you don't control directly, so you earn it by getting the parts you *do* control right.
-
-## The listing title: your one shot at a search match
+## Afternic: exact domain presentation, price, lander, and distribution
 
 ![Editorial illustration of a stack of marketplace search-result rows with the top row highlighted and its domain tag leading the row as a cursor points to it](../../assets/marketplace-seo-for-domain-listings-01-title.jpg)
 
-The title is the single most important field in any listing, and the rule it follows is borrowed straight from search. As Google's own guidance on result titles notes, the title is [the primary piece of information people use to decide which result to click](https://developers.google.com/search/docs/appearance/title-link#:~:text=the%20primary%20piece%20of%20information%20people%20use%20to%20decide%20which%20result%20to%20click). The same logic governs a marketplace listing: the title is what a buyer scans, and it's often what the marketplace's own search matches against.
+Afternic's documented bulk-listing workflow centers on the domain and its sales configuration. Its [current bulk-upload walkthrough](https://blog.afternic.com/bulk-upload-walkthrough/) documents CamelCasing through the Domain Name column, Buy It Now and Make Offer presentation on the Custom Lander, Lease to Own and its maximum term, and lander selection. It does not document seller-authored SEO titles, descriptions, keyword tags, or categories as shared listing inputs.
 
-For a domain listing, the title is usually the name itself, so the real work is the name's *presentation* and the copy around it:
+That changes the practical checklist:
 
-- **Lead with the exact string, cleanly.** A buyer searching for that name should hit it on the first match. Don't bury the name behind a slogan.
-- **Spell out the searchable words in the description.** Many names compress two words into one string. A buyer hunting "smart home" may not type `smarthome`. Put both the joined and spaced forms in the description so either query finds you.
-- **Write for the buyer's vocabulary, not yours.** Domainers think "brandable five-letter `.com`." Buyers think "name for my coffee subscription startup." The closer your text is to how a founder describes their need, the more searches you catch.
+- **Verify the exact domain and casing.** CamelCasing controls how multiword names are displayed on Afternic landers; it does not create a separate marketplace title.
+- **Set only the sales options you intend to honor.** Confirm Buy It Now, Make Offer, Lease to Own, maximum lease term, and lander selection in the current interface or template.
+- **Treat the listed price as transaction configuration, not an SEO field.** A fixed price can make a listing eligible for purchase paths that require one, but no price guarantees visibility or a sale.
+- **Use the lander as the explanatory surface.** If the selected lander supports custom presentation, verify what buyers actually see rather than assuming marketplace search indexes seller-written marketing copy.
 
-The title earns the click; the rest of the listing keeps it. For what happens after the buyer arrives, see [domain for sale landing pages](/en/blog/domain-for-sale-landing-pages/).
+Afternic also distributes listings through registrar search. Its site currently advertises exposure across [125 million monthly search queries at leading registrars](https://www.afternic.com/#:~:text=125M%20monthly%20search%20queries%20across%20leading%20domain%20registrars). That is Afternic's published network-level figure, not a promise that a particular listing will receive traffic.
 
-## Keywords: matching the search a buyer actually runs
+### What Afternic Search Insights actually measure
 
 ![Editorial illustration of an invented-name tag bridged by a chain of keyword chips to a cluster of use-case and industry icons](../../assets/marketplace-seo-for-domain-listings-02-keywords.jpg)
 
-Keywords are where most listings quietly fail. A name like `lumora.com` has no obvious dictionary meaning, so it surfaces only for buyers who already know to search for that exact string — almost nobody. The fix is to attach the *concepts* the name could serve. If `lumora` reads as a lighting or wellness brand, the listing's keyword fields should say so, because that's what a buyer in those categories will search.
+Afternic's [GoDaddy Search Insights](https://blog.afternic.com/godaddy-search-insights/) are exact-domain interest signals. If you own `example.com`, the metric counts filtered human searches for `example.com` at GoDaddy. Afternic explicitly says it excludes keyword-only searches such as `example` without the TLD and excludes non-exact matches.
 
-A few working rules for keyword fields:
+That means Search Insights should not be described as evidence that seller-added keywords make an Afternic listing rank. Use the 30-, 90-, and 365-day exact-search totals as one portfolio signal, subject to the product's membership requirements and filtering methodology. They measure observed exact-domain searches, not all buyer demand and not open-web [SEO](/en/glossary/seo/).
 
-- **Describe use cases, not the name.** "Skincare brand, beauty startup, cosmetics" pulls in buyers who'd never have guessed your made-up string. The keyword is the bridge from an invented name to a real intent.
-- **Include the industry, not just the word.** A name that works for fintech should carry "fintech, payments, finance" even if none of those letters appear in the domain.
-- **Don't keyword-stuff.** Marketplaces and the registrars that syndicate listings dislike spammy, irrelevant terms, and an over-broad listing attracts tire-kickers who waste your time. Precision beats volume here exactly as it does in outreach — the discipline is the same one we cover in [how to sell a domain name you own](/en/blog/how-to-sell-a-domain-name-you-own/).
-
-This is genuine, if small-scale, [SEO](/en/glossary/seo/): you're matching supply (your name) to a demand expressed as a query. The names that sell inbound are usually the ones whose listings answered a search the seller anticipated.
-
-## Categories and extension: getting filed where buyers browse
+## Sedo: sales formats, marketplace filters, categories, and promotion
 
 ![Editorial illustration of domain-name cards funneling into labeled category bins with one highlighted card landing in its correct matching bin](../../assets/marketplace-seo-for-domain-listings-03-categories.jpg)
 
-After search, the second way buyers find names is by filtering — and that runs on the structured fields you set: category, length, price band, and extension. These are easy to fill in carelessly and expensive to get wrong: a miscategorized name never appears in the filtered views where its buyer is looking.
+Sedo documents a different set of surfaces. Its current seller page offers Buy Now, Make Offer, marketplace auctions, direct auctions, brokerage, landers, and SedoMLS distribution. It also says marketplace buyers can narrow comparable offers with filter functions, including domain endings.
 
-- **Pick the category your buyer would pick.** A buyer shopping for a tech name filters to tech. If your `.ai` name is filed under "general," the AI founders browsing the [.ai](/en/tld/ai/) category never see it. Match the category to the most likely buyer, not to the most flattering label.
-- **Let the extension do its own filtering work.** Buyers self-select by [TLD](/en/glossary/tld/) constantly — startups gravitating to [.io](/en/tld/io/) and [.ai](/en/tld/ai/), local and creative projects to [.co](/en/tld/co/) and [.xyz](/en/tld/xyz/), app makers to [.app](/en/tld/app/). The extension you bought partly determines which filtered audience you can reach, which is one more reason extension choice is an acquisition decision, not an afterthought.
-- **Price into a searchable band.** Buyers routinely filter by maximum budget. A name with no listed price, or one parked far above its band, drops out of the results a serious buyer is scanning. Listing a real, reachable number keeps you in the search set.
+Categories are specifically documented in Sedo's **paid promotion** flow. A [Category Showcase](https://sedo.com/us/sell-domains/promotion-options/) lets a seller choose a category and pays for highlighted placement in that category's results for a defined term. Sedo also offers a broader Homepage Showcase. Do not generalize those promotion controls into an Afternic category field, and do not assume unpaid Sedo listings receive the same placement.
+
+SedoMLS is a separate distribution mechanism. Sedo currently says it promotes listings through [more than 650 sales and registrar partner sites](https://sedo.com/us/sell-domains/promotion-options/). Participation, commission, price-display preferences, registrar eligibility, and transfer behavior follow Sedo's current terms; the network size is not a per-domain traffic or sale guarantee.
 
 ## Internal discoverability: don't waste the traffic you already have
 
-Marketplaces aren't the only place a name gets found. A surprising share of inbound interest arrives at the domain itself — someone types it into a browser, or follows a stale link. That traffic is free, intent-rich, and easy to squander. Every visitor who lands on a [registrar](/en/glossary/registrar/) error or a generic ad page is a buyer you paid renewal fees to lose.
+Marketplaces aren't the only place a name can be found. A visitor may type the domain into a browser or follow an existing link. The amount and value of that traffic varies by name, so measure it rather than assuming it is a large or high-converting channel.
 
-Capturing that traffic is the job of two pages the [marketing pillar](/en/blog/marketing-your-domains-for-sale/) covers in depth: the parking page and the for-sale lander. Both should make the for-sale status obvious and point straight at your listing or contact path. We go deep on the revenue side in [domain parking and monetization](/en/blog/domain-parking-and-monetization/), and on conversion in [domain for sale landing pages](/en/blog/domain-for-sale-landing-pages/). The discoverability point is narrow: a buyer who finds the name directly should never have to wonder whether it's available or hunt for how to buy it. GoDaddy frames its lander's job exactly this way — it [lets interested buyers know your domain is for sale and provides all the information they need to purchase your domain](https://www.godaddy.com/help/add-a-for-sale-lander-to-my-domain-listing-41624#:~:text=lets%20interested%20buyers%20know%20your%20domain%20is%20for%20sale%20and%20provides%20all%20the%20information%20they%20need%20to%20purchase).
+The [marketing pillar](/en/blog/marketing-your-domains-for-sale/) covers parking pages and for-sale landers in depth. A lander should make the sale status and next step clear. We cover parking in [domain parking and monetization](/en/blog/domain-parking-and-monetization/) and buyer flow in [domain for sale landing pages](/en/blog/domain-for-sale-landing-pages/). GoDaddy describes its lander's job as letting interested buyers know the domain is for sale and providing the information needed to purchase it; verify the live lander yourself after configuration.
 
 ## External discoverability: being findable off the marketplaces
 
-The best buyer for a name often isn't browsing a marketplace at all. They're searching the open web for the name, the words inside it, or a problem the name solves. A few moves widen that net:
+Some prospective buyers may begin outside a marketplace. Those channels have their own rules and should not be confused with Afternic or Sedo's internal search:
 
-- **List on more than one marketplace where terms allow.** Some sellers keep a name on Afternic for registrar syndication and Sedo for its auction and brokerage reach. Read each marketplace's exclusivity terms first, but where it's allowed, more shelves catch more searches.
-- **Make the name itself indexable.** A simple for-sale page with the name in the title can rank for searches on that exact string, so a buyer Googling your domain finds your page rather than a dead end.
-- **Be present where buyers congregate.** Brokers and serious buyers read the [trader forums](/en/blog/top-domain-trader-forums/), [domainer newsletters](/en/blog/famous-domainer-blogs-and-newsletters/), and wider [industry media](/en/blog/domain-industry-media/). A name mentioned in the right place finds buyers a marketplace filter never would.
+- **Check multi-listing terms and stale-listing risk.** If you list on more than one service, read each platform's exclusivity, commission, synchronization, and removal rules. A sale on one venue can make an active listing elsewhere unsafe.
+- **Give the domain's own page a clear, crawlable title and sale path.** That can help an open-web searcher confirm the exact name, but indexing and ranking are controlled by the search engine and are not guaranteed.
+- **Use off-platform promotion selectively.** [Trader forums](/en/blog/top-domain-trader-forums/), [domainer newsletters](/en/blog/famous-domainer-blogs-and-newsletters/), and [industry media](/en/blog/domain-industry-media/) reach different audiences. Follow their rules and avoid presenting promotion as organic marketplace ranking.
 
 None of this replaces the listing. It surrounds it, so a buyer who starts anywhere can still find their way to your name.
 
 ## A short checklist before you publish a listing
 
-Before you hit publish on any listing, run it against five questions:
+Before publishing, check the platform-specific configuration rather than a generic SEO template:
 
-1. **Does the title lead with the exact name, cleanly?** No slogans in front of the string.
-2. **Do the keywords name the buyer's use cases and industry**, not just the domain?
-3. **Is it filed in the category and extension filter** the likely buyer actually browses?
-4. **Is there a real, reachable price** so the name survives a budget filter?
-5. **Does the name's own page** (park or lander) confirm it's for sale and link to the listing?
+1. **Is the domain string and display casing correct?**
+2. **Are the price, Make Offer, Lease to Own, and auction choices exactly what you intend?** Only check controls the selected platform actually exposes.
+3. **Is the correct lander selected and verified at the live domain?**
+4. **Are any Sedo category or homepage promotions deliberate, current, and within budget?** Do not assume promotion is free or permanent.
+5. **If multiple networks carry the listing, are price and availability synchronized and are the terms compatible?**
 
-Five yeses, and you've done the discoverability work that's in your control. The rest is the marketplace's search doing its job — and the [appraisal](/en/blog/how-to-value-a-domain-name/) and pricing that decide whether the buyers it sends you actually convert.
+Those checks reduce configuration mistakes. They do not guarantee impressions, inquiries, or conversion; [appraisal](/en/blog/how-to-value-a-domain-name/), pricing, buyer demand, platform distribution, and timing still matter.
 
 ## The Namefi angle
 
 Getting found is half the battle; the other half is the handoff. Once a listing does its job and a buyer commits, the trade still has to settle — and that's where high-value deals stall, because neither side wants to move first. The usual fix is a neutral [escrow](/en/glossary/escrow/) workflow, which we explain in [domain escrow explained](/en/blog/domain-escrow-explained/).
 
-[Namefi](https://namefi.io) narrows that friction a different way. Tokenized ownership makes control of a real [ICANN](/en/glossary/icann/) domain easier to verify and transfer, with [DNS](/en/glossary/dns/) continuity so the name keeps resolving through the handover. A listing's whole purpose is to start a conversation with the right buyer; a clean, auditable transfer is what turns that conversation into a closed sale.
+[Namefi](https://namefi.io) represents control of a real [ICANN](/en/glossary/icann/) domain through tokenized ownership. A supported marketplace transaction can make payment and token transfer atomic, while registrar records, [DNS](/en/glossary/dns/), platform rules, and any buyer-claim steps remain separate boundaries to verify. Listing visibility and settlement are different problems; neither guarantees the other.
 
 ## Friendly Disclaimer (Read Me!)
 
@@ -125,7 +116,9 @@ Getting found is half the battle; the other half is the handoff. Once a listing 
 ## Sources and further reading
 
 - Wikipedia — [Domain aftermarket (definition of the secondary resale market)](https://en.wikipedia.org/wiki/Domain_aftermarket#:~:text=is%20the%20secondary%20resale%20market%20for%20Internet%20domain%20names)
-- Wikipedia — [Sedo (American domain aftermarket company, founded 2000)](https://en.wikipedia.org/wiki/Sedo#:~:text=is%20an%20American%20domain%20aftermarket%20company)
 - Afternic — [registrar-network syndication claim (125M monthly search queries)](https://www.afternic.com/#:~:text=125M%20monthly%20search%20queries%20across%20leading%20domain%20registrars)
-- Google Search Central — [title links (the primary info people use to decide which result to click)](https://developers.google.com/search/docs/appearance/title-link#:~:text=the%20primary%20piece%20of%20information%20people%20use%20to%20decide%20which%20result%20to%20click)
+- Afternic — [bulk upload fields, CamelCasing, Lease to Own, and lander selection](https://blog.afternic.com/bulk-upload-walkthrough/)
+- Afternic — [GoDaddy Search Insights (exact-domain searches; excludes keyword-only and non-exact searches)](https://blog.afternic.com/godaddy-search-insights/)
+- Sedo — [seller options, filters, auctions, brokerage, landers, and SedoMLS](https://sedo.com/us/sell-domains/)
+- Sedo — [Homepage and Category Showcases; SedoMLS distribution](https://sedo.com/us/sell-domains/promotion-options/)
 - GoDaddy — [For Sale Lander (what a domain for-sale page does)](https://www.godaddy.com/help/add-a-for-sale-lander-to-my-domain-listing-41624#:~:text=lets%20interested%20buyers%20know%20your%20domain%20is%20for%20sale%20and%20provides%20all%20the%20information%20they%20need%20to%20purchase)


### PR DESCRIPTION
## Summary

- replace the article's generic marketplace-SEO model with platform-specific guidance for Afternic and Sedo
- document the seller controls each platform currently exposes, including Afternic pricing/lander fields and exact-domain Search Insights
- distinguish Sedo sales formats, paid category promotion, and SedoMLS distribution from Afternic behavior
- qualify traffic, visibility, settlement, and sales outcomes so they are not presented as guarantees

## Source accuracy

- Afternic bulk upload walkthrough and GoDaddy Search Insights documentation
- Sedo seller and promotion documentation
- current Afternic and Sedo published network figures, explicitly labeled as platform claims rather than per-domain guarantees

## Validation

- `TMPDIR=/private/tmp bun run data:validate` (passes; 29 pre-existing empty-keyword warnings)
- `TMPDIR=/private/tmp bun run lint:mdx`
- `TMPDIR=/private/tmp bun run check:termbase`
- `TMPDIR=/private/tmp bun .agents/skills/cross-link/link-audit.ts content/blog/en/marketplace-seo-for-domain-listings.md`
- `git diff --check`

## Access control

No new application surface or access-control boundary. This changes a public English article only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Public editorial content only; no application, auth, or data-layer changes.
> 
> **Overview**
> Rewrites the English **marketplace-seo-for-domain-listings** guide so it no longer treats Afternic and Sedo as sharing one “marketplace SEO” playbook (titles, keywords, categories). Front matter and keywords are retitled around **marketplace discoverability** and platform-specific controls.
> 
> **Afternic** is reframed around documented bulk-upload fields (domain/casing, BIN/Make Offer/lease, lander), registrar syndication as a published network claim—not per-listing traffic—and **Search Insights** as exact-domain GoDaddy search counts, not proof that seller keywords drive ranking.
> 
> **Sedo** is separated into documented sales formats, buyer filters (e.g. TLD), **paid** Category/Homepage Showcases, and **SedoMLS** distribution with terms and network size qualified.
> 
> Landers, off-marketplace discovery, the pre-publish checklist, and the Namefi section are tightened so visibility, traffic, and settlement are not implied guarantees; sources are updated to Afternic/Sedo docs and away from generic Google title SEO for listings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad05664acedbd8408f5f9f8e820620306a397ac4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->