### PR TITLE
docs(skill): brand-accurate real-colour marks + two-line domain-upgrade recipe

### DIFF
--- a/.agents/skills/namefi-resource-images/SKILL.md
+++ b/.agents/skills/namefi-resource-images/SKILL.md
@@ -95,8 +95,46 @@ explanation. Examples that produced the shipped set:
   `.com` bar stands tallest over shorter `.net/.org/.io/.ai` bars, a globe and
   connection lines behind, cursor on `.com`."*
 
-For brand-adjacent stories use brand-inspired colors and motifs (tags, arrows,
-storefronts, keys, receipts, maps) — **not** exact trademark logo recreations.
+For **generic / abstract** brand-adjacent stories use brand-inspired colors and
+motifs (tags, arrows, storefronts, keys, receipts, maps) — not exact trademark
+logo recreations. **But** when the *subject is a specific brand or a domain
+upgrade* (a company rename, a `getX.com → x.com` shortening, a brand history),
+the real brand marks and domain names ARE the subject — render them accurately
+per the next section.
+
+### Domain-upgrade & brand-history illustrations (domains are the hero)
+
+For a piece about upgrading from an older/longer domain to a newer/shorter one
+(e.g. `teslamotors.com → tesla.com`, `getdropbox.com → dropbox.com`,
+`ubercab.com → uber.com`), the **two domain names are the hero** — the largest,
+most central, most attention-grabbing elements. Everything else is a small
+decorative accent.
+
+- **Two-line, long → short layout.** Domain upgrades usually *shorten*, so stack
+  them vertically: the **older, longer** domain **smaller on top**, a bold arrow
+  pointing **down**, then the **newer, shorter** domain **bigger** below. (Not a
+  single left-to-right row — the size contrast is what tells the story.)
+- **Real trademark colours — colour is part of the trademark.** Render every
+  brand logo, wordmark and mark in its **own correct, real trademark colours**
+  exactly as the company uses them (Box blue, Dropbox blue, Tesla red, Uber
+  black, Snap yellow, Buffer navy). **Never invent or recolour a brand mark**,
+  and do **not** let the house palette cue (the "confident web blue", the
+  no-dark-blue aesthetic) override a brand's real colour — the aesthetic ban is
+  for *decorative* fills, not for a real brand mark that happens to be dark blue.
+- **Period-accurate marks.** Put the **old-era** logo beside the old domain and
+  the **current** logo beside the new domain, so the mark evolves with the name.
+- **Product / UI / vehicle stays decorative.** Any app screen, device, car or
+  object is a tiny accent tucked low or behind — never larger or more prominent
+  than the domain names.
+- **Spell every domain exactly** (both the old and the new), no missing/extra
+  characters — these locale-neutral strings are the subject and are QC-checked.
+
+> Reserved-zone variant: namefi-astra's `OgCard` demo renders a *text-free*
+> "bleed master" of this same recipe — the top-left title zone and top-right
+> wordmark corner are left as clean cream so a localized headline + logo overlay
+> later. Those masters live in namefi-astra
+> `apps/frontend/.storybook/og-fixtures/bleed-samples/` and are exercised by
+> `apps/resources/src/components/og-card.stories.tsx`.
 
 ## Per-image visual QC (mandatory)
 
@@ -114,6 +152,12 @@ Image models are non-deterministic; open every generated file and check:
 4. **Bottom bleed (covers)** — a cover's bottom ~22% is empty cream (room for the
    social caption); nothing important sits there.
 5. **Spelling** — all in-image text correct and matches the intended strings.
+6. **Brand fidelity (brand / domain-upgrade pieces)** — every brand mark is in
+   its **real trademark colours** (no invented or recoloured logos), the old-era
+   mark sits by the old domain and the current mark by the new, and the two
+   **domain names are the hero** (largest/central; product/UI stays a small
+   accent). For upgrades, confirm the **two-line long → short** layout reads
+   correctly (older/longer smaller on top, arrow down, newer/shorter bigger).
 
 If an image fails, regenerate just that one (tweak the prompt: pull content
 toward center, reinforce the empty reserves, shorten/relocate text), re-inspect,

--- a/.agents/skills/namefi-resource-images/SKILL.md
+++ b/.agents/skills/namefi-resource-images/SKILL.md
@@ -99,16 +99,16 @@ For **generic / abstract** brand-adjacent stories use brand-inspired colors and
 motifs (tags, arrows, storefronts, keys, receipts, maps) — not exact trademark
 logo recreations. **But** when the *subject is a specific brand or a domain
 upgrade* (a company rename, a `getX.com → x.com` shortening, a brand history),
-the real brand marks and domain names ARE the subject — render them accurately
-per the next section.
+the real brand marks ARE the subject — and, for an upgrade, the domain names too
+— so render them accurately per the next section.
 
-### Domain-upgrade & brand-history illustrations (domains are the hero)
+### Domain-upgrade illustrations (domains are the hero)
 
-For a piece about upgrading from an older/longer domain to a newer/shorter one
-(e.g. `teslamotors.com → tesla.com`, `getdropbox.com → dropbox.com`,
-`ubercab.com → uber.com`), the **two domain names are the hero** — the largest,
-most central, most attention-grabbing elements. Everything else is a small
-decorative accent.
+This section's **two-domain rules apply to a domain *upgrade*** — a piece pairing
+an older/longer domain with a newer/shorter one (e.g. `teslamotors.com →
+tesla.com`, `getdropbox.com → dropbox.com`, `ubercab.com → uber.com`). There the
+**two domain names are the hero** — the largest, most central, most
+attention-grabbing elements — and everything else is a small decorative accent.
 
 - **Two-line, long → short layout.** Domain upgrades usually *shorten*, so stack
   them vertically: the **older, longer** domain **smaller on top**, a bold arrow
@@ -121,6 +121,7 @@ decorative accent.
   and do **not** let the house palette cue (the "confident web blue", the
   no-dark-blue aesthetic) override a brand's real colour — the aesthetic ban is
   for *decorative* fills, not for a real brand mark that happens to be dark blue.
+  (This colour rule holds for **any** brand piece, upgrade or not.)
 - **Period-accurate marks.** Put the **old-era** logo beside the old domain and
   the **current** logo beside the new domain, so the mark evolves with the name.
 - **Product / UI / vehicle stays decorative.** Any app screen, device, car or
@@ -128,6 +129,14 @@ decorative accent.
   than the domain names.
 - **Spell every domain exactly** (both the old and the new), no missing/extra
   characters — these locale-neutral strings are the subject and are QC-checked.
+
+**Brand-history / logo-only pieces (no domain pair).** A brand piece that is
+*not* a domain upgrade — a logo evolution, a single-brand explainer — has no old
++ new domain to pair, so the two-line long→short layout, the domain-pairing, and
+the "spell every domain" rule **do not apply**. It still owes the **real
+trademark colours** and (if it shows more than one era of a mark)
+**period-accurate marks**; render whatever domain(s) it *does* name spelled
+exactly, and otherwise compose it like a normal house-style illustration.
 
 > Reserved-zone variant: namefi-astra's `OgCard` demo renders a *text-free*
 > "bleed master" of this same recipe — the top-left title zone and top-right
@@ -152,12 +161,15 @@ Image models are non-deterministic; open every generated file and check:
 4. **Bottom bleed (covers)** — a cover's bottom ~22% is empty cream (room for the
    social caption); nothing important sits there.
 5. **Spelling** — all in-image text correct and matches the intended strings.
-6. **Brand fidelity (brand / domain-upgrade pieces)** — every brand mark is in
-   its **real trademark colours** (no invented or recoloured logos), the old-era
-   mark sits by the old domain and the current mark by the new, and the two
-   **domain names are the hero** (largest/central; product/UI stays a small
-   accent). For upgrades, confirm the **two-line long → short** layout reads
-   correctly (older/longer smaller on top, arrow down, newer/shorter bigger).
+6. **Brand fidelity (any brand piece)** — every brand mark is in its **real
+   trademark colours** (no invented or recoloured logos); if it shows more than
+   one era of a mark, they are period-accurate.
+   **For a domain *upgrade* also confirm:** the old-era mark sits by the old
+   domain and the current mark by the new, the two **domain names are the hero**
+   (largest/central; product/UI stays a small accent), and the **two-line long →
+   short** layout reads correctly (older/longer smaller on top, arrow down,
+   newer/shorter bigger). (A logo-only brand-history piece with no domain pair is
+   exempt from the pairing/two-line/domain checks.)
 
 If an image fails, regenerate just that one (tweak the prompt: pull content
 toward center, reinforce the empty reserves, shorten/relocate text), re-inspect,


### PR DESCRIPTION
## Summary / Solution

Folds the **domain-upgrade illustration recipe** — validated while producing the
box.com / dropbox.com / tesla.com / buffer.com / uber.com / snap.com masters for
the astra `OgCard` demo — into the `namefi-resource-images` skill, so future
brand-history / domain-upgrade art follows it by default.

Two corrections the shipped set surfaced:

1. **Colour is part of the trademark.** The skill previously said "brand-inspired
   colors … **not** exact trademark logo recreations", which led to *invented*
   logo colours. Now: when the subject **is** a specific brand or a domain
   upgrade, render each brand mark in its **own real trademark colours** (Box
   blue, Tesla red, Snap yellow, Uber black, Dropbox blue, Buffer navy),
   period-accurate (old-era mark by the old domain, current mark by the new), and
   **never** let the house palette cue ("confident web blue" / the no-dark-blue
   aesthetic) override a brand's real colour. The generic/abstract
   "brand-inspired, not exact logos" guidance is retained for non-brand-subject
   pieces.
2. **Domains are the hero, two-line long → short.** For an upgrade the two domain
   names are the largest/central elements (product/UI drops to a small accent),
   stacked **older/longer smaller on top → arrow down → newer/shorter bigger
   below** — the size contrast is what tells the "upgrade = shorten" story.

Also adds QC item #6 (brand fidelity + two-line layout) and cross-references the
astra text-free reserved-zone "bleed master" variant of the same recipe.

**Scope of this increment.** Docs/skill-guidance only — updates
`.agents/skills/namefi-resource-images/SKILL.md`. It generates **no** new content
assets and changes **no** existing images; it only changes how future images are
prompted and QC'd.

## Test plan

- Docs-only change to a skill Markdown file; no code, no assets, no build output.
- Pre-push hooks green in this repo (`data_validate`, `links_audit`, `lint_mdx`).
- The recipe is not speculative — it distills the art direction empirically
  validated by the merged astra fixtures in d3servelabs/namefi-astra#5439.

## Documentation impact

This PR **is** the documentation change (the skill's `SKILL.md`). No other README
in the touched folder needs updating.

## Claude session summary

- **Main prompts (high level):** while art-directing the domain-upgrade OG
  masters, the user corrected two things — stop inventing brand-logo colours
  (colour is part of the trademark; use the real brand colours) and use a
  two-line long→short layout with the domain names as the hero — then approved
  capturing that recipe into the image-generation skill as a follow-up PR.
- **Timestamps:** authored 2026-07-20; see this branch's commit timestamp for the
  last update.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only skill guidance; no runtime code, builds, or shipped assets.
> 
> **Overview**
> Updates **`namefi-resource-images` `SKILL.md`** so future brand and domain-upgrade art follows rules validated on the shipped OG masters—**no code or image assets change**.
> 
> **Trademark colour:** When the subject is a **specific brand** or a **domain upgrade**, marks must use **real trademark colours** (not “brand-inspired” invented colours), with house palette rules limited to decorative fills. **Logo-only brand-history** pieces still get accurate colours and period marks but skip the domain-pair layout rules.
> 
> **Domain upgrades:** Adds a **domain-upgrade** recipe—**two domain names as the hero**, **two-line long→short** stack (older/longer smaller on top, arrow down, newer/shorter larger below), period-accurate logos beside each era, exact domain spelling, and product/UI kept as small accents.
> 
> Also adds **QC #6** (brand fidelity + upgrade layout checks) and points to namefi-astra **`OgCard` bleed-master** fixtures for the text-free reserved-zone variant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f5ef084d5619d314f34ca0938c2ff81bbdc21b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated imagery-generation guidance for domain-upgrade and brand-history illustrations.
  * Specified a long→short, two-line vertical layout for domain upgrades.
  * Added stricter requirements for accurately spelled old and new domain names, period-accurate marks, and exact trademark colors.
  * Limited product/UI elements to minor decorative accents.
  * Expanded the QC checklist to verify brand fidelity, correct old-vs-new mark placement, domain prominence, and layout accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->