### PR TITLE
docs(og): OG image system design spec + interactive layout sketch

### DIFF
--- a/docs/og-image-spec.md
+++ b/docs/og-image-spec.md
@@ -1,0 +1,61 @@
+# OG image system — design spec (v10)
+
+Interactive sketch: [`docs/og-layout-sketch.html`](./og-layout-sketch.html) — open it in a browser; it renders all
+four renditions at true resolution with toggles for fallback/custom art, 10 locales, output scale, zone overlays,
+and a simulated X title overlay. Layout guideline was measured from the live production OG
+(`email-sender-reputation-arms-race-og`), which is the visual reference.
+
+## Two types, one layout
+
+- **Custom**: the article has its own focus illustration (Layer 1 = art master).
+- **Fallback**: no per-article art (Layer 1 = brand motif background; the 1:1 becomes a plain brand tile).
+
+Same slot geometry either way. Three layers: canvas (art or motif) → localized text → brand wordmark.
+
+## Renditions (output at 2×)
+
+| Rendition | Size @2× | Layout | Consumed by | Declared via |
+|---|---|---|---|---|
+| 1.91:1 | 2400×1260 | title + subtitle, panoramic focus strip | X, Slack, Discord, LinkedIn, iMessage | `og:image` (first) · `twitter:image` |
+| 16:9 | 2400×1350 | same slots, taller focus crop | Google Discover, Article rich results; doubles as hero | Article JSON-LD `image[]` |
+| 4:3 | 2400×1800 | same slots, focus shows nearly the full master | Google Article rich results | Article JSON-LD `image[]` |
+| 1:1 | 2400×2400 | badge: focus crop above · rule · wordmark band ≈ ⅓ height, **no title** | Google SERP thumb, WhatsApp, Telegram | JSON-LD `image[]` · `og:image` (second) |
+
+Google requirements: all three of 16:9/4:3/1:1 in Article JSON-LD at ≥1200px wide; pages send
+`robots: max-image-preview:large`; images crawlable. JPG quality ~75; keep 1:1 under ~300 KB (WhatsApp
+drops oversized previews), others under ~500 KB. 3× adds nothing after platform recompression.
+
+## Title-rendition geometry (1200-based coordinate system; multiply by 2 for output)
+
+- Bleed: 60px all sides — croppable, scene/background only.
+- X-reserve: bottom 130px — **art OK, our text never** (X stamps its own title chip bottom-left).
+- Content margin `m`: 84 (16:9 family) / 96 (4:3).
+- Title: ≤2 lines, base 46px bold (shrink-to-fit floor 32), top at y=70, width ≤840.
+- Subtitle: one quiet line, 27px at 66% ink, baseline = title last baseline + 46. Truncate with ellipsis.
+- Wordmark: real `static/brand-kit/namefi-logotype.svg` at 40px tall, top-right, 64px inset (inside bleed).
+  No kicker, no accent rule.
+- Focus: full content width (`m` to `W−m`), from subtitle baseline + 34 down to `H−90` (90px clear
+  bottom strip). Height therefore flexes with title length — short titles buy a taller scene.
+- 1:1 badge: focus crop 900×675 at top, hairline rule (y≈765), wordmark 921×300 centered below
+  (band = bottom ~⅓). Fallback 1:1: single 840-wide wordmark centered, nothing else.
+
+## Standard focus asset (the per-article deliverable)
+
+One **16:9 master** per article, ≥1920×1080 (2× of the largest crop), composed as a **wide left-to-right
+scene**: subject cluster strung horizontally through the central band, calm top/bottom margins, no text,
+no logos. Each rendition crops its own height from it. This makes LLM/image-model generation a fixed,
+repeatable prompt template where only the subject description changes, and corner/edge QC automatable.
+
+## i18n
+
+Text is never baked into the art. Per-locale strings (title, subtitle) render in the template with
+per-script font stacks (Latin / SC / JP / KR / Devanagari / Tamil / Naskh), CJK per-character wrapping,
+and Arabic RTL right-aligned within the same slots. The 1:1 carries no text at all → one file serves all
+locales. Per article: 3 renditions × N locales + 1 icon.
+
+## Implementation direction (next step)
+
+React `<OgCard>` component in namefi-astra's resources app + Storybook stories (one per rendition,
+controls for locale/type/title), rendered to static JPGs via headless Chrome CDP at
+`deviceScaleFactor: 2` (wait for `document.fonts.ready`). Storybook's `iframe.html?id=…` bare render is
+the production render surface. Satori was considered and rejected: weak Arabic shaping.

--- a/docs/og-layout-sketch.html
+++ b/docs/og-layout-sketch.html
@@ -1,0 +1,490 @@
+<meta charset="utf-8">
+<title>Namefi OG layout sketch</title>
+<style>
+  :root{
+    --bg:#23262b; --panel:#2b2f35; --line:#3a3f47; --ink:#e8e9ea; --muted:#9aa1a9;
+    --accent:#d97757; --chip:#343a41;
+    --zone-bleed:rgba(217,90,70,.85); --zone-x:rgba(90,140,200,.9);
+  }
+  @media (prefers-color-scheme: light){
+    :root{ --bg:#eef0f2; --panel:#f8f9fa; --line:#d8dce0; --ink:#1d2126; --muted:#5d656e; --chip:#e6e9ec; }
+  }
+  :root[data-theme="dark"]{ --bg:#23262b; --panel:#2b2f35; --line:#3a3f47; --ink:#e8e9ea; --muted:#9aa1a9; --chip:#343a41; }
+  :root[data-theme="light"]{ --bg:#eef0f2; --panel:#f8f9fa; --line:#d8dce0; --ink:#1d2126; --muted:#5d656e; --chip:#e6e9ec; }
+
+  body{ background:var(--bg); color:var(--ink);
+    font:15px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+    padding:28px clamp(16px,4vw,48px) 64px; }
+  h1{ font-size:22px; font-weight:650; letter-spacing:-.01em; margin-bottom:4px; }
+  .sub{ color:var(--muted); max-width:68ch; margin-bottom:22px; }
+  .sub b{ color:var(--ink); font-weight:600; }
+
+  .controls{ display:flex; flex-wrap:wrap; gap:10px 22px; align-items:center;
+    background:var(--panel); border:1px solid var(--line); border-radius:10px;
+    padding:12px 16px; margin-bottom:24px; position:sticky; top:12px; z-index:5; }
+  .ctl{ display:flex; align-items:center; gap:8px; }
+  .ctl label{ font-size:12px; text-transform:uppercase; letter-spacing:.08em; color:var(--muted); }
+  .seg{ display:flex; border:1px solid var(--line); border-radius:8px; overflow:hidden; }
+  .seg button{ background:transparent; color:var(--muted); border:0; padding:6px 14px;
+    font:600 13px/1 inherit; cursor:pointer; }
+  .seg button.on{ background:var(--accent); color:#fff; }
+  select{ background:var(--chip); color:var(--ink); border:1px solid var(--line);
+    border-radius:8px; padding:6px 10px; font:600 13px/1 inherit; }
+  .switch{ display:flex; align-items:center; gap:7px; cursor:pointer; font-size:13px; font-weight:600; }
+  .switch input{ accent-color:var(--accent); width:15px; height:15px; }
+
+  .boards{ display:flex; flex-wrap:wrap; gap:32px; align-items:flex-start; }
+  .board{ flex:1 1 560px; max-width:780px; }
+  .board.square{ flex:0 1 470px; }
+  canvas{ width:100%; height:auto; display:block; border-radius:6px;
+    box-shadow:0 8px 28px rgba(0,0,0,.28); background:#faf9f5; }
+  .cap{ display:flex; justify-content:space-between; gap:12px; color:var(--muted);
+    font-size:12.5px; margin-top:9px; }
+  .cap b{ color:var(--ink); font-weight:650; }
+  .thumbrow{ display:flex; align-items:center; gap:12px; margin-top:12px; color:var(--muted);
+    font-size:12px; max-width:56ch; }
+  .thumbrow canvas{ width:auto; border-radius:8px; box-shadow:0 3px 10px rgba(0,0,0,.25); flex:none; }
+
+  .legend{ display:flex; flex-wrap:wrap; gap:8px 18px; margin:26px 0 10px; font-size:13px; color:var(--muted); }
+  .legend span{ display:inline-flex; align-items:center; gap:7px; }
+  .sw{ width:14px; height:14px; border-radius:3px; display:inline-block; }
+
+  table{ border-collapse:collapse; margin-top:14px; font-size:13.5px; min-width:640px; }
+  .tablewrap{ overflow-x:auto; }
+  th,td{ text-align:left; padding:7px 18px 7px 0; border-bottom:1px solid var(--line);
+    font-variant-numeric:tabular-nums; }
+  th{ font-size:11.5px; text-transform:uppercase; letter-spacing:.08em; color:var(--muted); font-weight:600; }
+  td:first-child{ font-weight:650; }
+  .note{ color:var(--muted); font-size:13px; max-width:70ch; margin-top:14px; }
+</style>
+
+<h1>Namefi OG layout — unified sketch (v2)</h1>
+<p class="sub">One layout, four renditions. <b>Fallback</b> swaps in the brand-motif canvas; <b>custom</b> swaps in the article illustration — every slot stays put.
+1.91:1 serves og:image / X; <b>16:9, 4:3 and 1:1 serve Google</b> (Article JSON-LD wants all three, ≥1200px wide, plus <code>max-image-preview:large</code>).
+Layout follows the live production OG: 1–2 line title (~56px), one quiet subtitle line, then <b>one wide focus scene spanning the content width</b>, with ~90px of clear background at the bottom. The focus box starts at the subtitle's actual baseline, so short titles get a taller scene.
+The 1:1 carries no title (every surface shows it tiny, next to the page title as text): focus crop above, hairline rule, and a wordmark band taking the bottom ~1/3.
+Toggle <b>zones</b> to see bleed / X-reserve / slots; toggle <b>X overlay</b> to simulate the title X stamps onto the image bottom-left.</p>
+
+<div class="controls">
+  <div class="ctl"><label>Canvas</label>
+    <div class="seg" id="typeSeg">
+      <button data-v="custom" class="on">Custom art</button>
+      <button data-v="fallback">Fallback</button>
+    </div>
+  </div>
+  <div class="ctl"><label>Locale</label>
+    <select id="locale"></select>
+  </div>
+  <div class="ctl"><label>Scale</label>
+    <div class="seg" id="scaleSeg">
+      <button data-v="1">1×</button>
+      <button data-v="2" class="on">2×</button>
+      <button data-v="3">3×</button>
+    </div>
+  </div>
+  <label class="switch"><input type="checkbox" id="longTitle"> Long-title stress test</label>
+  <label class="switch"><input type="checkbox" id="zones" checked> Zones</label>
+  <label class="switch"><input type="checkbox" id="xoverlay" checked> X title overlay</label>
+</div>
+
+<div class="boards">
+  <div class="board">
+    <canvas id="rect" width="1200" height="630"></canvas>
+    <div class="cap"><span><b class="dim" data-key="rect">1200 × 630</b> (1.91:1)</span><span>og:image · X summary_large_image</span></div>
+  </div>
+  <div class="board">
+    <canvas id="g169" width="1200" height="675"></canvas>
+    <div class="cap"><span><b class="dim" data-key="g169">1200 × 675</b> (16:9)</span><span>Article JSON-LD · Discover · doubles as hero</span></div>
+  </div>
+  <div class="board">
+    <canvas id="g43" width="1200" height="900"></canvas>
+    <div class="cap"><span><b class="dim" data-key="g43">1200 × 900</b> (4:3)</span><span>Article JSON-LD (Google wants 16:9 · 4:3 · 1:1)</span></div>
+  </div>
+  <div class="board square">
+    <canvas id="sq" width="1200" height="1200"></canvas>
+    <div class="cap"><span><b class="dim" data-key="sq">1200 × 1200</b> (1:1 · badge rendition)</span><span>JSON-LD · WhatsApp/Telegram · SERP thumb source</span></div>
+    <div class="thumbrow">
+      <canvas id="thumb116" width="116" height="116"></canvas>
+      <canvas id="thumb72" width="72" height="72"></canvas>
+      <span>Google mobile SERP thumbnail scale (116px / 72px) — badge anatomy: subject above, rule, namefi lockup below. Even when the wordmark is too small to read, "mark + line + label" still registers as a branded tile.</span>
+    </div>
+  </div>
+</div>
+
+<div class="legend">
+  <span><span class="sw" style="background:rgba(217,90,70,.55)"></span>Bleed ring — croppable, scene only (60px)</span>
+  <span><span class="sw" style="background:rgba(90,140,200,.5)"></span>X-reserve — art OK, our text never; X stamps its title here (bottom 130px)</span>
+  <span><span class="sw" style="border:2px dashed #888"></span>Slots: title + subtitle · wordmark · wide focus</span>
+</div>
+
+<div class="tablewrap">
+<table>
+  <tr><th>Rendition</th><th>Size</th><th>Layout family</th><th>Consumed by</th><th>Declared via</th></tr>
+  <tr><td>1.91:1</td><td>1200 × 630</td><td>title + subtitle, panoramic focus strip</td><td>X, Slack, Discord, LinkedIn, iMessage</td><td>og:image (first) · twitter:image</td></tr>
+  <tr><td>16:9</td><td>1200 × 675</td><td>same slots, taller focus crop</td><td>Google Discover · Article rich results · reuse as page hero</td><td>Article JSON-LD image[]</td></tr>
+  <tr><td>4:3</td><td>1200 × 900</td><td>same slots, focus shows nearly the full master</td><td>Google Article rich results</td><td>Article JSON-LD image[]</td></tr>
+  <tr><td>1:1</td><td>1200 × 1200</td><td>badge — focus center-crop above · rule · wordmark band ≈ 1/3 H</td><td>Google (incl. tiny SERP thumb) · WhatsApp/Telegram</td><td>JSON-LD image[] · og:image (second)</td></tr>
+</table>
+</div>
+<p class="note"><b>Standard focus asset:</b> one 16:9 master per article (≥1920×1080 for 2× output) with the subject cluster laid out as a
+wide scene in the central horizontal band and calm top/bottom margins — each rendition then crops it to its own height
+(1.91:1 shows a panoramic strip, 4:3 shows nearly all of it, the 1:1 badge takes a center crop). One asset, four renditions,
+and LLM art generation stays a fixed prompt template where only the subject changes. Wordmark is the real brand asset — <code>static/brand-kit/namefi-logotype.svg</code>, brand green <code>#1cd17d</code>,
+inlined as a data URI (the fallback 1:1 uses it as the focus subject itself, so no duplicate lockup there).
+Output at <b>2×</b> (2400px wide) — high-DPI phones are 2–3× DPR and every platform downscales from the file; 3× adds
+pixels nobody sees after platform recompression. Budgets: JPG quality ~75; keep the 1:1 under ~300&nbsp;KB (WhatsApp drops
+oversized previews), others under ~500&nbsp;KB. In the real pipeline this is just headless Chrome <code>deviceScaleFactor:&nbsp;2</code>
+over the 1200-CSS-px template; only the raster focus art needs a ≥1600px source. Google requirements baked in: Article JSON-LD lists all three of 16:9 / 4:3 / 1:1 at ≥1200px wide, pages send
+<code>robots: max-image-preview:large</code> (else Discover won't show a large card), and every rendition must be crawlable (no
+blocking in robots.txt). The X-reserve rule is now scoped to text only: artwork may run into the bottom band (X's chip floating
+over art is normal), but no title/wordmark of ours goes there. Locale switch proves the i18n mechanics: one text-free canvas, per-script
+font stacks, CJK per-character wrapping, Arabic right-aligned RTL inside the same title slot.</p>
+
+<script>
+const LOCALES = {
+  'en':   { title:'The Cat-and-Mouse War of Email Sender Reputation',
+            long:'The Email Sender Reputation Arms Race: How Deliverability Became a Domain Name Problem',
+            sub:'Thirty years of spam tricks, and how inbox providers caught each one.',
+            stack:'"Avenir Next","Segoe UI",Verdana,sans-serif' },
+  'es':   { title:'La carrera armamentista de la reputación del remitente',
+            long:'La carrera armamentista de la reputación del remitente de correo electrónico y los dominios',
+            sub:'Treinta años de trucos de spam, y cómo los proveedores detectaron cada uno.',
+            stack:'"Avenir Next","Segoe UI",Verdana,sans-serif' },
+  'de':   { title:'Das Wettrüsten um die E-Mail-Absender-Reputation',
+            long:'Das Wettrüsten um die E-Mail-Absender-Reputation und warum Domains darüber entscheiden',
+            sub:'Dreißig Jahre Spam-Tricks — und wie Postfach-Anbieter jeden davon stoppten.',
+            stack:'"Avenir Next","Segoe UI",Verdana,sans-serif' },
+  'fr':   { title:"La course aux armements de la réputation d'expéditeur",
+            long:"La course aux armements de la réputation d'expéditeur d'e-mails et le rôle des noms de domaine",
+            sub:'Trente ans de ruses de spam, et comment les messageries les ont déjouées.',
+            stack:'"Avenir Next","Segoe UI",Verdana,sans-serif' },
+  'zh-CN':{ title:'邮件发送者信誉的猫鼠之战',
+            long:'邮件发送者信誉的军备竞赛：送达率如何变成一个域名问题',
+            sub:'三十年的垃圾邮件伎俩，以及收件箱如何一一识破。',
+            stack:'"PingFang SC","Noto Sans SC",sans-serif', cjk:true },
+  'ja':   { title:'メール送信者レピュテーションの軍拡競争',
+            long:'メール送信者レピュテーションの軍拡競争 — 到達率はいかにしてドメインの問題になったか',
+            sub:'30年にわたるスパムの手口と、受信箱がそれを見破ってきた歴史。',
+            stack:'"Hiragino Sans","Noto Sans JP",sans-serif', cjk:true },
+  'ko':   { title:'이메일 발신자 평판 군비 경쟁',
+            long:'이메일 발신자 평판 군비 경쟁: 전달률은 어떻게 도메인 문제가 되었나',
+            sub:'30년간의 스팸 수법과 이를 잡아낸 메일 서비스의 역사.',
+            stack:'"Apple SD Gothic Neo","Noto Sans KR",sans-serif' },
+  'hi':   { title:'ईमेल प्रेषक प्रतिष्ठा की हथियारों की दौड़',
+            long:'ईमेल प्रेषक प्रतिष्ठा की हथियारों की दौड़: डिलीवरेबिलिटी कैसे एक डोमेन समस्या बन गई',
+            sub:'स्पैम की तीस साल की चालें, और इनबॉक्स ने उन्हें कैसे पकड़ा।',
+            stack:'"Kohinoor Devanagari","Noto Sans Devanagari",sans-serif' },
+  'ta':   { title:'மின்னஞ்சல் அனுப்புநர் நற்பெயர் ஆயுதப் போட்டி',
+            long:'மின்னஞ்சல் அனுப்புநர் நற்பெயர் ஆயுதப் போட்டி: டெலிவரி எப்படி டொமைன் பிரச்சனையானது',
+            sub:'ஸ்பேம் தந்திரங்களின் முப்பது ஆண்டுகள், அவற்றை இன்பாக்ஸ் எப்படி பிடித்தது.',
+            stack:'"InaiMathi","Noto Sans Tamil",sans-serif' },
+  'ar':   { title:'سباق التسلح في سمعة مرسلي البريد الإلكتروني',
+            long:'سباق التسلح في سمعة مرسلي البريد الإلكتروني: كيف أصبح وصول الرسائل مشكلة نطاقات',
+            sub:'ثلاثون عامًا من حيل البريد المزعج، وكيف كشفها مزودو البريد واحدة تلو الأخرى.',
+            stack:'"Geeza Pro","Noto Naskh Arabic",sans-serif', rtl:true },
+};
+
+const ART = { bg:'#faf9f5', ink:'#141413', grayA:'#e8e6dc', grayB:'#b0aea5',
+              orange:'#d97757', blue:'#6a9bcc', green:'#788c5d', brand:'#1cd17d' };
+
+// Real brand asset: static/brand-kit/namefi-logotype.svg (132×43, #1cd17d), inlined for CSP
+const WORDMARK_SVG = `<svg width="132" height="43" viewBox="0 0 132 43" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.64 41.668V0.987998H28.72V41.668H0.64ZM24.868 14.704H27.388V10.6H16.984V14.704H20.368V24.496H20.224L8.416 10.6H2.044V14.704H4.96V29.896H2.44V34H12.7V29.896H9.46V19.168H9.604L22.168 34.036L24.868 34V14.704ZM31.5916 41.668V0.987998H50.5636V41.668H31.5916ZM34.3996 18.916L33.6796 23.128L37.3876 23.524L37.9996 21.22C38.3836 21.028 38.7676 20.908 39.1516 20.86C39.5596 20.788 40.0036 20.752 40.4836 20.752C41.8036 20.752 42.5716 21.148 42.7876 21.94C43.0276 22.732 43.1476 23.548 43.1476 24.388V24.928C42.4036 24.832 41.5156 24.784 40.4836 24.784C38.6356 24.784 36.9076 25.108 35.2996 25.756C33.7156 26.404 32.9236 27.724 32.9236 29.716C32.9236 31.42 33.4636 32.62 34.5436 33.316C35.6236 34.012 36.7516 34.36 37.9276 34.36C39.2476 34.36 40.3276 34.024 41.1676 33.352C42.0316 32.68 42.6916 31.936 43.1476 31.12V31.156C43.3876 33.292 44.5756 34.36 46.7116 34.36C47.7196 34.36 48.6916 34.108 49.6276 33.604L49.5916 31.156C49.3516 31.228 49.1236 31.264 48.9076 31.264C48.1636 31.264 47.7916 30.844 47.7916 30.004V22.948C47.7916 21.1 47.1556 19.72 45.8836 18.808C44.6116 17.896 43.0996 17.44 41.3476 17.44C40.0276 17.44 38.8876 17.548 37.9276 17.764C36.9916 17.956 35.8156 18.34 34.3996 18.916ZM43.1476 27.376C43.0276 28.648 42.6076 29.584 41.8876 30.184C41.1916 30.76 40.4356 31.048 39.6196 31.048C38.9236 31.048 38.4316 30.868 38.1436 30.508C37.8556 30.148 37.7116 29.704 37.7116 29.176C37.7116 28.288 38.0236 27.7 38.6476 27.412C39.2716 27.1 39.9916 26.944 40.8076 26.944C41.1916 26.944 41.5756 26.968 41.9596 27.016C42.3676 27.064 42.7636 27.112 43.1476 27.16V27.376ZM53.4025 41.668V0.987998H85.6945V41.668H53.4025ZM78.0625 34H84.8665V30.508H82.7065V23.056C82.7065 21.136 82.1425 19.72 81.0145 18.808C79.8865 17.896 78.5905 17.44 77.1265 17.44C74.5585 17.44 72.7945 18.604 71.8345 20.932C71.4505 19.756 70.7665 18.88 69.7825 18.304C68.7985 17.728 67.7185 17.44 66.5425 17.44C64.2865 17.44 62.6425 18.364 61.6105 20.212V17.764H54.8425V21.292H56.9665V30.508H54.8065V34H64.7065V30.508H61.6105V24.82C61.6105 23.692 61.8505 22.768 62.3305 22.048C62.8105 21.328 63.6145 20.968 64.7425 20.968C65.6545 20.968 66.3385 21.268 66.7945 21.868C67.2745 22.468 67.5145 23.464 67.5145 24.856V34H74.3185V30.508H72.1585V24.82C72.1585 23.692 72.3985 22.768 72.8785 22.048C73.3825 21.328 74.1865 20.968 75.2905 20.968C76.2025 20.968 76.8865 21.268 77.3425 21.868C77.8225 22.468 78.0625 23.464 78.0625 24.856V34ZM88.5377 41.668V0.987998H106.61V41.668H88.5377ZM105.566 28.888L101.678 28.168C101.582 28.648 101.306 29.188 100.85 29.788C100.418 30.388 99.5777 30.688 98.3297 30.688C96.0497 30.688 94.7777 29.404 94.5137 26.836H105.17C105.338 26.068 105.422 25.288 105.422 24.496C105.398 22.384 104.678 20.68 103.262 19.384C101.87 18.088 100.046 17.44 97.7897 17.44C95.2217 17.44 93.2177 18.28 91.7777 19.96C90.3617 21.616 89.6537 23.692 89.6537 26.188C89.6537 28.9 90.4337 30.94 91.9937 32.308C93.5777 33.676 95.5817 34.36 98.0057 34.36C100.334 34.36 102.146 33.808 103.442 32.704C104.738 31.6 105.446 30.328 105.566 28.888ZM100.634 24.136H94.5497C94.6937 23.128 95.0297 22.312 95.5577 21.688C96.0857 21.064 96.8297 20.752 97.7897 20.752C98.8937 20.752 99.6617 21.112 100.094 21.832C100.55 22.552 100.73 23.32 100.634 24.136ZM109.435 41.668V0.987998H131.683V41.668H109.435ZM123.835 21.292V30.472H121.675V34H130.639V30.472H128.479V17.764H117.607V15.208C117.607 14.512 117.799 13.864 118.183 13.264C118.591 12.664 119.503 12.364 120.919 12.364C121.615 12.364 122.203 12.436 122.683 12.58C123.187 12.7 123.523 12.784 123.691 12.832L124.375 15.136L127.975 14.74L127.255 10.348C126.199 9.796 125.107 9.412 123.979 9.196C122.851 8.98 121.831 8.872 120.919 8.872C118.303 8.872 116.323 9.52 114.979 10.816C113.635 12.112 112.963 13.6 112.963 15.28V17.764H110.983V21.292H112.963V30.472H110.803V34H120.307V30.472H117.607V21.292H123.835Z" fill="#1cd17d"></path></svg>`;
+const WORDMARK_AR = 132/43;   // aspect ratio of the logotype viewBox
+const BRAND = { wordmark: new Image() };
+BRAND.wordmark.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(WORDMARK_SVG);
+
+// Layout guideline measured from the live production OG (email-sender-reputation-arms-race):
+// title ~56px ≤2 lines at m=84, one quiet ~27px subtitle line under it, wordmark ~40px tall
+// top-right, then ONE WIDE focus scene spanning the content width, with ~90px clear at the
+// very bottom. Focus MASTER is 16:9 with the subject cluster in a central horizontal band,
+// so each rendition just crops more or less of its height.
+const GEOM = {
+  rect: { W:1200, H:630, bleed:60, xres:130, m:84,
+          titleY:70, titleW:840, titleH:140, maxLines:2, base:46, min:32 },
+  g169: { W:1200, H:675, bleed:60, xres:130, m:84,
+          titleY:70, titleW:840, titleH:140, maxLines:2, base:46, min:32 },
+  g43:  { W:1200, H:900, bleed:60, xres:130, m:96,
+          titleY:70, titleW:820, titleH:140, maxLines:2, base:46, min:32 },
+  sq:   { W:1200, H:1200, bleed:60, xres:130, m:96, icon:true,
+          focus:{x:150,y:60,w:900,h:675} },
+};
+
+function computeLayout(ctx,g,loc,title){
+  if(g.icon) return {focus:g.focus};
+  const fit=fitTitle(ctx,title,g,loc);
+  const lastBase=g.titleY+fit.size+(fit.lines.length-1)*fit.lh;
+  const subBase=lastBase+46;            // subtitle baseline
+  const fy=subBase+34;
+  const bottom=g.H-90;                  // live-OG keeps ~90px of clear background at the bottom
+  return {fit, subBase, focus:{x:g.m,y:fy,w:g.W-2*g.m,h:bottom-fy}};
+}
+
+const state = { type:'custom', locale:'en', long:false, zones:true, xoverlay:true, scale:2 };
+
+function mulberry32(a){ return function(){ a|=0; a=a+0x6D2B79F5|0;
+  let t=Math.imul(a^a>>>15,1|a); t=t+Math.imul(t^t>>>7,61|t)^t;
+  return ((t^t>>>14)>>>0)/4294967296; }; }
+
+function tokenize(text,cjk){ return cjk ? Array.from(text.replace(/\s+/g,'')) : text.split(/\s+/); }
+
+function wrapLines(ctx,text,maxW,cjk){
+  const toks=tokenize(text,cjk), sep=cjk?'':' ', lines=[]; let cur='';
+  for(const t of toks){
+    const cand = cur? cur+sep+t : t;
+    if(ctx.measureText(cand).width<=maxW || !cur) cur=cand;
+    else { lines.push(cur); cur=t; }
+  }
+  if(cur) lines.push(cur);
+  return lines;
+}
+
+function fitTitle(ctx,text,g,loc){
+  for(let size=g.base; size>=g.min; size-=2){
+    ctx.font=`700 ${size}px ${loc.stack}`;
+    const lines=wrapLines(ctx,text,g.titleW,loc.cjk);
+    const lh=Math.round(size*1.22);
+    if(lines.length<=g.maxLines && lines.every(l=>ctx.measureText(l).width<=g.titleW)
+       && lines.length*lh<=g.titleH) return {size,lines,lh};
+  }
+  ctx.font=`700 ${g.min}px ${loc.stack}`;
+  return {size:g.min, lines:wrapLines(ctx,text,g.titleW,loc.cjk).slice(0,g.maxLines), lh:Math.round(g.min*1.22)};
+}
+
+function drawMotif(ctx,g,lay){
+  const rnd=mulberry32(7), {W,H}=g, cell=96;
+  const f=lay.focus;
+  const title = g.icon? null : {x:g.m-20,y:g.titleY-20,w:g.titleW+40,h:f.y-g.titleY+10};
+  const wm = g.icon? {x:120,y:H/2-210,w:960,h:420} : null;   // fallback tile: centered wordmark zone
+  const inBox=(x,y,b)=> !!b && x>b.x&&x<b.x+b.w&&y>b.y&&y<b.y+b.h;
+  ctx.lineWidth=2.5;
+  for(let gx=cell/2; gx<W; gx+=cell){
+    for(let gy=cell/2; gy<H; gy+=cell){
+      const x=gx+(rnd()-.5)*34, y=gy+(rnd()-.5)*34, r=6+rnd()*9, k=rnd();
+      if(g.icon){
+        if(inBox(x,y,wm)) continue;                        // keep the brand tile's wordmark clear
+      } else {
+        if(inBox(x,y,title)) continue;                     // keep title slot quiet
+        if(y>H-g.xres+16 && !inBox(x,y,f)) continue;       // quiet X-reserve outside the focus
+      }
+      const focus=inBox(x,y,f);
+      ctx.strokeStyle = focus ? [ART.orange,ART.blue,ART.green][Math.floor(rnd()*3)] : ART.grayA;
+      ctx.fillStyle = ctx.strokeStyle;
+      ctx.beginPath();
+      if(k<.4){ ctx.arc(x,y,r,0,7); focus&&rnd()<.5 ? ctx.fill() : ctx.stroke(); }
+      else if(k<.7){ ctx.moveTo(x-r,y+r); ctx.lineTo(x,y-r); ctx.lineTo(x+r,y+r); ctx.closePath(); ctx.stroke(); }
+      else { ctx.moveTo(x-r,y); ctx.lineTo(x+r,y); ctx.moveTo(x,y-r); ctx.lineTo(x,y+r); ctx.stroke(); }
+    }
+  }
+}
+
+function drawBrandGlyph(ctx,g){
+  // fallback icon: one big wordmark centered on the tile — no lockup below
+  const cx=g.W/2, cy=g.H/2, w=840, h=w/WORDMARK_AR;
+  ctx.drawImage(BRAND.wordmark, cx-w/2, cy-h/2, w, h);
+}
+
+function drawIconLockup(ctx,g){
+  // badge anatomy: 4:3 subject above · hairline rule · wordmark band = bottom ~1/3
+  const cx=g.W/2;
+  ctx.strokeStyle='rgba(176,174,165,.55)'; ctx.lineWidth=3;
+  ctx.beginPath(); ctx.moveTo(cx-330,765); ctx.lineTo(cx+330,765); ctx.stroke();
+  const h=300, w=h*WORDMARK_AR;   // 300×921 — as large as the wordmark's 3.07:1 aspect allows
+  ctx.drawImage(BRAND.wordmark, cx-w/2, 810, w, h);
+}
+
+function drawArt(ctx,g,f){
+  const {W,H}=g;
+  // full-bleed calm wash + shapes running off the edges (bleed proof)
+  const grad=ctx.createLinearGradient(0,0,W,H);
+  grad.addColorStop(0,'#faf9f5'); grad.addColorStop(1,'#f3f0e6');
+  ctx.fillStyle=grad; ctx.fillRect(0,0,W,H);
+  ctx.strokeStyle='rgba(176,174,165,.35)'; ctx.lineWidth=3;
+  ctx.beginPath(); ctx.arc(W+40, f.y+f.h*0.3, f.w*0.85, 0, 7); ctx.stroke();
+  ctx.beginPath(); ctx.arc(W*0.2, H+60, H*0.35, 0, 7); ctx.stroke();
+
+  // wide-scene scaling: subject cluster sits in a central horizontal band of the 16:9 master
+  const s=Math.min(f.w/470,f.h/(g.icon?320:230)), cx=f.x+f.w/2, cy=f.y+f.h/2;
+  ctx.save(); ctx.translate(cx,cy); ctx.scale(s,s);
+  // envelope
+  ctx.lineWidth=5; ctx.strokeStyle=ART.ink; ctx.fillStyle='#fff';
+  ctx.save(); ctx.translate(-130,-10); ctx.rotate(-0.06);
+  ctx.beginPath(); ctx.rect(-80,-55,160,110); ctx.fill(); ctx.stroke();
+  ctx.beginPath(); ctx.moveTo(-80,-55); ctx.lineTo(0,8); ctx.lineTo(80,-55); ctx.stroke();
+  ctx.restore();
+  // dashed flight path
+  ctx.strokeStyle=ART.orange; ctx.lineWidth=5; ctx.setLineDash([14,12]);
+  ctx.beginPath(); ctx.moveTo(-38,-6); ctx.quadraticCurveTo(30,-46,92,-14); ctx.stroke();
+  ctx.setLineDash([]);
+  ctx.fillStyle=ART.orange; ctx.beginPath();
+  ctx.moveTo(96,-10); ctx.lineTo(70,-26); ctx.lineTo(78,-2); ctx.closePath(); ctx.fill();
+  // shield
+  ctx.save(); ctx.translate(130,0);
+  ctx.fillStyle=ART.blue; ctx.strokeStyle=ART.ink; ctx.lineWidth=5;
+  ctx.beginPath(); ctx.moveTo(0,-72); ctx.lineTo(58,-50); ctx.lineTo(58,10);
+  ctx.quadraticCurveTo(58,58,0,80); ctx.quadraticCurveTo(-58,58,-58,10);
+  ctx.lineTo(-58,-50); ctx.closePath(); ctx.fill(); ctx.stroke();
+  ctx.strokeStyle='#fff'; ctx.lineWidth=9;
+  ctx.beginPath(); ctx.moveTo(-24,0); ctx.lineTo(-6,20); ctx.lineTo(30,-22); ctx.stroke();
+  ctx.restore();
+  // deflected spam dots
+  ctx.fillStyle=ART.grayB;
+  [[-10,64],[26,78],[58,96]].forEach(([x,y])=>{ ctx.beginPath(); ctx.arc(x,y,7,0,7); ctx.fill(); });
+  ctx.restore();
+}
+
+function drawWordmark(ctx,g){
+  // real namefi-logotype.svg, top-right — inset 64px so it sits fully inside the 60px bleed
+  const h=40, w=h*WORDMARK_AR;
+  ctx.drawImage(BRAND.wordmark, g.W-64-w, 64, w, h);
+}
+
+function drawText(ctx,g,loc,title,lay){
+  if(g.icon){                       // icon rendition: no localized text — brand lockup instead
+    if(state.type==='custom') drawIconLockup(ctx,g);   // fallback: wordmark is already the tile
+    return;
+  }
+  const rtl=!!loc.rtl, ax = rtl ? g.m+g.titleW : g.m;
+  ctx.direction = rtl ? 'rtl' : 'ltr';
+  ctx.textAlign = rtl ? 'right' : 'left';
+  // title (no kicker — vertical space goes to title + focus)
+  const fit=lay.fit;
+  ctx.fillStyle=ART.ink;
+  ctx.font=`700 ${fit.size}px ${loc.stack}`;
+  let y=g.titleY+fit.size;
+  for(const line of fit.lines){ ctx.fillText(line,ax,y); y+=fit.lh; }
+  // subtitle: one quiet line under the title (live-OG style)
+  ctx.fillStyle='rgba(20,20,19,.66)';
+  ctx.font=`400 27px ${loc.stack}`;
+  let sub=loc.sub||'';
+  const subMax=g.W-2*g.m;
+  while(ctx.measureText(sub+'…').width>subMax && sub.length>4) sub=sub.slice(0,-1)+'';
+  ctx.fillText(sub,ax,lay.subBase);
+  drawWordmark(ctx,g);
+}
+
+function drawXOverlay(ctx,g,title){
+  const fs=26, pad=14, x=18, y=g.H-18;
+  ctx.font=`600 ${fs}px -apple-system,"Segoe UI",sans-serif`;
+  let t=title, maxW=g.W*0.72;
+  while(ctx.measureText(t+'…').width>maxW && t.length>4) t=t.slice(0,-1);
+  if(t!==title) t+='…';
+  const w=ctx.measureText(t).width;
+  ctx.fillStyle='rgba(0,0,0,.77)';
+  ctx.beginPath(); ctx.roundRect(x,y-fs-pad*1.3,w+pad*2,fs+pad*1.4,10); ctx.fill();
+  ctx.fillStyle='#fff'; ctx.textAlign='left'; ctx.direction='ltr';
+  ctx.fillText(t,x+pad,y-pad*0.9);
+}
+
+let hatch=null;
+function hatchPattern(){
+  if(hatch) return hatch;
+  const c=document.createElement('canvas'); c.width=c.height=14;
+  const x=c.getContext('2d');
+  x.strokeStyle='rgba(90,140,200,.55)'; x.lineWidth=3;
+  x.beginPath(); x.moveTo(-4,18); x.lineTo(18,-4); x.stroke();
+  hatch=x.createPattern ? c : c; return c;
+}
+
+function chip(ctx,x,y,text,color){
+  ctx.font='700 19px -apple-system,"Segoe UI",sans-serif';
+  ctx.direction='ltr'; ctx.textAlign='left';
+  const w=ctx.measureText(text).width+20;
+  ctx.fillStyle=color; ctx.beginPath(); ctx.roundRect(x,y,w,30,6); ctx.fill();
+  ctx.fillStyle='#fff'; ctx.fillText(text,x+10,y+22);
+  return w;
+}
+
+function drawZones(ctx,g,lay){
+  const {W,H,bleed,xres}=g;
+  // bleed ring
+  ctx.fillStyle='rgba(217,90,70,.16)';
+  ctx.fillRect(0,0,W,bleed); ctx.fillRect(0,H-bleed,W,bleed);
+  ctx.fillRect(0,bleed,bleed,H-2*bleed); ctx.fillRect(W-bleed,bleed,bleed,H-2*bleed);
+  ctx.setLineDash([12,8]); ctx.lineWidth=3;
+  ctx.strokeStyle='rgba(217,90,70,.9)';
+  ctx.strokeRect(bleed,bleed,W-2*bleed,H-2*bleed);
+  if(!g.icon){
+    // X-reserve
+    const p=ctx.createPattern(hatchPattern(),'repeat');
+    ctx.fillStyle=p; ctx.fillRect(bleed,H-xres,W-2*bleed,xres-bleed);
+    ctx.strokeStyle='rgba(90,140,200,.95)';
+    ctx.strokeRect(bleed,H-xres,W-2*bleed,xres-bleed);
+    // title + subtitle slot (height follows the fitted title)
+    const th=lay.fit ? (lay.subBase-g.titleY)+16 : g.titleH;
+    ctx.strokeStyle='rgba(20,20,19,.55)';
+    ctx.strokeRect(g.m-14,g.titleY-6,g.titleW+28,th);                 // title + subtitle
+  }
+  const f=lay.focus, tile=g.icon && state.type!=='custom';
+  ctx.strokeStyle='rgba(20,20,19,.55)';
+  if(!tile){
+    ctx.strokeRect(f.x,f.y,f.w,f.h);                                  // focus (4:3)
+    if(g.icon) ctx.strokeRect(140,790,920,340);                       // wordmark band (~1/3)
+  }
+  ctx.setLineDash([]);
+  chip(ctx,bleed+8,bleed+8,'BLEED 60px','rgba(217,90,70,.92)');
+  if(!g.icon){
+    chip(ctx,bleed+8,H-xres+8,'X-RESERVE 130px — art OK, our text never','rgba(90,140,200,.92)');
+    chip(ctx,g.m-14,g.titleY-40,'TITLE ≤2 + SUBTITLE','rgba(20,20,19,.65)');
+  } else if(!tile){
+    chip(ctx,140,1086,'WORDMARK BAND ≈ 1/3 H','rgba(20,20,19,.65)');
+  } else {
+    chip(ctx,bleed+8,H-bleed-46,'BRAND TILE — single centered wordmark','rgba(20,20,19,.65)');
+  }
+  if(!tile) chip(ctx,f.x+f.w-330,f.y+8,'FOCUS — crop of 16:9 master','rgba(20,20,19,.65)');
+}
+
+function render(){
+  const loc=LOCALES[state.locale];
+  const title=state.long ? loc.long : loc.title;
+  const s=state.scale;
+  for(const key of Object.keys(GEOM)){
+    const g=GEOM[key], cv=document.getElementById(key);
+    if(cv.width!==g.W*s){ cv.width=g.W*s; cv.height=g.H*s; }
+    const ctx=cv.getContext('2d');
+    ctx.setTransform(s,0,0,s,0,0);           // template coords stay 1200-based; output pixels scale
+    ctx.clearRect(0,0,g.W,g.H);
+    ctx.fillStyle=ART.bg; ctx.fillRect(0,0,g.W,g.H);
+    const lay=computeLayout(ctx,g,loc,title);
+    if(state.type==='custom') drawArt(ctx,g,lay.focus);
+    else { drawMotif(ctx,g,lay); if(g.icon) drawBrandGlyph(ctx,g); }
+    drawText(ctx,g,loc,title,lay);
+    if(state.xoverlay && key==='rect') drawXOverlay(ctx,g,title);
+    if(state.zones) drawZones(ctx,g,lay);
+  }
+  // SERP-thumbnail-scale previews of the 1:1 (Google shows ~116px squares)
+  const src=document.getElementById('sq');
+  for(const [id,sz] of [['thumb116',116],['thumb72',72]]){
+    const tc=document.getElementById(id).getContext('2d');
+    tc.clearRect(0,0,sz,sz);
+    tc.drawImage(src,0,0,sz,sz);
+  }
+  document.querySelectorAll('.dim').forEach(el=>{
+    const g=GEOM[el.dataset.key];
+    el.textContent=`${g.W*s} × ${g.H*s}`+(s>1?` (@${s}×)`:'');
+  });
+}
+
+const sel=document.getElementById('locale');
+for(const k of Object.keys(LOCALES)){
+  const o=document.createElement('option'); o.value=k; o.textContent=k; sel.appendChild(o);
+}
+sel.onchange=e=>{ state.locale=e.target.value; render(); };
+document.getElementById('typeSeg').onclick=e=>{
+  const b=e.target.closest('button'); if(!b) return;
+  state.type=b.dataset.v;
+  document.querySelectorAll('#typeSeg button').forEach(x=>x.classList.toggle('on',x===b));
+  render();
+};
+document.getElementById('scaleSeg').onclick=e=>{
+  const b=e.target.closest('button'); if(!b) return;
+  state.scale=+b.dataset.v;
+  document.querySelectorAll('#scaleSeg button').forEach(x=>x.classList.toggle('on',x===b));
+  render();
+};
+document.getElementById('longTitle').onchange=e=>{ state.long=e.target.checked; render(); };
+document.getElementById('zones').onchange=e=>{ state.zones=e.target.checked; render(); };
+document.getElementById('xoverlay').onchange=e=>{ state.xoverlay=e.target.checked; render(); };
+render();
+if(BRAND.wordmark.decode) BRAND.wordmark.decode().then(render).catch(()=>{});
+else BRAND.wordmark.onload=render;
+</script>


### PR DESCRIPTION
## What

Design deliverables for the programmatic OG image system (fallback + custom, 4 renditions, i18n):

- **`docs/og-image-spec.md`** — the v10 design spec: rendition table (1.91:1 / 16:9 / 4:3 / 1:1 badge), slot geometry in 1200-based coordinates, the standard 16:9 focus-master contract, i18n rules, X-reserve semantics (art OK, our text never), 2× output + file-size budgets, and the implementation direction (React `<OgCard>` + Storybook in astra, headless-Chrome CDP rendering).
- **`docs/og-layout-sketch.html`** — self-contained interactive sketch (open in any browser): renders all four renditions at true resolution with toggles for custom/fallback canvas, 10 locales (incl. Arabic RTL, CJK wrapping), long-title stress test, 1×/2×/3× output scale, zone overlays, simulated X title overlay, and a Google-SERP-thumbnail-scale preview. Uses the real `static/brand-kit/namefi-logotype.svg` inlined.

## Why

Replaces the bake-everything-into-one-image approach with a layered template: art master generated once per article, localized text overlaid programmatically, wordmark composited from the real brand asset. Layout guideline was measured from the live production OG (`email-sender-reputation-arms-race-og`, 1200×630), which is the visual reference for proportions.

## Next

Implementation is being dispatched as a separate task: React `<OgCard>` component + Storybook stories in namefi-astra's resources app, geometry constants carried over from this spec.

Docs-only change: no runtime surface, deliberately public with the rest of the repo docs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a standalone HTML sketch only; no production code paths or deployments affected.
> 
> **Overview**
> Adds **design-only** deliverables for a programmatic OG image pipeline: layered templates (art or fallback motif → localized text → real wordmark) instead of baking everything into one raster per article.
> 
> **`docs/og-image-spec.md`** (v10) defines four renditions at **2×** (1.91:1 for social, 16:9 / 4:3 / 1:1 for Google Article JSON-LD), shared **1200-based** slot geometry (bleed, X-reserve for *our* text only, dynamic focus height from title fit), one **16:9 focus master** per article, i18n rules (text-free 1:1 badge), JPG size budgets, and planned implementation (**`<OgCard>`** + Storybook + headless Chrome CDP; Satori ruled out for Arabic).
> 
> **`docs/og-layout-sketch.html`** is a browser-openable prototype that renders all four sizes with toggles for custom vs fallback, **10 locales** (RTL, CJK wrapping), scale, zone overlays, simulated X title chip, and SERP thumb previews—inlining **`namefi-logotype.svg`**.
> 
> No application or runtime code changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a64b415ffdebaba2df62f05569bcaa662cbfbb29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive Open Graph image layout preview supporting multiple aspect ratios, custom or fallback artwork, localized text, RTL/CJK handling, scaling options, and long-title testing.
  * Added previews for 1:1 search thumbnails, title layout zones, focus crops, and branding treatments.
* **Documentation**
  * Documented OG image specifications, rendition requirements, typography, cropping, internationalization, image quality constraints, and rendering guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->