### PR TITLE
content(careers): applicant identity verification + multilingual priority

### DIFF
--- a/content/careers/en/how-we-hire.md
+++ b/content/careers/en/how-we-hire.md
@@ -89,4 +89,11 @@ We require professional fluency in English. A second language of any kind is a p
 4. **Team interviews** — Meet the people you would work with. We evaluate across all six dimensions of our hiring framework.
 5. **Offer** — If it is a mutual fit, we move fast.
 
+**Every application must include one identity check so we can verify you are who you say you are:**
+
+- **Current students** — email us **from your school email address** (for example `you@university.edu`). Sending from your institutional account is how we validate that you are currently enrolled, so a personal address on its own is not enough.
+- **Everyone else** (or if you do not have a school email) — include **at least one** of these: your **LinkedIn profile**, your **GitHub profile**, or your **personal website or project portfolio**.
+
+Applications with neither a school-email validation nor one of the three links above cannot be processed.
+
 Ready to apply? Reach us at **careers [at] namefi.io**.

--- a/content/careers/en/how-we-hire.md
+++ b/content/careers/en/how-we-hire.md
@@ -77,7 +77,11 @@ Namefi is a Delaware-incorporated company. All hiring is conducted in accordance
 
 ## Language
 
-We require professional fluency in English. A second language of any kind is a plus. A second language that none of our existing teammates speak is a *big* plus — it is a slight additional way for us to prioritize cultural and geographic diversity, though it is never a requirement.
+We require professional fluency in English. Beyond that, the languages you speak are a real advantage here. We work in the domain name industry, serving customers all over the world who care deeply about names, culture, and trademarks — the meaning a word carries in one language, the associations it picks up in another, the brands it might collide with. The languages on our team shape how well we can read those signals on our customers' behalf.
+
+We therefore give high priority to candidates who bring more than one language, and especially to those who **add coverage the team does not have yet** — a language none of us speaks. A second language of any kind is a plus; one that no current teammate speaks is a *big* plus, because it widens the range of markets and cultures we can serve well. It is never a hard requirement.
+
+If you speak other languages natively or with professional fluency, include them in your submission — and tell us which ones.
 
 ---
 

--- a/content/careers/en/how-we-hire.md
+++ b/content/careers/en/how-we-hire.md
@@ -95,7 +95,7 @@ If you speak other languages natively or with professional fluency, include them
 
 **Every application must include one identity check so we can verify you are who you say you are:**
 
-- **Current students** — email us **from your school email address** (for example `you@university.edu`). Sending from your institutional account is how we validate that you are currently enrolled, so a personal address on its own is not enough.
+- **Current students** — email us **from your school email address**: a `.edu` address, a country-specific school domain (such as `.edu.cn`, `.edu.au`, or `.ac.uk`), or any other email issued by your school. Sending from your school account is how we validate that you are currently enrolled, so a personal address on its own is not enough.
 - **Everyone else** (or if you do not have a school email) — include **at least one** of these: your **LinkedIn profile**, your **GitHub profile**, or your **personal website or project portfolio**.
 
 Applications with neither a school-email validation nor one of the three links above cannot be processed.


### PR DESCRIPTION
## Summary

Two related updates to the general hiring page (`content/careers/en/how-we-hire.md`),
so every role inherits them (one shared page, not per-posting):

1. **Applicant identity verification** — in the "Our Process" section, before the
   apply CTA.
2. **Multilingual priority** — an expanded "Language" section.

## 1. Applicant identity verification

Every application must include **one** identity check:

- **Current students** — email us **from their school email address** (e.g.
  `you@university.edu`); sending from the institutional account validates
  enrollment, so a personal address alone is not enough.
- **Everyone else** (or applicants without a school email) — include **at least
  one** of: a **LinkedIn profile**, a **GitHub profile**, or a **personal
  website / project portfolio**.

Applications with neither a school-email validation nor one of the three links
cannot be processed.

## 2. Multilingual priority

Reframes the "Language" section around the business rationale: as a company in
the domain name industry serving global customers who care about names, culture,
and trademarks, the languages the team speaks directly shape how well we serve
them. So we give high priority to candidates who bring multiple languages, and
especially those who **add coverage the team does not have yet** (a language none
of us speaks). Applicants are asked to list the languages they speak natively or
fluently in their submission. English professional fluency remains required; the
rest is a plus, never a hard requirement.

## Notes

- Placed on the shared `how-we-hire.md` (DRY) rather than per-posting.
- The `careers` collection is English-only, so there are no locale translations
  to update.
- The third identity signal is a **GitHub profile URL** (per request), not a
  GitHub issue.

## Test plan

- [x] `bun data:validate` — passes (warnings only)
- [x] `bun lint:mdx` on the file — clean
- [x] `link-audit` — 0 broken

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy on a careers page; no application code, auth, or data handling changes.
> 
> **Overview**
> Updates the shared **how-we-hire** careers page so every role inherits the same guidance.
> 
> The **Language** section is rewritten to explain why multilingual candidates matter for domain names, culture, and trademarks, and to stress priority for languages the team does not already cover. Applicants are asked to list fluent languages in their submission; English remains required.
> 
> Under **Our Process**, new **identity verification** rules require either applying from a school email (students) or at least one of LinkedIn, GitHub, or a personal site/portfolio. Applications missing both paths cannot be processed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9c42ab9da1445dabdc5fd8aac99a19adcef498c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->