### PR TITLE
fix(content): qualify premium Web3 TLD claims

### DIFF
--- a/content/blog/en/premium-web3-tlds.md
+++ b/content/blog/en/premium-web3-tlds.md
@@ -1,5 +1,5 @@
 ---
-title: "Premium Web3 TLDs: A 2026 Guide to the Most Valuable Tokenized Domain Extensions"
+title: "Premium Web3 TLDs: A 2026 Guide to Tokenized DNS Domains"
 date: '2026-06-10'
 language: en
 tags: ['guide']
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 draft: false
 cluster: choosing-a-tld
 format: roundup
-description: A clear 2026 guide to premium Web3 TLDs—what "Web3 TLD" really means, why tokenized ICANN extensions like .com, .ai, and .io beat blockchain-only names, and which domain extensions hold the most value.
+description: A 2026 guide to the ambiguous term "Web3 TLD," the difference between blockchain-native names and tokenized DNS domains, and how to evaluate extensions without assuming liquidity, lending support, or future value.
 keywords: ['premium web3 tld', 'premium web3 tlds', 'web3 tld', 'web3 tlds', 'premium web3 domains', 'best web3 domains', 'web3 domain extensions', 'web3 domain', 'web3 domains', 'tokenized domain extensions', 'premium domain extensions', 'most valuable domain extensions', 'tokenized tld', 'tokenized domains', 'ICANN tld', 'blockchain tld', 'NFT domain', 'premium .com', 'premium .ai', 'premium .io', 'premium .xyz', 'best domain extensions 2026', 'crypto tld', 'web3 naming', 'domain tld investment', 'namefi']
 relatedArticles:
   - /en/blog/what-are-tokenized-domains/
@@ -29,9 +29,9 @@ relatedGlossary:
   - /en/glossary/web3/
 ---
 
-Search for "premium Web3 TLD" and you'll find two completely different products wearing the same label. One is a **blockchain-only name** like a `.eth` or `.crypto` that lives outside the global [DNS](/en/glossary/dns/) root. The other is a **real, ICANN-recognized extension** (`.com`, `.ai`, `.io`, `.xyz`) that has been *tokenized* [on-chain](/en/glossary/on-chain/) so it behaves like a [Web3](/en/glossary/web3/) asset while still resolving in every browser on Earth.
+Search for "premium Web3 TLD" and you'll find two different products wearing the same label. One is a **blockchain-native name** such as a `.eth` or `.crypto` that lives outside the global [DNS](/en/glossary/dns/) root. The other is a **registered DNS domain** under an ICANN-root extension such as `.com`, `.ai`, `.io`, or `.xyz`, with its control represented by a token [on-chain](/en/glossary/on-chain/). Strictly speaking, the second-level domain is tokenized—not the entire TLD.
 
-These are not the same thing, and the difference decides whether your "premium Web3 domain" actually works as a website, an email address, or a brand. This guide untangles the terminology, then walks through which extensions are genuinely premium for tokenization and investment in 2026.
+These are not the same thing. Their resolution, email, custody, renewal, transfer, and platform-dependency boundaries differ. This guide untangles the terminology, then provides factors for evaluating extensions without ranking them or predicting investment returns.
 
 If you want the foundational background first, read [What Are Tokenized Domains?](/en/blog/what-are-tokenized-domains/) and [Tokenized Domain vs Web3 Domain](/en/blog/tokenized-domain-vs-web3-domain/).
 
@@ -45,65 +45,65 @@ The phrase "Web3 TLD" gets used for two architectures that have almost nothing i
 
 This is the world of [ENS](/en/glossary/ens/) (`.eth`), Unstoppable Domains (`.crypto`, `.x`, `.nft`), Freename's user-created [TLDs](/en/glossary/tld/), and Handshake. These extensions are minted as [NFTs](/en/glossary/nft/) or smart-contract records and are **not part of the [ICANN](/en/glossary/icann/) DNS root**. Each project effectively publishes its own namespace, governed by smart contracts and controlled by private keys.
 
-The strength: they're [wallet](/en/glossary/wallet/)-native by design—turning a long `0x…` address into `you.eth`, powering dApp logins, and serving as on-chain identity. The tradeoff: a `.eth` or `.crypto` does **not** resolve in a normal browser, mail server, CDN, or SSL/TLS certificate authority without a resolver, extension, or bridge. They sit *beside* the traditional internet's naming layer rather than *inside* it.
+The strength: they're [wallet](/en/glossary/wallet/)-native by design—turning a long `0x…` address into `you.eth`, powering supported dApp logins, and serving as on-chain identity. The tradeoff: a `.eth` or `.crypto` is not delegated in the ordinary DNS root. Resolution depends on protocol-aware software, a gateway, browser support, or another bridge. For example, ENS documents native support in some browsers and gateway forms for others. Conventional email, public TLS certificates, CDNs, and resolvers do not automatically treat these names as DNS domains.
 
 ### Meaning B: Real ICANN TLDs that are tokenized on-chain (Namefi's model)
 
-This is a different design entirely. You take a standard, globally recognized extension—`.com`, `.ai`, `.io`, `.xyz`—register a real DNS domain, and add an **on-chain ownership token** on top. The result is one domain with two synchronized layers: the DNS/[registry](/en/glossary/registry/) record *and* an [NFT](/en/glossary/nft/) in your wallet.
+This is a different design. You register a DNS domain under an extension such as `.com`, `.ai`, `.io`, or `.xyz`, then use a platform that represents control through an **on-chain ownership token**. The DNS/[registry](/en/glossary/registry/) state and [NFT](/en/glossary/nft/) are linked through the platform's registrar and contract design; users should verify the current import, mint, burn, export, recovery, and exception rules rather than assuming synchronization is unconditional.
 
-A tokenized `.com` is still a real `.com`. It resolves natively in Chrome and Safari, supports email and SSL, and pays normal annual renewals—while *also* being a tradable, composable on-chain asset you can sell, transfer, or use as [collateral](/en/glossary/collateral/) in seconds.
+A tokenized `.com` is still a DNS `.com` registration. Subject to its DNS configuration and registration status, it can resolve through ordinary DNS and support email and TLS like another `.com`; normal renewals and domain-policy obligations still apply. The token can be transferred on its supported chain. Marketplace trading, [collateral](/en/glossary/collateral/) use, and transaction timing depend on the token contract, chain, platform support, liquidity, lender terms, and the domain's status—tokenization alone does not provide them.
 
-> One-line summary: a **blockchain-native TLD replaces DNS**; a **tokenized ICANN TLD extends DNS**. Both can be called "Web3," but only one keeps universal browser and email compatibility.
+> One-line summary: a **blockchain-native namespace operates outside the ordinary DNS root**; a **tokenized DNS domain retains an ordinary registration and adds a token representation**. Both are sometimes called "Web3 domains," but their resolution and custody models differ.
 
 ---
 
 ## Why Tokenizing Real ICANN TLDs Gives You "Premium" + "Web3"
 
-If your goal is a premium asset that is *also* Web3-ready, tokenizing a real extension is usually the stronger play. Here's why.
+If you need ordinary DNS and email compatibility plus a wallet-held token, a tokenized DNS domain may fit that requirement. If you need a blockchain-native identity or naming protocol, a name such as `.eth` may fit a different requirement. Neither architecture is universally better.
 
 | | Blockchain-only TLD (`.eth`, `.crypto`) | Tokenized ICANN TLD (`.com`, `.ai`, `.io`) |
 |---|---|---|
-| Resolves in any browser | No (needs resolver/extension) | Yes, natively |
-| Works for email / SSL | No | Yes |
+| Ordinary DNS resolution | No; requires protocol-aware support, gateway, or bridge | Yes, while registration and DNS configuration remain valid |
+| Conventional email / public TLS | Not automatic | Supported through ordinary DNS configuration |
 | Recognized by ICANN | No | Yes |
-| Held as NFT in wallet | Yes | Yes |
-| Tradable on NFT marketplaces | Yes | Yes |
-| Usable as DeFi collateral | Yes | Yes |
-| Universal Web2 + Web3 reach | No | Yes |
+| Held as token in a wallet | Protocol-dependent | Platform and chain-dependent |
+| Tradable on third-party NFT marketplaces | Only where the chain and contract are supported | Only where the chain and contract are supported |
+| Usable as DeFi collateral | Only through a willing, compatible lending market | Only through a willing, compatible lending market |
+| Ordinary DNS reach | No | Yes, while the underlying registration and DNS configuration remain valid |
 
-The "premium" in *[premium domain](/en/glossary/premium-domain/)* has always come from scarcity, brand strength, and decades of universal support. A short, memorable `.com` or a category-defining `.ai` carries that value precisely *because* the whole internet already recognizes it. [Tokenizing](/en/glossary/tokenize/) it keeps every bit of that value and adds wallet-native ownership and on-chain [composability](/en/glossary/composability/)—without inheriting the resolution and compatibility problems of names that live only on-chain.
+The "premium" in *[premium domain](/en/glossary/premium-domain/)* is a market label, not a guaranteed value. Buyers may consider the name, extension, length, memorability, comparable sales, legal risk, renewal cost, and intended use. [Tokenizing](/en/glossary/tokenize/) changes the custody and transfer representation; it does not preserve every prior appraisal, manufacture demand, or guarantee on-chain [composability](/en/glossary/composability/). Each integration must explicitly support the chain and token contract.
 
-You don't have to choose sides, either. Many owners hold a tokenized `.com` for their real product *and* an [`.eth`](/en/tld/eth/) name as a wallet identity. They do different jobs. (See [Tokenized Domain vs Web3 Domain](/en/blog/tokenized-domain-vs-web3-domain/) for the full breakdown.)
+The two models can coexist. A project can use a tokenized `.com` for ordinary DNS and an [`.eth`](/en/tld/eth/) name for a supported wallet identity, but each adds its own renewal, custody, security, and configuration obligations. See [Tokenized Domain vs Web3 Domain](/en/blog/tokenized-domain-vs-web3-domain/) for the fuller breakdown.
 
 ---
 
 ## Which Real TLDs Are "Premium" for Tokenization?
 
-Not every extension carries the same weight. When investors and builders talk about premium TLDs for tokenization, a few names come up again and again—each for different reasons.
+Not every extension serves the same audience. The examples below are starting points for research, not a 2026 ranking and not a claim that every name under the extension is premium.
 
-### `.com` — the default premium standard
+### `.com` — a long-established general-purpose extension
 
-[`.com`](/en/tld/com/) remains the most universally trusted and most valuable extension overall, with the largest registered base and the deepest [aftermarket](/en/glossary/aftermarket/) history. A short, brandable, dictionary, or single-word `.com` is the blue-chip of domain investing. Tokenizing one combines that blue-chip status with instant, [registrar](/en/glossary/registrar/)-free transferability. See [How to Tokenize Your .com](/en/blog/how-to-tokenize-your-com/).
+[`.com`](/en/tld/com/) is a long-established general-purpose extension with a large registration base and substantial [aftermarket](/en/glossary/aftermarket/) history. Some short, dictionary, or brandable `.com` names have recorded high sales, but the extension alone does not establish value. On a supported platform, tokenization can move the ownership representation without initiating a conventional inter-registrar transfer for each token transaction; the domain still remains subject to the sponsoring [registrar](/en/glossary/registrar/), registry, renewal, dispute, and platform rules. See [How to Tokenize Your .com](/en/blog/how-to-tokenize-your-com/).
 
-### `.ai` — the highest-momentum premium extension
+### `.ai` — an extension associated with AI projects
 
-[`.ai`](/en/tld/ai/) has become the standout premium extension of this era, commanding high average aftermarket prices as demand from AI companies outstrips supply. For founders building in AI, a strong `.ai` is both a branding asset and a scarce investment—an ideal candidate for tokenization so it can trade with the [liquidity](/en/glossary/domain-liquidity/) of an NFT.
+[`.ai`](/en/tld/ai/) is widely used by AI-related products and companies. That association may matter to a buyer, but claims about average prices, demand exceeding supply, or momentum require a dated dataset and methodology. Tokenization does not give a `.ai` name the [liquidity](/en/glossary/domain-liquidity/) of the broader NFT market; liquidity remains specific to the domain and venue.
 
 ### `.io` — the developer and startup favorite
 
-[`.io`](/en/tld/io/) earned its premium status as the go-to extension for developer tools, SaaS, and crypto startups. It carries genuine brand cachet in tech circles. (Investors should note ongoing governance discussion around the extension's long-term status; as always, [do your own research](/en/blog/what-are-tokenized-domains/).)
+[`.io`](/en/tld/io/) is used by many developer-tool, SaaS, and crypto projects. A prospective registrant or buyer should evaluate the particular name, renewal price, audience, legal risk, and the ccTLD's policy and long-term governance rather than assuming "premium" status from the extension alone.
 
-### `.xyz` — the fast-growing modern alternative
+### `.xyz` — a modern general-purpose alternative
 
-[`.xyz`](/en/tld/xyz/) is one of the fastest-growing extensions by registration volume and a favorite of Web3-native and startup brands. It's open, affordable, and culturally aligned with crypto—making it a natural fit for tokenization and on-chain branding.
+[`.xyz`](/en/tld/xyz/) is used by some Web3 and startup brands and is available through many registrars. Registration volume, pricing, promotions, and renewal costs change over time, so "fastest-growing" or "affordable" claims need a dated registry dataset and the exact registrar price. Tokenization suitability still depends on platform support for the particular domain.
 
 ### Other notable premium and brandable extensions
 
-- [`.org`](/en/tld/org/) — trusted, institutional, with a strengthening aftermarket.
-- [`.app`](/en/tld/app/) and [`.dev`](/en/tld/dev/) — secure, developer-friendly Google TLDs popular for products and tooling.
-- [`.net`](/en/tld/net/) — a long-established legacy extension still in steady demand.
+- [`.org`](/en/tld/org/) — a long-established extension often used by organizations; evaluate the particular name and use.
+- [`.app`](/en/tld/app/) and [`.dev`](/en/tld/dev/) — Google Registry TLDs on the HSTS preload list; browser connections require HTTPS configuration.
+- [`.net`](/en/tld/net/) — a long-established general-purpose extension with its own registration and aftermarket history.
 
-The throughline: premium value comes from **scarcity, brand strength, and real-world demand**—not from being on a blockchain. Tokenization doesn't manufacture that value; it makes already-valuable extensions liquid, programmable, and wallet-native.
+The throughline: an extension and token wrapper are only parts of a domain's evaluation. Tokenization does not manufacture value or liquidity. It can make a supported domain wallet-held and programmatically transferable, while market demand and integrations remain separate.
 
 ---
 
@@ -111,11 +111,12 @@ The throughline: premium value comes from **scarcity, brand strength, and real-w
 
 If you want a premium Web3 domain that is also a real, browser-resolvable name, the path on Namefi is straightforward:
 
-1. **Pick or bring a premium extension** — register a new `.com`, `.ai`, `.io`, or `.xyz`, or tokenize one you already own.
-2. **Mint the on-chain token** — an NFT representing the domain is minted to your wallet, synchronized with the DNS record.
-3. **Use it everywhere** — host a site, set up email and SSL, and simultaneously list, trade, or collateralize the NFT on major marketplaces and lending protocols.
+1. **Check eligibility and current terms** — confirm that Namefi supports the exact TLD and domain status, and review pricing, renewal, import, custody, and export requirements.
+2. **Register or import the DNS domain** — a supported domain must be under Namefi's registrar/platform control before the ownership token is minted. Verify the current workflow rather than assuming every external registration can be tokenized immediately.
+3. **Mint and verify the token** — confirm the chain, contract, wallet address, domain status, DNS behavior, and recovery process.
+4. **Check each intended integration separately** — a marketplace or lending protocol must support the chain and token contract and may impose its own eligibility, valuation, liquidity, and loan terms.
 
-You keep the full premium value of a real ICANN extension and gain wallet-native ownership on top. Explore available extensions and tokenize or trade premium domains at [namefi.io](https://namefi.io).
+You retain a DNS registration subject to its ordinary obligations and gain a wallet-held token under the platform's current terms. Neither the prior appraisal nor future resale value is guaranteed. Explore currently supported domains and workflows at [namefi.io](https://namefi.io).
 
 ---
 
@@ -123,19 +124,19 @@ You keep the full premium value of a real ICANN extension and gain wallet-native
 
 ### What is a premium Web3 TLD?
 
-The term is used two ways. It can mean a blockchain-native extension like `.eth` or `.crypto` that lives outside the ICANN DNS root, or a real, premium ICANN extension (like `.com`, `.ai`, or `.io`) that has been **tokenized** on-chain. The tokenized-ICANN version keeps universal browser and email compatibility while adding wallet-native ownership.
+The term is used two ways. It can mean a blockchain-native extension such as `.eth` or `.crypto` outside the ordinary DNS root, or a registered DNS domain under an extension such as `.com`, `.ai`, or `.io` whose control is represented by a token. The latter retains ordinary DNS and email capabilities while adding a platform- and chain-specific wallet token.
 
 ### Is a tokenized `.com` a Web3 domain?
 
-It's a *tokenized DNS domain*. It has Web3 properties—it's an NFT in your wallet, tradable and composable on-chain—but unlike a blockchain-only name, it remains a real `.com` that resolves natively everywhere. Many people use "Web3 domain" specifically for `.eth`/`.crypto`-style names, so the precise term is "tokenized ICANN domain."
+It's a *tokenized DNS domain*. Its ownership representation can be an NFT in a wallet and can interact with applications that explicitly support its chain and contract. The underlying `.com` remains in the DNS root and resolves through ordinary DNS while the registration and configuration are valid. Because "Web3 domain" is ambiguous, "tokenized DNS domain" or "tokenized ICANN-root domain" is more precise.
 
 ### Which Web3 domain extensions are the best?
 
-If you mean blockchain-native, ENS's `.eth` is the most established for wallet identity. If you mean premium *tokenized* extensions for real-world use and investment, `.com`, `.ai`, `.io`, and `.xyz` are the standouts—real ICANN TLDs with deep demand that work everywhere.
+There is no context-free "best." For blockchain-native identity, compare protocol adoption, resolver support, renewal rules, chain, and integrations. For tokenized DNS domains, compare the particular name, DNS/email requirements, registrar and registry terms, renewal cost, platform and chain support, legal risk, and evidenced buyer demand. `.com`, `.ai`, `.io`, and `.xyz` are examples, not a value ranking.
 
 ### Why tokenize a real TLD instead of buying a blockchain-only name?
 
-Because a tokenized real TLD resolves in any browser, supports email and SSL, and is recognized by ICANN—while still being held in your wallet and tradable as an NFT. A blockchain-only name needs a resolver or extension to work and isn't part of the DNS root. For a website or brand that must work for everyone, the tokenized real TLD wins.
+Because the underlying DNS domain uses the ordinary DNS root and can support conventional web, email, and TLS configuration while its ownership representation is held in a wallet. A blockchain-native name may require protocol-aware browser support, a gateway, or another resolver because it is outside the DNS root. The better choice depends on the required resolution and identity model; NFT marketplace or lending support is not automatic for either one.
 
 ### Do premium tokenized domains still need annual renewal?
 
@@ -147,7 +148,13 @@ Yes. Because the underlying asset is a real DNS domain, it follows normal regist
 
 - "Web3 TLD" means two different things: **blockchain-native names** outside the DNS root (`.eth`, `.crypto`) and **real ICANN extensions tokenized on-chain** (`.com`, `.ai`, `.io`).
 - Tokenizing a real, premium extension gives you Web3 ownership *without* the resolution and compatibility problems of blockchain-only names.
-- The most premium extensions for tokenization—`.com`, `.ai`, `.io`, `.xyz`—are premium because of scarcity, brand, and demand, not because of any chain.
+- `.com`, `.ai`, `.io`, and `.xyz` illustrate different audiences; the extension and token wrapper do not guarantee that a particular domain is premium, liquid, or suitable as collateral.
 - You can hold both: a tokenized `.com` for your product and an `.eth` for wallet identity.
 
 To get started, read [What Are Tokenized Domains?](/en/blog/what-are-tokenized-domains/), compare categories in [Tokenized Domain vs Web3 Domain](/en/blog/tokenized-domain-vs-web3-domain/), or tokenize and trade premium domains at [namefi.io](https://namefi.io).
+
+## Sources and further reading
+
+- Namefi — [current tokenized-domain product overview](https://namefi.io/)
+- ENS — [browser resolution and decentralized website support for `.eth`](https://support.ens.domains/en/articles/7900302-what-can-i-do-with-an-ens-name)
+- Unstoppable Domains — [browser support and resolution requirements](https://support.unstoppabledomains.com/support/solutions/articles/48001183213-my-website-isn-t-loading)


### PR DESCRIPTION
## Summary

- distinguish blockchain-native namespaces from tokenized DNS domains without treating either architecture as universally superior
- remove unsupported 2026 TLD rankings and guarantees about value, liquidity, marketplace support, lending, and transfer speed
- make marketplace and collateral use explicitly dependent on chain, contract, platform, lender, and domain eligibility
- clarify Namefi import, mint, custody, export, DNS, registrar, and renewal boundaries

## Sources

- Namefi current product overview
- ENS browser-resolution documentation
- Unstoppable Domains browser-support documentation

## Validation

- `TMPDIR=/private/tmp bun run data:validate` (passes; 29 pre-existing empty-keyword warnings)
- `TMPDIR=/private/tmp bun run lint:mdx`
- `TMPDIR=/private/tmp bun run check:termbase`
- `TMPDIR=/private/tmp bun .agents/skills/cross-link/link-audit.ts content/blog/en/premium-web3-tlds.md`
- `git diff --check`

## Access control

No new application surface or access-control boundary. This changes a public English article only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Public marketing/content copy only; no application, auth, or data-handling changes.
> 
> **Overview**
> Rewrites the English **premium Web3 TLDs** guide to be more precise and less promotional about what “Web3 TLD” means and what tokenization actually delivers.
> 
> The article now clearly separates **blockchain-native names** from **tokenized DNS registrations** (second-level domain tokenized, not the whole TLD), compares them without declaring a universal winner, and tightens claims around DNS/email/TLS, custody, renewals, and platform-specific sync rules. **Marketplace trading, NFT liquidity, DeFi collateral, and fast transfers** are framed as conditional on chain, contract, platform, lender, and domain status—not automatic benefits of tokenization.
> 
> Extension sections (`.com`, `.ai`, `.io`, `.xyz`, etc.) drop **2026 rankings and investment hype** in favor of evaluation factors and dated-data caveats. The **Namefi how-to** becomes a four-step checklist (eligibility, import/register, mint/verify, per-integration checks) with explicit limits on guarantees. **Front matter**, FAQs, summary bullets, and a new **Sources and further reading** section (Namefi, ENS, Unstoppable) align with the toned-down messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0172e6abe2bef8f7bdbe76127ffc4c8e01e8214. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->