### PR TITLE
content(careers): update salary bands + move contractor note to comp section

### DIFF
--- a/content/careers/en/build-design-2026-05.md
+++ b/content/careers/en/build-design-2026-05.md
@@ -13,12 +13,10 @@ location: Remote (Worldwide)
 compensation: Competitive pay with equity
 baseSalary:
   currency: USD
-  minValue: 500
-  maxValue: 800
+  minValue: 400
+  maxValue: 2400
   unitText: MONTH
 ---
-
-**This is a contractor role.**
 
 ## What You Will Do
 

--- a/content/careers/en/build-dns-2026-05.md
+++ b/content/careers/en/build-dns-2026-05.md
@@ -14,11 +14,9 @@ compensation: Competitive pay with equity
 baseSalary:
   currency: USD
   minValue: 1500
-  maxValue: 6000
+  maxValue: 9000
   unitText: MONTH
 ---
-
-**This is a contractor role.**
 
 ## What You Will Do
 

--- a/content/careers/en/build-gen-2026-05.md
+++ b/content/careers/en/build-gen-2026-05.md
@@ -14,11 +14,9 @@ compensation: Competitive pay with equity
 baseSalary:
   currency: USD
   minValue: 1500
-  maxValue: 6000
+  maxValue: 9000
   unitText: MONTH
 ---
-
-**This is a contractor role.**
 
 ## What You Will Do
 

--- a/content/careers/en/build-nontraditional-2026-05.md
+++ b/content/careers/en/build-nontraditional-2026-05.md
@@ -14,11 +14,9 @@ compensation: Competitive pay with equity
 baseSalary:
   currency: USD
   minValue: 1500
-  maxValue: 6000
+  maxValue: 9000
   unitText: MONTH
 ---
-
-**This is a contractor role.**
 
 ## What You Will Do
 

--- a/content/careers/en/build-security-2026-05.md
+++ b/content/careers/en/build-security-2026-05.md
@@ -14,11 +14,9 @@ compensation: Competitive pay with equity
 baseSalary:
   currency: USD
   minValue: 1500
-  maxValue: 6000
+  maxValue: 9000
   unitText: MONTH
 ---
-
-**This is a contractor role.**
 
 ## What You Will Do
 

--- a/content/careers/en/build-web3-2026-05.md
+++ b/content/careers/en/build-web3-2026-05.md
@@ -14,11 +14,9 @@ compensation: Competitive pay with equity
 baseSalary:
   currency: USD
   minValue: 1500
-  maxValue: 6000
+  maxValue: 9000
   unitText: MONTH
 ---
-
-**This is a contractor role.**
 
 ## What You Will Do
 

--- a/content/careers/en/conn-bd-2026-05.md
+++ b/content/careers/en/conn-bd-2026-05.md
@@ -13,12 +13,10 @@ location: Remote (Worldwide)
 compensation: Competitive pay with equity
 baseSalary:
   currency: USD
-  minValue: 500
-  maxValue: 800
+  minValue: 400
+  maxValue: 2400
   unitText: MONTH
 ---
-
-**This is a contractor role.**
 
 ## What You Will Do
 

--- a/content/careers/en/conn-community-2026-05.md
+++ b/content/careers/en/conn-community-2026-05.md
@@ -13,12 +13,10 @@ location: Remote (Worldwide)
 compensation: Competitive pay with equity
 baseSalary:
   currency: USD
-  minValue: 500
-  maxValue: 800
+  minValue: 400
+  maxValue: 2400
   unitText: MONTH
 ---
-
-**This is a contractor role.**
 
 ## What You Will Do
 

--- a/content/careers/en/conn-creative-2026-05.md
+++ b/content/careers/en/conn-creative-2026-05.md
@@ -13,12 +13,10 @@ location: Remote (Worldwide)
 compensation: Competitive pay with equity
 baseSalary:
   currency: USD
-  minValue: 500
-  maxValue: 800
+  minValue: 400
+  maxValue: 2400
   unitText: MONTH
 ---
-
-**This is a contractor role.**
 
 ## What You Will Do
 


### PR DESCRIPTION
## What

- **Engineering** roles: `baseSalary` max **6000 → 9000** USD/MONTH (now **1500–9000**).
- **Non-engineering** roles: `baseSalary` **500–800 → 400–2400** USD/MONTH.
- Remove the inline **"This is a contractor role."** note from each body — it now renders in the **Compensation** section (driven by the `CONTRACTOR` employment type) in the companion **namefi-astra** PR, alongside the salary at the end of the page.

## Companion

namefi-astra PR adds the visible salary display (shown as `USD 1,500 – 9,000 / month`), the "On this page" outline, and the end-of-page Compensation section, and bumps `apps/resources/data` to this commit.

## Validation

`bun scripts/validate-data.ts` → passes (pre-existing TLD `keywords` warnings only).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only career frontmatter and copy changes with no application logic or security impact.
> 
> **Overview**
> Updates **monthly USD `baseSalary` ranges** in nine English career posts and removes the repeated **"This is a contractor role."** line from each job body.
> 
> **Engineering** listings (`build-dns`, `build-gen`, `build-nontraditional`, `build-security`, `build-web3`) raise the monthly max from **6,000 → 9,000** (min stays **1,500**). **Non-engineering** roles (`build-design`, `conn-bd`, `conn-community`, `conn-creative`) widen the band from **500–800 → 400–2,400**.
> 
> Contractor messaging is expected to come from the site **Compensation** section via `CONTRACTOR` in `employmentType` (companion **namefi-astra** PR), not from inline copy in these markdown files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 906c2b91a8f516ce41b2d154a00860762dba75e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Content Updates**
  - Updated monthly compensation ranges across several May 2026 career postings.
  - Increased maximum compensation for multiple Build roles to $9,000 per month.
  - Updated several connection-focused roles to a $400–$2,400 monthly range.
  - Removed the contractor-role notice from one posting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->