### PR TITLE
content(careers): rename roles to common titles + add monthly baseSalary

### DIFF
--- a/content/careers/en/build-design-2026-05.md
+++ b/content/careers/en/build-design-2026-05.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 draft: false
 type: job
 description: Drive product decisions, user experience, and design quality with AI agents as core collaborators in your daily workflow.
-employmentType: FULL_TIME
+employmentType: [FULL_TIME, CONTRACTOR]
 team: Product
 location: Remote (Worldwide)
 compensation: Competitive pay with equity
@@ -17,6 +17,8 @@ baseSalary:
   maxValue: 800
   unitText: MONTH
 ---
+
+**This is a contractor role.**
 
 ## What You Will Do
 

--- a/content/careers/en/build-design-2026-05.md
+++ b/content/careers/en/build-design-2026-05.md
@@ -1,5 +1,5 @@
 ---
-title: 'AI Empowered Builder: Non-Engineer (PM / Product Designer / UXUI Designer)'
+title: 'Product Designer (AI Empowered)'
 date: '2026-05-27'
 language: en
 tags: ['product', 'design', 'ai']
@@ -11,6 +11,11 @@ employmentType: FULL_TIME
 team: Product
 location: Remote (Worldwide)
 compensation: Competitive pay with equity
+baseSalary:
+  currency: USD
+  minValue: 500
+  maxValue: 800
+  unitText: MONTH
 ---
 
 ## What You Will Do

--- a/content/careers/en/build-dns-2026-05.md
+++ b/content/careers/en/build-dns-2026-05.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 draft: false
 type: job
 description: Lead technical depth in DNS and EPP domains while contributing broadly as a full-stack engineer, amplified by AI-assisted development workflows.
-employmentType: FULL_TIME
+employmentType: [FULL_TIME, CONTRACTOR]
 team: Engineering
 location: Remote (Worldwide)
 compensation: Competitive pay with equity
@@ -17,6 +17,8 @@ baseSalary:
   maxValue: 6000
   unitText: MONTH
 ---
+
+**This is a contractor role.**
 
 ## What You Will Do
 

--- a/content/careers/en/build-dns-2026-05.md
+++ b/content/careers/en/build-dns-2026-05.md
@@ -1,5 +1,5 @@
 ---
-title: 'AI Empowered Builder: Engineer with Specialty in DNS and EPP'
+title: 'DNS Engineer (AI Empowered)'
 date: '2026-05-27'
 language: en
 tags: ['engineering', 'dns', 'ai']
@@ -11,6 +11,11 @@ employmentType: FULL_TIME
 team: Engineering
 location: Remote (Worldwide)
 compensation: Competitive pay with equity
+baseSalary:
+  currency: USD
+  minValue: 1500
+  maxValue: 6000
+  unitText: MONTH
 ---
 
 ## What You Will Do

--- a/content/careers/en/build-gen-2026-05.md
+++ b/content/careers/en/build-gen-2026-05.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 draft: false
 type: job
 description: Deliver end-to-end product features across the entire stack, leveraging AI agents and the latest AI tooling to ship faster and smarter.
-employmentType: FULL_TIME
+employmentType: [FULL_TIME, CONTRACTOR]
 team: Engineering
 location: Remote (Worldwide)
 compensation: Competitive pay with equity
@@ -17,6 +17,8 @@ baseSalary:
   maxValue: 6000
   unitText: MONTH
 ---
+
+**This is a contractor role.**
 
 ## What You Will Do
 

--- a/content/careers/en/build-gen-2026-05.md
+++ b/content/careers/en/build-gen-2026-05.md
@@ -1,5 +1,5 @@
 ---
-title: 'AI Empowered Builder: General Full Stack Engineer'
+title: 'Full Stack Engineer (AI Empowered)'
 date: '2026-05-26'
 language: en
 tags: ['engineering', 'full-stack', 'ai']
@@ -11,6 +11,11 @@ employmentType: FULL_TIME
 team: Engineering
 location: Remote (Worldwide)
 compensation: Competitive pay with equity
+baseSalary:
+  currency: USD
+  minValue: 1500
+  maxValue: 6000
+  unitText: MONTH
 ---
 
 ## What You Will Do

--- a/content/careers/en/build-nontraditional-2026-05.md
+++ b/content/careers/en/build-nontraditional-2026-05.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 draft: false
 type: job
 description: Turn high AI and agent fluency into real product output — no conventional background required, just the ability to deliver with cutting-edge tools.
-employmentType: FULL_TIME
+employmentType: [FULL_TIME, CONTRACTOR]
 team: Engineering
 location: Remote (Worldwide)
 compensation: Competitive pay with equity
@@ -17,6 +17,8 @@ baseSalary:
   maxValue: 6000
   unitText: MONTH
 ---
+
+**This is a contractor role.**
 
 ## What You Will Do
 

--- a/content/careers/en/build-nontraditional-2026-05.md
+++ b/content/careers/en/build-nontraditional-2026-05.md
@@ -1,5 +1,5 @@
 ---
-title: 'AI Empowered Builder: Without Traditional Product Experience'
+title: 'Product Engineer (AI Empowered)'
 date: '2026-05-27'
 language: en
 tags: ['engineering', 'product', 'ai']
@@ -11,6 +11,11 @@ employmentType: FULL_TIME
 team: Engineering
 location: Remote (Worldwide)
 compensation: Competitive pay with equity
+baseSalary:
+  currency: USD
+  minValue: 1500
+  maxValue: 6000
+  unitText: MONTH
 ---
 
 ## What You Will Do

--- a/content/careers/en/build-security-2026-05.md
+++ b/content/careers/en/build-security-2026-05.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 draft: false
 type: job
 description: Apply security-first thinking across everything we ship while contributing as a hands-on engineer, amplified by AI-augmented tooling.
-employmentType: FULL_TIME
+employmentType: [FULL_TIME, CONTRACTOR]
 team: Engineering
 location: Remote (Worldwide)
 compensation: Competitive pay with equity
@@ -17,6 +17,8 @@ baseSalary:
   maxValue: 6000
   unitText: MONTH
 ---
+
+**This is a contractor role.**
 
 ## What You Will Do
 

--- a/content/careers/en/build-security-2026-05.md
+++ b/content/careers/en/build-security-2026-05.md
@@ -1,5 +1,5 @@
 ---
-title: 'AI Empowered Builder: Engineer with Specialty in Cyber Security'
+title: 'Security Engineer (AI Empowered)'
 date: '2026-05-27'
 language: en
 tags: ['engineering', 'security', 'ai']
@@ -11,6 +11,11 @@ employmentType: FULL_TIME
 team: Engineering
 location: Remote (Worldwide)
 compensation: Competitive pay with equity
+baseSalary:
+  currency: USD
+  minValue: 1500
+  maxValue: 6000
+  unitText: MONTH
 ---
 
 ## What You Will Do

--- a/content/careers/en/build-web3-2026-05.md
+++ b/content/careers/en/build-web3-2026-05.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 draft: false
 type: job
 description: Bring deep Web3 and smart contract expertise across the full product surface, using AI agents to accelerate on-chain and off-chain delivery.
-employmentType: FULL_TIME
+employmentType: [FULL_TIME, CONTRACTOR]
 team: Engineering
 location: Remote (Worldwide)
 compensation: Competitive pay with equity
@@ -17,6 +17,8 @@ baseSalary:
   maxValue: 6000
   unitText: MONTH
 ---
+
+**This is a contractor role.**
 
 ## What You Will Do
 

--- a/content/careers/en/build-web3-2026-05.md
+++ b/content/careers/en/build-web3-2026-05.md
@@ -1,5 +1,5 @@
 ---
-title: 'AI Empowered Builder: Engineer with Specialty in Smart Contract and Web3'
+title: 'Smart Contract Engineer (AI Empowered)'
 date: '2026-05-27'
 language: en
 tags: ['engineering', 'web3', 'ai']
@@ -11,6 +11,11 @@ employmentType: FULL_TIME
 team: Engineering
 location: Remote (Worldwide)
 compensation: Competitive pay with equity
+baseSalary:
+  currency: USD
+  minValue: 1500
+  maxValue: 6000
+  unitText: MONTH
 ---
 
 ## What You Will Do

--- a/content/careers/en/conn-bd-2026-05.md
+++ b/content/careers/en/conn-bd-2026-05.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 draft: false
 type: job
 description: Build relationships, identify opportunities, and expand our reach across industries and ecosystems, powered by AI-driven research and outreach workflows.
-employmentType: FULL_TIME
+employmentType: [FULL_TIME, CONTRACTOR]
 team: Business
 location: Remote (Worldwide)
 compensation: Competitive pay with equity
@@ -17,6 +17,8 @@ baseSalary:
   maxValue: 800
   unitText: MONTH
 ---
+
+**This is a contractor role.**
 
 ## What You Will Do
 

--- a/content/careers/en/conn-bd-2026-05.md
+++ b/content/careers/en/conn-bd-2026-05.md
@@ -1,5 +1,5 @@
 ---
-title: 'AI Empowered Connector: Business Development'
+title: 'Business Development Specialist (AI Empowered)'
 date: '2026-05-27'
 language: en
 tags: ['business', 'partnerships', 'ai']
@@ -11,6 +11,11 @@ employmentType: FULL_TIME
 team: Business
 location: Remote (Worldwide)
 compensation: Competitive pay with equity
+baseSalary:
+  currency: USD
+  minValue: 500
+  maxValue: 800
+  unitText: MONTH
 ---
 
 ## What You Will Do

--- a/content/careers/en/conn-community-2026-05.md
+++ b/content/careers/en/conn-community-2026-05.md
@@ -1,5 +1,5 @@
 ---
-title: 'AI Empowered Connector: Community Manager'
+title: 'Community Manager (AI Empowered)'
 date: '2026-05-27'
 language: en
 tags: ['community', 'engagement', 'ai']
@@ -11,6 +11,11 @@ employmentType: FULL_TIME
 team: Community
 location: Remote (Worldwide)
 compensation: Competitive pay with equity
+baseSalary:
+  currency: USD
+  minValue: 500
+  maxValue: 800
+  unitText: MONTH
 ---
 
 ## What You Will Do

--- a/content/careers/en/conn-community-2026-05.md
+++ b/content/careers/en/conn-community-2026-05.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 draft: false
 type: job
 description: Grow and nurture our community with meaningful engagement, using AI agents to stay responsive and surface insights at scale.
-employmentType: FULL_TIME
+employmentType: [FULL_TIME, CONTRACTOR]
 team: Community
 location: Remote (Worldwide)
 compensation: Competitive pay with equity
@@ -17,6 +17,8 @@ baseSalary:
   maxValue: 800
   unitText: MONTH
 ---
+
+**This is a contractor role.**
 
 ## What You Will Do
 

--- a/content/careers/en/conn-creative-2026-05.md
+++ b/content/careers/en/conn-creative-2026-05.md
@@ -1,5 +1,5 @@
 ---
-title: 'AI Empowered Connector: Creative Creator'
+title: 'Content Creator (AI Empowered)'
 date: '2026-05-27'
 language: en
 tags: ['content', 'creative', 'ai']
@@ -11,6 +11,11 @@ employmentType: FULL_TIME
 team: Marketing
 location: Remote (Worldwide)
 compensation: Competitive pay with equity
+baseSalary:
+  currency: USD
+  minValue: 500
+  maxValue: 800
+  unitText: MONTH
 ---
 
 ## What You Will Do

--- a/content/careers/en/conn-creative-2026-05.md
+++ b/content/careers/en/conn-creative-2026-05.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 draft: false
 type: job
 description: Create content and media that amplify our brand across every channel, using the latest AI and generative tools to move at creative speed.
-employmentType: FULL_TIME
+employmentType: [FULL_TIME, CONTRACTOR]
 team: Marketing
 location: Remote (Worldwide)
 compensation: Competitive pay with equity
@@ -17,6 +17,8 @@ baseSalary:
   maxValue: 800
   unitText: MONTH
 ---
+
+**This is a contractor role.**
 
 ## What You Will Do
 

--- a/content/careers/en/intern-builder-2026-05.md
+++ b/content/careers/en/intern-builder-2026-05.md
@@ -1,5 +1,5 @@
 ---
-title: 'Intern: AI Empowered Builder'
+title: 'Software Engineer Intern (AI Empowered)'
 date: '2026-05-27'
 language: en
 tags: ['intern', 'engineering', 'ai']

--- a/content/careers/en/intern-connector-2026-05.md
+++ b/content/careers/en/intern-connector-2026-05.md
@@ -1,5 +1,5 @@
 ---
-title: 'Intern: AI Empowered Connector'
+title: 'Marketing Intern (AI Empowered)'
 date: '2026-05-27'
 language: en
 tags: ['intern', 'content', 'community', 'ai']


### PR DESCRIPTION
## What

Renames the 11 EN job listings from the internal "AI Empowered Builder / Connector" naming to **commonly recognized job titles with `(AI Empowered)` appended**, and adds structured **`baseSalary`** frontmatter for Google JobPosting rich results.

### Title mapping

| File | Old | New |
|---|---|---|
| build-gen | Builder: General Full Stack Engineer | **Full Stack Engineer (AI Empowered)** |
| build-dns | Builder: DNS and EPP | **DNS Engineer (AI Empowered)** |
| build-security | Builder: Cyber Security | **Security Engineer (AI Empowered)** |
| build-web3 | Builder: Smart Contract and Web3 | **Smart Contract Engineer (AI Empowered)** |
| build-nontraditional | Builder: Without Traditional Product Experience | **Product Engineer (AI Empowered)** |
| build-design | Builder: Non-Engineer (PM / Designer) | **Product Designer (AI Empowered)** |
| conn-bd | Connector: Business Development | **Business Development Specialist (AI Empowered)** |
| conn-community | Connector: Community Manager | **Community Manager (AI Empowered)** |
| conn-creative | Connector: Creative Creator | **Content Creator (AI Empowered)** |
| intern-builder | Intern: AI Empowered Builder | **Software Engineer Intern (AI Empowered)** |
| intern-connector | Intern: AI Empowered Connector | **Marketing Intern (AI Empowered)** |

### baseSalary (units are explicit)

Structured `baseSalary` (`currency: USD`, `unitText: MONTH`) added to the **9 paid roles**, banded by the `team` field:

- **Engineering** roles → **1500–6000 USD / MONTH**
- **Non-engineering** roles → **500–800 USD / MONTH**
- **Intern** roles remain unpaid → no `baseSalary`.

## Why

- More recognizable titles improve candidate clarity and job-board / search discoverability.
- `baseSalary` with an explicit monthly period is a Google JobPosting signal; salary-annotated postings surface better in Google Jobs.

## Companion PR

`baseSalary` only reaches Google's structured data once the renderer emits it. The accompanying **namefi-astra** PR:
- parses `baseSalary` in `content.ts`,
- emits `baseSalary` (MonetaryAmount) in `JobPostingJsonLd`,
- computes **`validThrough` dynamically** (`max(now, datePosted) + 30 days`) so postings never expire,
- bumps the `apps/resources/data` submodule to this branch.

## Validation

- `bun scripts/validate-data.ts` → passes (pre-existing TLD `keywords` warnings only).
- Changes are EN-only; no other-locale career files reference the old titles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown and frontmatter only; no application code in this repo, with low risk unless published salary bands or contractor wording are wrong.
> 
> **Overview**
> Updates **11 English career postings** so titles use familiar role names with **`(AI Empowered)`**, instead of internal “Builder / Connector” labels.
> 
> For the **nine paid roles**, frontmatter now lists **`employmentType: [FULL_TIME, CONTRACTOR]`**, adds **`baseSalary`** (USD, **`unitText: MONTH`**) — **1500–6000** for Engineering, **500–800** for non-engineering — and a body line **“This is a contractor role.”** Intern listings only get title renames; they stay **`INTERN`** with no **`baseSalary`**.
> 
> Structured salary data is meant for Google JobPosting once the companion site renderer reads **`baseSalary`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c5caf584e1b85fab11f4974ccf93216efc7392e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->