### PR TITLE
content(authors): add github/website/blog links; keep locale-invariant fields in the en base

### DIFF
--- a/content/authors/ar/aileen-wright.mdx
+++ b/content/authors/ar/aileen-wright.mdx
@@ -1,8 +1,6 @@
 ---
 name: Aileen Wright
-avatar: /blog-assets/authors/aileen-wright.jpg
 occupation: كاتبة في الفن والتاريخ
-company: Namefi
 language: ar
 ---
 

--- a/content/authors/ar/alan-machin.mdx
+++ b/content/authors/ar/alan-machin.mdx
@@ -1,8 +1,6 @@
 ---
 name: Alan Machin
-avatar: /blog-assets/authors/alan-machin.jpg
 occupation: مترجم ومختص بتوطين المحتوى للفرنسية
-company: Namefi
 language: ar
 ---
 

--- a/content/authors/ar/arivu-iyandhiran.mdx
+++ b/content/authors/ar/arivu-iyandhiran.mdx
@@ -1,8 +1,6 @@
 ---
 name: Arivu Iyandhiran
-avatar: /blog-assets/authors/arivu-iyandhiran.jpg
 occupation: مترجم ومختص بتوطين المحتوى للتاميلية
-company: Namefi
 language: ar
 ---
 

--- a/content/authors/ar/chie-kudo.mdx
+++ b/content/authors/ar/chie-kudo.mdx
@@ -1,8 +1,6 @@
 ---
 name: Chie Kudō
-avatar: /blog-assets/authors/chie-kudo.jpg
 occupation: مترجمة ومختصة بتوطين المحتوى لليابانية
-company: Namefi
 language: ar
 ---
 

--- a/content/authors/ar/fenwei-bian.mdx
+++ b/content/authors/ar/fenwei-bian.mdx
@@ -3,6 +3,7 @@ name: Fenwei Bian
 avatar: /blog-assets/authors/fenwei-bian.jpg
 occupation: مطورة برمجيات وكاتبة
 company: Namefi
+github: https://github.com/weifenbian
 language: ar
 ---
 

--- a/content/authors/ar/fenwei-bian.mdx
+++ b/content/authors/ar/fenwei-bian.mdx
@@ -1,9 +1,6 @@
 ---
 name: Fenwei Bian
-avatar: /blog-assets/authors/fenwei-bian.jpg
 occupation: مطورة برمجيات وكاتبة
-company: Namefi
-github: https://github.com/weifenbian
 language: ar
 ---
 

--- a/content/authors/ar/gong-jihye.mdx
+++ b/content/authors/ar/gong-jihye.mdx
@@ -1,8 +1,6 @@
 ---
 name: Gong Ji-hye
-avatar: /blog-assets/authors/gong-jihye.jpg
 occupation: مترجمة ومختصة بتوطين المحتوى للكورية
-company: Namefi
 language: ar
 ---
 

--- a/content/authors/ar/iria-maquieira.mdx
+++ b/content/authors/ar/iria-maquieira.mdx
@@ -1,8 +1,6 @@
 ---
 name: Iria Maquieira
-avatar: /blog-assets/authors/iria-maquieira.jpg
 occupation: مترجمة ومختصة بتوطين المحتوى للإسبانية
-company: Namefi
 language: ar
 ---
 

--- a/content/authors/ar/kai-kunstmann.mdx
+++ b/content/authors/ar/kai-kunstmann.mdx
@@ -1,8 +1,6 @@
 ---
 name: Kai Kunstmann
-avatar: /blog-assets/authors/kai-kunstmann.jpg
 occupation: مترجم ومختص بتوطين المحتوى للألمانية
-company: Namefi
 language: ar
 ---
 

--- a/content/authors/ar/namefiteam.mdx
+++ b/content/authors/ar/namefiteam.mdx
@@ -1,10 +1,6 @@
 ---
 name: Namefi Team
-avatar: /static/images/sparrowhawk-avatar.jpg
 occupation: فريق Namefi
-company: Namefi
-twitter: https://twitter.com/namefi_io
-linkedin: https://www.linkedin.com/company/namefi
 language: ar
 ---
 

--- a/content/authors/ar/nirmit-buddhiraja.mdx
+++ b/content/authors/ar/nirmit-buddhiraja.mdx
@@ -1,8 +1,6 @@
 ---
 name: Nirmit Buddhiraja
-avatar: /blog-assets/authors/nirmit-buddhiraja.jpg
 occupation: مترجم ومختص بتوطين المحتوى للهندية
-company: Namefi
 language: ar
 ---
 

--- a/content/authors/ar/victor-zhou.mdx
+++ b/content/authors/ar/victor-zhou.mdx
@@ -4,6 +4,9 @@ avatar: /blog-assets/authors/victor-zhou.jpg
 occupation: مؤسس ومحرر معايير
 company: Namefi
 linkedin: https://www.linkedin.com/in/zainanzhou
+github: https://github.com/xinbenlv
+website: https://zzn.im
+blog: https://b.zzn.im
 language: ar
 ---
 

--- a/content/authors/ar/victor-zhou.mdx
+++ b/content/authors/ar/victor-zhou.mdx
@@ -1,12 +1,6 @@
 ---
 name: Victor Zhou
-avatar: /blog-assets/authors/victor-zhou.jpg
 occupation: مؤسس ومحرر معايير
-company: Namefi
-linkedin: https://www.linkedin.com/in/zainanzhou
-github: https://github.com/xinbenlv
-website: https://zzn.im
-blog: https://b.zzn.im
 language: ar
 ---
 

--- a/content/authors/ar/zakia-al-sinai.mdx
+++ b/content/authors/ar/zakia-al-sinai.mdx
@@ -1,8 +1,6 @@
 ---
 name: Zakia al-Sina'i
-avatar: /blog-assets/authors/zakia-al-sinai.jpg
 occupation: مترجمة ومختصة بتوطين المحتوى للعربية
-company: Namefi
 language: ar
 ---
 

--- a/content/authors/de/aileen-wright.mdx
+++ b/content/authors/de/aileen-wright.mdx
@@ -1,8 +1,6 @@
 ---
 name: Aileen Wright
-avatar: /blog-assets/authors/aileen-wright.jpg
 occupation: Autorin für Kunst und Geschichte
-company: Namefi
 language: de
 ---
 

--- a/content/authors/de/alan-machin.mdx
+++ b/content/authors/de/alan-machin.mdx
@@ -1,8 +1,6 @@
 ---
 name: Alan Machin
-avatar: /blog-assets/authors/alan-machin.jpg
 occupation: Übersetzer für französische Lokalisierung
-company: Namefi
 language: de
 ---
 

--- a/content/authors/de/arivu-iyandhiran.mdx
+++ b/content/authors/de/arivu-iyandhiran.mdx
@@ -1,8 +1,6 @@
 ---
 name: Arivu Iyandhiran
-avatar: /blog-assets/authors/arivu-iyandhiran.jpg
 occupation: Übersetzer für tamilische Lokalisierung
-company: Namefi
 language: de
 ---
 

--- a/content/authors/de/chie-kudo.mdx
+++ b/content/authors/de/chie-kudo.mdx
@@ -1,8 +1,6 @@
 ---
 name: Chie Kudō
-avatar: /blog-assets/authors/chie-kudo.jpg
 occupation: Übersetzerin für japanische Lokalisierung
-company: Namefi
 language: de
 ---
 

--- a/content/authors/de/fenwei-bian.mdx
+++ b/content/authors/de/fenwei-bian.mdx
@@ -3,6 +3,7 @@ name: Fenwei Bian
 avatar: /blog-assets/authors/fenwei-bian.jpg
 occupation: Softwareentwicklerin und Autorin
 company: Namefi
+github: https://github.com/weifenbian
 language: de
 ---
 

--- a/content/authors/de/fenwei-bian.mdx
+++ b/content/authors/de/fenwei-bian.mdx
@@ -1,9 +1,6 @@
 ---
 name: Fenwei Bian
-avatar: /blog-assets/authors/fenwei-bian.jpg
 occupation: Softwareentwicklerin und Autorin
-company: Namefi
-github: https://github.com/weifenbian
 language: de
 ---
 

--- a/content/authors/de/gong-jihye.mdx
+++ b/content/authors/de/gong-jihye.mdx
@@ -1,8 +1,6 @@
 ---
 name: Gong Ji-hye
-avatar: /blog-assets/authors/gong-jihye.jpg
 occupation: Übersetzerin für koreanische Lokalisierung
-company: Namefi
 language: de
 ---
 

--- a/content/authors/de/iria-maquieira.mdx
+++ b/content/authors/de/iria-maquieira.mdx
@@ -1,8 +1,6 @@
 ---
 name: Iria Maquieira
-avatar: /blog-assets/authors/iria-maquieira.jpg
 occupation: Übersetzerin für spanische Lokalisierung
-company: Namefi
 language: de
 ---
 

--- a/content/authors/de/kai-kunstmann.mdx
+++ b/content/authors/de/kai-kunstmann.mdx
@@ -1,8 +1,6 @@
 ---
 name: Kai Kunstmann
-avatar: /blog-assets/authors/kai-kunstmann.jpg
 occupation: Übersetzer für deutsche Lokalisierung
-company: Namefi
 language: de
 ---
 

--- a/content/authors/de/namefiteam.mdx
+++ b/content/authors/de/namefiteam.mdx
@@ -1,10 +1,6 @@
 ---
 name: Namefi Team
-avatar: /static/images/sparrowhawk-avatar.jpg
 occupation: Namefi-Team
-company: Namefi
-twitter: https://twitter.com/namefi_io
-linkedin: https://www.linkedin.com/company/namefi
 language: de
 ---
 

--- a/content/authors/de/nirmit-buddhiraja.mdx
+++ b/content/authors/de/nirmit-buddhiraja.mdx
@@ -1,8 +1,6 @@
 ---
 name: Nirmit Buddhiraja
-avatar: /blog-assets/authors/nirmit-buddhiraja.jpg
 occupation: Übersetzer für Hindi-Lokalisierung
-company: Namefi
 language: de
 ---
 

--- a/content/authors/de/victor-zhou.mdx
+++ b/content/authors/de/victor-zhou.mdx
@@ -1,12 +1,6 @@
 ---
 name: Victor Zhou
-avatar: /blog-assets/authors/victor-zhou.jpg
 occupation: Gründer und Redakteur für technische Standards
-company: Namefi
-linkedin: https://www.linkedin.com/in/zainanzhou
-github: https://github.com/xinbenlv
-website: https://zzn.im
-blog: https://b.zzn.im
 language: de
 ---
 

--- a/content/authors/de/victor-zhou.mdx
+++ b/content/authors/de/victor-zhou.mdx
@@ -4,6 +4,9 @@ avatar: /blog-assets/authors/victor-zhou.jpg
 occupation: Gründer und Redakteur für technische Standards
 company: Namefi
 linkedin: https://www.linkedin.com/in/zainanzhou
+github: https://github.com/xinbenlv
+website: https://zzn.im
+blog: https://b.zzn.im
 language: de
 ---
 

--- a/content/authors/de/zakia-al-sinai.mdx
+++ b/content/authors/de/zakia-al-sinai.mdx
@@ -1,8 +1,6 @@
 ---
 name: Zakia al-Sina'i
-avatar: /blog-assets/authors/zakia-al-sinai.jpg
 occupation: Übersetzerin für arabische Lokalisierung
-company: Namefi
 language: de
 ---
 

--- a/content/authors/en/fenwei-bian.mdx
+++ b/content/authors/en/fenwei-bian.mdx
@@ -3,6 +3,7 @@ name: Fenwei Bian
 avatar: /blog-assets/authors/fenwei-bian.jpg
 occupation: Software Developer & Writer
 company: Namefi
+github: https://github.com/weifenbian
 language: en
 ---
 

--- a/content/authors/en/victor-zhou.mdx
+++ b/content/authors/en/victor-zhou.mdx
@@ -4,6 +4,9 @@ avatar: /blog-assets/authors/victor-zhou.jpg
 occupation: Founder & Standards Editor
 company: Namefi
 linkedin: https://www.linkedin.com/in/zainanzhou
+github: https://github.com/xinbenlv
+website: https://zzn.im
+blog: https://b.zzn.im
 language: en
 ---
 

--- a/content/authors/es/aileen-wright.mdx
+++ b/content/authors/es/aileen-wright.mdx
@@ -1,8 +1,6 @@
 ---
 name: Aileen Wright
-avatar: /blog-assets/authors/aileen-wright.jpg
 occupation: Escritora sobre arte e historia
-company: Namefi
 language: es
 ---
 

--- a/content/authors/es/alan-machin.mdx
+++ b/content/authors/es/alan-machin.mdx
@@ -1,8 +1,6 @@
 ---
 name: Alan Machin
-avatar: /blog-assets/authors/alan-machin.jpg
 occupation: Traductor de localización al francés
-company: Namefi
 language: es
 ---
 

--- a/content/authors/es/arivu-iyandhiran.mdx
+++ b/content/authors/es/arivu-iyandhiran.mdx
@@ -1,8 +1,6 @@
 ---
 name: Arivu Iyandhiran
-avatar: /blog-assets/authors/arivu-iyandhiran.jpg
 occupation: Traductor de localización al tamil
-company: Namefi
 language: es
 ---
 

--- a/content/authors/es/chie-kudo.mdx
+++ b/content/authors/es/chie-kudo.mdx
@@ -1,8 +1,6 @@
 ---
 name: Chie Kudō
-avatar: /blog-assets/authors/chie-kudo.jpg
 occupation: Traductora de localización al japonés
-company: Namefi
 language: es
 ---
 

--- a/content/authors/es/fenwei-bian.mdx
+++ b/content/authors/es/fenwei-bian.mdx
@@ -1,9 +1,6 @@
 ---
 name: Fenwei Bian
-avatar: /blog-assets/authors/fenwei-bian.jpg
 occupation: Desarrolladora de software y escritora
-company: Namefi
-github: https://github.com/weifenbian
 language: es
 ---
 

--- a/content/authors/es/fenwei-bian.mdx
+++ b/content/authors/es/fenwei-bian.mdx
@@ -3,6 +3,7 @@ name: Fenwei Bian
 avatar: /blog-assets/authors/fenwei-bian.jpg
 occupation: Desarrolladora de software y escritora
 company: Namefi
+github: https://github.com/weifenbian
 language: es
 ---
 

--- a/content/authors/es/gong-jihye.mdx
+++ b/content/authors/es/gong-jihye.mdx
@@ -1,8 +1,6 @@
 ---
 name: Gong Ji-hye
-avatar: /blog-assets/authors/gong-jihye.jpg
 occupation: Traductora de localización al coreano
-company: Namefi
 language: es
 ---
 

--- a/content/authors/es/iria-maquieira.mdx
+++ b/content/authors/es/iria-maquieira.mdx
@@ -1,8 +1,6 @@
 ---
 name: Iria Maquieira
-avatar: /blog-assets/authors/iria-maquieira.jpg
 occupation: Traductora de localización al español
-company: Namefi
 language: es
 ---
 

--- a/content/authors/es/kai-kunstmann.mdx
+++ b/content/authors/es/kai-kunstmann.mdx
@@ -1,8 +1,6 @@
 ---
 name: Kai Kunstmann
-avatar: /blog-assets/authors/kai-kunstmann.jpg
 occupation: Traductor de localización al alemán
-company: Namefi
 language: es
 ---
 

--- a/content/authors/es/namefiteam.mdx
+++ b/content/authors/es/namefiteam.mdx
@@ -1,10 +1,6 @@
 ---
 name: Namefi Team
-avatar: /static/images/sparrowhawk-avatar.jpg
 occupation: Equipo de Namefi
-company: Namefi
-twitter: https://twitter.com/namefi_io
-linkedin: https://www.linkedin.com/company/namefi
 language: es
 ---
 

--- a/content/authors/es/nirmit-buddhiraja.mdx
+++ b/content/authors/es/nirmit-buddhiraja.mdx
@@ -1,8 +1,6 @@
 ---
 name: Nirmit Buddhiraja
-avatar: /blog-assets/authors/nirmit-buddhiraja.jpg
 occupation: Traductor de localización al hindi
-company: Namefi
 language: es
 ---
 

--- a/content/authors/es/victor-zhou.mdx
+++ b/content/authors/es/victor-zhou.mdx
@@ -1,12 +1,6 @@
 ---
 name: Victor Zhou
-avatar: /blog-assets/authors/victor-zhou.jpg
 occupation: Fundador y editor de estándares
-company: Namefi
-linkedin: https://www.linkedin.com/in/zainanzhou
-github: https://github.com/xinbenlv
-website: https://zzn.im
-blog: https://b.zzn.im
 language: es
 ---
 

--- a/content/authors/es/victor-zhou.mdx
+++ b/content/authors/es/victor-zhou.mdx
@@ -4,6 +4,9 @@ avatar: /blog-assets/authors/victor-zhou.jpg
 occupation: Fundador y editor de estándares
 company: Namefi
 linkedin: https://www.linkedin.com/in/zainanzhou
+github: https://github.com/xinbenlv
+website: https://zzn.im
+blog: https://b.zzn.im
 language: es
 ---
 

--- a/content/authors/es/zakia-al-sinai.mdx
+++ b/content/authors/es/zakia-al-sinai.mdx
@@ -1,8 +1,6 @@
 ---
 name: Zakia al-Sina'i
-avatar: /blog-assets/authors/zakia-al-sinai.jpg
 occupation: Traductora de localización al árabe
-company: Namefi
 language: es
 ---
 

--- a/content/authors/fr/aileen-wright.mdx
+++ b/content/authors/fr/aileen-wright.mdx
@@ -1,8 +1,6 @@
 ---
 name: Aileen Wright
-avatar: /blog-assets/authors/aileen-wright.jpg
 occupation: Rédactrice spécialisée en art et en histoire
-company: Namefi
 language: fr
 ---
 

--- a/content/authors/fr/alan-machin.mdx
+++ b/content/authors/fr/alan-machin.mdx
@@ -1,8 +1,6 @@
 ---
 name: Alan Machin
-avatar: /blog-assets/authors/alan-machin.jpg
 occupation: Traducteur chargé de la localisation française
-company: Namefi
 language: fr
 ---
 

--- a/content/authors/fr/arivu-iyandhiran.mdx
+++ b/content/authors/fr/arivu-iyandhiran.mdx
@@ -1,8 +1,6 @@
 ---
 name: Arivu Iyandhiran
-avatar: /blog-assets/authors/arivu-iyandhiran.jpg
 occupation: Traducteur chargé de la localisation tamoule
-company: Namefi
 language: fr
 ---
 

--- a/content/authors/fr/chie-kudo.mdx
+++ b/content/authors/fr/chie-kudo.mdx
@@ -1,8 +1,6 @@
 ---
 name: Chie Kudō
-avatar: /blog-assets/authors/chie-kudo.jpg
 occupation: Traductrice chargée de la localisation japonaise
-company: Namefi
 language: fr
 ---
 

--- a/content/authors/fr/fenwei-bian.mdx
+++ b/content/authors/fr/fenwei-bian.mdx
@@ -3,6 +3,7 @@ name: Fenwei Bian
 avatar: /blog-assets/authors/fenwei-bian.jpg
 occupation: Développeuse de logiciels et rédactrice
 company: Namefi
+github: https://github.com/weifenbian
 language: fr
 ---
 

--- a/content/authors/fr/fenwei-bian.mdx
+++ b/content/authors/fr/fenwei-bian.mdx
@@ -1,9 +1,6 @@
 ---
 name: Fenwei Bian
-avatar: /blog-assets/authors/fenwei-bian.jpg
 occupation: Développeuse de logiciels et rédactrice
-company: Namefi
-github: https://github.com/weifenbian
 language: fr
 ---
 

--- a/content/authors/fr/gong-jihye.mdx
+++ b/content/authors/fr/gong-jihye.mdx
@@ -1,8 +1,6 @@
 ---
 name: Gong Ji-hye
-avatar: /blog-assets/authors/gong-jihye.jpg
 occupation: Traductrice chargée de la localisation coréenne
-company: Namefi
 language: fr
 ---
 

--- a/content/authors/fr/iria-maquieira.mdx
+++ b/content/authors/fr/iria-maquieira.mdx
@@ -1,8 +1,6 @@
 ---
 name: Iria Maquieira
-avatar: /blog-assets/authors/iria-maquieira.jpg
 occupation: Traductrice chargée de la localisation espagnole
-company: Namefi
 language: fr
 ---
 

--- a/content/authors/fr/kai-kunstmann.mdx
+++ b/content/authors/fr/kai-kunstmann.mdx
@@ -1,8 +1,6 @@
 ---
 name: Kai Kunstmann
-avatar: /blog-assets/authors/kai-kunstmann.jpg
 occupation: Traducteur technique chargé de la localisation allemande
-company: Namefi
 language: fr
 ---
 

--- a/content/authors/fr/namefiteam.mdx
+++ b/content/authors/fr/namefiteam.mdx
@@ -1,10 +1,6 @@
 ---
 name: Namefi Team
-avatar: /static/images/sparrowhawk-avatar.jpg
 occupation: Équipe Namefi
-company: Namefi
-twitter: https://twitter.com/namefi_io
-linkedin: https://www.linkedin.com/company/namefi
 language: fr
 ---
 

--- a/content/authors/fr/nirmit-buddhiraja.mdx
+++ b/content/authors/fr/nirmit-buddhiraja.mdx
@@ -1,8 +1,6 @@
 ---
 name: Nirmit Buddhiraja
-avatar: /blog-assets/authors/nirmit-buddhiraja.jpg
 occupation: Traducteur chargé de la localisation hindi
-company: Namefi
 language: fr
 ---
 

--- a/content/authors/fr/victor-zhou.mdx
+++ b/content/authors/fr/victor-zhou.mdx
@@ -1,12 +1,6 @@
 ---
 name: Victor Zhou
-avatar: /blog-assets/authors/victor-zhou.jpg
 occupation: Fondateur et responsable éditorial des standards
-company: Namefi
-linkedin: https://www.linkedin.com/in/zainanzhou
-github: https://github.com/xinbenlv
-website: https://zzn.im
-blog: https://b.zzn.im
 language: fr
 ---
 

--- a/content/authors/fr/victor-zhou.mdx
+++ b/content/authors/fr/victor-zhou.mdx
@@ -4,6 +4,9 @@ avatar: /blog-assets/authors/victor-zhou.jpg
 occupation: Fondateur et responsable éditorial des standards
 company: Namefi
 linkedin: https://www.linkedin.com/in/zainanzhou
+github: https://github.com/xinbenlv
+website: https://zzn.im
+blog: https://b.zzn.im
 language: fr
 ---
 

--- a/content/authors/fr/zakia-al-sinai.mdx
+++ b/content/authors/fr/zakia-al-sinai.mdx
@@ -1,8 +1,6 @@
 ---
 name: Zakia al-Sina'i
-avatar: /blog-assets/authors/zakia-al-sinai.jpg
 occupation: Traductrice chargée de la localisation arabe
-company: Namefi
 language: fr
 ---
 

--- a/content/authors/hi/aileen-wright.mdx
+++ b/content/authors/hi/aileen-wright.mdx
@@ -1,8 +1,6 @@
 ---
 name: Aileen Wright
-avatar: /blog-assets/authors/aileen-wright.jpg
 occupation: कला और इतिहास लेखिका
-company: Namefi
 language: hi
 ---
 

--- a/content/authors/hi/alan-machin.mdx
+++ b/content/authors/hi/alan-machin.mdx
@@ -1,8 +1,6 @@
 ---
 name: Alan Machin
-avatar: /blog-assets/authors/alan-machin.jpg
 occupation: फ़्रेंच लोकलाइज़ेशन अनुवादक
-company: Namefi
 language: hi
 ---
 

--- a/content/authors/hi/arivu-iyandhiran.mdx
+++ b/content/authors/hi/arivu-iyandhiran.mdx
@@ -1,8 +1,6 @@
 ---
 name: Arivu Iyandhiran
-avatar: /blog-assets/authors/arivu-iyandhiran.jpg
 occupation: तमिल लोकलाइज़ेशन अनुवादक
-company: Namefi
 language: hi
 ---
 

--- a/content/authors/hi/chie-kudo.mdx
+++ b/content/authors/hi/chie-kudo.mdx
@@ -1,8 +1,6 @@
 ---
 name: Chie Kudō
-avatar: /blog-assets/authors/chie-kudo.jpg
 occupation: जापानी लोकलाइज़ेशन अनुवादक
-company: Namefi
 language: hi
 ---
 

--- a/content/authors/hi/fenwei-bian.mdx
+++ b/content/authors/hi/fenwei-bian.mdx
@@ -1,9 +1,6 @@
 ---
 name: Fenwei Bian
-avatar: /blog-assets/authors/fenwei-bian.jpg
 occupation: सॉफ़्टवेयर डेवलपर और लेखिका
-company: Namefi
-github: https://github.com/weifenbian
 language: hi
 ---
 

--- a/content/authors/hi/fenwei-bian.mdx
+++ b/content/authors/hi/fenwei-bian.mdx
@@ -3,6 +3,7 @@ name: Fenwei Bian
 avatar: /blog-assets/authors/fenwei-bian.jpg
 occupation: सॉफ़्टवेयर डेवलपर और लेखिका
 company: Namefi
+github: https://github.com/weifenbian
 language: hi
 ---
 

--- a/content/authors/hi/gong-jihye.mdx
+++ b/content/authors/hi/gong-jihye.mdx
@@ -1,8 +1,6 @@
 ---
 name: Gong Ji-hye
-avatar: /blog-assets/authors/gong-jihye.jpg
 occupation: कोरियाई लोकलाइज़ेशन अनुवादक
-company: Namefi
 language: hi
 ---
 

--- a/content/authors/hi/iria-maquieira.mdx
+++ b/content/authors/hi/iria-maquieira.mdx
@@ -1,8 +1,6 @@
 ---
 name: Iria Maquieira
-avatar: /blog-assets/authors/iria-maquieira.jpg
 occupation: स्पैनिश लोकलाइज़ेशन अनुवादक
-company: Namefi
 language: hi
 ---
 

--- a/content/authors/hi/kai-kunstmann.mdx
+++ b/content/authors/hi/kai-kunstmann.mdx
@@ -1,8 +1,6 @@
 ---
 name: Kai Kunstmann
-avatar: /blog-assets/authors/kai-kunstmann.jpg
 occupation: जर्मन लोकलाइज़ेशन अनुवादक
-company: Namefi
 language: hi
 ---
 

--- a/content/authors/hi/namefiteam.mdx
+++ b/content/authors/hi/namefiteam.mdx
@@ -1,10 +1,6 @@
 ---
 name: Namefi Team
-avatar: /static/images/sparrowhawk-avatar.jpg
 occupation: Namefi टीम
-company: Namefi
-twitter: https://twitter.com/namefi_io
-linkedin: https://www.linkedin.com/company/namefi
 language: hi
 ---
 

--- a/content/authors/hi/nirmit-buddhiraja.mdx
+++ b/content/authors/hi/nirmit-buddhiraja.mdx
@@ -1,8 +1,6 @@
 ---
 name: Nirmit Buddhiraja
-avatar: /blog-assets/authors/nirmit-buddhiraja.jpg
 occupation: हिंदी लोकलाइज़ेशन अनुवादक
-company: Namefi
 language: hi
 ---
 

--- a/content/authors/hi/victor-zhou.mdx
+++ b/content/authors/hi/victor-zhou.mdx
@@ -4,6 +4,9 @@ avatar: /blog-assets/authors/victor-zhou.jpg
 occupation: संस्थापक और मानक संपादक
 company: Namefi
 linkedin: https://www.linkedin.com/in/zainanzhou
+github: https://github.com/xinbenlv
+website: https://zzn.im
+blog: https://b.zzn.im
 language: hi
 ---
 

--- a/content/authors/hi/victor-zhou.mdx
+++ b/content/authors/hi/victor-zhou.mdx
@@ -1,12 +1,6 @@
 ---
 name: Victor Zhou
-avatar: /blog-assets/authors/victor-zhou.jpg
 occupation: संस्थापक और मानक संपादक
-company: Namefi
-linkedin: https://www.linkedin.com/in/zainanzhou
-github: https://github.com/xinbenlv
-website: https://zzn.im
-blog: https://b.zzn.im
 language: hi
 ---
 

--- a/content/authors/hi/zakia-al-sinai.mdx
+++ b/content/authors/hi/zakia-al-sinai.mdx
@@ -1,8 +1,6 @@
 ---
 name: Zakia al-Sina'i
-avatar: /blog-assets/authors/zakia-al-sinai.jpg
 occupation: अरबी लोकलाइज़ेशन अनुवादक
-company: Namefi
 language: hi
 ---
 

--- a/content/authors/ja/aileen-wright.mdx
+++ b/content/authors/ja/aileen-wright.mdx
@@ -1,8 +1,6 @@
 ---
 name: Aileen Wright
-avatar: /blog-assets/authors/aileen-wright.jpg
 occupation: 美術・歴史ライター
-company: Namefi
 language: ja
 ---
 

--- a/content/authors/ja/alan-machin.mdx
+++ b/content/authors/ja/alan-machin.mdx
@@ -1,8 +1,6 @@
 ---
 name: Alan Machin
-avatar: /blog-assets/authors/alan-machin.jpg
 occupation: フランス語ローカライゼーション翻訳者
-company: Namefi
 language: ja
 ---
 

--- a/content/authors/ja/arivu-iyandhiran.mdx
+++ b/content/authors/ja/arivu-iyandhiran.mdx
@@ -1,8 +1,6 @@
 ---
 name: Arivu Iyandhiran
-avatar: /blog-assets/authors/arivu-iyandhiran.jpg
 occupation: タミル語ローカライゼーション翻訳者
-company: Namefi
 language: ja
 ---
 

--- a/content/authors/ja/chie-kudo.mdx
+++ b/content/authors/ja/chie-kudo.mdx
@@ -1,8 +1,6 @@
 ---
 name: Chie Kudō
-avatar: /blog-assets/authors/chie-kudo.jpg
 occupation: 日本語ローカライゼーション翻訳者
-company: Namefi
 language: ja
 ---
 

--- a/content/authors/ja/fenwei-bian.mdx
+++ b/content/authors/ja/fenwei-bian.mdx
@@ -3,6 +3,7 @@ name: Fenwei Bian
 avatar: /blog-assets/authors/fenwei-bian.jpg
 occupation: ソフトウェア開発者・ライター
 company: Namefi
+github: https://github.com/weifenbian
 language: ja
 ---
 

--- a/content/authors/ja/fenwei-bian.mdx
+++ b/content/authors/ja/fenwei-bian.mdx
@@ -1,9 +1,6 @@
 ---
 name: Fenwei Bian
-avatar: /blog-assets/authors/fenwei-bian.jpg
 occupation: ソフトウェア開発者・ライター
-company: Namefi
-github: https://github.com/weifenbian
 language: ja
 ---
 

--- a/content/authors/ja/gong-jihye.mdx
+++ b/content/authors/ja/gong-jihye.mdx
@@ -1,8 +1,6 @@
 ---
 name: Gong Ji-hye
-avatar: /blog-assets/authors/gong-jihye.jpg
 occupation: 韓国語ローカライゼーション翻訳者
-company: Namefi
 language: ja
 ---
 

--- a/content/authors/ja/iria-maquieira.mdx
+++ b/content/authors/ja/iria-maquieira.mdx
@@ -1,8 +1,6 @@
 ---
 name: Iria Maquieira
-avatar: /blog-assets/authors/iria-maquieira.jpg
 occupation: スペイン語ローカライゼーション翻訳者
-company: Namefi
 language: ja
 ---
 

--- a/content/authors/ja/kai-kunstmann.mdx
+++ b/content/authors/ja/kai-kunstmann.mdx
@@ -1,8 +1,6 @@
 ---
 name: Kai Kunstmann
-avatar: /blog-assets/authors/kai-kunstmann.jpg
 occupation: ドイツ語ローカライゼーション翻訳者
-company: Namefi
 language: ja
 ---
 

--- a/content/authors/ja/namefiteam.mdx
+++ b/content/authors/ja/namefiteam.mdx
@@ -1,10 +1,6 @@
 ---
 name: Namefi Team
-avatar: /static/images/sparrowhawk-avatar.jpg
 occupation: Namefiチーム
-company: Namefi
-twitter: https://twitter.com/namefi_io
-linkedin: https://www.linkedin.com/company/namefi
 language: ja
 ---
 

--- a/content/authors/ja/nirmit-buddhiraja.mdx
+++ b/content/authors/ja/nirmit-buddhiraja.mdx
@@ -1,8 +1,6 @@
 ---
 name: Nirmit Buddhiraja
-avatar: /blog-assets/authors/nirmit-buddhiraja.jpg
 occupation: ヒンディー語ローカライゼーション翻訳者
-company: Namefi
 language: ja
 ---
 

--- a/content/authors/ja/victor-zhou.mdx
+++ b/content/authors/ja/victor-zhou.mdx
@@ -4,6 +4,9 @@ avatar: /blog-assets/authors/victor-zhou.jpg
 occupation: 創業者・標準仕様エディター
 company: Namefi
 linkedin: https://www.linkedin.com/in/zainanzhou
+github: https://github.com/xinbenlv
+website: https://zzn.im
+blog: https://b.zzn.im
 language: ja
 ---
 

--- a/content/authors/ja/victor-zhou.mdx
+++ b/content/authors/ja/victor-zhou.mdx
@@ -1,12 +1,6 @@
 ---
 name: Victor Zhou
-avatar: /blog-assets/authors/victor-zhou.jpg
 occupation: 創業者・標準仕様エディター
-company: Namefi
-linkedin: https://www.linkedin.com/in/zainanzhou
-github: https://github.com/xinbenlv
-website: https://zzn.im
-blog: https://b.zzn.im
 language: ja
 ---
 

--- a/content/authors/ja/zakia-al-sinai.mdx
+++ b/content/authors/ja/zakia-al-sinai.mdx
@@ -1,8 +1,6 @@
 ---
 name: Zakia al-Sina'i
-avatar: /blog-assets/authors/zakia-al-sinai.jpg
 occupation: アラビア語ローカライゼーション翻訳者
-company: Namefi
 language: ja
 ---
 

--- a/content/authors/ko/aileen-wright.mdx
+++ b/content/authors/ko/aileen-wright.mdx
@@ -1,8 +1,6 @@
 ---
 name: Aileen Wright
-avatar: /blog-assets/authors/aileen-wright.jpg
 occupation: 예술·역사 작가
-company: Namefi
 language: ko
 ---
 

--- a/content/authors/ko/alan-machin.mdx
+++ b/content/authors/ko/alan-machin.mdx
@@ -1,8 +1,6 @@
 ---
 name: Alan Machin
-avatar: /blog-assets/authors/alan-machin.jpg
 occupation: 프랑스어 현지화 번역가
-company: Namefi
 language: ko
 ---
 

--- a/content/authors/ko/arivu-iyandhiran.mdx
+++ b/content/authors/ko/arivu-iyandhiran.mdx
@@ -1,8 +1,6 @@
 ---
 name: Arivu Iyandhiran
-avatar: /blog-assets/authors/arivu-iyandhiran.jpg
 occupation: 타밀어 현지화 번역가
-company: Namefi
 language: ko
 ---
 

--- a/content/authors/ko/chie-kudo.mdx
+++ b/content/authors/ko/chie-kudo.mdx
@@ -1,8 +1,6 @@
 ---
 name: Chie Kudō
-avatar: /blog-assets/authors/chie-kudo.jpg
 occupation: 일본어 현지화 번역가
-company: Namefi
 language: ko
 ---
 

--- a/content/authors/ko/fenwei-bian.mdx
+++ b/content/authors/ko/fenwei-bian.mdx
@@ -1,9 +1,6 @@
 ---
 name: Fenwei Bian
-avatar: /blog-assets/authors/fenwei-bian.jpg
 occupation: 소프트웨어 개발자·작가
-company: Namefi
-github: https://github.com/weifenbian
 language: ko
 ---
 

--- a/content/authors/ko/fenwei-bian.mdx
+++ b/content/authors/ko/fenwei-bian.mdx
@@ -3,6 +3,7 @@ name: Fenwei Bian
 avatar: /blog-assets/authors/fenwei-bian.jpg
 occupation: 소프트웨어 개발자·작가
 company: Namefi
+github: https://github.com/weifenbian
 language: ko
 ---
 

--- a/content/authors/ko/gong-jihye.mdx
+++ b/content/authors/ko/gong-jihye.mdx
@@ -1,8 +1,6 @@
 ---
 name: Gong Ji-hye
-avatar: /blog-assets/authors/gong-jihye.jpg
 occupation: 한국어 현지화 번역가
-company: Namefi
 language: ko
 ---
 

--- a/content/authors/ko/iria-maquieira.mdx
+++ b/content/authors/ko/iria-maquieira.mdx
@@ -1,8 +1,6 @@
 ---
 name: Iria Maquieira
-avatar: /blog-assets/authors/iria-maquieira.jpg
 occupation: 스페인어 현지화 번역가
-company: Namefi
 language: ko
 ---
 

--- a/content/authors/ko/kai-kunstmann.mdx
+++ b/content/authors/ko/kai-kunstmann.mdx
@@ -1,8 +1,6 @@
 ---
 name: Kai Kunstmann
-avatar: /blog-assets/authors/kai-kunstmann.jpg
 occupation: 독일어 현지화 번역가
-company: Namefi
 language: ko
 ---
 

--- a/content/authors/ko/namefiteam.mdx
+++ b/content/authors/ko/namefiteam.mdx
@@ -1,10 +1,6 @@
 ---
 name: Namefi Team
-avatar: /static/images/sparrowhawk-avatar.jpg
 occupation: Namefi 팀
-company: Namefi
-twitter: https://twitter.com/namefi_io
-linkedin: https://www.linkedin.com/company/namefi
 language: ko
 ---
 

--- a/content/authors/ko/nirmit-buddhiraja.mdx
+++ b/content/authors/ko/nirmit-buddhiraja.mdx
@@ -1,8 +1,6 @@
 ---
 name: Nirmit Buddhiraja
-avatar: /blog-assets/authors/nirmit-buddhiraja.jpg
 occupation: 힌디어 현지화 번역가
-company: Namefi
 language: ko
 ---
 

--- a/content/authors/ko/victor-zhou.mdx
+++ b/content/authors/ko/victor-zhou.mdx
@@ -4,6 +4,9 @@ avatar: /blog-assets/authors/victor-zhou.jpg
 occupation: 창업자·표준 편집자
 company: Namefi
 linkedin: https://www.linkedin.com/in/zainanzhou
+github: https://github.com/xinbenlv
+website: https://zzn.im
+blog: https://b.zzn.im
 language: ko
 ---
 

--- a/content/authors/ko/victor-zhou.mdx
+++ b/content/authors/ko/victor-zhou.mdx
@@ -1,12 +1,6 @@
 ---
 name: Victor Zhou
-avatar: /blog-assets/authors/victor-zhou.jpg
 occupation: 창업자·표준 편집자
-company: Namefi
-linkedin: https://www.linkedin.com/in/zainanzhou
-github: https://github.com/xinbenlv
-website: https://zzn.im
-blog: https://b.zzn.im
 language: ko
 ---
 

--- a/content/authors/ko/zakia-al-sinai.mdx
+++ b/content/authors/ko/zakia-al-sinai.mdx
@@ -1,8 +1,6 @@
 ---
 name: Zakia al-Sina'i
-avatar: /blog-assets/authors/zakia-al-sinai.jpg
 occupation: 아랍어 현지화 번역가
-company: Namefi
 language: ko
 ---
 

--- a/content/authors/ta/aileen-wright.mdx
+++ b/content/authors/ta/aileen-wright.mdx
@@ -1,8 +1,6 @@
 ---
 name: Aileen Wright
-avatar: /blog-assets/authors/aileen-wright.jpg
 occupation: கலை மற்றும் வரலாற்று எழுத்தாளர்
-company: Namefi
 language: ta
 ---
 

--- a/content/authors/ta/alan-machin.mdx
+++ b/content/authors/ta/alan-machin.mdx
@@ -1,8 +1,6 @@
 ---
 name: Alan Machin
-avatar: /blog-assets/authors/alan-machin.jpg
 occupation: பிரெஞ்சு உள்ளூர்மயமாக்கல் மொழிபெயர்ப்பாளர்
-company: Namefi
 language: ta
 ---
 

--- a/content/authors/ta/arivu-iyandhiran.mdx
+++ b/content/authors/ta/arivu-iyandhiran.mdx
@@ -1,8 +1,6 @@
 ---
 name: Arivu Iyandhiran
-avatar: /blog-assets/authors/arivu-iyandhiran.jpg
 occupation: தமிழ் உள்ளூர்மயமாக்கல் மொழிபெயர்ப்பாளர்
-company: Namefi
 language: ta
 ---
 

--- a/content/authors/ta/chie-kudo.mdx
+++ b/content/authors/ta/chie-kudo.mdx
@@ -1,8 +1,6 @@
 ---
 name: Chie Kudō
-avatar: /blog-assets/authors/chie-kudo.jpg
 occupation: ஜப்பானிய உள்ளூர்மயமாக்கல் மொழிபெயர்ப்பாளர்
-company: Namefi
 language: ta
 ---
 

--- a/content/authors/ta/fenwei-bian.mdx
+++ b/content/authors/ta/fenwei-bian.mdx
@@ -1,9 +1,6 @@
 ---
 name: Fenwei Bian
-avatar: /blog-assets/authors/fenwei-bian.jpg
 occupation: மென்பொருள் உருவாக்குநர் மற்றும் எழுத்தாளர்
-company: Namefi
-github: https://github.com/weifenbian
 language: ta
 ---
 

--- a/content/authors/ta/fenwei-bian.mdx
+++ b/content/authors/ta/fenwei-bian.mdx
@@ -3,6 +3,7 @@ name: Fenwei Bian
 avatar: /blog-assets/authors/fenwei-bian.jpg
 occupation: மென்பொருள் உருவாக்குநர் மற்றும் எழுத்தாளர்
 company: Namefi
+github: https://github.com/weifenbian
 language: ta
 ---
 

--- a/content/authors/ta/gong-jihye.mdx
+++ b/content/authors/ta/gong-jihye.mdx
@@ -1,8 +1,6 @@
 ---
 name: Gong Ji-hye
-avatar: /blog-assets/authors/gong-jihye.jpg
 occupation: கொரிய உள்ளூர்மயமாக்கல் மொழிபெயர்ப்பாளர்
-company: Namefi
 language: ta
 ---
 

--- a/content/authors/ta/iria-maquieira.mdx
+++ b/content/authors/ta/iria-maquieira.mdx
@@ -1,8 +1,6 @@
 ---
 name: Iria Maquieira
-avatar: /blog-assets/authors/iria-maquieira.jpg
 occupation: ஸ்பானிய உள்ளூர்மயமாக்கல் மொழிபெயர்ப்பாளர்
-company: Namefi
 language: ta
 ---
 

--- a/content/authors/ta/kai-kunstmann.mdx
+++ b/content/authors/ta/kai-kunstmann.mdx
@@ -1,8 +1,6 @@
 ---
 name: Kai Kunstmann
-avatar: /blog-assets/authors/kai-kunstmann.jpg
 occupation: ஜெர்மன் உள்ளூர்மயமாக்கல் மொழிபெயர்ப்பாளர்
-company: Namefi
 language: ta
 ---
 

--- a/content/authors/ta/namefiteam.mdx
+++ b/content/authors/ta/namefiteam.mdx
@@ -1,10 +1,6 @@
 ---
 name: Namefi Team
-avatar: /static/images/sparrowhawk-avatar.jpg
 occupation: Namefi குழு
-company: Namefi
-twitter: https://twitter.com/namefi_io
-linkedin: https://www.linkedin.com/company/namefi
 language: ta
 ---
 

--- a/content/authors/ta/nirmit-buddhiraja.mdx
+++ b/content/authors/ta/nirmit-buddhiraja.mdx
@@ -1,8 +1,6 @@
 ---
 name: Nirmit Buddhiraja
-avatar: /blog-assets/authors/nirmit-buddhiraja.jpg
 occupation: இந்தி உள்ளூர்மயமாக்கல் மொழிபெயர்ப்பாளர்
-company: Namefi
 language: ta
 ---
 

--- a/content/authors/ta/victor-zhou.mdx
+++ b/content/authors/ta/victor-zhou.mdx
@@ -4,6 +4,9 @@ avatar: /blog-assets/authors/victor-zhou.jpg
 occupation: நிறுவனர் மற்றும் தரநிலைத் தொகுப்பாசிரியர்
 company: Namefi
 linkedin: https://www.linkedin.com/in/zainanzhou
+github: https://github.com/xinbenlv
+website: https://zzn.im
+blog: https://b.zzn.im
 language: ta
 ---
 

--- a/content/authors/ta/victor-zhou.mdx
+++ b/content/authors/ta/victor-zhou.mdx
@@ -1,12 +1,6 @@
 ---
 name: Victor Zhou
-avatar: /blog-assets/authors/victor-zhou.jpg
 occupation: நிறுவனர் மற்றும் தரநிலைத் தொகுப்பாசிரியர்
-company: Namefi
-linkedin: https://www.linkedin.com/in/zainanzhou
-github: https://github.com/xinbenlv
-website: https://zzn.im
-blog: https://b.zzn.im
 language: ta
 ---
 

--- a/content/authors/ta/zakia-al-sinai.mdx
+++ b/content/authors/ta/zakia-al-sinai.mdx
@@ -1,8 +1,6 @@
 ---
 name: Zakia al-Sina'i
-avatar: /blog-assets/authors/zakia-al-sinai.jpg
 occupation: அரபு உள்ளூர்மயமாக்கல் மொழிபெயர்ப்பாளர்
-company: Namefi
 language: ta
 ---
 

--- a/content/authors/zh-CN/aileen-wright.mdx
+++ b/content/authors/zh-CN/aileen-wright.mdx
@@ -1,8 +1,6 @@
 ---
 name: Aileen Wright
-avatar: /blog-assets/authors/aileen-wright.jpg
 occupation: 艺术与历史撰稿人
-company: Namefi
 language: zh-CN
 ---
 

--- a/content/authors/zh-CN/alan-machin.mdx
+++ b/content/authors/zh-CN/alan-machin.mdx
@@ -1,8 +1,6 @@
 ---
 name: Alan Machin
-avatar: /blog-assets/authors/alan-machin.jpg
 occupation: 法语本地化译者
-company: Namefi
 language: zh-CN
 ---
 

--- a/content/authors/zh-CN/arivu-iyandhiran.mdx
+++ b/content/authors/zh-CN/arivu-iyandhiran.mdx
@@ -1,8 +1,6 @@
 ---
 name: Arivu Iyandhiran
-avatar: /blog-assets/authors/arivu-iyandhiran.jpg
 occupation: 泰米尔语本地化译者
-company: Namefi
 language: zh-CN
 ---
 

--- a/content/authors/zh-CN/chie-kudo.mdx
+++ b/content/authors/zh-CN/chie-kudo.mdx
@@ -1,8 +1,6 @@
 ---
 name: Chie Kudō
-avatar: /blog-assets/authors/chie-kudo.jpg
 occupation: 日语本地化译者
-company: Namefi
 language: zh-CN
 ---
 

--- a/content/authors/zh-CN/fenwei-bian.mdx
+++ b/content/authors/zh-CN/fenwei-bian.mdx
@@ -1,9 +1,6 @@
 ---
 name: 卞芬薇
-avatar: /blog-assets/authors/fenwei-bian.jpg
 occupation: 软件开发者与撰稿人
-company: Namefi
-github: https://github.com/weifenbian
 language: zh-CN
 ---
 

--- a/content/authors/zh-CN/fenwei-bian.mdx
+++ b/content/authors/zh-CN/fenwei-bian.mdx
@@ -3,6 +3,7 @@ name: 卞芬薇
 avatar: /blog-assets/authors/fenwei-bian.jpg
 occupation: 软件开发者与撰稿人
 company: Namefi
+github: https://github.com/weifenbian
 language: zh-CN
 ---
 

--- a/content/authors/zh-CN/gong-jihye.mdx
+++ b/content/authors/zh-CN/gong-jihye.mdx
@@ -1,8 +1,6 @@
 ---
 name: Gong Ji-hye
-avatar: /blog-assets/authors/gong-jihye.jpg
 occupation: 韩语本地化译者
-company: Namefi
 language: zh-CN
 ---
 

--- a/content/authors/zh-CN/iria-maquieira.mdx
+++ b/content/authors/zh-CN/iria-maquieira.mdx
@@ -1,8 +1,6 @@
 ---
 name: Iria Maquieira
-avatar: /blog-assets/authors/iria-maquieira.jpg
 occupation: 西班牙语本地化译者
-company: Namefi
 language: zh-CN
 ---
 

--- a/content/authors/zh-CN/kai-kunstmann.mdx
+++ b/content/authors/zh-CN/kai-kunstmann.mdx
@@ -1,8 +1,6 @@
 ---
 name: Kai Kunstmann
-avatar: /blog-assets/authors/kai-kunstmann.jpg
 occupation: 德语本地化译者
-company: Namefi
 language: zh-CN
 ---
 

--- a/content/authors/zh-CN/namefiteam.mdx
+++ b/content/authors/zh-CN/namefiteam.mdx
@@ -1,10 +1,6 @@
 ---
 name: Namefi Team
-avatar: /static/images/sparrowhawk-avatar.jpg
 occupation: Namefi 团队
-company: Namefi
-twitter: https://twitter.com/namefi_io
-linkedin: https://www.linkedin.com/company/namefi
 language: zh-CN
 ---
 

--- a/content/authors/zh-CN/nirmit-buddhiraja.mdx
+++ b/content/authors/zh-CN/nirmit-buddhiraja.mdx
@@ -1,8 +1,6 @@
 ---
 name: Nirmit Buddhiraja
-avatar: /blog-assets/authors/nirmit-buddhiraja.jpg
 occupation: 印地语本地化译者
-company: Namefi
 language: zh-CN
 ---
 

--- a/content/authors/zh-CN/victor-zhou.mdx
+++ b/content/authors/zh-CN/victor-zhou.mdx
@@ -4,6 +4,9 @@ avatar: /blog-assets/authors/victor-zhou.jpg
 occupation: 创始人兼标准编辑
 company: Namefi
 linkedin: https://www.linkedin.com/in/zainanzhou
+github: https://github.com/xinbenlv
+website: https://zzn.im
+blog: https://b.zzn.im
 language: zh-CN
 ---
 

--- a/content/authors/zh-CN/victor-zhou.mdx
+++ b/content/authors/zh-CN/victor-zhou.mdx
@@ -1,12 +1,6 @@
 ---
 name: Victor Zhou
-avatar: /blog-assets/authors/victor-zhou.jpg
 occupation: 创始人兼标准编辑
-company: Namefi
-linkedin: https://www.linkedin.com/in/zainanzhou
-github: https://github.com/xinbenlv
-website: https://zzn.im
-blog: https://b.zzn.im
 language: zh-CN
 ---
 

--- a/content/authors/zh-CN/zakia-al-sinai.mdx
+++ b/content/authors/zh-CN/zakia-al-sinai.mdx
@@ -1,8 +1,6 @@
 ---
 name: Zakia al-Sina'i
-avatar: /blog-assets/authors/zakia-al-sinai.jpg
 occupation: 阿拉伯语本地化译者
-company: Namefi
 language: zh-CN
 ---
 


### PR DESCRIPTION
## Summary

Adds personal web/social links for two contributors, and makes locale-invariant
author metadata live in **one** place instead of being copied into all 10 locales.

**1. New links**
- **Victor Zhou** (`victor-zhou`): `github: https://github.com/xinbenlv`,
  `website: https://zzn.im`, `blog: https://b.zzn.im`
- **Fenwei Bian** (`fenwei-bian`): `github: https://github.com/weifenbian`

**2. `en` is now the base for locale-invariant fields**
`avatar`, `company`, and the external links (`twitter`, `linkedin`, `github`,
`website`, `blog`) never differ by language, but the per-locale profile model was
duplicating them into every locale file — so changing one link meant editing 10
files. They now live only in `content/authors/en/<slug>.mdx`; the 9 localized
profiles keep only what genuinely differs: the display `name`, the translated
`occupation`, `language`, and the translated bio body.

Example — `content/authors/zh-CN/victor-zhou.mdx` is now just:

```yaml
name: Victor Zhou
occupation: 创始人兼标准编辑
language: zh-CN
```

…and still renders the avatar and all four links, inherited from `en`.

## Solution

- Commit 1: add the link fields (initially replicated across all 10 locales).
- Commit 2: strip the redundant fields from the 9 non-`en` profiles —
  **108 files, 279 fields removed**. The migration only removed a field when its
  value was byte-identical to `en`; a genuine override would have been kept.
  There were none, confirming the fields were 100% duplication. Fenwei's zh-CN
  name override (卞芬薇) and every translated `occupation` are untouched.

## ⚠️ Merge order

This data depends on the overlay loader in **d3servelabs/namefi-astra#5464**.

> **Merge astra#5464 first, then this PR.**

The astra change is backward compatible (it works with both the old replicated
data and this stripped data), but the reverse is not: if this data reaches astra
dev via the submodule auto-bump before the loader lands, non-English author pages
would lose their avatar/company/links until it does.

## Test plan

- `bun data:validate` → passed (0 errors; only pre-existing `keywords` warnings).
- `bun lint:mdx` → passed.
- Rendered against astra#5464 locally (dev server, submodule pointed here):
  - `/r/zh-CN/authors/victor-zhou` — inherits avatar + Website/Blog/GitHub/LinkedIn
    from `en`, keeps the translated 创始人兼标准编辑.
  - `/r/ja/authors/fenwei-bian` — inherits avatar + GitHub.
  - `/r/zh-CN/authors/fenwei-bian` — localized name 卞芬薇 still wins.
  - `/r/en/authors/victor-zhou` — unchanged.
  - `/r/zh-CN/authors` index — all 12 authors, avatars + links present, all
    occupations translated.

## Claude session summary (redacted)

- 2026-07-21T13:40Z — Added the link fields across all 10 locale copies per author.
- 2026-07-21T14:55Z — Per review feedback that locale-invariant metadata should be
  shared, migrated to an `en`-base model and verified inheritance across locales.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior depends on merging astra#5464 first; otherwise non-English author pages may render without inherited avatars and links until the overlay loader is deployed.
> 
> **Overview**
> Author profiles are refactored so **locale-invariant** frontmatter (`avatar`, `company`, and social URLs) lives only in `content/authors/en/<slug>.mdx`, while the nine other locale files keep translated `occupation`, `language`, and bio text.
> 
> **New links** on the English base: Victor Zhou gets `github`, `website`, and `blog`; Fenwei Bian gets `github`. Non-English pages are expected to **inherit** those fields (and avatars) via the overlay loader in **d3servelabs/namefi-astra#5464**—that PR must land before this data ships, or localized author pages can lose images and links.
> 
> Across **108** localized MDX files, duplicated `avatar` / `company` / social fields were removed where they matched `en` byte-for-byte; localized overrides (e.g. zh-CN Fenwei name **卞芬薇**) stay untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11dfbdf04f8f2afeab6211588cbd017cb7a18f6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->