### PR TITLE
fix(content): correct financial and domain claims

### DIFF
--- a/content/blog/en/the-panix-com-domain-hijack.md
+++ b/content/blog/en/the-panix-com-domain-hijack.md
@@ -65,7 +65,7 @@ When you control a domain's DNS, you can redirect where its email is delivered. 
 
 Mail that is misrouted during a hijack may be delayed, bounced, dropped, or exposed to an unintended system. In this case the documented impact was loss of email service and messages, not confirmed attacker access to message contents.
 
-And there was nothing the customers could do. The problem was not on Panix's machines, which were running fine. It was in the global routing table of the [Domain Name System](/en/glossary/dns/), which had been told — by a [registrar](/en/glossary/registrar/) in Australia, acting on a fraudulent request — that panix.com now belonged to someone else.
+And there was nothing the customers could do. The problem was not on Panix's machines, which were running fine. The unauthorized registrar transfer enabled the attacker-controlled account to change the domain's delegation and [DNS](/en/glossary/dns/) data, sending web and mail traffic to different systems. DNS published where `panix.com` should resolve; it did not itself say who legally owned the registration.
 
 ## How it happened: authorization and process failures
 
@@ -83,7 +83,7 @@ Stack the failures and the picture is grim. The *gaining* registrar, through its
 
 Recovery, once humans got involved, was fast — and that is its own indictment, because it proved the transfer never should have been approved in the first place.
 
-By Sunday, [Panix had recovered its Panix.com domain from Australian domain hosting / registration firm Melbourne IT, where the purloined domain was parked](https://www.theregister.com/2005/01/17/panix_domain_hijack/#:~:text=Panix%20had%20recovered%20its%20Panix.com%20domain), and pointed it back to its natural home at Dotster. The fix at the [registry](/en/glossary/registry/) level was nearly instant; the global cleanup was not, because DNS does not forget on command. As The Register noted, [root servers](/en/glossary/root-zone/) were updated quickly but the distributed nature of DNS meant it would take up to 24 hours before normality was fully restored — caches around the world had to expire before every user saw the real panix.com again.
+By Sunday, [Panix had recovered its Panix.com domain from Australian domain hosting / registration firm Melbourne IT, where the purloined domain was parked](https://www.theregister.com/2005/01/17/panix_domain_hijack/#:~:text=Panix%20had%20recovered%20its%20Panix.com%20domain), and pointed it back to its natural home at Dotster. The registration and `.com` delegation data could be corrected quickly; the global cleanup was not instant, because cached DNS answers had to expire before every resolver saw the restored data. A contemporaneous Register report called the updated systems "root servers," but `panix.com` is a second-level name: the DNS root delegates `.com`, while the `.com` authoritative layer publishes the delegation for `panix.com`.
 
 Melbourne IT, to its credit, did not hide. Two days later The Register reported that [an Australian domain registrar has admitted to its part in last weekend's domain name hijack](https://www.theregister.com/2005/01/19/panix_hijack_more/#:~:text=An%20Australian%20domain%20registrar%20has%20admitted%20to%20its%20part), tracing the failure to a verification step in its transfer process that had not been performed and pledging that the loophole that allowed the error had been closed.
 
@@ -101,19 +101,19 @@ Strip away the dates and the registrar names, and Panix leaves a few durable les
 
 1. **Express authorization must be verified before a transfer starts.** The five-day losing-registrar window is not permission for the gaining registrar or reseller to skip identity checks. ICANN concluded that failure, not the new policy itself, enabled Panix.
 2. **Every party in the transfer chain has a security role.** The gaining side must authenticate the requester; the losing registrar must act on registry notices; and the registrant needs a reachable, monitored contact path. One party's silence should not erase another party's verification duty.
-3. **Turn on the lock.** `clientTransferProhibited` is the cheapest, most effective protection a domain owner has against this exact attack, and it costs nothing. A locked domain cannot be silently transferred no matter how convincing the paperwork is. Lock your important names and leave them locked.
-4. **Your domain is your single point of failure.** Panix's servers were never compromised, yet the company was effectively offline. When one record in a registry can redirect your entire web and email presence, that record deserves more protection than your servers do.
+3. **Use transfer locks as one layer.** `clientTransferProhibited` can block ordinary inter-registrar transfer requests until the status is removed, but it is not an absolute guarantee against registrar error, account compromise, policy processes, court orders, or unauthorized lock removal. Availability and pricing depend on the registrar. Use the lock for important names and pair it with strong account security, monitored contacts, and escalation procedures.
+4. **Treat domain control as critical infrastructure.** Panix's servers were never compromised, yet changing the registration and delegation disrupted web and email service. Protect registrar access, registry-facing workflows, DNS configuration, mail, and servers as separate layers rather than assuming server security alone protects reachability.
 5. **Watch notices, but do not rely on them alone.** Panix did not receive notice, while Dotster did and did not act. Maintain monitored contacts and escalation paths, and pair them with transfer locks and strong requester verification.
 
 ## The Namefi angle
 
-![Colorful illustration of verifiable, tamper-resistant domain ownership — a domain card secured by a green shield, a green Namefi token, and DNS continuity](../../assets/the-panix-com-domain-hijack-03-namefi-angle.jpg)
+![Colorful illustration of auditable on-chain token control — a domain card secured by a green shield, a green Namefi token, and DNS continuity](../../assets/the-panix-com-domain-hijack-03-namefi-angle.jpg)
 
 The Panix hijack is, at its heart, an authorization failure. A reseller and gaining registrar accepted a fraudulent request without obtaining the registrant's express approval, and the losing registrar did not stop it after receiving notice.
 
-[Namefi](https://namefi.io) provides an on-chain representation of [domain ownership](/en/glossary/domain-ownership/) and token transfer. That can make the tokenized ownership state and token-transfer authorization auditable. It does not, by itself, prevent a conventional registrar or registry from processing an unauthorized transfer of the underlying DNS domain, so registrar locks, verified contacts, and emergency restoration procedures remain essential.
+[Namefi](https://namefi.io) provides an on-chain token-control and transfer layer for supported domains. That can make token custody and token-transfer authorization auditable, but the token is not an unconditional legal title or a replacement for registrar and registry records. It does not, by itself, prevent a conventional registrar or registry from processing an unauthorized transfer of the underlying DNS domain, so registrar locks, verified contacts, and emergency restoration procedures remain essential.
 
-The lesson is narrower and stronger than a claim that one technology fixes transfer policy: high-value domains need independent ownership records **and** correctly enforced controls at every operational layer that can move or repoint the name.
+The lesson is narrower and stronger than a claim that one technology fixes transfer policy: high-value domains benefit from independently auditable token state **and** correctly enforced controls at every operational layer that can move or repoint the name.
 
 ## Sources and further reading
 

--- a/content/blog/en/tokenized-domain-use-cases-2026.md
+++ b/content/blog/en/tokenized-domain-use-cases-2026.md
@@ -37,11 +37,11 @@ We'll keep this platform-neutral. The use cases below apply across [Namefi](http
 
 ## Use Case 1: Wallet-Native Sale and Settlement
 
-**What it is:** Sell a domain by signing a single [on-chain](/en/glossary/on-chain/) transaction. The buyer pays, the [NFT](/en/glossary/nft/) moves, the [registrar](/en/glossary/registrar/) record updates, [atomically](/en/glossary/atomic-transfer/). No [escrow](/en/glossary/escrow/) service, no [auth code](/en/glossary/auth-code/), no 5-day registrar lock.
+**What it is:** On a compatible marketplace, the payment and [NFT](/en/glossary/nft/) can move together in one [atomic](/en/glossary/atomic-transfer/) on-chain settlement. That atomicity applies to the token and payment legs; it does **not** prove that every platform updates the [registrar](/en/glossary/registrar/) or registry record in the same transaction. The off-chain registration step is platform-specific and may require a separate claim, contact details, review, or approval.
 
-**Why it matters:** Traditional domain sales rely on third-party escrow services ([Escrow.com](https://www.escrow.com/), Sav, Sedo) to hold funds while the registrar transfer is in progress. That's slow and expensive — escrow fees of 3–6% and timelines measured in days, not minutes. Tokenized sales replace this with on-chain atomic settlement.
+**Why it matters:** Traditional domain sales may use third-party escrow services ([Escrow.com](https://www.escrow.com/), Sav, Sedo) while a registrar or registrant change is completed. Tokenized marketplaces can reduce the gap between the token and payment legs, but end-to-end time and cost still depend on marketplace fees, network gas, compliance, and the platform's registration-state workflow.
 
-**Reality check:** This is **live and working** in 2026 across multiple platforms. The hardest part is [liquidity](/en/glossary/domain-liquidity/) (do enough buyers find your listing?), not the mechanics.
+**Reality check:** Token-and-payment settlement is live in 2026, but platforms do not expose one universal registrar-update model. For example, Doma's [current transfer documentation](https://docs.doma.xyz/getting-started) says an NFT transfer puts the domain into temporary custody; the recipient then submits a Domain Claim and waits for registrar approval or rejection. Also distinguish ICANN's transfer-pending period from a lock: the [ICANN Transfer Policy](https://www.icann.org/en/contracted-parties/accredited-registrars/resources/domain-name-transfers/policy) describes separate five-calendar-day processing rules and 60-day inter-registrar lock conditions. Do not assume tokenization removes every auth-code, claim, approval, custody, or lock step across all platforms.
 
 For the deep dive, see [From Listing to Settlement](/en/blog/how-tokenized-marketplaces-replace-escrow/).
 
@@ -153,7 +153,7 @@ You don't have to use any of these to benefit from tokenizing. Many owners token
 ## Summary
 
 - Tokenized domains are useful because they let domains participate in the broader on-chain economy: sale and settlement, lending, leasing, fractionalization, AI-agent identity, marketplace listings, programmable transfers, and inheritance.
-- Some of these (sale, marketplace listing, lending) are **mature**. Others (AI agent identity, fractionalization) are **emerging**. A few (full decentralized DNS) are **still mostly aspirational**.
+- Some token listing and payment mechanics are live, while registrar synchronization, lending support, AI agent identity, and fractionalization vary by platform and remain at different stages of maturity. Full decentralized DNS is a separate, mostly aspirational goal.
 - The common thread: a domain that's a token plugs into everything else built on tokens.
 - You don't have to use any of these use cases to benefit. Faster transferability and self-custody are reasons enough for many owners.
 - Where the use case touches money, ownership structure, or legal status, **get professional help** — especially for lending, leasing, fractionalization, and estate planning.

--- a/content/blog/en/tokenized-domain-vs-web3-domain.md
+++ b/content/blog/en/tokenized-domain-vs-web3-domain.md
@@ -39,10 +39,10 @@ If you want the long form on tokenized domains specifically, start with [What Ar
 
 ## The One-Liner
 
-- **Tokenized domain** = a real [ICANN](/en/glossary/icann/) domain (`.com`, `.xyz`, `.io`, etc.) with an added [on-chain](/en/glossary/on-chain/) ownership token on top.
-- [**Web3**](/en/glossary/web3/) **domain** = a name that lives **only** on-chain (`.eth`, `.crypto`, `.x`, etc.). It's a separate naming system, not part of [DNS](/en/glossary/dns/).
+- **Tokenized domain** = a real [ICANN](/en/glossary/icann/) domain (`.com`, `.xyz`, `.io`, etc.) with an added [on-chain](/en/glossary/on-chain/) token-control layer.
+- [**Web3**](/en/glossary/web3/) **domain** = a name issued by a blockchain-oriented naming system (`.eth`, `.crypto`, `.x`, etc.). A Web3-native suffix such as `.eth` is outside the public [DNS](/en/glossary/dns/) root, but the broader ecosystem is not literally "only on-chain": ENS can [import DNS names](https://docs.ens.domains/learn/dns/) and resolvers can use [CCIP Read](https://docs.ens.domains/resolvers/ccip-read/) for data stored on another network or off-chain.
 
-A tokenized domain *extends* the existing DNS world. A Web3 domain *replaces* it (or sits beside it, depending on how you use it).
+A tokenized ICANN domain adds a token layer to the existing DNS and registration system. A Web3-native suffix usually sits beside public DNS and depends on support in the client or gateway where it is used.
 
 ---
 
@@ -53,7 +53,7 @@ Both involve NFTs in wallets. Both get called "domains." Both have ICANN in the 
 Here's the cleanest mental model:
 
 - If you type the name into a normal browser and it resolves to a website without any extension, plugin, or special resolver — it's a **DNS domain**. Tokenizing it doesn't change that.
-- If you need a browser extension, a special [wallet](/en/glossary/wallet/) feature, or a resolver gateway to make it work — it's a **Web3 domain**.
+- If a name is outside the public DNS root, it needs a Web3-aware client, [wallet](/en/glossary/wallet/) feature, gateway, or other resolver integration. That is common for Web3-native suffixes, but implementations differ.
 
 Both are valid. They do different things.
 
@@ -63,16 +63,16 @@ Both are valid. They do different things.
 
 | Feature | Tokenized ICANN Domain | Web3 Domain (ENS, .crypto, etc.) |
 |---|---|---|
-| Resolves in any browser | Yes, natively | No (needs resolver/extension) |
-| Works for email out of the box | Yes | No (different mechanism) |
-| Works for SSL/TLS certs | Yes (Let's Encrypt, etc.) | No (separate trust model) |
+| Resolves through public DNS | Yes, after DNS configuration | Not for Web3-native suffixes without a gateway or integration |
+| Works with standard email | Yes, after configuring a mail service and MX/DNS records | Not by default for a Web3-native suffix |
+| Eligible for standard SSL/TLS workflows | Yes, after CA validation and server configuration | Not by default for a Web3-native suffix |
 | Recognized by ICANN | Yes | No |
-| Lives on-chain | Yes (ownership layer) | Yes (entire identity) |
-| Held as NFT in wallet | Yes | Yes |
-| Used as wallet alias | Sometimes (via plugins) | Yes, natively |
-| Annual renewal at registrar | Yes (real DNS domain) | Typically one-time or different model |
-| Browser-extension free for end users | Yes | No |
-| Compatible with DNS infrastructure | Yes | Not directly |
+| On-chain component | Token-control layer | Naming records and control vary by system; some data can be off-chain |
+| Held as NFT in wallet | Yes, for supported tokenized domains | Common, but system-specific |
+| Used as wallet alias | With a supporting integration | With a supporting wallet or app |
+| Renewal model | Registrar renewal for the DNS domain | System-specific; ENS `.eth` uses renewals, while other providers differ |
+| Browser-extension free for end users | Yes, after normal website/DNS setup | Not universally for Web3-native suffixes |
+| Compatible with DNS infrastructure | Yes | Web3-native suffixes are not in public DNS; ENS also supports imported DNS names |
 
 ---
 
@@ -83,9 +83,9 @@ Both are valid. They do different things.
 Best when:
 
 - You're running a real website, app, or business and you want it to work for **everyone**, regardless of whether they've installed any Web3 software.
-- You want email at your domain, SSL certificates from standard CAs, CDN configs, etc.
-- You want **wallet-native ownership and transferability** for the domain itself — selling, gifting, lending — without the registrar bureaucracy.
-- You want the domain to be usable as on-chain [collateral](/en/glossary/collateral/) in [DeFi](/en/glossary/defi/) while still operating as a normal website.
+- You want to configure email, request SSL certificates from standard CAs, use CDNs, and operate through normal DNS tooling.
+- You want a **wallet-native token-control and transfer layer** while keeping the domain's registrar, registry, renewal, dispute, and legal dependencies.
+- You want a token that a compatible [DeFi](/en/glossary/defi/) protocol could choose to evaluate as [collateral](/en/glossary/collateral/). This is not automatic: protocol support, valuation, loan terms, and liquidation risk determine whether borrowing is actually available.
 
 Examples: a company's `.com`, a SaaS app's `.io`, a creator's `.xyz`, a brand's `.art`. Anything that needs to function in the real internet.
 
@@ -95,7 +95,7 @@ Best when:
 
 - You want a **wallet identity** — a name that, when typed into a crypto app or wallet, resolves to your address. `vitalik.eth` instead of `0x...`.
 - You want a Web3-native profile / handle in dapps that support it.
-- You don't need the name to work in standard email, browsers without plugins, or SSL.
+- You do not require the Web3-native suffix itself to work through standard public-DNS email, ordinary browsers without an integration, or ordinary CA workflows.
 - You like the cultural and community aspects of a specific TLD (`.eth`, `.crypto`, `.x`).
 
 Examples: your personal Web3 identity, a profile on a wallet, a memorable address for receiving crypto, NFT showcase pages.
@@ -112,7 +112,7 @@ See [DNS Still Works](/en/blog/dns-on-tokenized-domains/) for the practical deta
 
 ### ENS / Web3-name resolution
 
-You type `vitalik.eth`. A Web3-aware client (MetaMask, a dapp, certain browsers with [ENS](/en/glossary/ens/) support) queries the ENS [smart contract](/en/glossary/smart-contract/) on [Ethereum](/en/glossary/ethereum/), gets the associated address or content hash, and renders accordingly. A non-Web3-aware client (Chrome without extensions, your office email server, your SSL CA) doesn't know what `.eth` means and won't resolve it.
+You type `vitalik.eth`. A Web3-aware client can use ENS to find the relevant registry and resolver, then obtain records such as an address or content hash. Many records are read from [smart contracts](/en/glossary/smart-contract/) on [Ethereum](/en/glossary/ethereum/), but ENS also supports resolver designs such as [CCIP Read](https://docs.ens.domains/resolvers/ccip-read/) that retrieve authenticated data from L2 networks or off-chain systems. A client that only uses the public DNS root does not know what `.eth` means without an integration or gateway.
 
 That's not a flaw — it's the design. ENS and similar systems are built for a Web3-native experience, not for replacing the broader internet's naming layer. See the [official ENS documentation](https://docs.ens.domains/) for the underlying architecture.
 
@@ -142,8 +142,8 @@ The tokenized `.com` works for the open internet. The `.eth` works as a wallet a
 
 - **"ENS will replace DNS."** No, and it isn't trying to. ENS is a parallel naming system optimized for crypto identity.
 - **"A tokenized `.com` is a 'Web3 domain'."** It's a *tokenized DNS domain*. The "Web3 domain" label is usually used for `.eth`/`.crypto`-style names. The categories are different.
-- **"Browsers natively support `.eth` now."** Brave and a few specific extensions, yes. Mainstream browsers, no. For an end-user experience that works for everyone, DNS is still the answer.
-- **"If I tokenize my domain, I lose ICANN recognition."** No. The DNS / ICANN side is unchanged. You just add an on-chain ownership layer.
+- **"Browsers natively support `.eth` now."** There is no universal public-DNS treatment of `.eth`. Browser, wallet, extension, gateway, and resolver support can change, so test the clients your audience actually uses.
+- **"If I tokenize my domain, I lose ICANN recognition."** Tokenization does not move an ICANN domain out of public DNS. It adds a token-control layer, while the registration still depends on registrar and registry records, platform synchronization, renewals, agreements, policies, disputes, and legal controls.
 - **"Web3 domains are decentralized, tokenized domains aren't."** Both have some decentralized properties (on-chain ownership) and some centralized ones (registries, ICANN, smart contract upgrades). Decentralization is a spectrum, not a checkbox.
 
 ---
@@ -158,8 +158,8 @@ The tokenized `.com` works for the open internet. The `.eth` works as a wallet a
 
 ## Summary
 
-- **Tokenized domains** are real ICANN domains with an added on-chain ownership token. They resolve normally in every browser, support email, work with SSL, and pay normal annual renewals.
-- **Web3 domains** (ENS, Unstoppable Domains, Freename) are a different category — names that live entirely on-chain and act as wallet aliases / Web3 identities.
+- **Tokenized domains** are ICANN domains with an added on-chain token-control layer. After the usual DNS, mail, hosting, and certificate configuration, they use standard internet infrastructure and retain normal registrar renewals.
+- **Web3 naming systems** (ENS, Unstoppable Domains, Freename) issue Web3-native names and wallet identities under system-specific architectures. Do not assume every record lives on-chain or every provider uses the same renewal, resolution, or custody model.
 - The categories aren't competitors. They solve different problems and many people hold both.
 - If you need the name to work everywhere on the internet, you want a tokenized DNS domain. If you want a Web3-native handle and address, you want an ENS-style name.
 - The same wallet can hold both.

--- a/content/blog/en/top-domain-trader-forums.md
+++ b/content/blog/en/top-domain-trader-forums.md
@@ -9,7 +9,7 @@ cluster: domain-investing
 series: domain-investor-field-guide
 seriesOrder: 4
 format: roundup
-description: A practical guide to the English-language forums and communities where domain investors actually congregate in 2026 — from NamePros and DNForum to the Twitter/X and Telegram channels that have quietly replaced them.
+description: A practical guide to active English-language domain-investing forums and other public channels in 2026, with dead forum listings removed.
 ogImage: ../../assets/top-domain-trader-forums-og.jpg
 keywords: ['domain forums', 'namepros', 'dnforum', 'domain investing community', 'domain trader forum', 'domaining', 'domain investor twitter', 'domain telegram groups']
 relatedArticles:
@@ -32,65 +32,57 @@ relatedGlossary:
   - /en/glossary/registry/
 ---
 
-If you are getting into domain investing — or coming back to it after a few years away — the first practical question is almost always the same: *where do domainers actually talk?* The honest answer in 2026 is "in more places than they used to, and not all of them are forums anymore." This is a short, opinionated map of the English-language communities worth bookmarking, ordered by how much real activity they get.
+If you are getting into domain investing — or coming back to it after a few years away — the first practical question is almost always the same: *where do domainers actually talk?* The honest answer in 2026 is "in more places than they used to, and not all of them are forums anymore." This is a short, opinionated map rather than an audited activity ranking; communities and access can change, so check the linked destination before relying on any listing.
 
-## The forums that still matter
+## Current discussion forums and boards
 
 ### 1. NamePros — [namepros.com](https://www.namepros.com/)
 
-The center of gravity. If you only join one community, this is it. [NamePros](https://www.namepros.com/) has been the largest English-language domain forum for well over a decade, and the membership skews toward people who actually buy, sell, and broker domains — not just hobbyists. You will find:
+If you only join one public forum, NamePros is a practical starting point. Its live boards cover people who buy, sell, broker, and study domains. You will find:
 
 - **Sales boards** for fixed-price, make-offer, and [auction](/en/glossary/auction/) listings.
 - **Appraisal threads** where the community will tell you, with varying levels of tact, what your name is worth.
 - **[Registrar](/en/glossary/registrar/)-specific threads** for [GoDaddy](https://www.godaddy.com/), [Dynadot](https://www.dynadot.com/), [Namecheap](https://www.namecheap.com/), [Afternic](https://www.afternic.com/), [Sav](https://www.sav.com/), and friends — useful when a platform changes a policy and you want to know if it is just you.
 - **End-user discussion**, which is the slowest-moving but often the most valuable section, because closing end-user sales is where the actual money is.
 
-NamePros is not perfect — the appraisal subforum in particular has a reputation for harsh, sometimes wrong, and occasionally cruel feedback — but the signal-to-noise ratio is still the best in the English-speaking domain world.
+NamePros is not perfect — appraisal feedback can be blunt or wrong — but its breadth makes it useful for comparing multiple opinions and seeing current listings and questions.
 
 ### 2. DNForum — [dnforum.com](https://www.dnforum.com/)
 
-One of the oldest domain forums on the internet. Much smaller than it used to be, but still active enough to be worth reading. The culture is a little quieter and a little more old-school than [NamePros](https://www.namepros.com/), which some people prefer.
+One of the older domain forums on the internet. Its public pages and recent-post views were still active when this article was checked, although it is a quieter venue than [NamePros](https://www.namepros.com/).
 
-### 3. DomainState — [domainstate.com](https://www.domainstate.com/)
-
-Half community, half toolset. [DomainState](https://www.domainstate.com/) is best known for its [drop](/en/glossary/pending-delete/) and auction tracking tools, but it also hosts a forum that picks up traffic around expired-domain strategy and platform discussion.
-
-### 4. DNGeek and smaller niche forums
-
-Newer and smaller communities ([DNGeek](https://www.dngeek.com/) and similar) come and go. They are worth a look if you want a slower, less-crowded room, but do not expect the depth of NamePros.
-
-### 5. Reddit — [r/Domains](https://www.reddit.com/r/Domains/) and [r/Domaining](https://www.reddit.com/r/Domaining/)
+### 3. Reddit — [r/Domains](https://www.reddit.com/r/Domains/) and [r/Domaining](https://www.reddit.com/r/Domaining/)
 
 Reddit is where beginners ask their first questions. The quality is uneven, but [r/Domains](https://www.reddit.com/r/Domains/) and [r/Domaining](https://www.reddit.com/r/Domaining/) are reasonable places to lurk if you want a sense of what newcomers are confused about — which is a useful market signal in itself.
 
 ## Not forums, but where the actual conversation happens
 
-This is the part most "best domain forums" lists miss. In 2026, a lot of the live, high-end domain conversation has migrated off forums entirely.
+Some public discussion also happens outside dedicated forums. The following channels serve different purposes and should not be treated as equivalent to searchable, moderated forum archives.
 
 ### Twitter / X — "domain Twitter"
 
-For breaking sales, hot takes on registrar policy, end-user negotiation stories, and informal deal flow, **[X](https://x.com/) is now arguably more active than any single forum**. Follow a handful of long-time domain investors, brokers, and industry reporters and you will see the news before it hits any aggregator. The downside is that it is unsearchable in any serious way — good for a feed, bad for an archive.
+On [X](https://x.com/), domain investors, brokers, and industry reporters post sales claims, registrar-policy reactions, negotiation stories, and informal deal flow. It can be useful for fast-moving discussion, but feed visibility, search results, and activity levels are personalized and change over time; independently verify reported sales and policy claims.
 
-If you do not know anyone to follow yet, the fastest way in is to search the hashtags. The ones with the most consistent daily volume in English domain Twitter:
+If you do not know anyone to follow yet, searching hashtags can surface accounts and posts. Common English-language tags include:
 
 - [#domaining](https://x.com/hashtag/domaining) — the broadest catch-all; sales screenshots, market commentary, broker chatter.
-- [#domains](https://x.com/hashtag/domains) — noisier (overlaps with generic "domain expertise" content), but high volume.
-- [#domainnames](https://x.com/hashtag/domainnames) — slightly more curated than `#domains`.
+- [#domains](https://x.com/hashtag/domains) — broad and noisy because it overlaps with general domain content.
+- [#domainnames](https://x.com/hashtag/domainnames) — another broad name-industry tag.
 - [#domainforsale](https://x.com/hashtag/domainforsale) — listings; useful for watching what is being offered and at what asks.
 - [#domainsales](https://x.com/hashtag/domainsales) — closed-deal reports (often from [NameBio](https://namebio.com/) and the major brokers).
-- [#domaininvesting](https://x.com/hashtag/domaininvesting) — more analytical, fewer listings.
-- [#domainnameinvesting](https://x.com/hashtag/domainnameinvesting) — same crowd, less noise.
+- [#domaininvesting](https://x.com/hashtag/domaininvesting) — investing discussion and commentary.
+- [#domainnameinvesting](https://x.com/hashtag/domainnameinvesting) — a related investing tag.
 - [#NamePros](https://x.com/hashtag/NamePros) — when threads on the forum spill onto X.
 
-For niche TLDs, the convention is to just hashtag the extension itself — [#dotcom](https://x.com/hashtag/dotcom), [#dotai](https://x.com/hashtag/dotai), [#dotio](https://x.com/hashtag/dotio), and so on. The `.ai` and `.io` tags in particular are where most of the current "new extension" chatter lives.
+For niche TLDs, people also hashtag the extension itself — [#dotcom](https://x.com/hashtag/dotcom), [#dotai](https://x.com/hashtag/dotai), [#dotio](https://x.com/hashtag/dotio), and so on.
 
 ### Telegram and Discord groups
 
-Most of these are invite-based and grow around individual brokers, platforms (e.g., [Efty](https://www.efty.com/), [Atom](https://www.atom.com/)), or specific deal pipelines. They are where private-channel offers, joint ventures, and "anyone holding X?" pings actually happen. Worth asking around for invites once you have made a few real connections.
+Some groups are invite-based and grow around individual brokers, platforms, or specific interests. Their activity, moderation, membership, and trustworthiness are hard to verify from the public web. Treat private offers and joint ventures cautiously, verify counterparties, and do not assume an invitation implies endorsement by a named platform.
 
 ### Domaining.com and the domainer blog ring
 
-[Domaining.com](https://www.domaining.com/) is not a forum; it is the canonical aggregator of domainer blogs. Most of the long-form English discussion in the industry happens in the comments sections of those blogs — [DomainInvesting.com](https://domaininvesting.com/) (Elliot Silver), [OnlineDomain.com](https://onlinedomain.com/) (Konstantinos Zournas), [DomainGang](https://domaingang.com/), [TheDomains](https://thedomains.com/), and [DomainNameWire](https://domainnamewire.com/), among others. If "where do domainers talk?" means "where is the substantive written analysis?", the answer splits in two — individual voices are covered in the [famous domainer blogs and newsletters post](/en/blog/famous-domainer-blogs-and-newsletters), and the news outlets in the [domain industry media post](/en/blog/domain-industry-media).
+[Domaining.com](https://www.domaining.com/) is not a forum; it aggregates domainer blogs. Long-form English commentary also appears on sites such as [DomainInvesting.com](https://domaininvesting.com/), [OnlineDomain.com](https://onlinedomain.com/), [DomainGang](https://domaingang.com/), [TheDomains](https://thedomains.com/), and [DomainNameWire](https://domainnamewire.com/). Individual voices are covered in the [famous domainer blogs and newsletters post](/en/blog/famous-domainer-blogs-and-newsletters), and news outlets in the [domain industry media post](/en/blog/domain-industry-media).
 
 ### LinkedIn
 

--- a/content/blog/en/top-tlds-to-secure-for-your-law-firm.md
+++ b/content/blog/en/top-tlds-to-secure-for-your-law-firm.md
@@ -10,7 +10,7 @@ series: best-tlds-by-industry
 seriesOrder: 6
 format: guide
 ogImage: ../../assets/top-tlds-to-secure-for-your-law-firm-og.jpg
-description: 'The top 10 TLDs to secure for your law firm, including the credential restrictions on .law and .abogado, the open registration of .esq and other legal-themed options, and a defensive strategy.'
+description: 'Ten TLDs a law firm can evaluate, including credential restrictions on .law and .abogado, current .esq policy, and a defensive-registration strategy that requires live eligibility checks.'
 keywords: ['tlds for law firms', 'best domains for lawyers', '.law domain', 'is .esq restricted', 'legal domain extensions', 'defensive domain registration', 'attorney domain names', 'law firm branding', 'restricted legal TLDs', 'register law firm domains']
 relatedArticles:
   - /en/blog/top-tlds-to-secure-for-your-accounting-firm/
@@ -34,17 +34,17 @@ relatedGlossary:
 
 For a law firm, a domain name is more than an address — it is a trust signal. Clients judge credibility in seconds, and a clean, professional domain on a recognized extension does quiet work that a brochure cannot. Securing the right set of **TLDs for your law firm** protects the names that matter most: your firm, your partners, and the practice areas you want to rank for.
 
-There is also a defensive dimension. If you only register [`.com`](/en/tld/com), nothing stops a competitor, a disgruntled party, or a typosquatter from grabbing the same name on [`.net`](/en/tld/net), [`.law`](/en/tld/law), or a misspelling. Buying a handful of relevant extensions up front is far cheaper than litigating a [cybersquatting](/en/glossary/cybersquatting/) dispute later, and it keeps your brand consistent across the web.
+There is also a defensive dimension. If you only register [`.com`](/en/tld/com), another party may be able to register the same label on [`.net`](/en/tld/net), [`.law`](/en/tld/law), or a misspelling, subject to the registry's rules and existing rights. A focused set of defensive registrations can reduce some impersonation opportunities, but it does not prevent every abuse or replace trademark monitoring and legal remedies for [cybersquatting](/en/glossary/cybersquatting/). Compare renewal costs with your actual risk rather than assuming defensive registration is always cheaper than a dispute.
 
 ## How to choose TLDs for your law firm
 
-Three criteria matter most. First, **trust signals**: extensions like `.com` and legal-themed TLDs can communicate professional positioning. Second, **restricted TLDs**: `.law` and [`.abogado`](/en/tld/abogado) both require eligible licensed legal professionals, law firms, legal regulators, or other categories defined by their current registry policies. In contrast, [`.esq`](/en/tld/esq), [`.legal`](/en/tld/legal), [`.attorney`](/en/tld/attorney), and [`.lawyer`](/en/tld/lawyer) do not currently impose the same registry-level credential gate. Third, **defensive coverage**: register the variants that fit your actual brand, risk, and budget rather than assuming every extension is necessary.
+Three criteria matter most. First, **brand fit**: extensions like `.com` and legal-themed TLDs can communicate different positioning, but no extension proves professional competence. Second, **eligibility and use rules**: `.law` and [`.abogado`](/en/tld/abogado) publish credential-based policies. Google Registry's [`.esq` startup policy](https://www.registry.google/policies/startup/esq/) says any interested registrant may register during general availability, subject to the registry agreement and rights-protection rules. For [`.legal`](/en/tld/legal), [`.attorney`](/en/tld/attorney), and [`.lawyer`](/en/tld/lawyer), the IANA delegation page and base ICANN agreement identify the operator but are not, by themselves, proof that no current eligibility, acceptable-use, registrar, or jurisdiction-specific conditions apply. Check the live registry and registrar terms at purchase. Third, **defensive coverage**: register only the variants that fit your actual brand, risk, and budget.
 
 ## The top 10 TLDs to secure for your law firm
 
 ### 1. [.com](/en/tld/com) — the non-negotiable anchor
 
-`.com` remains the most recognized and trusted extension in the world, and most clients will type it by default. Secure your firm's primary `.com` first and point everything else to it. It is the one domain you should never let lapse. The registry is operated by [Verisign](https://www.iana.org/domains/root/db/com.html) under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/com).
+`.com` is a long-established generic extension and a common primary choice for commercial organizations. If your firm adopts a `.com` as its main address, protect its renewal and point deliberate defensive variants to it. The registry is operated by [Verisign](https://www.iana.org/domains/root/db/com.html) under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/com).
 
 ### 2. .law — the verified flag for legal professionals (RESTRICTED)
 
@@ -54,17 +54,17 @@ Three criteria matter most. First, **trust signals**: extensions like `.com` and
 
 `.esq` (for "Esquire") is marketed to individual attorneys and legal professionals, but contrary to common belief it is **not** credential-gated — there is no registry-level verification of legal status, so anyone can register one. It is operated by [Charleston Road Registry (Google Registry)](https://www.iana.org/domains/root/db/esq.html) and, like Google's other TLDs, is served HTTPS-only via [HSTS preloading](https://hstspreload.org/); see [Google Registry's .esq page](https://www.registry.google/tlds/esq/) for the registry operator's positioning. Because it is open, register it defensively rather than assuming the credential bar protects your name.
 
-### 4. .legal — a descriptive, openly available option
+### 4. .legal — a descriptive option; verify current terms
 
-`.legal` reads clearly and works for firms, legal-tech products, and resource sites. Unlike `.law`, `.legal` is **not** subject to verified-credential restrictions and is openly available to register, per its [IANA root entry](https://www.iana.org/domains/root/db/legal.html) and [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/legal). It is a strong, unrestricted alternative if you want a legal-themed name without the verification step.
+`.legal` reads clearly for firms, legal-tech products, and resource sites. Its [IANA root entry](https://www.iana.org/domains/root/db/legal.html) and [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/legal) establish delegation and the registry relationship; they do not establish every current registration condition. Confirm eligibility, use, premium pricing, renewal, and registrar terms before treating it as an unrestricted alternative to `.law`.
 
-### 5. .attorney — practice-specific and unrestricted
+### 5. .attorney — practice-specific; verify current terms
 
-`.attorney` is descriptive and self-explanatory, and it is open to anyone — there is no credential gate, so you should also register it defensively. It is operated under a standard [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/attorney); see its [IANA root entry](https://www.iana.org/domains/root/db/attorney.html). Useful for personal-brand domains like `firstname.attorney`.
+`.attorney` is descriptive and can fit a personal-brand domain such as `firstname.attorney`. Its [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/attorney) and [IANA root entry](https://www.iana.org/domains/root/db/attorney.html) identify the registry arrangement, but prospective registrants should check the operator's and registrar's current eligibility, use, pricing, and renewal terms rather than infer unrestricted status from those documents.
 
-### 6. .lawyer — a clean personal-brand option
+### 6. .lawyer — a personal-brand option; verify current terms
 
-`.lawyer` pairs naturally with an individual practitioner's name and, like `.attorney`, is **not** restricted to verified credentials. You can confirm its delegation in the [IANA root database](https://www.iana.org/domains/root/db/lawyer.html) and its [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/lawyer). Grab it to protect your name and to support partner microsites.
+`.lawyer` pairs naturally with an individual practitioner's name. You can confirm its delegation in the [IANA root database](https://www.iana.org/domains/root/db/lawyer.html) and its [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/lawyer), but verify current eligibility, use, pricing, and registrar conditions before registration. Consider it only where the label and site will comply with professional-responsibility and advertising rules in the relevant jurisdiction.
 
 ### 7. [.abogado](/en/tld/abogado) — Spanish-language legal positioning (RESTRICTED)
 
@@ -72,7 +72,7 @@ Three criteria matter most. First, **trust signals**: extensions like `.com` and
 
 ### 8. [.net](/en/tld/net) — the classic defensive backup
 
-`.net` is one of the oldest and most trusted generic extensions, making it the natural defensive companion to your `.com`. Registering it prevents confusion and blocks an easy impersonation vector. It is operated by [Verisign](https://www.iana.org/domains/root/db/net.html) under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/net).
+`.net` is a long-established generic extension and may be a useful defensive companion to your `.com`. Registering the matching label removes one potential impersonation vector, but it does not prevent confusing registrations on other labels or extensions. It is operated by [Verisign](https://www.iana.org/domains/root/db/net.html) under an [ICANN registry agreement](https://www.icann.org/en/registry-agreements/details/net).
 
 ### 9. [.org](/en/tld/org) — for nonprofits, clinics, and associations
 
@@ -80,7 +80,7 @@ Three criteria matter most. First, **trust signals**: extensions like `.com` and
 
 ### 10. [.info](/en/tld/info) — for client-facing resources
 
-[`.info`](/en/tld/info) suits FAQ hubs, practice-area explainers, and intake resources where the name should say "information." It is an inexpensive defensive registration and a flexible home for content. See its [IANA root entry](https://www.iana.org/domains/root/db/info.html) for delegation details.
+[`.info`](/en/tld/info) can suit FAQ hubs, practice-area explainers, and intake resources where the name should say "information." Registration, premium, and renewal prices vary by registrar and over time, so check the full recurring cost. See its [IANA root entry](https://www.iana.org/domains/root/db/info.html) for delegation details.
 
 ## Defensive registration strategy
 
@@ -90,19 +90,19 @@ You will not — and should not — buy every extension in existence. Focus on t
 
 ## Register your law firm domains at Namefi
 
-[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) built for exactly this kind of multi-domain strategy. You get transparent pricing with no surprise upsells, fast and reliable DNS so your sites resolve quickly, and one dashboard to manage your whole portfolio and its renewals.
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/). Check its live catalog, checkout price, renewal price, supported DNS features, and agreements for each TLD before registering or transferring a portfolio.
 
-Namefi also supports [Web3](/en/glossary/web3/) domain tokenization, letting you hold eligible domains as NFTs — useful if your firm advises on digital assets or wants verifiable, transferable [on-chain](/en/glossary/on-chain/) ownership of its names. Whether you are securing a single `.com` or a full defensive set, you can register and manage your law firm's domains in one place.
+Namefi also supports [Web3](/en/glossary/web3/) domain tokenization for eligible domains. The token provides an auditable, transferable [on-chain](/en/glossary/on-chain/) control layer; it is not proof that the holder owns trademark rights, is licensed to practice law, or has unconditional legal title to the domain. The underlying registration remains subject to the registration agreement, registry and registrar procedures, renewal, disputes, sanctions, court orders, and the platform authority described in Namefi's [Terms of Service](https://namefi.io/tos).
 
 ## Frequently asked questions
 
 ### Can any law firm register a .law domain?
 
-No. `.law` is restricted to qualified legal registrants under its current eligibility requirements. `.abogado` also has a registry-level eligibility policy for licensed legal professionals and specified legal organizations. Despite being marketed to attorneys, `.esq` is not currently credential-gated, and `.legal`, `.attorney`, and `.lawyer` do not have the same restriction.
+No. `.law` is restricted to qualified legal registrants under its current eligibility requirements, and `.abogado` publishes a registry-level eligibility policy for licensed legal professionals and specified legal organizations. Google Registry's current `.esq` general-registration policy allows any interested registrant, subject to other rules. For `.legal`, `.attorney`, and `.lawyer`, check the live registry and registrar terms rather than relying on their IANA delegation pages as proof of unrestricted eligibility.
 
 ### Does the TLD I choose affect my SEO?
 
-Not directly. Google treats all generic TLDs equally, and using a keyword-rich extension does not give a ranking boost — Google's [Search Central documentation](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites) explains that ccTLDs are mainly used as a geotargeting signal, while gTLDs are not. Your extension can still affect SEO indirectly through user trust and click-through rates, so a credible domain helps.
+Not directly. Google says keyword-rich generic TLDs do not receive a ranking boost, while country-code TLDs can act as a geotargeting signal; see [Search Central's multi-regional guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites). Branding and user response are separate questions, and this article does not claim a particular extension will improve click-through rate or rankings.
 
 ### How many TLDs should a law firm actually register?
 
@@ -110,4 +110,4 @@ There is no fixed number, but most firms are well served by their primary `.com`
 
 ### Should I register a legal TLD I am not yet eligible for?
 
-Do not register `.law` or `.abogado` unless you satisfy the applicable current eligibility policy and can pass verification. If you are not eligible, focus on unrestricted options such as `.esq`, `.legal`, `.attorney`, `.lawyer`, and `.com`, while still checking each registry's live terms before registration.
+Do not register `.law` or `.abogado` unless you satisfy the applicable current eligibility policy and can pass verification. If you are not eligible, `.esq` and other legal-themed or general-purpose TLDs may be alternatives, but check each registry's and registrar's live eligibility, acceptable-use, pricing, renewal, and jurisdiction-specific terms before registration.

--- a/content/blog/en/what-are-stablecoins.md
+++ b/content/blog/en/what-are-stablecoins.md
@@ -35,55 +35,55 @@ For anyone navigating the [Web3](https://en.wikipedia.org/wiki/Web3) landscapeâ€
 
 ## The Core Concept: Stability Amidst Volatility
 
-At its simplest, a **stablecoin** is a type of cryptocurrency designed to maintain a fixed value over time. While Bitcoin operates on supply and demand dynamics that can cause massive price fluctuations, stablecoins are "pegged" to a stable asset, most commonly the US Dollar (USD), giving them a value of exactly $1.00.
+At its simplest, a **stablecoin** is a type of cryptocurrency designed to track a reference asset, most commonly the US Dollar (USD). A dollar-pegged stablecoin generally targets $1.00, but that target is not a guarantee: secondary-market prices can move above or below the peg, and redemption terms vary by issuer and product.
 
-This stability allows users to keep assets on the blockchain without being exposed to the risk of market crashes. According to [Investopedia](https://www.investopedia.com/terms/s/stablecoin.asp), stablecoins attempt to offer the best of both worlds: the instant processing, security, and privacy of payments of cryptocurrencies, and the volatility-free stable valuations of fiat currencies.
+Stablecoins can reduce exposure to the price swings of unpegged crypto assets, but they do not remove financial risk. They can face depegging, redemption, reserve, issuer, custodian, network, and smart-contract risks. The [Federal Reserve](https://www.federalreserve.gov/newsevents/speech/waller20250212a.htm) notes that stablecoins are private money, have experienced depegs, and remain subject to run and payment-system risks.
 
 ## How Do Stablecoins Maintain Their Value?
 
-Not all stablecoins are created equal. To maintain that $1.00 peg, they rely on different mechanisms. Here are the three main categories:
+Not all stablecoins are created equal. To try to maintain a peg, they use different reserve, collateral, redemption, and incentive mechanisms. Three broad categories are useful, although some products use hybrid designs:
 
 ### 1. Fiat-Collateralized Stablecoins
-These are the most popular and easiest to understand. For every digital token issued, the issuer holds one unit of real fiat currency (like the US Dollar or Euro) in a bank reserve.
-*   **Examples**: [Tether (USDT)](https://tether.to/) and [USD Coin (USDC)](https://www.circle.com/en/usdc).
-*   **Why it matters**: These are widely trusted for payments and trading because they claim 1:1 backing by cash and cash equivalents.
+These tokens are issued against reserves intended to support redemption at or near the reference value. The reserve is not necessarily one unit of cash in a bank for every token: its composition can include cash, government securities, repurchase agreements, or other assets permitted by the issuer's framework.
+*   **Examples**: [Tether (USDT)](https://tether.to/en/transparency/) and [USD Coin (USDC)](https://www.circle.com/usdc).
+*   **Why it matters**: Reserve composition, liquidity, custody, attestations, legal redemption rights, and issuer risk all matter. For example, [Circle's current disclosures](https://www.circle.com/transparency) describe USDC reserves as cash and highly liquid cash-equivalent assets, with most of the reserve held in a government money-market fund that may hold short-dated US Treasuries and overnight Treasury repurchase agreements.
 
 ### 2. Crypto-Collateralized Stablecoins
 These are backed by other cryptocurrencies rather than fiat in a bank. Because the backing asset (like Ethereum) is volatile, these stablecoins are "over-collateralized." For example, to mint $100 worth of a stablecoin, you might need to lock up $150 worth of ETH.
-*   **Example**: [DAI by MakerDAO](https://makerdao.com/en/).
-*   **Why it matters**: This allows for a decentralized stablecoin that doesn't rely on a central bank or corporate entity.
+*   **Example**: [DAI](https://sky.money/) in the Sky ecosystem.
+*   **Why it matters**: On-chain collateral and smart contracts can make parts of the system transparent and programmable, but governance, collateral composition, price oracles, custodians, and centralized assets may still introduce dependencies.
 
 ### 3. Algorithmic Stablecoins
-These do not use [collateral](/en/glossary/collateral/). Instead, they use smart contracts and algorithms to control the supply of tokens. If the price goes above $1.00, the system mints more tokens to lower the price. If it drops, it burns tokens to raise the price.
-*   **Note**: This is the riskiest class of stablecoins, as seen in the [Terra/Luna crash of 2022](https://www.coindesk.com/learn/the-fall-of-terra-a-timeline-of-the-algorithmic-stablecoins-crash/).
+These rely substantially on smart-contract incentives, supply changes, arbitrage, or a related token rather than only on directly redeemable fiat reserves. Some are uncollateralized; others are partially collateralized or hybrid, so "algorithmic" is not one uniform design.
+*   **Note**: These mechanisms can fail abruptly if confidence and arbitrage incentives collapse. The [Federal Reserve's study of algorithmic-stablecoin runs](https://www.federalreserve.gov/econres/notes/feds-notes/runs-on-algorithmic-stablecoins-evidence-from-iron-titan-and-steel-20220602.html) explains that a peg can break and trigger run dynamics.
 
 ## Why Stablecoins Are Essential for the Future of the Web
 
 Stablecoins have grown into a multi-billion dollar market because they solve practical problems that raw cryptocurrencies cannot.
 
-*   **Seamless Transactions**: You can send millions of dollars in stablecoins across the globe in seconds for a fraction of the cost of a bank wire, 24/7/365.
-*   **[DeFi](/en/glossary/defi/) (Decentralized Finance)**: Stablecoins are the lifeblood of [DeFi](https://ethereum.org/en/defi/). Users can lend their stablecoins to earn yield (interest) often significantly higher than traditional savings accounts.
-*   **Safe Harbor**: When crypto markets dip, traders swap their volatile assets into stablecoins to protect their portfolio value without cashing out to a bank.
+*   **On-chain settlement**: Supported networks can operate outside bank hours and may settle quickly, but actual time and cost depend on the chain, congestion, bridges, exchanges, compliance checks, and the issuer's minting or redemption process.
+*   **[DeFi](/en/glossary/defi/) (Decentralized Finance)**: Stablecoins are widely used for trading, lending, and collateral in [DeFi](https://ethereum.org/en/defi/). Advertised yields are not bank interest or guaranteed returns; users can lose funds through depegs, liquidations, smart-contract failures, protocol insolvency, or counterparty risk.
+*   **Trading and cash management**: Traders often move from volatile crypto assets into stablecoins without first using a bank. That may reduce exposure to the original asset, but it replaces that exposure with the stablecoin's own peg, reserve, issuer, custody, and liquidity risks; a stablecoin is not a risk-free safe harbor or an insured bank deposit.
 
 ## The Namefi Angle: Stable Payments for On-Chain Assets
 
 At **Namefi**, we are bridging the gap between the traditional internet (DNS) and the decentralized web (blockchain). We allow users to buy, manage, and transfer domains [on-chain](/en/glossary/on-chain/) as NFTs. Stablecoins play a pivotal role in this ecosystem.
 
 ### 1. Price Predictability
-When you buy a premium [domain name](/en/blog/what-is-domain/), you want to know exactly what you are paying. While paying in ETH is possible, the price of ETH could change by 5% while you are at the checkout screen. Stablecoins allow Namefi users to transact with the precision of fiat currency while enjoying the speed of blockchain.
+When you buy a premium [domain name](/en/blog/what-is-domain/), quoting the price in a dollar-pegged asset can reduce the checkout's exposure to ETH price movements. It still does not guarantee a fiat-dollar value: the stablecoin can depeg, and network or settlement conditions can change.
 
 ### 2. Frictionless Global Commerce
-Domain investing is a global industry. Traditionally, buying a high-value domain involves [Escrow](/en/glossary/escrow/) services, bank wires, and currency conversion fees. With Namefi and stablecoins, a buyer in Tokyo can instantly purchase a domain from a seller in New York using USDC or USDT. The transaction is settled on-chain immediately, and ownership (the NFT) is transferred instantly.
+Domain investing is a global industry. Traditionally, buying a high-value domain may involve [Escrow](/en/glossary/escrow/) services, bank wires, and currency conversion. Namefi currently documents a wallet-signed **USDC** checkout for supported domain registrations through its [x402 flow](/en/blog/wallet-checkout/). Availability, accepted networks and assets, finality, fees, registration completion, and compliance requirements depend on the live product and transaction; this article does not establish a general USDT checkout or instant secondary-market settlement.
 
 ### 3. Future DeFi Integrations
-Because Namefi treats domains as Real-World Assets (RWAs) on the blockchain, the future possibilities are vast. Imagine using your high-value [domain portfolio](/en/blog/domain-portfolio-management/) as collateral to borrow stablecoins via a DeFi protocol. This unlocks liquidity for business owners without forcing them to sell their digital identity.
+Because Namefi represents supported domains with on-chain tokens, a compatible protocol could choose to evaluate a [domain portfolio](/en/blog/domain-portfolio-management/) as [collateral](/en/glossary/collateral/). That is an emerging possibility, not an automatic feature or a promise of liquidity: it depends on protocol support, valuation, loan-to-value limits, oracle design, legal and registration constraints, and liquidation risk.
 
 ## Conclusion
 
-Stablecoins are more than just a place to park cash during a crypto bear market; they are the foundational infrastructure for a new global economy. They enable the programmable money revolution that [Web3](https://hbr.org/2022/05/what-is-web3) promises, providing the reliability required for serious business operations.
+Stablecoins are widely used as settlement and trading assets in crypto markets and as building blocks for programmable applications. Their usefulness comes from targeting a reference value and integrating with blockchains, not from being equivalent to cash or eliminating risk.
 
-As the lines between traditional finance and blockchain blur, the utility of stablecoins will only increase. Whether you are buying your first domain on the blockchain or managing a complex portfolio of digital assets, stablecoins provide the solid ground you need to build your digital presence.
+Whether you are buying a domain through a supported wallet-payment flow or managing digital assets, evaluate the specific stablecoin, issuer, reserve and redemption terms, network, protocol, and jurisdiction before relying on it.
 
-**Ready to step into the future of [domain ownership](/en/glossary/domain-ownership/)? Experience instant, secure, and transparent domain management today.**
+**Ready to explore [domain ownership](/en/glossary/domain-ownership/)? Review the live payment terms, supported assets, and risks before you transact.**
 
 **[Start your journey with Namefi](https://namefi.io)**

--- a/content/blog/en/why-tokenize-domains.md
+++ b/content/blog/en/why-tokenize-domains.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 draft: false
 cluster: domain-tokenization
 format: opinion
-description: This article explains why traditional domains should be tokenized on-chain and highlights the benefits such as clearer ownership, financial composability, and freer, faster trading.
+description: This article explains why traditional domains can add an on-chain token-control layer, including its interoperability benefits and the registration and legal limits that remain.
 keywords: ['domain tokenization', 'blockchain domains', 'NFT domains', 'on-chain domains', 'domain ownership', 'decentralized domains', 'domain trading', 'web3 domains', 'smart contracts', 'domain composability', 'DNS tokenization', 'digital assets']
 relatedArticles:
   - /en/blog/what-are-tokenized-domains/
@@ -63,7 +63,7 @@ On Namefi, eligible supported domains you register (e.g. `mybrand.xyz`) can be r
 - List it for sale on marketplaces like OpenSea  
 - Combine it with contracts, [DAOs](/en/glossary/dao/), websites, or other apps  
 
-This brings new flexibility and utility to domain ownership.
+This can add flexibility to supported token-control and integration workflows. It does not replace the registrant's contractual rights, the registrar and registry records, or the policies that govern the underlying domain.
 
 ---
 
@@ -76,7 +76,7 @@ By tokenizing domains, Namefi acts as a **bridge** between traditional [DNS](/en
 | Registrar and registry records | A [smart-contract](/en/glossary/smart-contract/) token-control layer on a public blockchain  |
 | Account, registrar, and policy workflows | Potentially [atomic transfers](/en/glossary/atomic-transfer/) for the token and payment legs |
 | Static records            | [Composable](/en/glossary/composability/) into DeFi, identity, [DAOs](/en/glossary/dao/)  |
-| Centralized verification  | Ownership verifiable on-chain         |
+| Registrar and registry verification | Token control and transfer history auditable on-chain |
 
 You hold a programmable token-control layer in your own [wallet](/en/glossary/wallet/), while your rights to the underlying domain still come from the applicable registration agreement and policies.
 
@@ -95,17 +95,17 @@ Transferring domains traditionally involves:
 
 Within Namefi's supported tokenization flow, the onchain token-control leg can transfer in a blockchain transaction. Confirmation time depends on the chain, and the underlying registrar, registry, renewal, dispute, contractual, and legal layers still apply. Compatible [smart contracts](/en/glossary/smart-contract/) can add approvals or management logic around the token.
 
-### ✅ 2. Clearer Ownership & User-Controlled Access
+### ✅ 2. Auditable Token Control & Wallet-Based Access
 
 With a traditional [registrar](/en/glossary/registrar/), a registrant holds contractual rights under the registration agreement and applicable policies. Account access and operational controls are provided through the registrar; that is different from private-key custody, but it does not mean the registrant has no rights or is merely borrowing an account.
 
 With Namefi:
 
-- Your ownership is recorded [on-chain](/en/glossary/on-chain/) as an [NFT](/en/glossary/nft/)  
-- You manage it with your own [wallet](/en/glossary/wallet/)—not a hosted account  
-- While still subject to real-world DNS rules (renewals, lawful use), your **control is cryptographically secured**
+- Control of the [NFT](/en/glossary/nft/) and its transfers is recorded [on-chain](/en/glossary/on-chain/)
+- You can manage that token through your own [wallet](/en/glossary/wallet/) rather than only through a hosted dashboard
+- The underlying registration remains subject to renewal, registry and registrar procedures, Namefi's agreements, disputes, sanctions, court orders, and other legal controls; Namefi's [Terms of Service](https://namefi.io/tos) also describe platform authority over supported tokens in specified circumstances
 
-> It's not about "permanent, [censorship-free](/en/glossary/censorship-free/) domains"—it's about *clearer, user-first ownership*.
+> It is not "permanent" or [censorship-free](/en/glossary/censorship-free/). The benefit is an auditable, programmable token-control layer alongside the existing registration system—not a replacement for legal registrant rights.
 
 ### ✅ 3. Unlocking New Use Cases
 
@@ -120,11 +120,11 @@ Tokenized domains can be:
 
 ## 🔗 Composability: From Closed Market to Internet-Native Asset
 
-This is perhaps the most revolutionary but overlooked feature:
+This is one of the main practical opportunities:
 
 > Tokenizing turns domains into *open [protocol assets](/en/glossary/protocol-asset/)*—anyone can build services, exchanges, or financial layers around them.
 
-### ✅ Dramatically Lower Trading Costs
+### ✅ More Choice in Trading Workflows and Costs
 
 Traditional domain [marketplaces](/en/glossary/marketplace/) publish different commission schedules by venue, sales path, and service. Onchain venues also vary by transaction type and can add marketplace fees, creator earnings, and network gas.
 
@@ -132,7 +132,9 @@ In contrast, [on-chain](/en/glossary/on-chain/) [NFT](/en/glossary/nft/) platfor
 
 - Publish venue- and transaction-specific fee policies that can change
 - Allow direct [wallet](/en/glossary/wallet/)-to-[wallet](/en/glossary/wallet/) transfers  
-- Settle fast, scale globally, and support automation  
+- Can support automated token settlement across supported wallets and networks
+
+Neither model is universally cheaper or faster. Compare marketplace commissions, payment and escrow services, network gas, smart-contract risk, compliance checks, and any registrar or platform steps for the actual transaction.
 
 ### ✅ Faster Token Settlement Where Supported
 
@@ -187,22 +189,22 @@ Tokenizing real estate doesn't exempt it from city zoning, property taxes, or em
 
 - We support eligible TLDs in the ordinary DNS root (`.xyz`, `.com`, `.art`, etc.); current coverage depends on Namefi's live catalog
 - We work with accredited [registrars](/en/glossary/registrar/)  
-- Token ownership is kept in sync with off-chain DNS records  
+- Namefi's supported workflow coordinates token control with the applicable off-chain registration state; DNS records remain separate configuration data used for resolution and services
 - Domains still work with [SEO](/en/glossary/seo/), email, browser compatibility, etc.
 
-What you get is **real usability** and **real freedom**, not an illusion of decentralization.
+What you get is another programmable control and integration surface, with the same underlying registration, policy, and DNS dependencies stated above.
 
 ---
 
 ## ✅ Conclusion: On-Chain Domains Are Evolution, Not Escape
 
-> Tokenizing domains doesn't make them "more blockchain"—it makes them *more usable, ownable, and programmable*.
+> Tokenizing domains adds a more auditable and programmable token-control layer without turning that token into an unconditional legal title.
 
 It:
 
 - Doesn't make them censorship-proof  
 - Doesn't bypass legal oversight  
-- But **does** make them composable, transparent, and Internet-native
+- But **can** make supported token-control workflows composable, auditable, and easier to integrate with on-chain applications
 
 ---
 


### PR DESCRIPTION
## Summary

- correct high-risk stablecoin claims about peg guarantees, reserves, yield, settlement, and current Namefi payment support
- distinguish token control from legal registrant rights and from registrar, registry, and DNS state
- remove dead domain-forum recommendations and avoid unsupported activity rankings
- correct ENS/Web3 architecture, email/TLS setup, renewal, resolution, and collateral caveats
- clarify legal-TLD eligibility evidence and remove unsupported trust, pricing, SEO, and ownership promises
- separate atomic token/payment settlement from asynchronous registrar claim and transfer-policy workflows
- correct Panix recovery DNS architecture and qualify transfer-lock and token-control claims

## Verification

- `TMPDIR=/private/tmp BUN_TMPDIR=/private/tmp BUN_INSTALL_CACHE_DIR=/private/tmp/namefi-bun-cache bun run data:validate` (passes with the 29 pre-existing empty-keyword warnings)
- `TMPDIR=/private/tmp BUN_TMPDIR=/private/tmp BUN_INSTALL_CACHE_DIR=/private/tmp/namefi-bun-cache bun run lint:mdx`
- `TMPDIR=/private/tmp BUN_TMPDIR=/private/tmp BUN_INSTALL_CACHE_DIR=/private/tmp/namefi-bun-cache bun run check:termbase`
- targeted cross-link audit for all seven changed articles
- `git diff --check`
- pre-push hook: data validation, full link audit, and MDX lint passed

## Access control

No new endpoint, page, dashboard, storage surface, or privileged operation is introduced. These are corrections to already-public English articles.
