### PR TITLE
fix(content): update MCP auth guidance

### DIFF
--- a/content/blog/en/mcp-quickstart.md
+++ b/content/blog/en/mcp-quickstart.md
@@ -7,8 +7,8 @@ authors: ['namefiteam']
 draft: false
 format: guide
 ogImage: ../../assets/mcp-quickstart-og.jpg
-description: "Per-editor MCP setup for Claude Code, Cursor, and Windsurf, then a 5-step quickstart from a new app to a live custom domain, without leaving the editor."
-keywords: ["claude code mcp domain", "cursor mcp domain", "windsurf mcp domain", "in-editor domain registration", "coding agent domain registration", "register domain from editor", "mcp quickstart", "namefi mcp config", "vercel custom domain namefi", "cloudflare pages custom domain namefi", "deploy custom domain ai agent", "domain registration quickstart", "x-api-key mcp config", "point domain at deployment"]
+description: "Per-editor OAuth and API-key MCP setup for Claude Code, Cursor, and Windsurf, then a five-step quickstart from a new app to a live custom domain."
+keywords: ["claude code mcp domain", "cursor mcp domain", "windsurf mcp domain", "in-editor domain registration", "coding agent domain registration", "register domain from editor", "mcp quickstart", "namefi mcp config", "MCP OAuth PKCE", "vercel custom domain namefi", "cloudflare pages custom domain namefi", "deploy custom domain ai agent", "domain registration quickstart", "x-api-key mcp config", "point domain at deployment"]
 relatedArticles:
   - /en/blog/ai-agent-register/
   - /en/blog/claude-mcp-domains/
@@ -29,7 +29,7 @@ relatedGlossary:
   - /en/glossary/domain-renewal/
 ---
 
-You're already in the editor. The app is scaffolded, the first deploy just went out to a platform subdomain, and the only thing left before you can point people at it is a real domain. This is the quickstart for doing that registration step without opening a browser tab, filling out a checkout form, or leaving the same [coding agent](/en/glossary/ai-agent/) session that built the app: exact [MCP](https://modelcontextprotocol.io) connection config for Claude Code, Cursor, and Windsurf, a condensed five-step flow, and — the part most domain guides skip — how to take the domain you just registered and actually point it at the deployment you just shipped.
+You're already in the editor. The app is scaffolded, the first deploy just went out to a platform subdomain, and the only thing left before you can point people at it is a real domain. This is the quickstart for doing that registration step from the same [coding agent](/en/glossary/ai-agent/) session that built the app: exact [MCP](https://modelcontextprotocol.io) connection config for Claude Code, Cursor, and Windsurf, a condensed five-step flow, and — the part most domain guides skip — how to take the domain you just registered and point it at the deployment you just shipped. OAuth may open a browser once for authorization; the domain workflow then returns to the editor.
 
 This guide covers three editors on purpose. If you're on OpenAI Codex, Gemini CLI, or Claude Desktop instead, [How to Register a Domain with Your AI Agent on Namefi](/en/blog/ai-agent-register/) is the canonical hub with a verified setup for all six clients plus the raw REST path for anything that isn't MCP-native. Everything here connects to the same [Namefi](https://namefi.io) MCP server that hub documents, so nothing below contradicts it — this page is just the condensed, developer-tool-first cut through it, with a deployment step the hub doesn't cover.
 
@@ -41,21 +41,42 @@ The alternative is to let the same agent that scaffolded the project and wired u
 
 ## Set up the connection: three editors, three config files
 
-All three editors below connect to the same endpoint, `https://api.namefi.io/mcp`, over Streamable HTTP, with your Namefi [API key](https://namefi.io/api-key) sent as an `x-api-key` header. What changes per editor is only the file format and the command that writes it.
+All three editors below connect to `https://api.namefi.io/mcp` over Streamable HTTP. The current server advertises two authentication paths: OAuth 2.1 authorization code with PKCE (plus dynamic client registration) and a Namefi [API key](https://namefi.io/api-key) in the `x-api-key` header. Prefer OAuth when the client supports it and you do not already have a key; use a key for explicit header-based or automated setups.
+
+One current-behavior caveat matters for this quickstart. Namefi's discovery descriptor says read-only tools need no authentication, but an unauthenticated MCP `initialize` request returned `401 Unauthorized` when this article was verified on **July 14, 2026**. A client must initialize the MCP session before it can call even a read-only tool, so treat the live endpoint as authentication-required until the server behavior or descriptor changes.
 
 ### Claude Code
 
-Claude Code's own documentation gives a direct CLI command for adding a remote HTTP server with a custom header:
+For OAuth, add the server without a static authentication header:
+
+```bash
+claude mcp add --transport http namefi https://api.namefi.io/mcp
+claude mcp login namefi
+```
+
+Claude Code can also start the OAuth flow from `/mcp` inside an interactive session. Its documentation says a `401` or `403` marks the remote server as needing authentication; follow the browser authorization steps. For API-key authentication instead, add the custom header:
 
 ```bash
 claude mcp add --transport http namefi https://api.namefi.io/mcp --header "x-api-key: YOUR_KEY"
 ```
 
-Run it once from a terminal in your project, with your real key swapped in. By default it writes the server at **local** scope — available to you, in this project only. Add `--scope user` to make it available across every project on your machine instead, and confirm it connected with `claude mcp list`.
+Run only the authentication variant you intend to use. For the key command, replace `YOUR_KEY` with the real key and avoid committing it. By default Claude Code writes the server at **local** scope — available to you, in this project only. Add `--scope user` to make it available across every project on your machine, and confirm the connection with `claude mcp list`.
 
 ### Cursor
 
-Cursor reads MCP servers from `mcp.json` — a project copy at `.cursor/mcp.json`, or a global copy at `~/.cursor/mcp.json`. Its documented remote-server shape supports header-based auth with environment-variable interpolation, so the key itself doesn't have to live in the file:
+Cursor reads MCP servers from `mcp.json` — a project copy at `.cursor/mcp.json`, or a global copy at `~/.cursor/mcp.json`. Cursor documents OAuth support for Streamable HTTP servers. For OAuth, configure only the URL, enable the server, and complete the interactive authentication prompt:
+
+```json
+{
+  "mcpServers": {
+    "namefi": {
+      "url": "https://api.namefi.io/mcp"
+    }
+  }
+}
+```
+
+For API-key authentication, Cursor's documented remote-server shape supports headers with environment-variable interpolation, so the key itself does not have to live in the file:
 
 ```json
 {
@@ -70,11 +91,23 @@ Cursor reads MCP servers from `mcp.json` — a project copy at `.cursor/mcp.json
 }
 ```
 
-`${env:NAMEFI_API_KEY}` resolves from whatever that variable holds in the shell that launched Cursor — export it before opening the editor.
+`${env:NAMEFI_API_KEY}` resolves from whatever that variable holds in the shell that launched Cursor — export it before opening the editor. If an OAuth-capable server remains in a “Needs authentication” state, use Cursor's MCP settings to start the authorization flow; client-version and Remote SSH behavior can differ, so keep the API-key configuration as a fallback.
 
 ### Windsurf (Cascade)
 
-Windsurf's MCP integration — branded Cascade — reads `~/.codeium/windsurf/mcp_config.json`. Remote servers there use a `serverUrl` field rather than `url`, with the same `headers` and `${env:VAR}` pattern as Cursor:
+Windsurf's MCP integration — branded Cascade — reads `~/.codeium/windsurf/mcp_config.json`. Current Cascade documentation says Streamable HTTP supports OAuth. Start with a URL-only entry and complete authorization from the MCP settings UI:
+
+```json
+{
+  "mcpServers": {
+    "namefi": {
+      "serverUrl": "https://api.namefi.io/mcp"
+    }
+  }
+}
+```
+
+For API-key authentication, add the header through environment interpolation:
 
 ```json
 {
@@ -95,8 +128,8 @@ One thing worth flagging: as of this guide's publish date, `docs.windsurf.com/wi
 
 Once one of the connections above is live, the rest of the flow is the same regardless of which editor you're in.
 
-1. **Get an API key** from [namefi.io/api-key](https://namefi.io/api-key), generated from the wallet that should own the new domain.
-2. **Connect** using the config for your editor above, then sanity-check it: ask "check whether `<yourapp>.com` is available on Namefi, and tell me which tool you called." That's a read-only `checkAvailability` call, so it works before you've funded anything.
+1. **Choose authentication.** Use the editor's OAuth flow, or generate an API key at [namefi.io/api-key](https://namefi.io/api-key) and keep it outside version control.
+2. **Connect and authenticate** using the matching config above. Then sanity-check it: ask "check whether `<yourapp>.com` is available on Namefi, and tell me which tool you called." `checkAvailability` is read-only and does not spend funds, but the MCP session currently still requires authentication to initialize.
 3. **Register.** Confirm a name and duration in plain language — "register it for one year." The agent submits `registerDomain` and polls the order until it reaches `SUCCEEDED` (or a terminal failure state); a typical registration finishes in a handful of poll cycles.
 4. **Point it at your deploy.** This is the step the next section covers in detail — add the DNS records your hosting platform asks for, through the same conversation.
 5. **Verify it resolves.** [DNS propagation](/en/glossary/dns-propagation/) isn't instant, so give it a few minutes, then confirm with a public DNS lookup or by just loading the domain in a browser.
@@ -137,7 +170,7 @@ Namefi's MCP server covers the full lifecycle today — registration, DNS, [auto
 Not here — this guide is deliberately scoped to Claude Code, Cursor, and Windsurf. [How to Register a Domain with Your AI Agent on Namefi](/en/blog/ai-agent-register/) has the same exact, verified config for Codex CLI, Gemini CLI, and Claude Desktop.
 
 ### Do I need a Namefi account before I can try this?
-No. A read-only availability check needs no authentication, so you can connect any editor above and run the test prompt in step 2 before generating an API key or funding anything.
+You need an authenticated MCP session before the current live endpoint will initialize. Use OAuth, or provide an API key. The availability call itself is read-only and does not require funds, but do not rely on the discovery descriptor's unauthenticated-read claim until it matches live behavior.
 
 ### What if my deployment platform isn't Vercel or Cloudflare Pages?
 The pattern holds everywhere: your platform's dashboard tells you which DNS record type it needs — almost always an A record for an apex domain, a CNAME for a subdomain — and you hand that value to your agent to write via `createDnsRecord`.
@@ -146,19 +179,19 @@ The pattern holds everywhere: your platform's dashboard tells you which DNS reco
 Yes, by default — the domain registers as an NFT on Base, to the wallet tied to your API key, unless you specify a different `nftReceivingWallet` in the request. See [What Are Tokenized Domains?](/en/blog/what-are-tokenized-domains/) if that's new to you.
 
 ### Can I skip the API key entirely?
-Yes, with a caveat: Namefi's wallet-signed [x402](/en/glossary/x402/) checkout path lets a funded wallet pay for a registration with no account or API key at all. It needs its own explanation, covered in [Pay for Domains with a Crypto Wallet](/en/blog/wallet-checkout/).
+Yes. Use OAuth 2.1 with PKCE in a compatible MCP client, so no static Namefi API key is stored in the editor configuration. Separately, Namefi's wallet-signed [x402](/en/glossary/x402/) checkout path can authorize and pay for a registration without an API key, as covered in [Pay for Domains with a Crypto Wallet](/en/blog/wallet-checkout/). That x402 transaction path does not make an unauthenticated MCP `initialize` request succeed.
 
 ## Ship the name with the app
 
-The domain is infrastructure, same as the deploy target and the database — there's no real reason it should be the one piece of shipping an app that still requires leaving your tools and filling out a web form. Connect one of the three configs above, run the five-step flow, and the domain goes live pointed at the same deployment your agent just built, without a single browser tab.
+The domain is infrastructure, like the deploy target and the database. Connect one of the three configs above, complete OAuth or provide a key, then run the five-step flow. OAuth may require a browser authorization step; registration, DNS changes, and verification can continue from the editor after that.
 
-**[Generate a Namefi API key](https://namefi.io/api-key)** and try the availability-check prompt in whichever editor you already have open, or read the [full Claude Code walkthrough with an annotated transcript](/en/blog/claude-mcp-domains/) if you want to see every step spelled out.
+Use OAuth or **[generate a Namefi API key](https://namefi.io/api-key)**, then try the availability-check prompt in whichever editor you already have open. Read the [full Claude Code walkthrough with an annotated transcript](/en/blog/claude-mcp-domains/) if you want to see every step spelled out.
 
 ## Sources and further reading
 
 - Namefi — [namefi.io/llms.txt](https://namefi.io/llms.txt) (MCP server URL, transport, authentication, registration/DNS endpoint reference — primary source for every Namefi-specific claim in this guide)
 - Namefi — [docs.namefi.io: Register a domain](https://docs.namefi.io/docs/03-getting-started/01-your-first-domain.mdx) (registration request fields, polling flow, order status values)
-- Namefi — [namefi.io/.well-known/mcp/servers.json](https://namefi.io/.well-known/mcp/servers.json) (MCP discovery descriptor)
+- Namefi — [namefi.io/.well-known/mcp/servers.json](https://namefi.io/.well-known/mcp/servers.json) (MCP discovery descriptor, OAuth metadata, and the read-only authentication claim that differed from live `initialize` behavior on July 14, 2026)
 - Anthropic / Claude Code — [Connect Claude Code to tools via MCP](https://code.claude.com/docs/en/mcp#:~:text=claude%20mcp%20add%20%2D%2Dtransport%20http) (`claude mcp add --transport http` syntax, `--header`, `--scope` flags)
 - Cursor — [cursor.com/docs/mcp](https://cursor.com/docs/mcp) (`mcp.json` remote-server format, `headers`, `${env:VAR}` interpolation, project vs global config locations)
 - Windsurf / Cascade — [docs.windsurf.com/windsurf/cascade/mcp](https://docs.windsurf.com/windsurf/cascade/mcp) (redirects to [docs.devin.ai/desktop/cascade/mcp](https://docs.devin.ai/desktop/cascade/mcp) as of this guide's publish date; `mcp_config.json` format, `serverUrl`, `headers`)

--- a/content/blog/en/namefi-mcp.md
+++ b/content/blog/en/namefi-mcp.md
@@ -179,7 +179,7 @@ Not necessarily. A compatible MCP client can authenticate with OAuth instead of 
 It can use OAuth for the MCP connection, without storing a Namefi API key. For direct REST integration, EIP-712 and SIWE cover supported request types. The x402 and MPP registration flows are separate HTTP endpoints, not MCP tools or substitutes for MCP connection authentication, so inspect the current documentation for the particular operation you need.
 
 ### Is a domain automatically tokenized when I register it through any of these paths?
-Yes, by default, across every registration path. If `nftReceivingWallet` isn't specified, the domain registers as an ERC-721 NFT to the wallet tied to the caller's API key, on Base.
+For the documented `/v-next` `registerDomain` flow, Namefi mints the domain token to the designated receiving wallet on its supported chain. This catalog does not establish identical defaults for every separate registration and payment path, so inspect the current documentation for the path you are calling rather than assuming an API-key wallet or a particular chain.
 
 ### Which operations should a human confirm before an autonomous agent runs them?
 At minimum, the four Namefi's docs mark as consequential — `registerDomain`, `registerWithRecords`, `startOutboundRun`, `prepareOutboundOutreach` — plus any DNS write on a domain already serving live traffic.

--- a/content/blog/en/namefi-mcp.md
+++ b/content/blog/en/namefi-mcp.md
@@ -7,8 +7,8 @@ authors: ['namefiteam']
 draft: false
 format: explainer
 ogImage: ../../assets/namefi-mcp-og.jpg
-description: "Every tool the Namefi MCP server exposes to AI agents: search, register, DNS, renewals, tokenization, plus the auth model and example workflows."
-keywords: ["namefi mcp server", "mcp tools list", "namefi mcp capabilities", "mcp server domain management", "domain registrar mcp server", "namefi api key scopes", "dns mcp tools", "register domain mcp", "tokenize domain mcp", "x402 domain payment", "siwe authentication domains", "eip-712 domain signing", "outbound lead finding domains", "namefi openapi", "ai agent domain tools"]
+description: "The Namefi MCP server's current /v-next tool surface: search, registration, DNS, renewals, outbound workflows, OAuth and API-key authentication, plus separate x402 and MPP HTTP payment paths."
+keywords: ["namefi mcp server", "mcp tools list", "namefi mcp capabilities", "mcp server domain management", "domain registrar mcp server", "Namefi MCP OAuth", "OAuth 2.1 PKCE MCP", "namefi api key scopes", "dns mcp tools", "register domain mcp", "tokenize domain mcp", "x402 domain payment", "siwe authentication domains", "eip-712 domain signing", "outbound lead finding domains", "namefi openapi", "ai agent domain tools"]
 relatedArticles:
   - /en/blog/claude-mcp-domains/
   - /en/blog/ai-agent-register/
@@ -29,27 +29,27 @@ relatedGlossary:
   - /en/glossary/ens/
 ---
 
-Every [AI agent](/en/glossary/ai-agent/) that connects to the Namefi MCP server sees the same list of callable tools — one per operation the API defines, covering search, registration, DNS, domain-level configuration, outbound lead finding, and payment. This page is the catalog: every tool, what it does, what auth it needs, and three worked examples combining several tools into an actual workflow.
+An [AI agent](/en/glossary/ai-agent/) that connects to the Namefi MCP server receives callable tools generated from the server's supported `/v-next` API surface, covering search, registration, DNS, domain configuration, account operations, and outbound lead finding. The x402 and MPP payment flows use separate HTTP endpoints; they are not MCP tools. This page catalogs the documented MCP surface, explains authentication, and gives three workflows.
 
 If you haven't connected an agent to Namefi yet, start with [How to Register a Domain with Your AI Agent on Namefi](/en/blog/ai-agent-register/) for per-client setup, or [Buy a Domain with Claude: Namefi MCP Step-by-Step Guide](/en/blog/claude-mcp-domains/) for a full transcript. This page assumes the connection already exists.
 
 ## What the Namefi MCP server is
 
-Namefi runs a single MCP server for its entire API, at `https://api.namefi.io/mcp`, over the Streamable HTTP transport. Instead of an agent hand-rolling REST calls from documentation pasted into a chat, it connects once and receives a typed tool for every operation the API defines — generated straight from Namefi's own OpenAPI 3 specification at [api.namefi.io/v-next/openapi/doc.json](https://api.namefi.io/v-next/openapi/doc.json), so the MCP catalog and the REST API can't drift apart from each other.
+Namefi runs a Streamable HTTP MCP server at `https://api.namefi.io/mcp`. Instead of an agent hand-rolling REST calls from documentation pasted into chat, it connects and receives typed tools for the supported `/v-next` operations generated from Namefi's OpenAPI 3 specification at [api.namefi.io/v-next/openapi/doc.json](https://api.namefi.io/v-next/openapi/doc.json). Generation reduces manual drift, but the live tool list, OpenAPI document, discovery descriptor, and blog snapshot can still change at different times; inspect `tools/list` for the connection you are actually using.
 
-A machine-readable discovery descriptor at [namefi.io/.well-known/mcp/servers.json](https://namefi.io/.well-known/mcp/servers.json) lets an agent find the server without a human pasting a URL into a config file by hand: it names the server `namefi-api`, reports `streamable-http` transport, and declares `apiKey`/`x-api-key` as the connection auth. Namefi, an [ICANN](/en/glossary/icann/)-accredited [registrar](/en/glossary/registrar/), also publishes the same operations as plain HTTPS endpoints at [namefi.io/llms.txt](https://namefi.io/llms.txt), for agents and scripts that don't speak MCP.
+A machine-readable discovery descriptor at [namefi.io/.well-known/mcp/servers.json](https://namefi.io/.well-known/mcp/servers.json) names the server `namefi-api`, reports `streamable-http` transport, and documents both `x-api-key` and OAuth 2.1 authorization-code authentication with PKCE, protected-resource discovery, refresh tokens, device flow, and dynamic client registration. Namefi, an [ICANN](/en/glossary/icann/)-accredited [registrar](/en/glossary/registrar/), also publishes plain HTTPS endpoints at [namefi.io/llms.txt](https://namefi.io/llms.txt) for agents and scripts that do not speak MCP. That file explicitly identifies `/x402/...` and `/mpp/...` as separate HTTP payment endpoints, not MCP tools.
 
 ## The complete capability catalog
 
-Below is every operation the API defines as of this writing, grouped the way Namefi's own reference groups them. The **Operation** column is the `operationId` from the OpenAPI spec — the name an MCP client's tool list is built from. The **Auth** column shows the simplest path (an API key covers nearly everything); the full auth model, including the alternatives to an API key, is in the next section.
+Below is a dated snapshot of the documented `/v-next` operation groups. The **Operation** column is the OpenAPI `operationId` from which an MCP tool name is built. The **Auth** column shows the REST-level API-key path; an MCP client can instead authenticate its session with an OAuth bearer token. Rows labeled public REST do not imply an anonymous MCP connection: an unauthenticated `initialize` request returned `401 Unauthorized` when verified on **July 14, 2026**.
 
 ### Search & discovery
 
 | Operation | Endpoint | What it does | Auth |
 | --- | --- | --- | --- |
-| `checkAvailability` | `GET /v-next/search/availability` | Check whether one domain name is free to register | None |
-| `checkBulkAvailability` | `GET /v-next/search/bulk-availability` | Screen a batch of candidate names in a single call | None |
-| `getSuggestions` | `GET /v-next/search/suggestions` | Get algorithmic name suggestions related to a query | None |
+| `checkAvailability` | `GET /v-next/search/availability` | Check whether one domain name is free to register | Public REST; authenticated MCP session currently required |
+| `checkBulkAvailability` | `GET /v-next/search/bulk-availability` | Screen a batch of candidate names in a single call | Public REST; authenticated MCP session currently required |
+| `getSuggestions` | `GET /v-next/search/suggestions` | Get algorithmic name suggestions related to a query | Public REST; authenticated MCP session currently required |
 
 ### Registration & orders
 
@@ -63,11 +63,11 @@ Registration is asynchronous — `registerDomain` returns an order `id` immediat
 
 ### DNS record management
 
-Full CRUD, one record at a time or batched, plus a read that needs no authentication at all:
+Full CRUD, one record at a time or batched. The REST read is documented as public, while the live MCP endpoint currently requires the session itself to authenticate:
 
 | Operation | Endpoint | What it does | Auth |
 | --- | --- | --- | --- |
-| `getDnsRecords` | `GET /v-next/dns/records` | List every record in a zone | None |
+| `getDnsRecords` | `GET /v-next/dns/records` | List every record in a zone | Public REST; authenticated MCP session currently required |
 | `createDnsRecord` | `POST /v-next/dns/records` | Create one record | API key |
 | `updateDnsRecord` | `PUT /v-next/dns/record` | Update a record by ID | API key |
 | `deleteDnsRecord` | `DELETE /v-next/dns/record` | Delete a record by ID | API key |
@@ -84,7 +84,7 @@ These flip a whole feature on or off, distinct from a single DNS record:
 | Operation | Endpoint | What it does | Auth |
 | --- | --- | --- | --- |
 | `toggleDomainParking` / `parkDomain` | `PUT` / `POST /v-next/dns/park` | Turn [domain parking](/en/glossary/domain-parking/) on or off | API key |
-| `isDomainParked` | `GET /v-next/dns/parked` | Check whether a domain is currently parked | None |
+| `isDomainParked` | `GET /v-next/dns/parked` | Check whether a domain is currently parked | Public REST; authenticated MCP session currently required |
 | `toggleForwarding` | `PUT /v-next/dns/forwarding` | Turn [domain forwarding](/en/glossary/domain-forwarding/) on or off | API key |
 | `toggleAutoEns` | `PUT /v-next/dns/auto-ens` | Turn automatic [ENS](/en/glossary/ens/) record publishing on or off | API key |
 | `toggleVercelAnyCastRecords` | `PUT /v-next/dns/vercel-anycast` | Turn Vercel Anycast DNS records on or off | API key |
@@ -115,35 +115,44 @@ The newest surface, turning owned domains into a sales pipeline instead of a sta
 
 The response excludes internal ranking mechanics — score, model details, suppressed-lead status — so an agent summarizing results for a human only sees the public rationale, the contact found, and whether a draft exists.
 
-### Payments & account
+### Account tools available through `/v-next`
 
 | Operation | Endpoint | What it does | Auth |
 | --- | --- | --- | --- |
 | `getBalance` | `GET /v-next/balance` | Check the NFSC (Namefi Service Credit) balance funding registrations | API key |
 | `requestNfscFaucet` | `POST /v-next/user/faucet` | Request free test NFSC credits (development environments only) | API key |
-| `registerDomainX402` | `GET /x402/domain/{domainName}` | Register and pay in one stablecoin-signed HTTP 402 flow, no Namefi account | Wallet signature |
-| — | `GET /x402/purchase/{purchaseId}` | Poll an x402 purchase's status | None |
-| `registerDomainMPP` | `GET /mpp/domain/{domainName}` | Register and pay via the MPP (Machine Payable Protocol) challenge-response flow | Wallet signature |
 
-That covers every operation in scope for search, registration, DNS, domain configuration, outbound, and payment — each reachable as an MCP tool through the single server connection, or as a plain HTTPS call for agents that don't speak MCP. (Namefi's API also exposes a few account-management and EIP-712/SIWE helper operations outside this list; the full set is always current in the OpenAPI spec linked in Sources below.)
+The sections above are a dated snapshot of the documented `/v-next` operations that the MCP server can expose. The live `tools/list` response is authoritative for a connected client; the OpenAPI document linked below is authoritative for plain REST operations and may include helpers outside this editorial catalog.
 
-## The auth model: three paths in, one wallet behind all of them
+### Outside MCP: x402 and MPP payment endpoints
 
-Every write operation above checks the same thing — does the caller control the wallet that owns, or will own, the domain — by one of three paths. Which applies depends on the operation, not a single account-level setting.
+Namefi also publishes wallet-paid registration flows as plain HTTP endpoints. They can be called by an agent with a general HTTP client, but they do not appear merely because the agent connected to the Namefi MCP server.
 
-**API key (`x-api-key`).** The simplest option, and the one every worked example in this cluster uses. Generate one at [namefi.io/api-key](https://namefi.io/api-key); it works for every operation above, including DNS writes, parking, and registration, because the key inherits the permissions of the wallet that generated it — pass it as a plain HTTP header, no SDK required.
+| HTTP endpoint | What it does | Auth |
+| --- | --- | --- |
+| `GET /x402/domain/{domainName}` | Begin a stablecoin-paid registration using the x402 HTTP 402 flow | Wallet payment authorization |
+| `GET /x402/purchase/{purchaseId}` | Poll an x402 purchase's status | Follow the live endpoint's current requirements |
+| `GET /mpp/domain/{domainName}` | Begin a registration using the MPP challenge-response flow | Wallet payment authorization |
+
+## Authentication: MCP connection auth and REST request auth are different layers
+
+An MCP client must first authenticate the server connection. The current discovery descriptor advertises OAuth 2.1 bearer tokens, with authorization code plus PKCE, protected-resource and authorization-server metadata, refresh tokens, device flow, and dynamic client registration. Compatible clients can therefore connect with the MCP URL and complete an OAuth flow without storing a Namefi API key in their configuration.
+
+**API key (`x-api-key`).** For explicit header-based or automated setups, generate a key at [namefi.io/api-key](https://namefi.io/api-key) and pass it as an HTTP header. A key is sensitive: keep it out of committed MCP configuration and scope its use to the permissions Namefi grants it.
+
+The descriptor also says certain read-only tools need no authentication. However, an unauthenticated MCP `initialize` request returned `401 Unauthorized` when verified on **July 14, 2026**. Because initialization comes before any tool call, treat the live MCP connection as authentication-required until the implementation and descriptor agree.
+
+For direct REST calls, Namefi documents additional request-level authentication modes. These are not a promise that an MCP client will automatically obtain a wallet signature for every tool call:
 
 **EIP-712 typed-data signature.** For programmatic use without a stored key, sign each request with an Ethereum [wallet](/en/glossary/wallet/): headers `x-namefi-signer`, `x-namefi-signature`, and `x-namefi-eip712-type` wrap the payload in an envelope with a timestamp and single-use nonce that expires after 300 seconds — the mode operations like `toggleDomainParking`, `createDnsRecord`, and `registerDomain` require without an API key. The domain and type definitions come from live endpoints (`GET /v-next/eip712/domain`, `/eip712/types`) rather than a hardcoded constant, since Namefi's docs note they can change. Smart-contract wallets can't sign directly, so an approved externally-owned account signs on the contract's behalf, with `x-namefi-erc1271-account` or `x-namefi-eip7702-account` naming which contract is authorizing the request.
 
-**SIWE (Sign-In with Ethereum).** A session token (`x-namefi-siwe-token`) for protected reads that don't need a fresh signature per call, like listing owned domains or orders — fetch a nonce, get the message to sign, sign it with `personal_sign`, verify it, then reuse the token.
+**SIWE (Sign-In with Ethereum).** A session token (`x-namefi-siwe-token`) for protected REST reads that do not need a fresh signature per call, such as listing owned domains or orders — fetch a nonce, get the message to sign, sign it with `personal_sign`, verify it, then reuse the token.
 
-A handful of operations need no authentication — `checkAvailability`, `getSuggestions`, `getDnsRecords`, `isDomainParked`, and the EIP-712 metadata endpoints — because they're read-only and expose nothing a domain's public DNS wouldn't already show a browser.
-
-Layered on top is payment. `registerDomainX402` settles a purchase via the [x402 protocol](https://x402.org): the buyer's wallet signs an EIP-3009 `transferWithAuthorization` for a [stablecoin](/en/glossary/stablecoin/) like USDC, no Namefi account involved. `registerDomainMPP` reaches the same outcome via a signed challenge-response instead. Both let an agent skip account creation and pay per transaction — [Pay for Domains with a Crypto Wallet: No Account Needed](/en/blog/wallet-checkout/) covers that path end to end.
+The x402 and MPP flows add payment authorization to their separate HTTP endpoints; they are not alternate authentication methods for an unauthenticated MCP connection. [Pay for Domains with a Crypto Wallet: No Account Needed](/en/blog/wallet-checkout/) covers those HTTP flows end to end.
 
 ## Tokenization runs through the catalog, not beside it
 
-`registerDomain` mints the domain as an [NFT](/en/glossary/nft/) — an [ERC-721](/en/glossary/erc-721/) token, [the standard interface](https://eips.ethereum.org/EIPS/eip-721) most marketplaces and wallets already read — on Base by default, to the wallet tied to the caller's API key. `nftReceivingWallet` redirects that to a different wallet or chain at registration time, and everything downstream — DNS writes, parking, auto-renewal, outbound lead-finding — checks that same on-chain ownership record rather than a separate account database. A [tokenized domain](/en/glossary/tokenized-domain/) traded on a marketplace like [OpenSea](https://opensea.io) carries its DNS control and ERC-721 ownership as one object, not two systems to keep in sync by hand.
+`registerDomain` can mint the domain as an [NFT](/en/glossary/nft/) — an [ERC-721](/en/glossary/erc-721/) token, [the standard interface](https://eips.ethereum.org/EIPS/eip-721) many wallets and marketplaces can display — on Namefi's supported chain to the designated receiving wallet. `nftReceivingWallet` selects that wallet; it does not select an arbitrary chain. The token represents on-chain control within Namefi's system, while registrar, registry, ICANN policy, Namefi's agreements, and court orders remain separate layers. Marketplace display and trading support also depend on the platform and collection configuration.
 
 ## Three agents, three ways to use the same toolset
 
@@ -155,7 +164,7 @@ Layered on top is payment. `registerDomainX402` settles a purchase via the [x402
 
 ## Before an agent runs any of this unattended
 
-Namefi's own outbound documentation flags four operations as **consequential** — `registerDomain`, `registerWithRecords`, `startOutboundRun`, `prepareOutboundOutreach` — because each spends balance or takes an externally visible action. Read-only tools like `checkAvailability` carry no risk to run autonomously; anything that writes an order, a DNS record on a live domain, or an outreach draft is worth a confirmation step. [What Is an Agent-Native Domain Registrar?](/en/blog/agent-native/) has a fuller checklist for evaluating any registrar's agent-facing surface this way.
+Namefi's own outbound documentation flags four operations as **consequential** — `registerDomain`, `registerWithRecords`, `startOutboundRun`, `prepareOutboundOutreach` — because each spends balance or takes an externally visible action. A read-only call such as `checkAvailability` does not spend funds, but the current MCP session still needs authentication and its output can influence later actions. Anything that writes an order, changes DNS on a live domain, or creates externally directed outreach deserves an explicit confirmation step. [What Is an Agent-Native Domain Registrar?](/en/blog/agent-native/) has a fuller checklist for evaluating any registrar's agent-facing surface this way.
 
 ## Keeping this catalog current
 
@@ -164,10 +173,10 @@ This table mirrors Namefi's live OpenAPI specification as of the publish date ab
 ## Frequently Asked Questions
 
 ### Do I need an API key just to check whether a name is available?
-No. `checkAvailability`, `checkBulkAvailability`, and `getSuggestions` require no authentication, so they work against a freshly connected agent before funding anything.
+Not necessarily. A compatible MCP client can authenticate with OAuth instead of a static API key. The underlying availability REST operations are documented as public, but the live MCP endpoint required authentication to initialize when checked on July 14, 2026. Availability checks do not require funding.
 
 ### Can an agent use this whole catalog without me ever holding a Namefi API key?
-Yes. `registerDomainX402` and `registerDomainMPP` both settle a registration through a wallet signature with no Namefi account, and EIP-712 signing covers the rest of the write operations directly from a wallet.
+It can use OAuth for the MCP connection, without storing a Namefi API key. For direct REST integration, EIP-712 and SIWE cover supported request types. The x402 and MPP registration flows are separate HTTP endpoints, not MCP tools or substitutes for MCP connection authentication, so inspect the current documentation for the particular operation you need.
 
 ### Is a domain automatically tokenized when I register it through any of these paths?
 Yes, by default, across every registration path. If `nftReceivingWallet` isn't specified, the domain registers as an ERC-721 NFT to the wallet tied to the caller's API key, on Base.
@@ -175,23 +184,23 @@ Yes, by default, across every registration path. If `nftReceivingWallet` isn't s
 ### Which operations should a human confirm before an autonomous agent runs them?
 At minimum, the four Namefi's docs mark as consequential — `registerDomain`, `registerWithRecords`, `startOutboundRun`, `prepareOutboundOutreach` — plus any DNS write on a domain already serving live traffic.
 
-## Connect your agent to the full catalog
+## Connect your agent to the current catalog
 
-Every tool above is live behind one connection: `https://api.namefi.io/mcp`. If you haven't set that up yet, [How to Register a Domain with Your AI Agent on Namefi](/en/blog/ai-agent-register/) covers exact configuration for six different clients, and [llms.txt for Domains](/en/blog/llms-txt/) explains the discovery layer underneath it.
+The MCP tools generated from the supported `/v-next` surface are available through `https://api.namefi.io/mcp`; x402 and MPP remain separate HTTP endpoints. Because the catalog can change, inspect the connected server's `tools/list` rather than treating this article as a permanent schema. If you have not connected yet, [How to Register a Domain with Your AI Agent on Namefi](/en/blog/ai-agent-register/) covers configuration for six clients, and [llms.txt for Domains](/en/blog/llms-txt/) explains the discovery layer underneath it.
 
-**[Generate a Namefi API key](https://namefi.io/api-key)** and point your agent at the server — the tools above are what it will find waiting.
+Connect with OAuth in a compatible client, or **[generate a Namefi API key](https://namefi.io/api-key)** for an explicit header-based setup, then inspect the live tool list.
 
 ## Sources and further reading
 
 - Namefi — [namefi.io/llms.txt](https://namefi.io/llms.txt) (MCP server URL, transport, authentication, core operation reference — primary source for this catalog)
 - Namefi — [namefi.io/llms-full.txt](https://namefi.io/llms-full.txt) (single-file reference inlining Web3 payments and outbound lead-finding)
 - Namefi — [namefi.io/web3/llms.txt](https://namefi.io/web3/llms.txt) (x402, MPP, EIP-712, and SIWE flows in detail)
-- Namefi — [namefi.io/.well-known/mcp/servers.json](https://namefi.io/.well-known/mcp/servers.json) (MCP discovery descriptor: server name, URL, transport, auth type)
+- Namefi — [namefi.io/.well-known/mcp/servers.json](https://namefi.io/.well-known/mcp/servers.json) (MCP discovery descriptor: server name, URL, transport, OAuth metadata, API-key authentication, and the read-only auth claim that differed from live `initialize` behavior on July 14, 2026)
 - Namefi — [api.namefi.io/v-next/openapi/doc.json](https://api.namefi.io/v-next/openapi/doc.json) (machine-readable OpenAPI 3 spec — source of every `operationId` and endpoint in the capability catalog above)
 - Namefi — [docs.namefi.io: Authentication](https://docs.namefi.io/docs/02-authentication.mdx#:~:text=The%20Namefi%20API%20supports%20three%20authentication%20methods) (API key, EIP-712, and SIWE auth modes; per-operation auth requirements; ERC-1271/EIP-7702 delegation)
 - Namefi — [docs.namefi.io: Register a domain](https://docs.namefi.io/docs/03-getting-started/01-your-first-domain.mdx) (registration request fields, polling flow, order status values)
 - Namefi — [docs.namefi.io: Managing your balance](https://docs.namefi.io/docs/03-getting-started/02-your-balance.mdx) (NFSC balance and faucet endpoints)
 - Model Context Protocol — [What is the Model Context Protocol?](https://modelcontextprotocol.io/docs/getting-started/intro#:~:text=Think%20of%20MCP%20like%20a%20USB%2DC%20port%20for%20AI%20applications) (protocol overview)
 - llmstxt.org — [The /llms.txt file](https://llmstxt.org) (specification and rationale for the discovery convention Namefi's file follows)
-- x402.org — [x402 protocol](https://x402.org) (HTTP 402-based stablecoin payment standard underlying `registerDomainX402`)
+- x402.org — [x402 protocol](https://x402.org) (HTTP 402-based stablecoin payment standard used by Namefi's separate `/x402/...` endpoints)
 - Ethereum Improvement Proposals — [ERC-721: Non-Fungible Token Standard](https://eips.ethereum.org/EIPS/eip-721) (the token standard Namefi's domain NFTs implement)


### PR DESCRIPTION
## Summary

- update the MCP quickstart for current OAuth 2.1 + PKCE and API-key authentication paths
- distinguish MCP `/v-next` tools from the separate x402 and MPP HTTP endpoints
- document the July 14, 2026 descriptor/live mismatch: anonymous `initialize` currently returns 401
- qualify tokenization and live-catalog claims so the articles do not overstate chain, marketplace, or ownership behavior

## Why

Tamil source-gate review found that both English articles described API-key-only setup, anonymous read access, and x402/MPP as MCP tools. Those claims no longer match the current discovery metadata and live endpoint behavior.

## Validation

- `TMPDIR=/private/tmp bun run data:validate` (passes; 29 pre-existing empty-keyword warnings)
- `TMPDIR=/private/tmp bun run lint:mdx`
- `TMPDIR=/private/tmp bun run check:termbase`
- `TMPDIR=/private/tmp bun .agents/skills/cross-link/link-audit.ts content/blog/en/mcp-quickstart.md`
- `TMPDIR=/private/tmp bun .agents/skills/cross-link/link-audit.ts content/blog/en/namefi-mcp.md`
- `git diff --check`

## Access control

No new endpoint, page, dashboard, storage surface, or privileged action is introduced. These are corrections to already-public English articles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to public blog posts; no application code, APIs, or access control changes.
> 
> **Overview**
> Updates two English blog posts so Namefi MCP setup and capabilities match current discovery metadata and live behavior.
> 
> **`mcp-quickstart.md`** now documents **OAuth 2.1 + PKCE** alongside **`x-api-key`** for Claude Code, Cursor, and Windsurf (URL-only OAuth configs plus existing header/env patterns). The intro and five-step flow stress that **MCP sessions must authenticate before `initialize`**—including for read-only tools like `checkAvailability`—because an unauthenticated `initialize` returned **401** on July 14, 2026 despite the descriptor’s unauthenticated-read claim. FAQs and CTAs were adjusted so OAuth and x402 are not conflated with skipping MCP auth.
> 
> **`namefi-mcp.md`** reframes the catalog as a dated **`/v-next`** snapshot with **`tools/list`** as authoritative, moves **x402 and MPP** into a separate “Outside MCP” section (not MCP tools), and splits **MCP connection auth** (OAuth bearer or API key) from **REST request auth** (EIP-712, SIWE). Auth table rows for public REST reads note that MCP still needs an authenticated session. Tokenization and “use without API key” FAQs are qualified so chain, marketplace, and payment-path defaults are not overstated. Front matter descriptions/keywords were refreshed to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b69d01c79b74241370c9393f82c930b3e6ebb9cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MCP quickstart instructions for Claude Code, Cursor, and Windsurf.
  * Clarified OAuth, API-key, and API-key-free authentication options.
  * Documented that authenticated MCP sessions are required, including for read-only operations.
  * Refreshed the tool catalog, account capabilities, FAQs, and setup flow to reflect the current `/v-next` behavior.
  * Added clearer guidance for domain registration, deployment, DNS, and payment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->