### PR TITLE
fix(content): correct zero knowledge classifications

### DIFF
--- a/content/blog/en/perfect-vs-computational-zero-knowledge.md
+++ b/content/blog/en/perfect-vs-computational-zero-knowledge.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 draft: false
 cluster: web3-foundations
 format: explainer
-description: Zero-knowledge proofs come in three flavors—perfect, statistical, and computational—and the difference matters more than most engineering discussions admit. This post explains each in plain language, why nearly every production ZK system in 2026 is computational, and what that buys and costs.
+description: Zero-knowledge protocols can provide perfect, statistical, or computational privacy. This guide explains those definitions, why proof-system families do not have one universal flavor, and how privacy differs from soundness and post-quantum security.
 ogImage: ../../assets/perfect-vs-computational-zero-knowledge-og.jpg
 keywords: ['zero knowledge proof', 'perfect zero knowledge', 'computational zero knowledge', 'zk snark', 'zk stark', 'cryptography', 'simulator', 'commitment scheme', 'namefi']
 relatedArticles:
@@ -30,48 +30,50 @@ relatedGlossary:
   - /en/glossary/registry/
 ---
 
-When people in crypto talk about "zero-knowledge proofs," they almost always mean one specific thing: a SNARK or STARK that proves some computation was performed correctly, without revealing the inputs. That mental model is fine for most engineering conversations. It hides a distinction that becomes important the moment you try to reason about *what the security actually guarantees*.
+When people in crypto talk about "zero-knowledge proofs," they may mean a SNARK, STARK, range proof, or another protocol that proves a statement without exposing a witness. That shorthand hides several independent axes: privacy can be perfect, statistical, or computational; soundness can be information-theoretic or computational; the protocol can be interactive or non-interactive; and a compiler such as Fiat–Shamir can change the security model.
 
-Zero-knowledge proofs come in three formal flavors—**perfect**, **statistical**, and **computational** zero-knowledge—and they differ in *what the verifier can possibly learn even with unlimited resources*. The system you ship is almost certainly computational. It is worth knowing why, and what that buys.
+The important lesson is not that one named family always has one flavor. It is that you must read the theorem and implementation for the exact construction you deploy.
 
 ## The shape of a zero-knowledge proof
 
 The classical setup: a *prover* wants to convince a *verifier* that some statement is true, without the verifier learning anything else. "True" here means something like "I know an `x` such that `H(x) = y`" or "I know a path in this graph" or "I executed this program correctly on private inputs."
 
-A proof system is **zero-knowledge** when, informally, *the verifier could have generated the proof on their own without the secret*. Formally, this is captured by the existence of a **simulator**: a polynomial-time algorithm that, given only the public statement (no witness), produces a transcript that looks indistinguishable from a real proof transcript.
+A proof system is **zero-knowledge** when, informally, the verifier's view can be reproduced without the witness. Formally, a simulator receives the public statement (and whatever setup or oracle the security model permits) but not the witness, and produces a view that is related to a real interaction in a specified way. Definitions also say which verifiers are covered: honest-verifier zero-knowledge is weaker than security against arbitrary malicious verifiers.
 
 The three flavors of zero-knowledge differ in what "looks indistinguishable" means.
 
 ### Perfect zero-knowledge
 
-The simulator's output is **identically distributed** to a real proof. There is no statistical test, no test you could run with a quantum computer, no test you could run in 10^100 years, that distinguishes the simulator from the real prover. Mathematically, the two distributions are the *same*.
+The simulator's output is **identically distributed** to the real view under the definition's model. Mathematically, the two distributions are the same. Computation cannot distinguish distributions that are identical, but the guarantee still covers only what the theorem models; public inputs, circuit shape, timing, implementation bugs, and side channels may remain visible.
 
-This is the gold standard. It says: even an unbounded adversary—no time limit, no computational assumption—learns nothing from the proof.
+For the modeled transcript, this is an information-theoretic privacy statement. It does not imply information-theoretic soundness or remove setup and implementation assumptions.
 
 ### Statistical zero-knowledge
 
-The simulator's output is **statistically close** to a real proof. The total variation distance between the two distributions is negligible. An unbounded adversary might in principle learn something, but the amount they could learn falls off exponentially with the security parameter.
+The simulator's output is **statistically close** to the real view. The total variation distance is negligible in the security parameter, so even an unbounded distinguisher has only negligible advantage. "Negligible" means smaller than every inverse polynomial beyond some point; it does not necessarily mean a specific exponential rate.
 
-For all practical purposes statistical ZK is as good as perfect ZK. The simulator just doesn't have to match the real distribution exactly; it has to match it close enough that no amount of computation can amplify the gap.
+Statistical ZK is weaker than perfect ZK because the distributions need not be identical, but its privacy bound is not based on limiting the distinguisher to efficient computation.
 
 ### Computational zero-knowledge
 
-The simulator's output is **computationally indistinguishable** from a real proof: no *polynomial-time* algorithm can tell them apart. An unbounded adversary—someone with the ability to brute-force the underlying hash function or solve the underlying hard problem—might well be able to distinguish them, and might learn the witness.
+The simulator's output is **computationally indistinguishable** from the real view: no probabilistic polynomial-time distinguisher has more than negligible advantage under the stated assumptions and model.
 
-This is the weakest of the three, in the formal sense, and it is the one almost every modern system actually offers.
+This is weaker than statistical or perfect indistinguishability. If an assumption later fails, the proof of privacy may no longer apply; that fact alone does **not** show that archived transcripts reveal the witness. Leakage must be analyzed construction by construction.
 
-## Why nearly every production ZK system is computational
+## Why the protocol family does not determine the flavor
 
-There is a theorem hiding behind this: **for NP-complete languages, perfect zero-knowledge is unlikely to exist** unless the polynomial hierarchy collapses ([Goldreich and Krawczyk, 1996](https://www.wisdom.weizmann.ac.il/~oded/PSX/zk-poly.pdf)). In other words, if you want to prove *arbitrary* statements in zero-knowledge—statements as expressive as "I ran this program correctly"—you cannot have perfect zero-knowledge without making the proof itself depend on unproven complexity assumptions.
+Perfect zero-knowledge is not limited to a small statement class when computational soundness, setup, or other models are allowed. Groth, Ostrovsky, and Sahai constructed a **perfect non-interactive zero-knowledge argument for every NP language**. That does not contradict lower bounds for other models: an **argument** has computational soundness, and a NIZK commonly uses a common reference string.
 
-What you *can* have for arbitrary NP statements:
+The frequently cited Goldreich–Krawczyk result is also narrower than a blanket impossibility for perfect ZK and NP. It proves round- and composition-related lower bounds, including limits for three-round and constant-round public-coin protocols with black-box simulation. It does not establish that an expressive NP argument cannot have perfect zero-knowledge.
 
-- **Computational zero-knowledge proofs**, which exist if one-way functions exist. ([Goldreich, Micali, Wigderson 1991](https://dl.acm.org/doi/10.1145/116825.116852).)
-- **Statistical zero-knowledge for limited classes** of statements (random self-reducible problems, graph isomorphism), but not for general NP.
+Concrete systems show why labels are unsafe:
 
-So when a real system—Groth16, PLONK, Halo2, STARK, Bulletproofs—says it is "zero-knowledge," it virtually always means *computational* zero-knowledge. The proof reveals nothing to a polynomial-time verifier, conditional on assumptions about elliptic curves, hash functions, or other cryptographic primitives.
+- **Groth16:** the original pairing-based argument states perfect zero-knowledge, while soundness is computational.
+- **PLONK:** the paper intentionally leaves zero-knowledge out of its idealized polynomial-protocol definition because the final property depends on what the selected polynomial commitment and compilation leak.
+- **Bulletproofs:** the interactive aggregate range proof is proven perfect honest-verifier zero-knowledge. The paper then obtains a non-interactive protocol through Fiat–Shamir and analyzes it in the random-oracle model.
+- **STARKs:** the original paper's underlying STIK can have perfect ZK. Its hash-based interactive and random-oracle non-interactive compilations are described as computational ZK.
 
-If those assumptions break—say, a future algorithm breaks the discrete log problem on a curve that a scheme relies on—the zero-knowledge argument can weaken retroactively. Exactly what becomes possible depends on the construction: an attacker may be able to distinguish real transcripts from simulated ones, forge proofs, or extract information that was previously protected. You should not assume old computational-ZK transcripts retain the same privacy margin after their underlying assumptions fail.
+Implementations may add or omit blinding, batch protocols, recursion, transcript transformations, or setup checks. Classify the deployed construction, not the marketing family name.
 
 ## A worked example: commitment schemes
 
@@ -84,41 +86,47 @@ Two security properties:
 - **Hiding** — the envelope reveals nothing about `v`.
 - **Binding** — I cannot open the envelope to a value other than the one I originally committed.
 
-You cannot have both perfectly. A perfectly hiding commitment is computationally binding (with enough computation, an attacker can find a second opening). A perfectly binding commitment is computationally hiding (with enough computation, an attacker can extract the committed value).
+In the ordinary non-interactive classical setting, a nontrivial commitment cannot be both perfectly hiding and perfectly binding: perfect hiding requires the commitment distributions to overlap, while perfect binding requires unique openings. Constructions and setup models decide which property is information-theoretic and which is computational.
 
-[Pedersen commitments](https://link.springer.com/chapter/10.1007/3-540-46766-1_9) are perfectly hiding and computationally binding—they reveal *nothing* about the committed value even to an unbounded attacker, but a future break of discrete log lets you cheat the binding. Hash-based commitments (`c = H(v || r)`) are computationally hiding and (when the hash is collision-resistant) computationally binding.
+[Pedersen commitments](https://link.springer.com/chapter/10.1007/3-540-46766-1_9) are perfectly hiding and computationally binding under their standard group setup. Knowing the discrete-log relation between generators can break binding without retroactively removing the commitment's perfect-hiding distribution. A hash commitment such as `c = H(v || r)` is generally analyzed with computational hiding and binding assumptions; its hiding also depends on adequate randomness and message entropy.
 
-Which flavor you want depends on which property is allowed to weaken over time. For long-term privacy of a vote or a bid, you usually want perfect hiding even if binding is only computational—because you can re-prove binding before the discrete-log assumption breaks, but you cannot retroactively unblind a leaked vote.
+Which construction you want depends on which property must survive and for how long. Long-term privacy may favor information-theoretic hiding, but the full protocol can still leak metadata or depend on computational ZK elsewhere. Binding cannot generally be "re-proved" away after an assumption fails; retention and migration plans must be designed before deployment.
 
 ## Why this matters for ZK rollups and L2 systems
 
-Most ZK rollups use SNARKs with computational zero-knowledge. The practical implications:
+Do not assume that every "ZK rollup" hides transaction data: many rollups use validity proofs primarily for computational integrity and publish the transaction data needed for state reconstruction. Privacy is an application and protocol property, not a consequence of the letters "ZK."
 
-- **Today**, the proofs reveal nothing to any feasible attacker. The privacy guarantee is strong.
-- **Long term**, the proofs reveal whatever the underlying assumption protects. If a rollup uses a SNARK whose security rests on BN254 discrete log, and BN254 is broken in 2050, every proof published before then becomes potentially un-blindable.
-- **Post-quantum considerations** matter: discrete-log-based SNARKs (Groth16, PLONK over standard pairing curves) are *not* post-quantum secure. STARKs, which rely only on hash collision resistance, are. ([StarkWare](https://eprint.iacr.org/2018/046.pdf), the paper that established the STARK acronym.)
-- **Statistical or perfect ZK** is possible in restricted settings (e.g., proving certain algebraic relations) and is sometimes used when the long-term privacy budget matters more than expressiveness.
+For a system that does protect witnesses, separate these questions:
 
-For applications like anonymous voting, whistleblower channels, and other systems where transcripts may be archived for decades, the choice between computational and statistical ZK is not pedantic. It is the difference between privacy that holds against tomorrow's adversary and privacy that holds against any adversary.
+- **What exactly is public?** Public inputs, state transitions, circuit shape, proof timing, and data-availability material may reveal information outside the simulator's claim.
+- **What is the ZK theorem?** Check perfect vs statistical vs computational, honest vs malicious verifier, setup, oracle, and composition model.
+- **What is the soundness theorem?** A proof can have perfect ZK and computational soundness. Breaking a curve assumption may enable forgery without revealing historical witnesses.
+- **What protects archived transcripts?** A BN254 discrete-log break does not automatically make every old proof "unblindable." Determine which transcript elements hide the witness and which assumptions protect them.
+- **What is the quantum threat model?** Pairing- and discrete-log-based soundness is vulnerable to a sufficiently capable quantum computer. Hash-based STARK designs target post-quantum computational integrity, but concrete hash parameters, Grover-style speedups, the Fiat–Shamir/random-oracle model, and implementation choices still matter. The original STARK paper itself distinguishes a perfect-ZK information-theoretic layer from computational-ZK compiled realizations.
 
 ## A simple decision tree
 
 If you are picking a ZK system for production:
 
-- **Verifier-only privacy, short-lived data, performance matters most:** computational ZK from a battle-tested SNARK or STARK is fine. This is most rollups, most ZK-KYC, most ZK-login.
-- **Long-term privacy, audit/legal sensitivity:** prefer a hash-based system (STARK) or a Pedersen-style commitment underneath. Document the assumption.
-- **Provable privacy regardless of computational assumptions:** you are looking for perfect or statistical ZK on a restricted statement class. Expect to give up some expressiveness or interactivity.
+1. **Define the secret and retention period.** Say exactly which witness fields and linkages must remain private, and for how long.
+2. **Identify the deployed theorem.** Record the exact protocol version, blinding steps, commitment scheme, compiler, setup, random-oracle assumptions, and verifier class.
+3. **Separate privacy from integrity.** Document the ZK flavor independently from completeness, soundness, knowledge soundness, and extractability.
+4. **Test the implementation boundary.** Side channels, malformed setup, weak randomness, public metadata, circuit bugs, and unsafe transcript reuse can defeat a correct theorem.
+5. **Plan for cryptographic migration.** Specify what happens to future verification and archived transcripts if a curve, hash, setup, or compiler assumption weakens.
 
-There is no free lunch. The flavors of ZK trade off against each other and against efficiency. The question is *which trade-off you make consciously*.
+The right trade-off is application-specific. A family name alone is not a security decision.
 
 ## How Namefi thinks about this
 
-In [domain ownership](/en/glossary/domain-ownership/) flows, the most interesting use of ZK is proving you own a name without revealing *which* name. Ownership proofs against an [on-chain](/en/glossary/on-chain/) [registry](/en/glossary/registry/) can be made computational ZK with very mature tooling (Groth16, PLONK), and that is what production systems run on today. For more sensitive flows—say, proving a domain belongs to a *set* of trusted entities without revealing which—statistical or perfect ZK schemes on restricted statements may become relevant. The point of this post is to make the trade-off legible: pick what you actually need, and write down the assumptions you are buying.
+A future [domain ownership](/en/glossary/domain-ownership/) flow might prove membership in an [on-chain](/en/glossary/on-chain/) [registry](/en/glossary/registry/) or possession of a credential without revealing the domain. The appropriate protocol would depend on what is public, how the credential is issued and revoked, whether the chain data already identifies the holder, and which verifier and setup models are acceptable. This article does not claim that Namefi currently deploys such a flow. The engineering rule is to state the privacy and soundness theorems separately and record every assumption.
 
 ## Sources and further reading
 
 - Goldreich, Micali, Wigderson — [Proofs that yield nothing but their validity (J. ACM 1991)](https://dl.acm.org/doi/10.1145/116825.116852).
-- Goldreich and Krawczyk — [On the composition of zero-knowledge proof systems (1996)](https://www.wisdom.weizmann.ac.il/~oded/PSX/zk-poly.pdf).
+- Goldreich and Krawczyk — [On the composition of zero-knowledge proof systems (1996)](https://research.ibm.com/publications/on-the-composition-of-zero-knowledge-proof-systems).
 - Pedersen — [Non-interactive and information-theoretic secure verifiable secret sharing (1991)](https://link.springer.com/chapter/10.1007/3-540-46766-1_9).
 - Ben-Sasson, Bentov, Horesh, Riabzev — [Scalable, transparent, and post-quantum secure computational integrity (STARK paper, 2018)](https://eprint.iacr.org/2018/046.pdf).
-- a16z crypto — [Justin Thaler's "Proofs, Arguments, and Zero-Knowledge"](https://people.cs.georgetown.edu/jthaler/ProofsArgsAndZK.html), the canonical modern textbook.
+- Groth, Ostrovsky, Sahai — [Perfect Non-Interactive Zero Knowledge for NP (2005)](https://eprint.iacr.org/2005/290.pdf).
+- Groth — [On the Size of Pairing-Based Non-interactive Arguments (Groth16, 2016)](https://discovery.ucl.ac.uk/id/eprint/1501201/).
+- Gabizon, Williamson, Ciobotaru — [PLONK (2019)](https://eprint.iacr.org/2019/953.pdf).
+- Bünz et al. — [Bulletproofs (2018)](https://web.stanford.edu/~buenz/pubs/bulletproofs.pdf).


### PR DESCRIPTION
## Summary

- correct the blanket claim that expressive or production ZK systems are necessarily computational zero-knowledge
- separate ZK flavor from proof-vs-argument soundness, interaction, setup, Fiat-Shamir, and post-quantum security
- classify Groth16, PLONK, Bulletproofs, and STARKs from their primary papers instead of by family-name shorthand
- remove the incorrect claim that a future BN254 discrete-log break would automatically unblind historical proofs
- correct statistical-distance and commitment-scheme explanations and make the Namefi example explicitly hypothetical

## Primary sources

- Goldreich–Krawczyk composition and round-complexity result
- Groth–Ostrovsky–Sahai perfect NIZK arguments for NP
- Groth16, PLONK, Bulletproofs, and the original STARK paper
- Pedersen commitments

## Validation

- `TMPDIR=/private/tmp bun run data:validate` (passes; 29 pre-existing empty-keyword warnings)
- `TMPDIR=/private/tmp bun run lint:mdx`
- `TMPDIR=/private/tmp bun run check:termbase`
- `TMPDIR=/private/tmp bun .agents/skills/cross-link/link-audit.ts content/blog/en/perfect-vs-computational-zero-knowledge.md`
- `git diff --check`

## Access control

No new application surface or access-control boundary. This changes a public English article only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Public English blog content only; no application, auth, or data-handling changes.
> 
> **Overview**
> Rewrites the **perfect vs computational zero-knowledge** explainer so it no longer treats production ZK as uniformly computational or conflates privacy with soundness, setup, and Fiat–Shamir.
> 
> The article now frames **privacy flavor** (perfect / statistical / computational) as separate from **soundness** (proof vs argument), verifier models, and compilers. It replaces broad impossibility claims with narrower readings of Goldreich–Krawczyk and cites **perfect NIZK arguments for NP**, then classifies **Groth16, PLONK, Bulletproofs, and STARKs** from their primary papers instead of family-name shorthand.
> 
> Other corrections include **commitment-scheme** hiding/binding tradeoffs, the claim that a **BN254 break automatically unblinds old proofs**, rollup **privacy vs validity-proof** expectations, a production **checklist** instead of a simple decision tree, and a **hypothetical** Namefi ownership example. The **description**, body copy, and **bibliography** are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fee450effa88f28a829b7768a75a61b1e6b99fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->