### PR TITLE
content(tld): regenerate 39 oldest .a* TLD pages onto current template

### DIFF
--- a/content/tld/en/aaa.md
+++ b/content/tld/en/aaa.md
@@ -1,31 +1,22 @@
 ---
-title: 'Unlock Digital Excellence: What is the .aaa TLD and Why Choose It?'
-date: '2025-12-10'
+title: "What Is the .aaa Domain? AAA's Brand TLD Explained"
+date: '2026-07-24'
 language: 'en'
-tags:
-  - tld
-authors:
-  - namefiteam
-editors:
-  - victor-zhou
+tags: ['tld']
+authors: ['namefiteam']
+editors: ['victor-zhou']
 draft: false
-description: 'Discover the power of the .aaa top-level domain. Learn why this unique extension signifies quality and trust, and how it fits into the future of domain investing and Web3.'
-keywords:
-  - .aaa domains
-  - TLD
-  - top-level domain
-  - what is .aaa
-  - why choose .aaa
-  - what is the .aaa domain
-  - why choose the .aaa domain
-  - buy .aaa domain
-  - .aaa extension
-  - domain investing .aaa
-  - blockchain domains
-  - tokenized domains
-  - premium short domains
-  - Web3 identity
-  - brand TLDs
+description: 'The .aaa domain is the closed brand TLD of the American Automobile Association, not open to the public. Learn what it is, who runs it, and what to register instead.'
+keywords: ['.aaa domain', 'what is .aaa', '.aaa TLD', 'AAA brand domain', 'dot-brand TLD', 'American Automobile Association registry', 'closed generic TLD', 'is .aaa available']
+faqs:
+  - question: 'Can anyone register a .aaa domain?'
+    answer: 'No. .aaa is a closed brand TLD delegated to the American Automobile Association, Inc. Only AAA and its authorized motor clubs and affiliates can hold a .aaa name, so it is not available to the general public through any registrar.'
+  - question: 'Who operates the .aaa registry?'
+    answer: 'The American Automobile Association, Inc. is the registry operator, with GoDaddy Registry providing the technical back-end. The TLD was delegated to the DNS root zone on August 13, 2015.'
+  - question: 'Does "AAA" in the domain mean the same thing as a triple-A rating?'
+    answer: 'No. "AAA" is also used generically for top credit ratings, battery sizes, and service tiers, but the .aaa top-level domain itself is delegated exclusively to the American Automobile Association and is not a generic quality mark anyone can register into.'
+  - question: 'What can I register instead of .aaa?'
+    answer: 'Because .aaa is closed, choose an open extension for your own project. A matching .com, or a modern alternative like .io or .xyz, can be registered by anyone through an accredited registrar such as Namefi.'
 relatedArticles:
   - /en/blog/what-are-tokenized-domains/
   - /en/blog/what-is-a-tld/
@@ -46,55 +37,112 @@ relatedGlossary:
   - /en/glossary/registry/
 ---
 
-In the ever-expanding universe of the internet, choosing the right digital identity is more crucial than ever. While everyone is familiar with `.com` or `.net`, the introduction of new generic [Top-Level Domains](/en/glossary/tld/) (gTLDs) has opened the door for more specific, branded, and memorable web addresses. One such intriguing extension is the **.aaa** TLD.
+The **.aaa** domain is a **closed brand [top-level domain](/en/glossary/tld/)** operated by the **American Automobile Association, Inc.** (AAA), the federation of motor clubs across the United States and Canada. It is not a public extension: unlike [.com](/en/tld/com/) or [.io](/en/tld/io/), you cannot register a `.aaa` name for your own project, because the entire namespace belongs to one organization.
 
-Whether you are a domain investor looking for the next big asset, a developer building a [Web3](/en/glossary/web3/) project, or a business aiming for a top-tier reputation, understanding the nuance of the `.aaa` domain is essential.
+If you searched for the ".aaa domain" hoping to buy one, the short answer is that you can't — but this page explains exactly what `.aaa` is, who controls it, why the string is more than a generic quality mark, and what you can register instead.
 
-## **What is .aaa?**
+## .aaa at a glance
 
-The **.aaa** extension is a specific type of Top-Level Domain known as a "Brand TLD." It was originally applied for and delegated to the **American Automobile Association (AAA)**. Unlike open gTLDs (like `.xyz` or `.online`) that are available for immediate public registration by anyone, Brand TLDs are often managed with stricter eligibility requirements intended to protect the brand's identity and security.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | American Automobile Association, Inc. (technical back-end by GoDaddy Registry) |
+| Year delegated | 2015 |
+| IDN support | Not relevant — closed namespace |
+| DNSSEC | Supported |
+| Registration restrictions | **Closed** — restricted to AAA and its authorized motor clubs and affiliates; not available to the public |
+| Best for | AAA's own club, roadside-assistance, travel, and insurance sites |
 
-However, in the broader context of the [domain name system](/en/glossary/dns/) (DNS) and the evolving [ICANN](https://www.icann.org/) landscape, extensions like `.aaa` represent the pinnacle of trust. The string "AAA" itself is universally recognized as a symbol of the highest quality—from credit ratings to battery sizes and service tiers.
+## What is .aaa?
 
-As the internet moves toward Web3, the concept of [domain ownership](/en/glossary/domain-ownership/) is shifting. Tokenized domains and [blockchain](/en/glossary/blockchain/) naming services are creating new opportunities for unique identifiers, making short, repeating-character domains like `.aaa` highly coveted assets in the digital real estate market.
+`.aaa` is a **[generic top-level domain](/en/glossary/gtld/)** that ICANN delegated to the **American Automobile Association, Inc.** during its New gTLD Program. AAA is a federation of regional motor clubs that provides roadside assistance, travel services, and insurance across North America, and the three letters in the TLD are the organization's own name, not a coincidence.
 
-## **How People Are Using .aaa**
+The string "AAA" is also a familiar generic term elsewhere — a top-tier credit rating, a battery size, a hotel or service grade — but this particular top-level domain is not open to whoever wants to trade on that reputation. It is a **brand TLD** ("dot-brand"), delegated so that AAA, and only AAA, controls every domain ending in `.aaa`. You can confirm the delegation and operator on the authoritative [IANA root-zone record for .aaa](https://www.iana.org/domains/root/db/aaa.html).
 
-Because `.aaa` acts primarily as a proprietary extension, its usage is focused on distinct, high-trust applications. However, the *concept* of using such a domain applies broadly to how businesses utilize exclusive TLDs:
+## History of .aaa
 
-*   **Brand Ecosystems:** Large organizations use extensions like `.aaa` to create a secure ecosystem for their affiliates, regional clubs, and internal portals.
-*   **Service Verification:** Using a restricted TLD acts as a badge of authenticity. Users know that a site ending in `.aaa` is genuinely affiliated with the organization, mitigating [phishing](/en/glossary/phishing/) risks.
-*   **Marketing Campaigns:** Short, memorable domains are often used for specific landing pages or service locators (e.g., `roadside.aaa`).
+The `.aaa` string was **delegated to the DNS [root zone](/en/glossary/root-zone/) on August 13, 2015**, with **GoDaddy Registry** handling the technical back-end operation on AAA's behalf. As with other dot-brands, its registry agreement with [ICANN](/en/glossary/icann/) includes Specification 13, the contract clause that formally designates a TLD as a brand and lets the operator keep it closed.
 
-## **Notable Entities Using .aaa**
+The record has stayed active since delegation. AAA runs its main public presence from [aaa.com](https://www.aaa.com), and uses the dot-brand selectively rather than as a full replacement for its legacy domain.
 
-Given its status as a Brand TLD, the primary entity utilizing this extension is the [registry](/en/glossary/registry/) owner itself.
+## Is .aaa available to register?
 
-*   **The American Automobile Association:** The primary user, utilizing the domain for regional clubs and services (e.g., `calif.aaa` or `texas.aaa`).
-*   **Affiliated Insurance and Travel Services:** Various branches of the organization utilize the domain to segregate services while maintaining brand unity.
+**No.** `.aaa` is a **closed brand TLD**, so there is no open registration and no [registrar](/en/glossary/registrar/) — including Namefi — can sell you a `.aaa` name. Registrations are limited to the American Automobile Association and organizations it authorizes, such as its member motor clubs and affiliated insurance or travel businesses. This is by design: a dot-brand exists precisely so the trademark holder controls the whole namespace and no one else can register a confusing or malicious lookalike.
 
-*For investors and developers:* While the list of entities is exclusive, this exclusivity drives the fascination with the TLD. In the Web3 and [tokenized domain](/en/glossary/tokenized-domain/) space, acquiring "AAA" rated assets or similar 3-letter combinations on other chains is a massive trend due to their scarcity and prestige.
+If you have a genuine business relationship with AAA and a legitimate need for a `.aaa` address, that request would go through AAA's own corporate channels, not a commercial registrar.
 
-## **Why Choose .aaa?**
+## How AAA uses .aaa
 
-If you have the opportunity to acquire a domain within this namespace, or if you are considering the value of "AAA" branding in the domain [aftermarket](/en/glossary/aftermarket/), here is why it stands out:
+Brand TLDs give an organization a private space to organize its web presence. Typical uses for a dot-brand like `.aaa` include:
 
-*   **Implicit Trust:** The "AAA" moniker implies a "Triple-A" rating—the highest standard of excellence. It psychologically primes the visitor to expect premium service.
-*   **Unbeatable Memorability:** Repeating characters are the easiest for the human brain to recall. A domain like `.aaa` requires zero effort to remember.
-*   **Brevity:** In a mobile-first world, shorter is better. A 3-letter TLD saves keystrokes and looks cleaner on social media profiles and business cards.
-*   **Security:** For those operating within the authorized ecosystem, the closed nature of the TLD virtually eliminates the risk of [cybersquatting](/en/glossary/cybersquatting/) or fraudulent look-alike domains.
+- **Regional club sites** tied directly to the federation's shared brand.
+- **Service and campaign pages** that are obviously official because only AAA can create them.
+- **Member portals** where a branded suffix signals a trusted, first-party destination for benefits and insurance.
 
-## **Register Your .aaa Domain at Namefi**
+**Who it's not for:** anyone outside the AAA federation. Because the namespace is closed, there is no scenario in which an independent developer, investor, or business can build on `.aaa`.
 
-Whether you are looking to secure a standard domain or exploring the frontier of **tokenized real-world assets**, Namefi is your gateway to the future of digital identity.
+## Notable sites using .aaa
 
-At Namefi, we bridge the gap between traditional Web2 DNS and the Web3 blockchain ecosystem. By registering or managing your domains with us, you unlock:
-*   **Seamless Web3 Integration:** Manage your DNS domains using your crypto wallet.
-*   **Instant Liquidity:** Trade your domains as NFTs on marketplaces without complex [escrow](/en/glossary/escrow/) paperwork.
-*   **ICANN Accreditation:** Trust in a fully compliant, secure [registrar](/en/glossary/registrar/) platform.
+There are **no third-party sites** on `.aaa`, and there never will be while it stays a closed brand TLD — every `.aaa` address is controlled by the American Automobile Association. AAA continues to run most of its public presence from its long-established `.com` domain, and uses the brand TLD selectively rather than as a wholesale replacement. Rather than point to a specific address that may change, the honest description is simple: `.aaa` is AAA's private namespace, used only for the federation's own properties.
 
-Are you ready to elevate your digital presence with a [premium domain](/en/glossary/premium-domain/) strategy?
+## What is a dot-brand TLD?
 
-[**Start your search at Namefi**](https://namefi.io)
+A **dot-brand** (or brand TLD) is a top-level domain that a single company or organization owns and operates for its exclusive use, secured through ICANN's [New gTLD Program](/en/glossary/new-gtld/). Hundreds were delegated, and they share a few defining traits:
 
-*Secure your digital legacy today. Don't let the perfect name slip away.*
+- **Closed registration.** Only the brand and its affiliates can hold names.
+- **Specification 13.** A registry-agreement addendum that formally recognizes the TLD as a brand and relaxes some rules that apply to open generics.
+- **Security and control.** The brand eliminates the risk of anyone else registering a `.aaa` lookalike, which strengthens resistance to [phishing](/en/glossary/phishing/) and impersonation.
+
+Some brands invest heavily in their TLD; others register it defensively and barely use it. A number of companies have even terminated their dot-brands after deciding the upkeep was not worth it.
+
+## .aaa vs open domain alternatives
+
+If your goal was a short, brandable name rather than the `.aaa` string specifically, an open extension is the right tool. Here is how a closed brand TLD compares with domains you can actually register:
+
+| Feature | .aaa | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.xyz](/en/tld/xyz/) |
+| --- | --- | --- | --- | --- |
+| Who can register | AAA only | Anyone | Anyone | Anyone |
+| Type | Brand new gTLD (closed) | Legacy gTLD | ccTLD used generically | New gTLD |
+| Core use | AAA's own sites | Universal default | Tech & startups | Generic / Web3 |
+| Available to you | No | Yes | Yes | Yes |
+
+For your own venture, a matching `.com` remains the safest default; [.io](/en/tld/io/) suits technical products; and [.xyz](/en/tld/xyz/) is a flexible, low-cost modern option.
+
+## Reputation and trust
+
+Ironically, the closed nature of `.aaa` is exactly what makes it trustworthy: because only AAA can create these addresses, a `.aaa` link is verifiably official, which is why brand TLDs are considered strong against impersonation and email spoofing. That trust, however, benefits AAA alone — it does not transfer to any name you might register, since you cannot register one. For your own project, deliverability and reputation will come from a well-configured domain on an open extension, not from a brand TLD you don't control.
+
+## Looking for an "aaa" name? Register an alternative at Namefi
+
+You can't buy a `.aaa` domain, but if you want a short name — maybe an acronym of your own — you can secure it on an open extension in minutes:
+
+1. **Search** your desired name across open TLDs like `.com`, `.io`, or `.xyz`.
+2. **Choose** the extension that fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can anyone register a .aaa domain?
+
+No. `.aaa` is a closed brand TLD delegated to the American Automobile Association, Inc. Only AAA and its authorized motor clubs and affiliates can hold a `.aaa` name, so it is not available to the general public through any registrar.
+
+### Who operates the .aaa registry?
+
+The American Automobile Association, Inc. is the registry operator, with GoDaddy Registry providing the technical back-end. The TLD was delegated to the DNS root zone on August 13, 2015.
+
+### Does "AAA" in the domain mean the same thing as a triple-A rating?
+
+No. "AAA" is also used generically for top credit ratings, battery sizes, and service tiers, but the `.aaa` top-level domain itself is delegated exclusively to the American Automobile Association and is not a generic quality mark anyone can register into.
+
+### What can I register instead of .aaa?
+
+Because `.aaa` is closed, choose an open extension for your own project. A matching `.com`, or a modern alternative like `.io` or `.xyz`, can be registered by anyone through an accredited registrar such as Namefi.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals behind top-level domains.
+- [.com TLD guide](/en/tld/com/) — the open default to compare against.
+- [.io TLD guide](/en/tld/io/) and [.xyz TLD guide](/en/tld/xyz/) — modern open alternatives.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [registry](/en/glossary/registry/), [ICANN](/en/glossary/icann/).

--- a/content/tld/en/aaa.md
+++ b/content/tld/en/aaa.md
@@ -3,7 +3,7 @@ title: "What Is the .aaa Domain? AAA's Brand TLD Explained"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .aaa domain is the closed brand TLD of the American Automobile Association, not open to the public. Learn what it is, who runs it, and what to register instead.'

--- a/content/tld/en/aarp.md
+++ b/content/tld/en/aarp.md
@@ -1,12 +1,22 @@
 ---
-title: "The .aarp TLD: A Symbol of Trust and Community"
-date: '2025-12-10'
+title: "What Is the .aarp Domain? AARP's Brand TLD Explained"
+date: '2026-07-24'
 language: 'en'
-tags: ['tld', 'domain-names', 'branding', 'internet-security']
+tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: "Discover the purpose of the .aarp Top-Level Domain. Learn how this restricted TLD represents security and community, and how to secure your own digital identity."
+description: 'The .aarp domain is the closed brand TLD of the nonprofit AARP, not open to the public. Learn what it is, who runs it, why it exists, and what to register instead.'
+keywords: ['.aarp domain', 'what is .aarp', '.aarp TLD', 'AARP brand domain', 'dot-brand TLD', 'AARP registry', 'closed generic TLD', 'is .aarp available']
+faqs:
+  - question: 'Can anyone register a .aarp domain?'
+    answer: 'No. .aarp is a closed brand TLD delegated to AARP. Only AARP and parties it authorizes can hold a .aarp name, so it is not available to the general public through any registrar.'
+  - question: 'Who operates the .aarp registry?'
+    answer: 'AARP is the registry operator, with GoDaddy Registry providing the technical back-end. The TLD was delegated to the DNS root zone on October 22, 2015.'
+  - question: 'What does AARP stand for?'
+    answer: 'AARP was originally the American Association of Retired Persons. It is now a large US nonprofit membership organization for people age 50 and over, and the organization uses the initialism AARP as its primary name.'
+  - question: 'What can I register instead of .aarp?'
+    answer: 'Because .aarp is closed, choose an open extension for your own project. A matching .com, or a modern alternative like .io or .xyz, can be registered by anyone through an accredited registrar such as Namefi.'
 relatedArticles:
   - /en/blog/top-tlds-to-secure-for-your-accounting-firm/
   - /en/blog/top-tlds-to-secure-for-your-business/
@@ -27,48 +37,112 @@ relatedGlossary:
   - /en/glossary/registry/
 ---
 
-## **What is .aarp?**
+The **.aarp** domain is a **closed brand [top-level domain](/en/glossary/tld/)** operated by **AARP**, the large US nonprofit membership organization for people age 50 and over. It is not a public extension: unlike [.com](/en/tld/com/) or [.io](/en/tld/io/), you cannot register a `.aarp` name for your own project, because the entire namespace belongs to one organization.
 
-The **.aarp** extension is a specialized generic [Top-Level Domain](/en/glossary/tld/) (gTLD) classified specifically as a "Brand TLD." Unlike open domains such as [.com](/en/tld/com/) or [.net](/en/tld/net/) which are available for public registration, **.aarp** is a restricted [registry](/en/glossary/registry/) delegated exclusively to AARP (formerly the American Association of Retired Persons).
+If you searched for the ".aarp domain" hoping to buy one, the short answer is that you can't — but this page explains exactly what `.aarp` is, who controls it, why a nonprofit runs its own TLD, and what you can register instead.
 
-Launched during the [ICANN](/en/glossary/icann/) [New gTLD](/en/glossary/new-gtld/) Program, the primary purpose of this domain is to create a secure, authenticated, and trusted digital namespace for the organization and its millions of members. It serves as a digital stamp of authenticity, ensuring that any website ending in `.aarp` is officially sanctioned by the organization. As internet security becomes paramount in 2025, TLDs like this are essential for protecting users from [phishing](/en/glossary/phishing/) and brand impersonation.
+## .aarp at a glance
 
-## **How People Are Using .aarp**
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | AARP (technical back-end by GoDaddy Registry) |
+| Year delegated | 2015 |
+| IDN support | Not relevant — closed namespace |
+| DNSSEC | Supported |
+| Registration restrictions | **Closed** — restricted to AARP and parties it authorizes; not available to the public |
+| Best for | AARP's own membership, benefits, and advocacy sites |
 
-Because `.aarp` is a closed ecosystem, its usage is distinct from standard commercial domains. It is utilized strategically to streamline digital services and enhance user safety.
+## What is .aarp?
 
-*   **Verified Communications:** The domain is used to host official information pages, ensuring members know they are reading legitimate health, financial, or lifestyle advice.
-*   **Secure Portals:** It serves as a secure anchor for member login portals and benefit management systems, reducing the risk of credential theft.
-*   **Campaign Specifics:** Using the TLD for specific advocacy campaigns or events (e.g., `vote.aarp` or `rewards.aarp`) allows for memorable, short URLs that are easy to type on mobile devices.
-*   **Brand Protection:** By owning the extension, the organization prevents cybersquatters from purchasing misleading domain names that could confuse the elderly demographic the organization serves.
+`.aarp` is a **[generic top-level domain](/en/glossary/gtld/)** that ICANN delegated to **AARP** during its New gTLD Program. AARP was founded as the American Association of Retired Persons; today it is one of the largest nonprofit membership organizations in the United States, serving people age 50 and older with advocacy, benefits, and information on health, finance, and lifestyle.
 
-## **Notable Entities Using .aarp**
+`.aarp` is a **brand TLD** — often called a "dot-brand" — not an open extension anyone can buy into. AARP applied for the string specifically so that it, and only it, would control every domain ending in `.aarp`. You can confirm the delegation and operator on the authoritative [IANA root-zone record for .aarp](https://www.iana.org/domains/root/db/aarp.html).
 
-As a Brand TLD, the "entities" using this extension are strictly departments, subsidiaries, or initiatives within the AARP ecosystem. Here are the primary ways it is deployed:
+## History of .aarp
 
-1.  **AARP Member Benefits:** Subdomains dedicated to specific insurance, travel, or health benefits offered to members.
-2.  **AARP Foundation:** Charitable and philanthropic initiatives often utilize the clear branding of the TLD to drive donations and volunteerism.
-3.  **Internal Infrastructure:** The organization uses the domain for backend infrastructure and employee portals to maintain high-level cybersecurity standards.
+The `.aarp` string was **delegated to the DNS [root zone](/en/glossary/root-zone/) on October 22, 2015**, with **GoDaddy Registry** handling the technical operation on AARP's behalf. As with other dot-brands, its registry agreement with [ICANN](/en/glossary/icann/) includes Specification 13, the contract clause that formally designates a TLD as a brand and lets the operator keep it closed.
 
-## **Why Choose .aarp?**
+The record has remained active since delegation. AARP's primary public site for the TLD is [nic.aarp](https://nic.aarp), the registry-information page that every dot-brand operator is required to publish.
 
-While the general public cannot register a `.aarp` domain, understanding its advantages highlights why choosing the right TLD is crucial for any business strategy. For the organization and its users, the benefits are clear:
+## Is .aarp available to register?
 
-*   **Unmatched Trust:** When a user sees `.aarp` in the browser bar, they have 100% certainty they are interacting with the official organization.
-*   **SEO Authority:** Search engines recognize the strict governance of Brand TLDs, often associating them with high authority and relevance for related search queries.
-*   **Security:** Because the registry is closed, there is zero risk of third-party abuse, malware distribution, or phishing sites being hosted on the extension.
-*   **Branding Clarity:** It removes the need for long, hyphenated URLs, providing a clean and modern web address.
+**No.** `.aarp` is a **closed brand TLD**, so there is no open registration and no [registrar](/en/glossary/registrar/) — including Namefi — can sell you a `.aarp` name. Registrations are limited to AARP and organizations it authorizes, such as affiliated programs and partners. This is by design: a dot-brand exists precisely so the organization controls the whole namespace and no one else can register a confusing or malicious lookalike aimed at its members.
 
-## **Register Your Domain at Namefi**
+If you have a genuine relationship with AARP and a legitimate need for a `.aarp` address, that request would go through AARP's own channels, not a commercial registrar.
 
-While `.aarp` is exclusive to the AARP organization, you can still secure a powerful, trustworthy, and memorable domain for your own business or personal brand. At **Namefi**, we specialize in helping you find the perfect digital identity among hundreds of available TLDs.
+## How AARP uses .aarp
 
-Whether you are looking for a classic `.com`, a tech-savvy `.io`, or exploring the future of the internet with [Web3](/en/glossary/web3/) integrations, Namefi makes the process seamless.
+Brand TLDs give an organization a private space to organize its web presence. Typical uses for a dot-brand like `.aarp` include:
 
-*   **ICANN-Accredited:** We are a fully compliant and trusted [registrar](/en/glossary/registrar/).
-*   **Web3 Ready:** Seamlessly mint your Web2 domains [on-chain](/en/glossary/on-chain/) to unlock the power of [DeFi](/en/glossary/defi/) and [decentralized identity](/en/glossary/did/).
-*   **Instant Setup:** effortless management and DNS configuration.
+- **Member benefit and program pages** on clean, memorable addresses tied directly to the brand.
+- **Advocacy and campaign pages** that are obviously official because only AARP can create them.
+- **Internal tools and portals** where a branded suffix signals a trusted, first-party destination for an older membership base that is a frequent phishing target.
 
-Don't leave your brand to chance. Secure your perfect domain name today.
+**Who it's not for:** anyone outside AARP. Because the namespace is closed, there is no scenario in which an independent developer, business, or advocacy group can build on `.aarp`.
 
-[**Register your domain at Namefi**](https://namefi.io)
+## Notable sites using .aarp
+
+There are **no third-party sites** on `.aarp`, and there never will be while it stays a closed brand TLD — every `.aarp` address is controlled by AARP. The organization runs its main public presence from its long-established `.org` domain, and uses the brand TLD selectively rather than as a wholesale replacement. Rather than point to a specific address that may change, the honest description is simple: `.aarp` is AARP's private namespace, used only for the organization's own properties.
+
+## What is a dot-brand TLD?
+
+A **dot-brand** (or brand TLD) is a top-level domain that a single organization owns and operates for its exclusive use, secured through ICANN's [New gTLD Program](/en/glossary/new-gtld/). Hundreds were delegated, and they share a few defining traits:
+
+- **Closed registration.** Only the brand and its affiliates can hold names.
+- **Specification 13.** A registry-agreement addendum that formally recognizes the TLD as a brand and relaxes some rules that apply to open generics.
+- **Security and control.** The brand eliminates the risk of anyone else registering a `.aarp` lookalike, which strengthens resistance to [phishing](/en/glossary/phishing/) and impersonation — a meaningful concern for an organization whose members are frequent targets of scams.
+
+Some brands invest heavily in their TLD; others register it defensively and barely use it. A number of companies have even terminated their dot-brands after deciding the upkeep was not worth it.
+
+## .aarp vs open domain alternatives
+
+If your goal was a short, brandable name rather than the `.aarp` string specifically, an open extension is the right tool. Here is how a closed brand TLD compares with domains you can actually register:
+
+| Feature | .aarp | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.xyz](/en/tld/xyz/) |
+| --- | --- | --- | --- | --- |
+| Who can register | AARP only | Anyone | Anyone | Anyone |
+| Type | Brand new gTLD (closed) | Legacy gTLD | ccTLD used generically | New gTLD |
+| Core use | AARP's own sites | Universal default | Tech & startups | Generic / Web3 |
+| Available to you | No | Yes | Yes | Yes |
+
+For your own venture, a matching `.com` remains the safest default; [.io](/en/tld/io/) suits technical products; and [.xyz](/en/tld/xyz/) is a flexible, low-cost modern option.
+
+## Reputation and trust
+
+Ironically, the closed nature of `.aarp` is exactly what makes it trustworthy: because only AARP can create these addresses, a `.aarp` link is verifiably official, which is why brand TLDs are considered strong against impersonation and email spoofing. That trust, however, benefits AARP alone — it does not transfer to any name you might register, since you cannot register one. For your own project, deliverability and reputation will come from a well-configured domain on an open extension, not from a brand TLD you don't control.
+
+## Looking for an "aarp" name? Register an alternative at Namefi
+
+You can't buy a `.aarp` domain, but if you want a short, memorable name of your own, you can secure it on an open extension in minutes:
+
+1. **Search** your desired name across open TLDs like `.com`, `.io`, or `.xyz`.
+2. **Choose** the extension that fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can anyone register a .aarp domain?
+
+No. `.aarp` is a closed brand TLD delegated to AARP. Only AARP and parties it authorizes can hold a `.aarp` name, so it is not available to the general public through any registrar.
+
+### Who operates the .aarp registry?
+
+AARP is the registry operator, with GoDaddy Registry providing the technical back-end. The TLD was delegated to the DNS root zone on October 22, 2015.
+
+### What does AARP stand for?
+
+AARP was originally the American Association of Retired Persons. It is now a large US nonprofit membership organization for people age 50 and over, and the organization uses the initialism AARP as its primary name.
+
+### What can I register instead of .aarp?
+
+Because `.aarp` is closed, choose an open extension for your own project. A matching `.com`, or a modern alternative like `.io` or `.xyz`, can be registered by anyone through an accredited registrar such as Namefi.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals behind top-level domains.
+- [.com TLD guide](/en/tld/com/) — the open default to compare against.
+- [.io TLD guide](/en/tld/io/) and [.xyz TLD guide](/en/tld/xyz/) — modern open alternatives.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [registry](/en/glossary/registry/), [ICANN](/en/glossary/icann/).

--- a/content/tld/en/aarp.md
+++ b/content/tld/en/aarp.md
@@ -3,7 +3,7 @@ title: "What Is the .aarp Domain? AARP's Brand TLD Explained"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .aarp domain is the closed brand TLD of the nonprofit AARP, not open to the public. Learn what it is, who runs it, why it exists, and what to register instead.'

--- a/content/tld/en/abarth.md
+++ b/content/tld/en/abarth.md
@@ -1,12 +1,22 @@
 ---
-title: What is .abarth TLD and why choose it?
-date: '2025-12-10'
+title: 'What Was the .abarth Domain? A Terminated Brand TLD'
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: Learn about the .abarth TLD, its uses, advantages, and how to register your .abarth domain with Namefi. Secure your unique online identity today!
+description: 'The .abarth domain was a brand TLD for the Abarth car marque that ICANN terminated in 2023. Learn its history, why it was removed, and what to register instead.'
+keywords: ['.abarth domain', 'what is .abarth', '.abarth TLD', 'Abarth brand domain', 'terminated TLD', 'discontinued gTLD', 'dot-brand TLD', 'is .abarth available']
+faqs:
+  - question: 'Can I register a .abarth domain?'
+    answer: 'No. .abarth was terminated in 2023 and removed from the DNS root zone, so it no longer exists as a working extension and cannot be registered through any registrar. Even before that, it was a closed brand TLD never open to the public.'
+  - question: 'What happened to .abarth?'
+    answer: 'ICANN removed .abarth from the root zone on 5 June 2023 after the brand chose to end its registry agreement. The sister marque .alfaromeo was withdrawn on the same day, part of Stellantis stepping back from its dot-brand TLDs.'
+  - question: 'Was .abarth ever open to the public?'
+    answer: 'No. .abarth was always a closed brand TLD, meaning only the Abarth marque and its parent group could ever register names under it. It was never sold to outside individuals or businesses.'
+  - question: 'Where can I find official Abarth websites now?'
+    answer: 'Abarth runs its official presence from conventional domains such as abarth.com and country-specific sites, alongside its parent group Stellantis. The .abarth extension is no longer part of that footprint.'
 relatedArticles:
   - /en/blog/top-tlds-to-secure-for-your-business/
   - /en/blog/what-are-tokenized-domains/
@@ -27,38 +37,85 @@ relatedGlossary:
   - /en/glossary/registry/
 ---
 
-## **What is .abarth?**
+The **.abarth** domain was a **brand [top-level domain](/en/glossary/tld/)** created for **Abarth**, the Italian performance-car marque within the Fiat group (now part of Stellantis). It is no longer active: ICANN **removed `.abarth` from the DNS [root zone](/en/glossary/root-zone/) in 2023**, so the extension no longer resolves and cannot be registered.
 
-The .abarth [Top-Level Domain](/en/glossary/tld/) (TLD) is a brand [gTLD](/en/glossary/gtld/), representing the iconic Italian automobile marque, Abarth. Abarth, originally Abarth & C., is known for its high-performance vehicles and racing heritage. This TLD provides a dedicated online space for the Abarth brand, its community, and related content. While relatively new, the .abarth TLD is intended to serve as a hub for Abarth enthusiasts, owners, and the company itself, showcasing products, news, events, and fostering brand engagement.
+If you searched for the ".abarth domain," this page explains what it was, why it disappeared, and what the story of a terminated dot-brand means for anyone choosing a domain today.
 
-## **How People Are Using .abarth**
+## .abarth at a glance
 
-The .abarth TLD is primarily used by:
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | Abarth marque (Fiat / Stellantis) — agreement now terminated |
+| Year delegated | 2016 |
+| Year terminated | 2023 (removed from the root zone) |
+| Current status | **Terminated** — not present in the DNS root zone |
+| Registration restrictions | **Not available** — the TLD no longer exists |
 
-*   Abarth S.p.A. for official brand representation and communication.
-*   Abarth dealerships for localized marketing and customer engagement.
-*   Abarth clubs and enthusiast groups for community building.
-*   Third-party vendors selling Abarth-related merchandise or services.
-*   Blogs and forums dedicated to Abarth vehicles and motorsports.
+## What was .abarth?
 
-## **Notable Entities Using .abarth**
+`.abarth` was a **closed brand [gTLD](/en/glossary/new-gtld/)**: a top-level domain reserved for a single company's exclusive use. The string is the name of **Abarth**, the racing and tuning marque founded in 1949 and long associated with high-performance versions of Fiat cars. Its parent, Fiat Chrysler Automobiles, became part of **Stellantis** in 2021.
 
-While specific examples are limited due to the relatively new nature of the TLD, here are some hypothetical or potential best use cases:
+Like other dot-brands, `.abarth` was never open to the public. Only the brand could create names under it, and the point of holding the TLD was brand control rather than public registration. You can confirm its status on the authoritative [IANA root-zone record for .abarth](https://www.iana.org/domains/root/db/abarth.html), which now shows the domain is not present in the root zone.
 
-*   **abarth.com**: The official website of Abarth, showcasing models, history, and company information.
-*   **dealership.abarth**: A domain used by a specific Abarth dealership for local marketing.
-*   **clubitalia.abarth**: A potential domain for an Italian Abarth owners' club.
-*   **performanceparts.abarth**: A website selling aftermarket parts and accessories for Abarth vehicles.
-*   **racingteam.abarth**: A domain for an Abarth-sponsored racing team.
+## History of .abarth
 
-## **Why Choose .abarth?**
+`.abarth` was **delegated in 2016** as part of ICANN's New gTLD Program, the 2012 expansion that let hundreds of companies apply for their own brand as a suffix. Fiat's group secured `.abarth` alongside several other automotive brand strings.
 
-*   **Brand Association:** Instantly associate your website with the prestigious Abarth brand and its legacy of performance and style.
-*   **Targeted Audience:** Reach a highly specific and passionate audience of Abarth enthusiasts and owners.
-*   **Exclusivity:** The .abarth TLD is relatively exclusive, offering a unique opportunity to stand out from the competition.
-*   **Brand Protection:** Prevents others from using the Abarth name to impersonate or misrepresent your brand (if you are Abarth S.p.A. or an authorized partner).
-*   **Community Building:** Fosters a sense of community and belonging among Abarth enthusiasts.
+In practice, the brand made little public use of the extension. On **5 June 2023, ICANN removed `.abarth` from the root zone** after the registry agreement was ended — the same day it withdrew the sister marque **`.alfaromeo`**. Both removals reflected **Stellantis** stepping back from the dot-brand TLDs it had inherited, a common pattern across the industry as owners weighed the cost of running a namespace they barely used.
 
-## **Register Your .abarth Domain at Namefi**
+## Why was .abarth discontinued?
 
-Ready to accelerate your online presence with a .abarth domain? [Namefi](https://namefi.io) is an [ICANN](/en/glossary/icann/)-accredited [registrar](/en/glossary/registrar/) offering seamless domain registration and Web3 integration. With Namefi, you can easily secure your .abarth domain and manage it with our user-friendly platform. Don't miss out on the opportunity to establish your brand within the Abarth community. Secure your .abarth domain today!
+A brand TLD is only worth keeping if the company actively builds on it, and many owners concluded the effort did not justify the annual [ICANN](/en/glossary/icann/) fees and technical upkeep. When a brand decides to stop, it can **voluntarily terminate** its registry agreement; ICANN then removes the TLD from the root zone, and the extension stops resolving worldwide.
+
+`.abarth` is one of dozens of dot-brands retired this way. Because these TLDs were closed, their termination affected no public registrants — there were none — but it does illustrate that even a delegated TLD is not guaranteed to last forever.
+
+## Can you register a .abarth domain?
+
+**No.** `.abarth` no longer exists in the DNS, so there is nothing to register and no [registrar](/en/glossary/registrar/) can offer it. It was never available to the public even when it was active, because it was a closed brand namespace controlled by the marque.
+
+If a `.abarth` link ever appears in the future, it would only be because the brand re-applied in a later ICANN round — there is no public path to owning one.
+
+## What .abarth teaches about choosing a TLD
+
+The rise and removal of `.abarth` is a useful reminder for anyone picking a domain:
+
+- **Brand TLDs are private.** A dot-brand like `.abarth`, `.abb`, or `.airbus` is never something an outside project can build on.
+- **Not every TLD is permanent.** Delegated strings can be handed back and removed, so long-term projects are safest on well-established, widely used extensions.
+- **Openness matters.** For your own venture, an open extension anyone can register and renew is far more dependable than a niche or single-owner string.
+
+## What to register instead at Namefi
+
+Since `.abarth` is gone, choose a stable, open extension for your own name:
+
+1. **Search** your desired name across open TLDs such as [.com](/en/tld/com/), [.io](/en/tld/io/), or [.xyz](/en/tld/xyz/).
+2. **Choose** the extension that best fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can I register a .abarth domain?
+
+No. `.abarth` was terminated in 2023 and removed from the DNS root zone, so it no longer exists as a working extension and cannot be registered through any registrar. Even before that, it was a closed brand TLD never open to the public.
+
+### What happened to .abarth?
+
+ICANN removed `.abarth` from the root zone on 5 June 2023 after the brand chose to end its registry agreement. The sister marque `.alfaromeo` was withdrawn on the same day, part of Stellantis stepping back from its dot-brand TLDs.
+
+### Was .abarth ever open to the public?
+
+No. `.abarth` was always a closed brand TLD, meaning only the Abarth marque and its parent group could ever register names under it. It was never sold to outside individuals or businesses.
+
+### Where can I find official Abarth websites now?
+
+Abarth runs its official presence from conventional domains such as abarth.com and country-specific sites, alongside its parent group Stellantis. The `.abarth` extension is no longer part of that footprint.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — how top-level domains work.
+- [What is a domain?](/en/blog/what-is-domain/) — the basics for newcomers.
+- [How a TLD affects domain value](/en/blog/how-tld-affects-domain-value/) — why the extension matters.
+- [.com TLD guide](/en/tld/com/), [.io TLD guide](/en/tld/io/), and [.xyz TLD guide](/en/tld/xyz/) — open extensions you can actually register.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [ICANN](/en/glossary/icann/), [root zone](/en/glossary/root-zone/).

--- a/content/tld/en/abarth.md
+++ b/content/tld/en/abarth.md
@@ -3,7 +3,7 @@ title: 'What Was the .abarth Domain? A Terminated Brand TLD'
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .abarth domain was a brand TLD for the Abarth car marque that ICANN terminated in 2023. Learn its history, why it was removed, and what to register instead.'

--- a/content/tld/en/abb.md
+++ b/content/tld/en/abb.md
@@ -3,7 +3,7 @@ title: "What Is the .abb Domain? ABB's Brand TLD Explained"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .abb domain is the closed brand TLD of engineering group ABB Ltd, not open to the public. Learn what it is, who runs it, why it exists, and what to register instead.'

--- a/content/tld/en/abb.md
+++ b/content/tld/en/abb.md
@@ -1,13 +1,22 @@
 ---
-title: 'Unlocking the Power of the .abb TLD: A Symbol of Industrial Innovation'
-date: '2025-12-10'
+title: "What Is the .abb Domain? ABB's Brand TLD Explained"
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: 'Explore the .abb TLD, a domain extension synonymous with technological leadership. Learn about its origins, usage, and value for domain investors.'
-keywords: ['.abb domains', 'TLD', 'top-level domain', 'what is .abb', 'why choose .abb', 'what is the .abb domain', 'why choose the .abb domain', 'domain investing .abb', 'blockchain domains', 'tokenized domain', 'industrial domains', 'brand TLD', 'Web3 domains', 'Namefi']
+description: 'The .abb domain is the closed brand TLD of engineering group ABB Ltd, not open to the public. Learn what it is, who runs it, why it exists, and what to register instead.'
+keywords: ['.abb domain', 'what is .abb', '.abb TLD', 'ABB brand domain', 'dot-brand TLD', 'ABB Ltd registry', 'closed generic TLD', 'is .abb available']
+faqs:
+  - question: 'Can anyone register a .abb domain?'
+    answer: 'No. .abb is a closed brand TLD delegated to ABB Ltd. Only ABB and parties it authorizes can hold a .abb name, so it is not available to the general public through any registrar.'
+  - question: 'Who operates the .abb registry?'
+    answer: 'ABB Ltd is the registry operator, with Identity Digital providing the technical back-end. The TLD was delegated to the DNS root zone in 2015 under ICANN''s New gTLD Program.'
+  - question: 'What does ABB stand for?'
+    answer: 'ABB stands for ASEA Brown Boveri. The company was formed in 1988 through the merger of Sweden''s ASEA and Switzerland''s BBC Brown Boveri, and is now a global electrification and automation group based in Zurich.'
+  - question: 'What can I register instead of .abb?'
+    answer: 'Because .abb is closed, choose an open extension for your own project. A matching .com, or a modern alternative like .io or .xyz, can be registered by anyone through an accredited registrar such as Namefi.'
 relatedArticles:
   - /en/blog/what-is-a-tld/
   - /en/blog/what-are-tokenized-domains/
@@ -28,50 +37,113 @@ relatedGlossary:
   - /en/glossary/web3/
 ---
 
-## **What is .abb?**
+The **.abb** domain is a **closed brand [top-level domain](/en/glossary/tld/)** operated by **ABB Ltd**, the Swiss-based electrification and automation group. It is not a public extension: unlike [.com](/en/tld/com/) or [.io](/en/tld/io/), you cannot register a `.abb` name for your own project, because the entire namespace belongs to one company.
 
-The **.abb** extension is a generic [Top-Level Domain](/en/glossary/tld/) ([gTLD](/en/glossary/gtld/)) that originated as a "Brand TLD." It was established for the exclusive use of **ABB (ASEA Brown Boveri)**, a Swedish-Swiss multinational corporation headquartered in Zürich, Switzerland. ABB is a global leader in robotics, power, heavy electrical equipment, and automation technology.
+If you searched for the ".abb domain" hoping to buy one, the short answer is that you can't — but this page explains exactly what `.abb` is, who controls it, why a company runs its own TLD, and what you can register instead.
 
-Unlike open extensions like [.com](/en/tld/com/) or [.net](/en/tld/net/), .abb belongs to a specific category of domains delegated by [ICANN](https://www.icann.org/) to organizations wishing to manage their own digital identity on the root level of the internet. While historically restricted to the entity and its affiliates, Brand TLDs like .abb represent the pinnacle of corporate digital authority, signaling security, verification, and industrial prestige.
+## .abb at a glance
 
-In the evolving landscape of 2025, understanding the value of such specific extensions is crucial for domain investors and [Web3](/en/glossary/web3/) enthusiasts looking at the tokenization of high-value digital assets. You can verify the delegation details on the [IANA Root Zone Database](https://www.iana.org/domains/root/db/abb.html).
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | ABB Ltd (technical back-end by Identity Digital) |
+| Year delegated | 2015 |
+| IDN support | Not relevant — closed namespace |
+| DNSSEC | Supported |
+| Registration restrictions | **Closed** — restricted to ABB Ltd and parties it authorizes; not available to the public |
+| Best for | ABB's own corporate, product, and campaign websites |
 
-## **How People Are Using .abb**
+## What is .abb?
 
-Because .abb is primarily a corporate infrastructure TLD, its usage differs from standard commercial domains. It is utilized to create a unified, secure, and trusted ecosystem for one of the world's largest engineering companies.
+`.abb` is a **[generic top-level domain](/en/glossary/gtld/)** that ICANN delegated to **ABB Ltd** during the 2012 round of its New gTLD Program. The three letters are the company's own name: **ABB** stands for **ASEA Brown Boveri**, and the group is one of the world's largest engineering firms, active in electrification, robotics, industrial automation, and motion.
 
-*   **Corporate Identity & Trust:** The primary use is to host official corporate pages, investor relations, and global press centers. When a user sees a URL ending in .abb, they know immediately that the site is an official property of the ABB Group, eliminating [phishing](/en/glossary/phishing/) risks.
-*   **Product & Service Portals:** Specific subdomains are used to highlight distinct verticals such as robotics, electrification, and motion control, providing a clean architecture for complex industrial services.
-*   **Partner & Employee Gateways:** Secure portals for supply chain management and employee internal networks often utilize this extension to segregate traffic from the public web.
+But `.abb` is a **brand TLD** — often called a "dot-brand" — not an open extension anyone can buy into. The company applied for the string specifically so that it, and only it, would control every domain ending in `.abb`. You can confirm the delegation and operator on the authoritative [IANA root-zone record for .abb](https://www.iana.org/domains/root/db/abb.html).
 
-## **Notable Entities Using .abb**
+## History of .abb
 
-Given the restrictive nature of this Brand TLD, the notable entities are exclusively within the corporate hierarchy of the [registry](/en/glossary/registry/) owner. However, they serve as excellent examples of how a short, branded TLD creates a powerful digital footprint:
+ABB as a company dates to **1988**, when Sweden's **ASEA** merged with Switzerland's **BBC Brown Boveri** to form ASEA Brown Boveri, headquartered in Zurich. Decades later, when ICANN opened applications for hundreds of new suffixes, ABB was among the many large corporations that applied for their own name as a TLD.
 
-1.  **ABB Group Main Portal:** The central hub for the global conglomerate, showcasing the brand's shift from a traditional .com approach to a branded ecosystem.
-2.  **ABB Formula E:** As a title partner in electric racing, promotional campaigns and digital assets often leverage the branded TLD to unify their marketing regarding sustainability and e-mobility.
-3.  **Industrial IoT Projects:** Various internal projects linking "Ability" (ABB's unified, cross-industry digital capability) often utilize the extension to create short, memorable command center URLs.
+The `.abb` string was **delegated to the DNS [root zone](/en/glossary/root-zone/) in 2015**, with **Identity Digital** (the registry services provider formerly known as Afilias/Donuts) handling the technical operation on ABB's behalf. Its registry agreement with [ICANN](/en/glossary/icann/) includes **Specification 13**, the contract clause that formally designates a TLD as a brand and lets the operator keep it closed. The record has remained active since delegation, unlike several brand TLDs that were later handed back and removed from the root.
 
-## **Why Choose .abb?**
+## Is .abb available to register?
 
-For those interested in the domain industry, the mechanics of the .abb TLD offer several lessons in value proposition. Whether you are analyzing it from an investment perspective or looking at similar Brand TLD structures, here are the key advantages:
+**No.** `.abb` is a **closed brand TLD**, so there is no open registration and no [registrar](/en/glossary/registrar/) — including Namefi — can sell you a `.abb` name. Registrations are limited to ABB Ltd and organizations it authorizes, such as subsidiaries or partners. This is by design: a dot-brand exists precisely so the trademark holder controls the whole namespace and no one else can register a confusing or malicious lookalike.
 
-*   **Unrivaled Trust:** A restricted TLD implies the highest level of security. There is zero "noise" or [cybersquatting](/en/glossary/cybersquatting/) within the .abb namespace.
-*   **Brand Authority:** It cements the organization as a digital leader. Owning your own TLD is the ultimate status symbol in the internet hierarchy.
-*   **Short and Memorable:** "ABB" is a three-letter acronym that is globally recognized. The TLD mirrors the stock ticker and the logo, providing seamless branding synergy.
-*   **Asset Value:** In the context of tokenized domains and Web3, exclusive namespaces hold immense theoretical value due to their scarcity and the significant capital required to maintain the registry.
+If you have a genuine business relationship with ABB and a legitimate need for a `.abb` address, that request would go through ABB's own corporate channels, not a commercial registrar.
 
-## **Register Your .abb Domain at Namefi**
+## How ABB uses .abb
 
-Are you looking to secure premium domains or explore the world of tokenized real-world assets? At **Namefi**, we simplify the complex world of [domain ownership](/en/glossary/domain-ownership/) by bridging the gap between Web2 DNS and Web3 [blockchain](/en/glossary/blockchain/) technology.
+Brand TLDs give a company a private space to organize its web presence. Typical uses for a dot-brand like `.abb` include:
 
-While .abb is a restricted Brand TLD, Namefi offers a vast [marketplace](/en/glossary/marketplace/) of premium, generic, and next-generation TLDs that can elevate your digital presence. Whether you are an investor looking for high-value short domains or a developer needing a seamless Web3 integration, we have you covered.
+- **Product and division sites** on clean, memorable addresses tied directly to the brand.
+- **Campaign and event pages** that are obviously official because only the company can create them.
+- **Internal tools and portals** where a branded suffix signals a trusted, first-party destination.
 
-**Why choose Namefi?**
-*   **Seamless Integration:** We use standard NFT standards to represent domain ownership, making transfer and management instant.
-*   **ICANN Accredited:** We adhere to global standards, ensuring your ownership is secure and recognized.
-*   **[Defi](/en/glossary/defi/) Compatible:** Use your domains as [collateral](/en/glossary/collateral/) or trade them effortlessly on open marketplaces.
+**Who it's not for:** anyone outside ABB. Because the namespace is closed, there is no scenario in which an independent developer, investor, or business can build on `.abb`.
 
-Don't wait to claim your stake in the digital future.
+## Notable sites using .abb
 
-**[Register Your Next Domain at Namefi](https://namefi.io)**
+There are **no third-party sites** on `.abb`, and there never will be while it stays a closed brand TLD — every `.abb` address is controlled by ABB Ltd. ABB continues to run most of its public presence from its long-established [.com](/en/tld/com/) domain, and uses the brand TLD selectively rather than as a wholesale replacement. Rather than point to a specific address that may change, the honest description is simple: `.abb` is ABB's private namespace, used only for the company's own properties.
+
+## What is a dot-brand TLD?
+
+A **dot-brand** (or brand TLD) is a top-level domain that a single company owns and operates for its exclusive use, secured through ICANN's [New gTLD Program](/en/glossary/new-gtld/). Hundreds were delegated — examples in this same alphabetical band include `.abbott`, `.accenture`, and `.airbus` — and they share a few defining traits:
+
+- **Closed registration.** Only the brand and its affiliates can hold names.
+- **Specification 13.** A registry-agreement addendum that formally recognizes the TLD as a brand and relaxes some rules that apply to open generics.
+- **Security and control.** The brand eliminates the risk of anyone else registering a `.abb` lookalike, which strengthens resistance to [phishing](/en/glossary/phishing/) and impersonation.
+
+Some brands invest heavily in their TLD; others register it defensively and barely use it. A number of companies have even terminated their dot-brands after deciding the upkeep was not worth it.
+
+## .abb vs open domain alternatives
+
+If your goal was a short, brandable name rather than the `.abb` string specifically, an open extension is the right tool. Here is how a closed brand TLD compares with domains you can actually register:
+
+| Feature | .abb | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.xyz](/en/tld/xyz/) |
+| --- | --- | --- | --- | --- |
+| Who can register | ABB Ltd only | Anyone | Anyone | Anyone |
+| Type | Brand new gTLD (closed) | Legacy gTLD | ccTLD used generically | New gTLD |
+| Core use | ABB's own sites | Universal default | Tech & startups | Generic / Web3 |
+| Available to you | No | Yes | Yes | Yes |
+
+For your own venture, a matching `.com` remains the safest default; [.io](/en/tld/io/) suits technical products; and [.xyz](/en/tld/xyz/) is a flexible, low-cost modern option.
+
+## Reputation and trust
+
+Ironically, the closed nature of `.abb` is exactly what makes it trustworthy: because only ABB can create these addresses, a `.abb` link is verifiably official, which is why brand TLDs are considered strong against impersonation and email spoofing. That trust, however, benefits ABB alone — it does not transfer to any name you might register, since you cannot register one. For your own project, deliverability and reputation will come from a well-configured domain on an open extension, not from a brand TLD you don't control.
+
+## Looking for an "abb" name? Register an alternative at Namefi
+
+You can't buy a `.abb` domain, but if you want a short name — maybe an "abb" acronym of your own — you can secure it on an open extension in minutes:
+
+1. **Search** your desired name across open TLDs like `.com`, `.io`, or `.xyz`.
+2. **Choose** the extension that fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can anyone register a .abb domain?
+
+No. `.abb` is a closed brand TLD delegated to ABB Ltd. Only ABB and parties it authorizes can hold a `.abb` name, so it is not available to the general public through any registrar.
+
+### Who operates the .abb registry?
+
+ABB Ltd is the registry operator, with Identity Digital providing the technical back-end. The TLD was delegated to the DNS root zone in 2015 under ICANN's New gTLD Program.
+
+### What does ABB stand for?
+
+ABB stands for ASEA Brown Boveri. The company was formed in 1988 through the merger of Sweden's ASEA and Switzerland's BBC Brown Boveri, and is now a global electrification and automation group based in Zurich.
+
+### What can I register instead of .abb?
+
+Because `.abb` is closed, choose an open extension for your own project. A matching `.com`, or a modern alternative like `.io` or `.xyz`, can be registered by anyone through an accredited registrar such as Namefi.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals behind top-level domains.
+- [How a TLD affects domain value](/en/blog/how-tld-affects-domain-value/) — why the extension matters.
+- [.com TLD guide](/en/tld/com/) — the open default to compare against.
+- [.io TLD guide](/en/tld/io/) and [.xyz TLD guide](/en/tld/xyz/) — modern open alternatives.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [registry](/en/glossary/registry/), [ICANN](/en/glossary/icann/).

--- a/content/tld/en/abbott.md
+++ b/content/tld/en/abbott.md
@@ -3,7 +3,7 @@ title: "What Is the .abbott Domain? Abbott's Brand TLD Explained"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .abbott domain is the closed brand TLD of Abbott Laboratories, not open to the public. Learn what it is, who runs it, why it exists, and what to register instead.'

--- a/content/tld/en/abbott.md
+++ b/content/tld/en/abbott.md
@@ -1,13 +1,22 @@
 ---
-title: "What is .abbott TLD and why is it unique?"
-date: '2025-12-10'
+title: "What Is the .abbott Domain? Abbott's Brand TLD Explained"
+date: '2026-07-24'
 language: 'en'
-tags: ['tld', 'brand domains', 'domain investing', 'internet security']
+tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: "Everything you need to know about the .abbott TLD. Explore the purpose of this exclusive domain, its use cases in healthcare, and the benefits of Brand TLDs."
-keywords: [".abbott domains", ".abbott TLD", "top-level domain", "what is .abbott", "why choose .abbott", "what is the .abbott domain", "why choose the .abbott domain", "brand TLDs", "healthcare domain names", "restricted top-level domains", "Abbott Laboratories domain", "domain investing", "blockchain domains", "tokenized domain", "Namefi"]
+description: 'The .abbott domain is the closed brand TLD of Abbott Laboratories, not open to the public. Learn what it is, who runs it, why it exists, and what to register instead.'
+keywords: ['.abbott domain', 'what is .abbott', '.abbott TLD', 'Abbott brand domain', 'dot-brand TLD', 'Abbott Laboratories registry', 'closed generic TLD', 'is .abbott available']
+faqs:
+  - question: 'Can anyone register a .abbott domain?'
+    answer: 'No. .abbott is a closed brand TLD delegated to Abbott Laboratories. Only Abbott and parties it authorizes can hold a .abbott name, so it is not available to the general public through any registrar.'
+  - question: 'Who operates the .abbott registry?'
+    answer: 'Abbott Laboratories is the registry operator, with Identity Digital providing the technical back-end. The TLD was delegated to the DNS root zone on November 20, 2014.'
+  - question: 'What kind of company is Abbott Laboratories?'
+    answer: 'Abbott Laboratories is a global healthcare company working in medical devices, diagnostics, and nutrition products, headquartered in the United States.'
+  - question: 'What can I register instead of .abbott?'
+    answer: 'Because .abbott is closed, choose an open extension for your own project. A matching .com, or a modern alternative like .io or .xyz, can be registered by anyone through an accredited registrar such as Namefi.'
 relatedArticles:
   - /en/blog/what-is-a-tld/
   - /en/blog/top-tlds-to-secure-for-your-business/
@@ -28,56 +37,112 @@ relatedGlossary:
   - /en/glossary/dns/
 ---
 
-## **What is .abbott?**
+The **.abbott** domain is a **closed brand [top-level domain](/en/glossary/tld/)** operated by **Abbott Laboratories**, the global healthcare company. It is not a public extension: unlike [.com](/en/tld/com/) or [.io](/en/tld/io/), you cannot register a `.abbott` name for your own project, because the entire namespace belongs to one company.
 
-The **.abbott** [Top-Level Domain](/en/glossary/tld/) (TLD) is a unique and specific extension in the landscape of the internet. Unlike open domains such as [`.com`](/en/tld/com/) or `.net` that anyone can register, **.abbott** is classified as a **Brand TLD** (or "dot brand"). It is a generic Top-Level Domain ([gTLD](/en/glossary/gtld/)) that was acquired during [ICANN’s new gTLD program](https://newgtlds.icann.org/en/about/program), specifically delegated to **Abbott Laboratories**, the global healthcare and pharmaceutical giant.
+If you searched for the ".abbott domain" hoping to buy one, the short answer is that you can't — but this page explains exactly what `.abbott` is, who controls it, why a healthcare company runs its own TLD, and what you can register instead.
 
-The primary purpose of the .abbott TLD is to serve as a trusted, digital namespace exclusively for Abbott Laboratories and its affiliates. By operating their own [registry](/en/glossary/registry/), Abbott creates a closed loop of digital identity. When a user sees a URL ending in `.abbott`, they can be 100% certain that the content is published by the official healthcare company, ensuring authenticity in an industry where trust is paramount.
+## .abbott at a glance
 
-## **How People Are Using .abbott**
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | Abbott Laboratories (technical back-end by Identity Digital) |
+| Year delegated | 2014 |
+| IDN support | Not relevant — closed namespace |
+| DNSSEC | Supported |
+| Registration restrictions | **Closed** — restricted to Abbott Laboratories and parties it authorizes; not available to the public |
+| Best for | Abbott's own corporate, product, and campaign websites |
 
-Because .abbott is a restricted Brand TLD, "usage" is defined by how the corporation leverages it for its digital strategy, rather than how the general public uses it. Abbott utilizes this extension to streamline their massive global presence.
+## What is .abbott?
 
-Here is how the TLD is effectively deployed:
+`.abbott` is a **[generic top-level domain](/en/glossary/gtld/)** that ICANN delegated to **Abbott Laboratories** during its New gTLD Program. Abbott is a global healthcare company active in medical devices, diagnostics, and nutrition, and the string is simply the company's own name.
 
-*   **Corporate Identity & Communications:** It allows the company to move away from long, complex URLs (like `abbott-healthcare-division.com`) to clean, branded navigation.
-*   **Product Verification:** In the pharmaceutical and medical device sector, counterfeit products are a major risk. A `.abbott` domain acts as a digital seal of authenticity for product information.
-*   **Campaign Specific Sites:** Marketing campaigns for new health initiatives or medical devices can be hosted on intuitive domains (e.g., `heart.abbott` or `nutrition.abbott`).
-*   **Investor and Employee Relations:** Secure portals for stakeholders can be managed under the brand umbrella, reducing the risk of [phishing](/en/glossary/phishing/) attacks targeting sensitive corporate data.
+But `.abbott` is a **brand TLD** — often called a "dot-brand" — not an open extension anyone can buy into. The company applied for the string specifically so that it, and only it, would control every domain ending in `.abbott`. You can confirm the delegation and operator on the authoritative [IANA root-zone record for .abbott](https://www.iana.org/domains/root/db/abbott.html).
 
-## **Notable Entities Using .abbott**
+## History of .abbott
 
-Since this is a closed registry, the "notable entities" are exclusively departments, products, or campaigns within the Abbott ecosystem. However, this strategy sets a powerful example for how major corporations manage digital assets.
+The `.abbott` string was **delegated to the DNS [root zone](/en/glossary/root-zone/) on November 20, 2014**, with **Identity Digital** handling the technical operation on Abbott's behalf. Its registry agreement with [ICANN](/en/glossary/icann/) includes Specification 13, the contract clause that formally designates a TLD as a brand and lets the operator keep it closed.
 
-Examples of the ecosystem include:
+The record has remained active since delegation. Abbott continues to run its primary public site at [abbott.com](https://www.abbott.com), and uses the dot-brand as a supplementary namespace rather than a replacement for its legacy domain.
 
-1.  **Abbott.com vs. .abbott:** While the main site remains `abbott.com`, the company utilizes the TLD for redirects and specific campaign infrastructure, securing their brand name across the internet's root layer.
-2.  **Life.abbott:** Often associated with their corporate philosophy "Life. To the Fullest." This usage highlights the branding potential of combining a keyword with a Brand TLD.
-3.  **Regional Divisions:** Global companies often use Brand TLDs to organize regional sites (e.g., `uk.abbott` or `jobs.abbott`) to provide a seamless user experience without relying on directory slashes.
+## Is .abbott available to register?
 
-*Note: You can verify the delegation and active status of the .abbott TLD via the [IANA Root Zone Database](https://www.iana.org/domains/root/db/abbott.html).*
+**No.** `.abbott` is a **closed brand TLD**, so there is no open registration and no [registrar](/en/glossary/registrar/) — including Namefi — can sell you a `.abbott` name. Registrations are limited to Abbott Laboratories and organizations it authorizes, such as subsidiaries or partners. This is by design: a dot-brand exists precisely so the trademark holder controls the whole namespace and no one else can register a confusing or malicious lookalike — a meaningful concern in healthcare, where counterfeit or misleading sites carry real risk.
 
-## **Why Choose .abbott?**
+If you have a genuine business relationship with Abbott and a legitimate need for a `.abbott` address, that request would go through Abbott's own corporate channels, not a commercial registrar.
 
-While you cannot register a `.abbott` domain for your personal blog (unless you are Abbott Laboratories), understanding *why* they chose to invest in this TLD highlights important lessons for choosing your own domain strategy.
+## How Abbott uses .abbott
 
-Here are the advantages of a controlled namespace:
+Brand TLDs give a company a private space to organize its web presence. Typical uses for a dot-brand like `.abbott` include:
 
-*   **Unrivaled Trust and Security:** The most significant advantage is security. Because the registry is closed, there is zero risk of cybersquatters or bad actors registering a misleading `.abbott` domain to phish customers.
-*   **Branding Authority:** Owning the TLD signals market dominance. It transforms the domain name from a rented address (on .com) to a owned digital asset.
-*   **SEO and Semantic Relevance:** Search engines like Google recognize the authority of Brand TLDs. A domain like `nutrition.abbott` is semantically clear—it tells the search engine exactly what the content is (nutrition) and exactly who provides it (Abbott).
-*   **Availability:** For the registry owner, availability is 100%. They never have to negotiate to buy a domain from a squatter; they simply create it.
+- **Product and division sites** on clean, memorable addresses tied directly to the brand.
+- **Campaign and event pages** for health initiatives that are obviously official because only the company can create them.
+- **Investor and internal portals** where a branded suffix signals a trusted, first-party destination.
 
-## **Register Your Domain at Namefi**
+**Who it's not for:** anyone outside Abbott. Because the namespace is closed, there is no scenario in which an independent developer, investor, or business can build on `.abbott`.
 
-While `.abbott` is exclusive to the healthcare giant, the power of a distinct, secure, and memorable domain name is available to everyone. Whether you are looking for a professional `.com`, a tech-savvy `.io`, or exploring the future of **tokenized domains**, Namefi is your gateway.
+## Notable sites using .abbott
 
-At **Namefi**, we simplify the domain registration process by combining traditional [ICANN](/en/glossary/icann/)-accredited reliability with seamless Web3 integration.
+There are **no third-party sites** on `.abbott`, and there never will be while it stays a closed brand TLD — every `.abbott` address is controlled by Abbott Laboratories. Abbott continues to run most of its public presence from its long-established `.com` domain, and uses the brand TLD selectively rather than as a wholesale replacement. Rather than point to a specific address that may change, the honest description is simple: `.abbott` is Abbott's private namespace, used only for the company's own properties.
 
-*   **Secure your brand:** Search for short, impactful names across hundreds of available TLDs.
-*   **Tokenized Real-World Assets:** Namefi treats your domain as a true asset, allowing for easy transfer and management on the [blockchain](/en/glossary/blockchain/).
-*   **Instant Setup:** Get your business online in minutes.
+## What is a dot-brand TLD?
 
-Don't wait for your perfect name to be taken. Secure your digital identity today.
+A **dot-brand** (or brand TLD) is a top-level domain that a single company owns and operates for its exclusive use, secured through ICANN's [New gTLD Program](/en/glossary/new-gtld/). Hundreds were delegated, and they share a few defining traits:
 
-**[Register your domain at Namefi](https://namefi.io)**
+- **Closed registration.** Only the brand and its affiliates can hold names.
+- **Specification 13.** A registry-agreement addendum that formally recognizes the TLD as a brand and relaxes some rules that apply to open generics.
+- **Security and control.** The brand eliminates the risk of anyone else registering a `.abbott` lookalike, which strengthens resistance to [phishing](/en/glossary/phishing/) and impersonation.
+
+Some brands invest heavily in their TLD; others register it defensively and barely use it. A number of companies have even terminated their dot-brands after deciding the upkeep was not worth it.
+
+## .abbott vs open domain alternatives
+
+If your goal was a short, brandable name rather than the `.abbott` string specifically, an open extension is the right tool. Here is how a closed brand TLD compares with domains you can actually register:
+
+| Feature | .abbott | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.xyz](/en/tld/xyz/) |
+| --- | --- | --- | --- | --- |
+| Who can register | Abbott only | Anyone | Anyone | Anyone |
+| Type | Brand new gTLD (closed) | Legacy gTLD | ccTLD used generically | New gTLD |
+| Core use | Abbott's own sites | Universal default | Tech & startups | Generic / Web3 |
+| Available to you | No | Yes | Yes | Yes |
+
+For your own venture, a matching `.com` remains the safest default; [.io](/en/tld/io/) suits technical products; and [.xyz](/en/tld/xyz/) is a flexible, low-cost modern option.
+
+## Reputation and trust
+
+Ironically, the closed nature of `.abbott` is exactly what makes it trustworthy: because only Abbott can create these addresses, a `.abbott` link is verifiably official, which is why brand TLDs are considered strong against impersonation and email spoofing. That trust, however, benefits Abbott alone — it does not transfer to any name you might register, since you cannot register one. For your own project, deliverability and reputation will come from a well-configured domain on an open extension, not from a brand TLD you don't control.
+
+## Looking for an "abbott" name? Register an alternative at Namefi
+
+You can't buy a `.abbott` domain, but if you want a short, memorable name of your own, you can secure it on an open extension in minutes:
+
+1. **Search** your desired name across open TLDs like `.com`, `.io`, or `.xyz`.
+2. **Choose** the extension that fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can anyone register a .abbott domain?
+
+No. `.abbott` is a closed brand TLD delegated to Abbott Laboratories. Only Abbott and parties it authorizes can hold a `.abbott` name, so it is not available to the general public through any registrar.
+
+### Who operates the .abbott registry?
+
+Abbott Laboratories is the registry operator, with Identity Digital providing the technical back-end. The TLD was delegated to the DNS root zone on November 20, 2014.
+
+### What kind of company is Abbott Laboratories?
+
+Abbott Laboratories is a global healthcare company working in medical devices, diagnostics, and nutrition products, headquartered in the United States.
+
+### What can I register instead of .abbott?
+
+Because `.abbott` is closed, choose an open extension for your own project. A matching `.com`, or a modern alternative like `.io` or `.xyz`, can be registered by anyone through an accredited registrar such as Namefi.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals behind top-level domains.
+- [.com TLD guide](/en/tld/com/) — the open default to compare against.
+- [.io TLD guide](/en/tld/io/) and [.xyz TLD guide](/en/tld/xyz/) — modern open alternatives.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [registry](/en/glossary/registry/), [ICANN](/en/glossary/icann/).

--- a/content/tld/en/abbvie.md
+++ b/content/tld/en/abbvie.md
@@ -1,31 +1,22 @@
 ---
-title: 'What is the .abbvie TLD? Understanding Brand Domains in Pharma'
-date: '2025-12-10'
+title: "What Is the .abbvie Domain? AbbVie's Brand TLD Explained"
+date: '2026-07-24'
 language: 'en'
-tags:
-  - 'tld'
-authors:
-  - 'namefiteam'
-editors:
-  - victor-zhou
+tags: ['tld']
+authors: ['namefiteam']
+editors: ['victor-zhou']
 draft: false
-description: 'Explore the .abbvie top-level domain. Learn what this Brand TLD means for digital trust, corporate identity, and the future of domain investing.'
-keywords:
-  - '.abbvie domains'
-  - '.abbvie TLD'
-  - 'top-level domain'
-  - 'what is .abbvie'
-  - 'why choose .abbvie'
-  - 'what is the .abbvie domain'
-  - 'why choose the .abbvie domain'
-  - 'brand TLDs'
-  - 'pharmaceutical domains'
-  - 'domain investing'
-  - 'blockchain domains'
-  - 'tokenized domain'
-  - 'secure corporate domains'
-  - 'AbbVie digital identity'
-  - 'ICANN new gTLD'
+description: 'The .abbvie domain is the closed brand TLD of biopharmaceutical company AbbVie, not open to the public. Learn what it is, who runs it, and what to register instead.'
+keywords: ['.abbvie domain', 'what is .abbvie', '.abbvie TLD', 'AbbVie brand domain', 'dot-brand TLD', 'AbbVie Inc registry', 'closed generic TLD', 'is .abbvie available']
+faqs:
+  - question: 'Can anyone register a .abbvie domain?'
+    answer: 'No. .abbvie is a closed brand TLD delegated to AbbVie Inc. Only AbbVie and parties it authorizes can hold a .abbvie name, so it is not available to the general public through any registrar.'
+  - question: 'Who operates the .abbvie registry?'
+    answer: 'AbbVie Inc. is the registry operator, with Nominet providing the technical back-end. The TLD was delegated to the DNS root zone on February 26, 2016.'
+  - question: 'Is AbbVie related to Abbott?'
+    answer: 'Yes. AbbVie Inc. is a biopharmaceutical company that was spun off from Abbott Laboratories in 2013, and it operates its own separate .abbvie brand TLD distinct from Abbott dot-brand .abbott.'
+  - question: 'What can I register instead of .abbvie?'
+    answer: 'Because .abbvie is closed, choose an open extension for your own project. A matching .com, or a modern alternative like .io or .xyz, can be registered by anyone through an accredited registrar such as Namefi.'
 relatedArticles:
   - /en/blog/what-are-tokenized-domains/
   - /en/blog/what-is-a-tld/
@@ -46,62 +37,112 @@ relatedGlossary:
   - /en/glossary/registry/
 ---
 
-## **What is .abbvie?**
+The **.abbvie** domain is a **closed brand [top-level domain](/en/glossary/tld/)** operated by **AbbVie Inc.**, the biopharmaceutical company. It is not a public extension: unlike [.com](/en/tld/com/) or [.io](/en/tld/io/), you cannot register a `.abbvie` name for your own project, because the entire namespace belongs to one company.
 
-The **.abbvie** domain extension is a specific type of internet address known as a **Brand TLD** ([Top-Level Domain](/en/glossary/tld/)). Unlike standard extensions such as [.com](/en/tld/com/) or [.org](/en/tld/org/), .abbvie falls under the category of **new gTLDs** (generic Top-Level Domains) introduced by [ICANN](https://www.icann.org/) (Internet Corporation for Assigned Names and Numbers) to expand the internet's namespace.
+If you searched for the ".abbvie domain" hoping to buy one, the short answer is that you can't — but this page explains exactly what `.abbvie` is, who controls it, why the company runs its own TLD, and what you can register instead.
 
-Specifically, the .abbvie [Registry](/en/glossary/registry/) is operated by **AbbVie Inc.**, a global biopharmaceutical company. This TLD was created to provide a secure, dedicated digital space for the company's brands, products, and corporate communications. It represents a growing trend where major corporations move away from crowded legacy domains to secure their own digital infrastructure.
+## .abbvie at a glance
 
-Because this is a "closed" or "restricted" Brand TLD, it is not generally available for public registration like a [.net](/en/tld/net/) or [.io](/en/tld/io/) domain might be. Instead, it serves as an authoritative signal of trust, ensuring that any website ending in `.abbvie` is officially owned and authenticated by the pharmaceutical giant.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | AbbVie Inc. (technical back-end by Nominet) |
+| Year delegated | 2016 |
+| IDN support | Not relevant — closed namespace |
+| DNSSEC | Supported |
+| Registration restrictions | **Closed** — restricted to AbbVie Inc. and parties it authorizes; not available to the public |
+| Best for | AbbVie's own corporate, product, and research websites |
 
-## **How People Are Using .abbvie**
+## What is .abbvie?
 
-As a restricted Brand TLD, the usage of .abbvie is strictly controlled by the registry owner. It is not used by the general public, but rather strategically deployed by the corporation to streamline its digital presence.
+`.abbvie` is a **[generic top-level domain](/en/glossary/gtld/)** that ICANN delegated to **AbbVie Inc.** during its New gTLD Program. AbbVie is a biopharmaceutical company that was **spun off from Abbott Laboratories in 2013**, and it operates as an independent business with its own products, research pipeline, and brand.
 
-Current and potential use cases include:
+`.abbvie` is a **brand TLD** — often called a "dot-brand" — not an open extension anyone can buy into. The company applied for the string specifically so that it, and only it, would control every domain ending in `.abbvie`. You can confirm the delegation and operator on the authoritative [IANA root-zone record for .abbvie](https://www.iana.org/domains/root/db/abbvie.html).
 
-*   **Corporate Verification:** Ensuring that investors and patients know they are on an official site.
-*   **Product Portals:** creating memorable, short links for specific medications or research initiatives (e.g., `product.abbvie`).
-*   **Internal Infrastructure:** Secure employee portals and intranet access points that are less susceptible to external DNS attacks.
-*   **Marketing Campaigns:** Creating cohesive branding across different regions without relying on country-code TLDs (like .co.uk or .de) for every single page.
+## History of .abbvie
 
-## **Notable Entities Using .abbvie**
+The `.abbvie` string was **delegated to the DNS [root zone](/en/glossary/root-zone/) on February 26, 2016**, with **Nominet** handling the technical operation on AbbVie's behalf. Its registry agreement with [ICANN](/en/glossary/icann/) includes Specification 13, the contract clause that formally designates a TLD as a brand and lets the operator keep it closed.
 
-Since the domain is exclusive to AbbVie Inc., the "notable entities" using it are the various departments and subsidiaries of the company itself.
+Because AbbVie only became a standalone company in 2013, after separating from Abbott, its dot-brand followed a few years later than Abbott's own `.abbott` TLD. The two remain separate registries controlled by separate companies, even though they share a common corporate origin.
 
-While specific subdomains may change based on corporate strategy, typical examples found in Brand TLD ecosystems include:
+## Is .abbvie available to register?
 
-1.  **Corporate Headquarters:** Main landing pages directing traffic to official corporate news.
-2.  **Investor Relations:** Dedicated subdomains for stock reports and financial disclosures.
-3.  **Research & Development:** Pages dedicated to clinical trials and pipeline updates.
+**No.** `.abbvie` is a **closed brand TLD**, so there is no open registration and no [registrar](/en/glossary/registrar/) — including Namefi — can sell you a `.abbvie` name. Registrations are limited to AbbVie Inc. and organizations it authorizes, such as subsidiaries or partners. This is by design: a dot-brand exists precisely so the trademark holder controls the whole namespace and no one else can register a confusing or malicious lookalike — a meaningful concern in pharmaceuticals, where counterfeit or misleading sites carry real risk.
 
-By consolidating their digital footprint under one TLD, the company ensures that high-value traffic remains within a controlled, safe ecosystem.
+If you have a genuine business relationship with AbbVie and a legitimate need for a `.abbvie` address, that request would go through AbbVie's own corporate channels, not a commercial registrar.
 
-## **Why Choose .abbvie?**
+## How AbbVie uses .abbvie
 
-While you cannot currently register a .abbvie domain for your personal blog, understanding *why* a corporation chooses to operate its own TLD offers valuable insights for domain investors and businesses looking at the future of [Web3](/en/glossary/web3/) and digital identity.
+Brand TLDs give a company a private space to organize its web presence. Typical uses for a dot-brand like `.abbvie` include:
 
-The advantages of operating a TLD like .abbvie include:
+- **Product and research sites** on clean, memorable addresses tied directly to the brand.
+- **Campaign and event pages** that are obviously official because only the company can create them.
+- **Investor and internal portals** where a branded suffix signals a trusted, first-party destination.
 
-*   **Unparalleled Trust:** In the pharmaceutical industry, trust is paramount. A .abbvie link guarantees the user is not on a [phishing](/en/glossary/phishing/) site or a counterfeit medication store.
-*   **SEO Authority:** Search engines reward authority. Owning the entire extension signals to Google and other search engines that the content is the primary source of truth for that brand.
-*   **Total Availability:** The registry owner never has to worry if a domain name is taken. If they want `research.abbvie`, they simply create it.
-*   **Security:** The registry has stricter control over DNS protocols, reducing the risk of man-in-the-middle attacks.
+**Who it's not for:** anyone outside AbbVie. Because the namespace is closed, there is no scenario in which an independent developer, investor, or business can build on `.abbvie`.
 
-For domain investors and developers, the rise of Brand TLDs highlights the value of **niche** and **verified** domains. This parallels the movement toward [blockchain](/en/glossary/blockchain/) and **tokenized domains**, where ownership and authenticity are verifiable [on-chain](/en/glossary/on-chain/).
+## Notable sites using .abbvie
 
-## **Register Your Domain at Namefi**
+There are **no third-party sites** on `.abbvie`, and there never will be while it stays a closed brand TLD — every `.abbvie` address is controlled by AbbVie Inc. AbbVie continues to run most of its public presence from its long-established `.com` domain, and uses the brand TLD selectively rather than as a wholesale replacement. Rather than point to a specific address that may change, the honest description is simple: `.abbvie` is AbbVie's private namespace, used only for the company's own properties.
 
-While the .abbvie extension is restricted to the corporation, the world of domains offers thousands of other opportunities to secure your unique digital identity. Whether you are looking for medical-related domains (like .med, .health, or .bio) or tech-forward extensions (like .io, [.ai](/en/tld/ai/), or [.xyz](/en/tld/xyz/)), finding the right name is the first step toward online success.
+## What is a dot-brand TLD?
 
-At **Namefi**, we are revolutionizing how you buy, manage, and trade domains.
+A **dot-brand** (or brand TLD) is a top-level domain that a single company owns and operates for its exclusive use, secured through ICANN's [New gTLD Program](/en/glossary/new-gtld/). Hundreds were delegated, and they share a few defining traits:
 
-*   **Seamless Web3 Integration:** We bridge the gap between Web2 DNS and Web3 assets.
-*   **Tokenized Ownership:** Treat your domain like a true asset with easy transfers and enhanced [liquidity](/en/glossary/domain-liquidity/).
-*   **ICANN Accredited:** We provide the security of a traditional [registrar](/en/glossary/registrar/) with the innovation of blockchain technology.
+- **Closed registration.** Only the brand and its affiliates can hold names.
+- **Specification 13.** A registry-agreement addendum that formally recognizes the TLD as a brand and relaxes some rules that apply to open generics.
+- **Security and control.** The brand eliminates the risk of anyone else registering a `.abbvie` lookalike, which strengthens resistance to [phishing](/en/glossary/phishing/) and impersonation.
 
-**Ready to secure your digital future?**
+Some brands invest heavily in their TLD; others register it defensively and barely use it. A number of companies have even terminated their dot-brands after deciding the upkeep was not worth it.
 
-[**Start your search at Namefi**](https://namefi.io)
+## .abbvie vs open domain alternatives
 
-Don't wait for the perfect name to be taken. Search for your domain today and experience the future of domain management.
+If your goal was a short, brandable name rather than the `.abbvie` string specifically, an open extension is the right tool. Here is how a closed brand TLD compares with domains you can actually register:
+
+| Feature | .abbvie | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.xyz](/en/tld/xyz/) |
+| --- | --- | --- | --- | --- |
+| Who can register | AbbVie only | Anyone | Anyone | Anyone |
+| Type | Brand new gTLD (closed) | Legacy gTLD | ccTLD used generically | New gTLD |
+| Core use | AbbVie's own sites | Universal default | Tech & startups | Generic / Web3 |
+| Available to you | No | Yes | Yes | Yes |
+
+For your own venture, a matching `.com` remains the safest default; [.io](/en/tld/io/) suits technical products; and [.xyz](/en/tld/xyz/) is a flexible, low-cost modern option.
+
+## Reputation and trust
+
+Ironically, the closed nature of `.abbvie` is exactly what makes it trustworthy: because only AbbVie can create these addresses, a `.abbvie` link is verifiably official, which is why brand TLDs are considered strong against impersonation and email spoofing. That trust, however, benefits AbbVie alone — it does not transfer to any name you might register, since you cannot register one. For your own project, deliverability and reputation will come from a well-configured domain on an open extension, not from a brand TLD you don't control.
+
+## Looking for an "abbvie" name? Register an alternative at Namefi
+
+You can't buy a `.abbvie` domain, but if you want a short, memorable name of your own, you can secure it on an open extension in minutes:
+
+1. **Search** your desired name across open TLDs like `.com`, `.io`, or `.xyz`.
+2. **Choose** the extension that fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can anyone register a .abbvie domain?
+
+No. `.abbvie` is a closed brand TLD delegated to AbbVie Inc. Only AbbVie and parties it authorizes can hold a `.abbvie` name, so it is not available to the general public through any registrar.
+
+### Who operates the .abbvie registry?
+
+AbbVie Inc. is the registry operator, with Nominet providing the technical back-end. The TLD was delegated to the DNS root zone on February 26, 2016.
+
+### Is AbbVie related to Abbott?
+
+Yes. AbbVie Inc. is a biopharmaceutical company that was spun off from Abbott Laboratories in 2013, and it operates its own separate `.abbvie` brand TLD distinct from Abbott's `.abbott`.
+
+### What can I register instead of .abbvie?
+
+Because `.abbvie` is closed, choose an open extension for your own project. A matching `.com`, or a modern alternative like `.io` or `.xyz`, can be registered by anyone through an accredited registrar such as Namefi.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals behind top-level domains.
+- [.com TLD guide](/en/tld/com/) — the open default to compare against.
+- [.io TLD guide](/en/tld/io/) and [.xyz TLD guide](/en/tld/xyz/) — modern open alternatives.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [registry](/en/glossary/registry/), [ICANN](/en/glossary/icann/).

--- a/content/tld/en/abbvie.md
+++ b/content/tld/en/abbvie.md
@@ -3,7 +3,7 @@ title: "What Is the .abbvie Domain? AbbVie's Brand TLD Explained"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .abbvie domain is the closed brand TLD of biopharmaceutical company AbbVie, not open to the public. Learn what it is, who runs it, and what to register instead.'

--- a/content/tld/en/abc.md
+++ b/content/tld/en/abc.md
@@ -3,7 +3,7 @@ title: "What Is the .abc Domain? Disney/ABC's Brand TLD Explained"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .abc domain is the closed brand TLD of Disney Enterprises for the ABC television network, not open to the public. Learn what it is and what to register instead.'

--- a/content/tld/en/abc.md
+++ b/content/tld/en/abc.md
@@ -1,34 +1,22 @@
 ---
-title: "What is the .abc TLD and Why Choose It? The Ultimate Guide"
-date: '2025-12-10'
+title: "What Is the .abc Domain? Disney/ABC's Brand TLD Explained"
+date: '2026-07-24'
 language: 'en'
-tags:
-  - tld
-  - domain-investing
-  - branding
-  - web3
-authors:
-  - namefiteam
-editors:
-  - victor-zhou
+tags: ['tld']
+authors: ['namefiteam']
+editors: ['victor-zhou']
 draft: false
-description: "Discover the power of the .abc TLD. Learn why this short, memorable domain extension is perfect for education, startups, and Web3 investors. Secure your future today."
-keywords:
-  - what is .abc
-  - why choose .abc
-  - what is the .abc domain
-  - why choose the .abc domain
-  - .abc TLD
-  - .abc domains
-  - top-level domain
-  - domain investing
-  - blockchain domains
-  - tokenized domain
-  - new gTLD
-  - buy .abc domain
-  - short domain names
-  - brand identity
-  - Web3 naming
+description: 'The .abc domain is the closed brand TLD of Disney Enterprises for the ABC television network, not open to the public. Learn what it is and what to register instead.'
+keywords: ['.abc domain', 'what is .abc', '.abc TLD', 'ABC brand domain', 'dot-brand TLD', 'Disney Enterprises registry', 'closed generic TLD', 'is .abc available']
+faqs:
+  - question: 'Can anyone register a .abc domain?'
+    answer: 'No. .abc is a closed brand TLD delegated to Disney Enterprises, Inc. Only Disney and parties it authorizes can hold a .abc name, so it is not available to the general public through any registrar.'
+  - question: 'Who operates the .abc registry?'
+    answer: 'Disney Enterprises, Inc. is the registry operator, with Identity Digital providing the technical back-end. The TLD was delegated to the DNS root zone on July 21, 2016.'
+  - question: 'What does ABC stand for and who owns it?'
+    answer: 'ABC stands for the American Broadcasting Company, the US television network. The .abc TLD is registered to Disney Enterprises, Inc., which owns the ABC network; it is not related to Alphabet Inc.'
+  - question: 'What can I register instead of .abc?'
+    answer: 'Because .abc is closed, choose an open extension for your own project. A matching .com, or a modern alternative like .io or .xyz, can be registered by anyone through an accredited registrar such as Namefi.'
 relatedArticles:
   - /en/blog/what-is-a-tld/
   - /en/blog/why-are-io-domains-expensive/
@@ -49,52 +37,112 @@ relatedGlossary:
   - /en/glossary/web3/
 ---
 
-## **What is .abc?**
+The **.abc** domain is a **closed brand [top-level domain](/en/glossary/tld/)** operated by **Disney Enterprises, Inc.** on behalf of **ABC**, the American Broadcasting Company television network. It is not a public extension: unlike [.com](/en/tld/com/) or [.io](/en/tld/io/), you cannot register a `.abc` name for your own project, because the entire namespace belongs to Disney.
 
-The **.abc** [Top-Level Domain](/en/glossary/tld/) (TLD) represents one of the most intuitive and recognizable strings on the internet. In the world of domain names, brevity and familiarity are king, and few combinations are as universally understood as the first three letters of the alphabet.
+If you searched for the ".abc domain" hoping to buy one, the short answer is that you can't — but this page explains exactly what `.abc` is, who controls it, and what you can register instead.
 
-While legacy TLDs like [`.com`](/en/tld/com/) or `.net` have been the standard for decades, the introduction of [New gTLDs (Generic Top-Level Domains)](https://newgtlds.icann.org/en/about/program) has opened the door for more creative and specific extensions. The .abc TLD falls into a unique category of "generic" domains that offer immense versatility. It serves as a symbol for basics, foundations, and starting points.
+## .abc at a glance
 
-In the context of **domain investing** and the evolving **[Web3](/en/glossary/web3/)** landscape, unique strings like .abc are increasingly viewed as high-value digital assets. Whether utilized on traditional DNS or explored through alternative [blockchain](/en/glossary/blockchain/) naming roots, .abc signifies simplicity.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | Disney Enterprises, Inc. (technical back-end by Identity Digital) |
+| Year delegated | 2016 |
+| IDN support | Not relevant — closed namespace |
+| DNSSEC | Supported |
+| Registration restrictions | **Closed** — restricted to Disney Enterprises, Inc. and parties it authorizes; not available to the public |
+| Best for | ABC's own network, show, and programming websites |
 
-## **How People Are Using .abc**
+## What is .abc?
 
-The versatility of the .abc extension allows it to be adopted across various industries. Here is how individuals and businesses are leveraging this TLD:
+`.abc` is a **[generic top-level domain](/en/glossary/gtld/)** that ICANN delegated to **Disney Enterprises, Inc.**, the entity through which The Walt Disney Company holds the **American Broadcasting Company (ABC)**, the long-running US television network. The three-letter string is the network's own initialism, not a spelled-out reference to the alphabet.
 
-*   **Educational Platforms:** Schools, tutoring services, and e-learning platforms use it to signify literacy, fundamentals, and learning (e.g., `math.abc` or `learn.abc`).
-*   **Tech Startups & SaaS:** Companies that aim to make complex processes simple often use .abc to suggest that their software is "as easy as A-B-C."
-*   **Corporate Portfolios:** Large conglomerates use it to organize subsidiaries or distinct product lines under a clean, alphabetical hierarchy.
-*   **Testing and Development:** Developers often utilize .abc domains for staging environments or beta testing sites due to the memorable nature of the extension.
-*   **Creative Portfolios:** Designers and writers use it to showcase the "ABCs" of their work—the fundamental elements of their style.
+One important clarification: **`.abc` belongs to Disney/ABC, not to Alphabet Inc.** (Google's parent company). The two are unrelated companies that happen to share an interest in the same three letters. `.abc` is a **brand TLD**, or "dot-brand," delegated so that Disney, and only Disney, controls every domain ending in `.abc`. You can confirm the delegation and operator on the authoritative [IANA root-zone record for .abc](https://www.iana.org/domains/root/db/abc.html).
 
-## **Notable Entities Using .abc**
+## History of .abc
 
-While usage of new gTLDs is still growing compared to the `.com` giant, the concept of "ABC" in [domaining](/en/glossary/domaining/) has been popularized by some of the world's largest entities.
+The `.abc` string was **delegated to the DNS [root zone](/en/glossary/root-zone/) on July 21, 2016**, with **Identity Digital** handling the technical operation on Disney's behalf. Its registry agreement with [ICANN](/en/glossary/icann/) includes Specification 13, the contract clause that formally designates a TLD as a brand and lets the operator keep it closed.
 
-*   **Alphabet Inc. (Google):** Perhaps the most famous utilization of the "ABC" concept is by Google’s parent company, Alphabet. While they famously utilize `abc.xyz`, their branding strategy validated the immense power of the "ABC" string, driving interest in the specific `.abc` extension among investors.
-*   **ABC News/Media:** Various broadcasting corporations around the globe share the acronym ABC. As digital rights evolve, owning the exact match `.abc` domain becomes a defensive branding asset for major media outlets.
-*   **Blockchain Projects:** In the decentralized web, shorter domains are highly coveted for [wallet](/en/glossary/wallet/) addresses. The .abc string is popular in [Handshake (HNS)](https://handshake.org/) and other decentralized naming ecosystems for its brevity and ease of typing.
+ABC is one of the oldest US broadcast networks, and Disney has owned it since 1996. The `.abc` TLD gives the network a controlled namespace alongside its long-standing primary domain, [abc.com](https://abc.com).
 
-## **Why Choose .abc?**
+## Is .abc available to register?
 
-Choosing the right extension is critical for your digital identity. Here is why the .abc TLD is a smart choice for your next project or investment:
+**No.** `.abc` is a **closed brand TLD**, so there is no open registration and no [registrar](/en/glossary/registrar/) — including Namefi — can sell you a `.abc` name. Registrations are limited to Disney Enterprises, Inc. and organizations it authorizes, such as ABC's own divisions and production partners. This is by design: a dot-brand exists precisely so the trademark holder controls the whole namespace and no one else can register a confusing or malicious lookalike.
 
-*   **Ultimate Simplicity:** It is impossible to misspell "abc." It is the first thing we learn, making it globally recognized across all languages that use the Latin alphabet.
-*   **Memorable Branding:** In an era of short attention spans, a domain ending in .abc is catchy and rhythmic.
-*   **Availability:** Unlike .com, where most short names were registered in the 90s, .abc offers a higher chance of securing a short, premium keyword (e.g., `fitness.abc` vs. `fitness.com`).
-*   **Semantic Meaning:** It immediately conveys a message of "fundamentals" and "ease of use," which is excellent for marketing conversion rates.
-*   **Investment Potential:** As the digital real estate market expands into tokenized domains, short 3-letter TLDs retain high value and [liquidity](/en/glossary/domain-liquidity/).
+If you have a genuine business relationship with Disney or ABC and a legitimate need for a `.abc` address, that request would go through the company's own channels, not a commercial registrar.
 
-## **Register Your .abc Domain at Namefi**
+## How ABC uses .abc
 
-Ready to secure a domain that is as easy as 1-2-3?
+Brand TLDs give a media company a private space to organize its web presence. Typical uses for a dot-brand like `.abc` include:
 
-At **Namefi**, we bridge the gap between traditional Web2 domain registration and the future of Web3. When you register with us, you aren't just buying a name; you are securing a digital asset that is fully [ICANN](/en/glossary/icann/)-accredited and ready for the tokenized economy.
+- **Show and programming pages** on clean, memorable addresses tied directly to the network.
+- **Campaign and event microsites** that are obviously official because only the network can create them.
+- **Internal tools and portals** where a branded suffix signals a trusted, first-party destination.
 
-*   **Seamless Web3 Integration:** Manage your domains with the security of blockchain technology.
-*   **Transparent Pricing:** No hidden fees, just premium service.
-*   **Instant Ownership:** [Tokenize](/en/glossary/tokenize/) your domain instantly for easier trading and management.
+**Who it's not for:** anyone outside Disney/ABC. Because the namespace is closed, there is no scenario in which an independent developer, broadcaster, or business can build on `.abc`.
 
-Don't let the perfect name slip away. Start your journey with the fundamental building block of the internet.
+## Notable sites using .abc
 
-[**Search and Register at Namefi**](https://namefi.io)
+There are **no third-party sites** on `.abc`, and there never will be while it stays a closed brand TLD — every `.abc` address is controlled by Disney Enterprises, Inc. ABC continues to run its main public presence from its long-established `.com` domain, and uses the brand TLD selectively rather than as a wholesale replacement. Rather than point to a specific address that may change, the honest description is simple: `.abc` is Disney/ABC's private namespace, used only for the network's own properties.
+
+## What is a dot-brand TLD?
+
+A **dot-brand** (or brand TLD) is a top-level domain that a single company owns and operates for its exclusive use, secured through ICANN's [New gTLD Program](/en/glossary/new-gtld/). Hundreds were delegated, and they share a few defining traits:
+
+- **Closed registration.** Only the brand and its affiliates can hold names.
+- **Specification 13.** A registry-agreement addendum that formally recognizes the TLD as a brand and relaxes some rules that apply to open generics.
+- **Security and control.** The brand eliminates the risk of anyone else registering a `.abc` lookalike, which strengthens resistance to [phishing](/en/glossary/phishing/) and impersonation.
+
+Some brands invest heavily in their TLD; others register it defensively and barely use it. A number of companies have even terminated their dot-brands after deciding the upkeep was not worth it.
+
+## .abc vs open domain alternatives
+
+If your goal was a short, brandable name rather than the `.abc` string specifically, an open extension is the right tool. Here is how a closed brand TLD compares with domains you can actually register:
+
+| Feature | .abc | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.xyz](/en/tld/xyz/) |
+| --- | --- | --- | --- | --- |
+| Who can register | Disney/ABC only | Anyone | Anyone | Anyone |
+| Type | Brand new gTLD (closed) | Legacy gTLD | ccTLD used generically | New gTLD |
+| Core use | ABC's own sites | Universal default | Tech & startups | Generic / Web3 |
+| Available to you | No | Yes | Yes | Yes |
+
+For your own venture, a matching `.com` remains the safest default; [.io](/en/tld/io/) suits technical products; and [.xyz](/en/tld/xyz/) is a flexible, low-cost modern option.
+
+## Reputation and trust
+
+Ironically, the closed nature of `.abc` is exactly what makes it trustworthy: because only Disney/ABC can create these addresses, a `.abc` link is verifiably official, which is why brand TLDs are considered strong against impersonation and email spoofing. That trust, however, benefits ABC alone — it does not transfer to any name you might register, since you cannot register one. For your own project, deliverability and reputation will come from a well-configured domain on an open extension, not from a brand TLD you don't control.
+
+## Looking for an "abc" name? Register an alternative at Namefi
+
+You can't buy a `.abc` domain, but if you want a short name of your own, you can secure it on an open extension in minutes:
+
+1. **Search** your desired name across open TLDs like `.com`, `.io`, or `.xyz`.
+2. **Choose** the extension that fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can anyone register a .abc domain?
+
+No. `.abc` is a closed brand TLD delegated to Disney Enterprises, Inc. Only Disney and parties it authorizes can hold a `.abc` name, so it is not available to the general public through any registrar.
+
+### Who operates the .abc registry?
+
+Disney Enterprises, Inc. is the registry operator, with Identity Digital providing the technical back-end. The TLD was delegated to the DNS root zone on July 21, 2016.
+
+### What does ABC stand for and who owns it?
+
+ABC stands for the American Broadcasting Company, the US television network. The `.abc` TLD is registered to Disney Enterprises, Inc., which owns the ABC network; it is not related to Alphabet Inc.
+
+### What can I register instead of .abc?
+
+Because `.abc` is closed, choose an open extension for your own project. A matching `.com`, or a modern alternative like `.io` or `.xyz`, can be registered by anyone through an accredited registrar such as Namefi.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals behind top-level domains.
+- [.com TLD guide](/en/tld/com/) — the open default to compare against.
+- [.io TLD guide](/en/tld/io/) and [.xyz TLD guide](/en/tld/xyz/) — modern open alternatives.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [registry](/en/glossary/registry/), [ICANN](/en/glossary/icann/).

--- a/content/tld/en/able.md
+++ b/content/tld/en/able.md
@@ -3,7 +3,7 @@ title: "What Is the .able Domain? Able Inc.'s Brand TLD Explained"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .able domain is the closed brand TLD of Japanese real-estate company Able Inc., not open to the public. Learn what it is, and what to register instead.'

--- a/content/tld/en/able.md
+++ b/content/tld/en/able.md
@@ -1,12 +1,22 @@
 ---
-title: "Unlock Potential: What is the .able TLD and Why Choose It?"
-date: '2025-12-10'
+title: "What Is the .able Domain? Able Inc.'s Brand TLD Explained"
+date: '2026-07-24'
 language: 'en'
-tags: ['tld', 'branding', 'domain-names', 'web3']
+tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: "Discover the creative power of the .able domain extension. Learn how this versatile TLD boosts branding for startups, developers, and creatives. Secure yours at Namefi."
+description: 'The .able domain is the closed brand TLD of Japanese real-estate company Able Inc., not open to the public. Learn what it is, and what to register instead.'
+keywords: ['.able domain', 'what is .able', '.able TLD', 'Able Inc brand domain', 'dot-brand TLD', 'Able Inc registry', 'closed generic TLD', 'is .able available']
+faqs:
+  - question: 'Can anyone register a .able domain?'
+    answer: 'No. .able is a closed brand TLD delegated to Able Inc. Only Able Inc. and parties it authorizes can hold a .able name, so it is not available to the general public through any registrar.'
+  - question: 'Who operates the .able registry?'
+    answer: 'Able Inc. is the registry operator, with GoDaddy Registry providing the technical back-end. The TLD was delegated to the DNS root zone on March 3, 2016.'
+  - question: 'Is .able the same as the English word "able"?'
+    answer: 'The string reads as a common English adjective and suffix, but the .able top-level domain itself is not a generic wordplay extension. It is delegated exclusively to Able Inc., a Japanese real-estate and apartment-rental company, so it cannot be registered as a "domain hack" for words like reliable or sustainable.'
+  - question: 'What can I register instead of .able?'
+    answer: 'Because .able is closed, choose an open extension for your own project. A matching .com, or a modern alternative like .io or .xyz, can be registered by anyone through an accredited registrar such as Namefi.'
 relatedArticles:
   - /en/blog/top-tlds-to-secure-for-your-startup/
   - /en/blog/what-are-tokenized-domains/
@@ -27,53 +37,112 @@ relatedGlossary:
   - /en/glossary/dns/
 ---
 
-## **What is .able?**
+The **.able** domain is a **closed brand [top-level domain](/en/glossary/tld/)** operated by **Able Inc.**, a Japanese real-estate and apartment-rental company. It is not a public extension: unlike [.com](/en/tld/com/) or [.io](/en/tld/io/), you cannot register a `.able` name for your own project, because the entire namespace belongs to one company — no matter how tempting it looks for wordplay like *reli.able* or *sustain.able*.
 
-The **.able** [Top-Level Domain](/en/glossary/tld/) (TLD) is one of the most versatile and linguistically powerful extensions in the new [generic Top-Level Domain](/en/glossary/gtld/) ([new gTLD](/en/glossary/new-gtld/)) landscape. Unlike traditional domains that signify a type of organization (like [.com](/en/tld/com/) for commercial or [.org](/en/tld/org/) for organizations), **.able** is designed to play a functional grammatical role in your web address.
+If you searched for the ".able domain" hoping to buy one, the short answer is that you can't — but this page explains exactly what `.able` is, who controls it, why it isn't the open "domain hack" extension it looks like, and what you can register instead.
 
-It serves as a suffix that transforms nouns into adjectives, signifying capability, possibility, and fitness. The primary purpose of this TLD is to allow businesses and individuals to create "domain hacks"—URL structures that form complete, readable words (e.g., *sustain.able* or *reli.able*).
+## .able at a glance
 
-As the digital space becomes more crowded, usage trends show a shift toward these descriptive domains. They allow brands to communicate their core value proposition directly within the URL, making **.able** a favorite among modern startups, SaaS platforms, and creative agencies.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | Able Inc. (technical back-end by GoDaddy Registry) |
+| Year delegated | 2016 |
+| IDN support | Not relevant — closed namespace |
+| DNSSEC | Supported |
+| Registration restrictions | **Closed** — restricted to Able Inc. and parties it authorizes; not available to the public |
+| Best for | Able Inc.'s own property-listing and corporate websites |
 
-## **How People Are Using .able**
+## What is .able?
 
-The .able TLD offers a unique opportunity for wordplay and clear messaging. Here is how different sectors are utilizing this extension:
+`.able` is a **[generic top-level domain](/en/glossary/gtld/)** that ICANN delegated to **Able Inc.**, a real-estate and apartment-rental company based in Japan. The string is a common English adjective and suffix — it's easy to assume `.able` is an open extension built for wordplay domains, but it is not.
 
-*   **SaaS and Tech Companies:** Technology firms often use it to highlight features, such as *scal.able* or *track.able*, emphasizing the utility of their software.
-*   **Green Energy and Non-Profits:** Organizations focused on the environment frequently register *sustain.able* or *renew.able* to align their digital identity with their mission statement.
-*   **Creative Portfolios:** Designers and consultants use domains like *market.able* or *memor.able* to showcase their ability to deliver results.
-*   **Marketing Campaigns:** Brands use specific .able domains for landing pages dedicated to a specific product benefit (e.g., a camera company using *zooma.able*).
-*   **Web3 and Blockchain Projects:** Given the emphasis on interoperability in [Web3](/en/glossary/web3/), domains like *bridge.able* or *swap.able* are becoming increasingly popular for decentralized applications (dApps).
+`.able` is a **brand TLD** — often called a "dot-brand" — not an open extension anyone can buy into. Able Inc. applied for the string specifically so that it, and only it, would control every domain ending in `.able`. You can confirm the delegation and operator on the authoritative [IANA root-zone record for .able](https://www.iana.org/domains/root/db/able.html).
 
-## **Notable Entities Using .able**
+## History of .able
 
-While .able is a rapidly growing namespace, it is best defined by the *types* of innovative entities securing these names to define their market position.
+The `.able` string was **delegated to the DNS [root zone](/en/glossary/root-zone/) on March 3, 2016**, with **GoDaddy Registry** handling the technical operation on Able Inc.'s behalf. Its registry agreement with [ICANN](/en/glossary/icann/) includes Specification 13, the contract clause that formally designates a TLD as a brand and lets the operator keep it closed.
 
-*   **Innovative Tech Startups:** Companies offering cloud solutions and API integrations are the primary adopters, using the TLD to turn their brand name into a statement of capability.
-*   **Lifestyle and Coaching Brands:** Personal development coaches and fitness brands utilize domains like *cap.able* or *unstopp.able* to inspire confidence in their potential clients immediately.
-*   **E-commerce Logistics:** New shipping and logistics platforms are adopting domains such as *shipp.able* or *return.able* to signal ease of use to customers.
+Able Inc. runs its main public presence from [able.co.jp](https://www.able.co.jp), and the `.able` dot-brand exists as a supplementary namespace controlled entirely by the company.
 
-*As adoption grows, we are seeing a trend where companies redirect these creative URLs to their primary .com pages or use them as dedicated product microsites.*
+## Is .able available to register?
 
-## **Why Choose .able?**
+**No.** `.able` is a **closed brand TLD**, so there is no open registration and no [registrar](/en/glossary/registrar/) — including Namefi — can sell you a `.able` name, however catchy the word combination. Registrations are limited to Able Inc. and organizations it authorizes, such as subsidiaries or partners. This is by design: a dot-brand exists precisely so the trademark holder controls the whole namespace and no one else can register a confusing or malicious lookalike.
 
-Choosing a .able domain offers distinct advantages over traditional extensions:
+If you have a genuine business relationship with Able Inc. and a legitimate need for a `.able` address, that request would go through the company's own channels, not a commercial registrar.
 
-*   **Instant Memorability:** By forming a complete word, your domain becomes a "phrase" that is easier for users to recall than a random brand name followed by .com.
-*   **Built-in Marketing:** The domain itself describes what you do. If you own *depend.able*, you have already made a promise to your customer before the page even loads.
-*   **High Availability:** compared to the saturated .com or [.net](/en/tld/net/) markets, .able offers a much higher chance of securing a short, impactful, and keyword-rich domain name.
-*   **Modern Branding:** It signals that your brand is forward-thinking and creative. It appeals to a younger, digital-native demographic that appreciates clever branding.
-*   **SEO Potential:** While the extension itself is neutral for SEO, having a domain that is clicked more often due to its cleverness and clarity can indirectly boost your traffic metrics.
+## How Able Inc. uses .able
 
-## **Register Your .able Domain at Namefi**
+Brand TLDs give a company a private space to organize its web presence. Typical uses for a dot-brand like `.able` include:
 
-Ready to prove what your brand is capable of? Securing a **.able** domain is a strategic move to future-proof your digital identity.
+- **Property and listing pages** on clean, memorable addresses tied directly to the brand.
+- **Campaign and regional pages** that are obviously official because only the company can create them.
+- **Internal tools and portals** where a branded suffix signals a trusted, first-party destination.
 
-At **Namefi**, we make domain registration simple, secure, and ready for the future of the internet.
-*   **[ICANN](/en/glossary/icann/)-Accredited:** We provide fully compliant, secure registration services.
-*   **Web3 Integration:** Namefi is at the forefront of the domain revolution, allowing you to easily bridge your Web2 domains [on-chain](/en/glossary/on-chain/) for seamless management and tokenization.
-*   **Instant Setup:** Get your creative URL running in minutes with our user-friendly dashboard.
+**Who it's not for:** anyone outside Able Inc. — including the many businesses that might want a *reli.able* or *depend.able* domain hack. Because the namespace is closed, there is no scenario in which an independent developer, investor, or business can build on `.able`.
 
-Don't wait until the perfect adjective is taken.
+## Notable sites using .able
 
-[**Register Your .able Domain at Namefi**](https://namefi.io) and start building a brand that is truly remark.able.
+There are **no third-party sites** on `.able`, and there never will be while it stays a closed brand TLD — every `.able` address is controlled by Able Inc. The company continues to run most of its public presence from its long-established `.co.jp` domain, and uses the brand TLD selectively rather than as a wholesale replacement. Rather than point to a specific address that may change, the honest description is simple: `.able` is Able Inc.'s private namespace, used only for the company's own properties.
+
+## What is a dot-brand TLD?
+
+A **dot-brand** (or brand TLD) is a top-level domain that a single company owns and operates for its exclusive use, secured through ICANN's [New gTLD Program](/en/glossary/new-gtld/). Hundreds were delegated, and they share a few defining traits:
+
+- **Closed registration.** Only the brand and its affiliates can hold names.
+- **Specification 13.** A registry-agreement addendum that formally recognizes the TLD as a brand and relaxes some rules that apply to open generics.
+- **Security and control.** The brand eliminates the risk of anyone else registering a `.able` lookalike, which strengthens resistance to [phishing](/en/glossary/phishing/) and impersonation.
+
+Some brands invest heavily in their TLD; others register it defensively and barely use it. A number of companies have even terminated their dot-brands after deciding the upkeep was not worth it. `.able` is a useful reminder that a string looking like a common word or a clever suffix does not mean the extension is open — always check the registry status before planning a domain hack.
+
+## .able vs open domain alternatives
+
+If your goal was a short, brandable, or wordplay name rather than the `.able` string specifically, an open extension is the right tool. Here is how a closed brand TLD compares with domains you can actually register:
+
+| Feature | .able | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.xyz](/en/tld/xyz/) |
+| --- | --- | --- | --- | --- |
+| Who can register | Able Inc. only | Anyone | Anyone | Anyone |
+| Type | Brand new gTLD (closed) | Legacy gTLD | ccTLD used generically | New gTLD |
+| Core use | Able Inc.'s own sites | Universal default | Tech & startups | Generic / Web3 |
+| Available to you | No | Yes | Yes | Yes |
+
+For your own venture, a matching `.com` remains the safest default; [.io](/en/tld/io/) suits technical products; and [.xyz](/en/tld/xyz/) is a flexible, low-cost modern option.
+
+## Reputation and trust
+
+Ironically, the closed nature of `.able` is exactly what makes it trustworthy: because only Able Inc. can create these addresses, a `.able` link is verifiably official, which is why brand TLDs are considered strong against impersonation and email spoofing. That trust, however, benefits Able Inc. alone — it does not transfer to any name you might register, since you cannot register one. For your own project, deliverability and reputation will come from a well-configured domain on an open extension, not from a brand TLD you don't control.
+
+## Looking for an "able" name? Register an alternative at Namefi
+
+You can't buy a `.able` domain, but if you want a word-based or "domain hack" name of your own — *reliable*, *dependable*, *sustainable* — you can secure it on an open extension in minutes:
+
+1. **Search** your desired name across open TLDs like `.com`, `.io`, or `.xyz`.
+2. **Choose** the extension that fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can anyone register a .able domain?
+
+No. `.able` is a closed brand TLD delegated to Able Inc. Only Able Inc. and parties it authorizes can hold a `.able` name, so it is not available to the general public through any registrar.
+
+### Who operates the .able registry?
+
+Able Inc. is the registry operator, with GoDaddy Registry providing the technical back-end. The TLD was delegated to the DNS root zone on March 3, 2016.
+
+### Is .able the same as the English word "able"?
+
+The string reads as a common English adjective and suffix, but the `.able` top-level domain itself is not a generic wordplay extension. It is delegated exclusively to Able Inc., a Japanese real-estate and apartment-rental company, so it cannot be registered as a "domain hack" for words like reliable or sustainable.
+
+### What can I register instead of .able?
+
+Because `.able` is closed, choose an open extension for your own project. A matching `.com`, or a modern alternative like `.io` or `.xyz`, can be registered by anyone through an accredited registrar such as Namefi.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals behind top-level domains.
+- [.com TLD guide](/en/tld/com/) — the open default to compare against.
+- [.io TLD guide](/en/tld/io/) and [.xyz TLD guide](/en/tld/xyz/) — modern open alternatives.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [registry](/en/glossary/registry/), [ICANN](/en/glossary/icann/).

--- a/content/tld/en/abudhabi.md
+++ b/content/tld/en/abudhabi.md
@@ -3,7 +3,7 @@ title: 'What Is the .abudhabi Domain? A Geo-TLD for Abu Dhabi'
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .abudhabi domain is a geographic gTLD for the Emirate of Abu Dhabi in the UAE. Learn who operates it, who can register, and whether it suits your brand.'

--- a/content/tld/en/abudhabi.md
+++ b/content/tld/en/abudhabi.md
@@ -1,13 +1,22 @@
 ---
-title: "What is .abudhabi TLD and why choose it?"
-date: '2025-12-10'
+title: 'What Is the .abudhabi Domain? A Geo-TLD for Abu Dhabi'
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: "Establish your digital presence in the UAE capital with the .abudhabi TLD. Learn about its benefits, SEO advantages, and how to register with Namefi."
-keywords: [".abudhabi domains", ".abudhabi TLD", "top-level domain", "what is .abudhabi", "why choose .abudhabi", "what is the .abudhabi domain", "why choose the .abudhabi domain", "Abu Dhabi domain registration", "UAE digital identity", "Geo-TLD Abu Dhabi", "Middle East business domains", "domain investing UAE", "tokenized domain assets", "blockchain domains Abu Dhabi", "local SEO Abu Dhabi"]
+description: 'The .abudhabi domain is a geographic gTLD for the Emirate of Abu Dhabi in the UAE. Learn who operates it, who can register, and whether it suits your brand.'
+keywords: ['.abudhabi domains', '.abudhabi TLD', 'what is .abudhabi', 'Abu Dhabi domain name', 'geographic gTLD', 'UAE domain extension', 'Abu Dhabi government domain', 'geo-targeted domain']
+faqs:
+  - question: 'Can anyone register a .abudhabi domain?'
+    answer: 'Not without a connection to the emirate. Registration expects a genuine nexus to Abu Dhabi, such as a local business, institution, or government affiliation, under rules set by the registry operator. It is not an open, anyone-anywhere gTLD like .com.'
+  - question: 'Does a .abudhabi domain affect SEO?'
+    answer: 'As a geographic gTLD, .abudhabi carries a built-in place signal for Abu Dhabi and UAE searches. Site owners can reinforce this with explicit geotargeting in tools like Google Search Console. Beyond that signal, normal ranking factors such as content and links still decide results.'
+  - question: 'Who operates the .abudhabi registry?'
+    answer: 'The .abudhabi registry is operated by the Abu Dhabi Systems and Information Centre, the Emirate of Abu Dhabi government IT authority. It was delegated to the DNS root zone on February 26, 2016.'
+  - question: 'Who should register a .abudhabi domain?'
+    answer: 'Government bodies, local businesses, and institutions with a genuine connection to Abu Dhabi. It suits organizations that want to signal a direct, verifiable link to the emirate rather than a generic global presence.'
 relatedArticles:
   - /en/blog/what-is-a-tld/
   - /en/blog/top-tlds-to-secure-for-your-accounting-firm/
@@ -28,52 +37,132 @@ relatedGlossary:
   - /en/glossary/registry/
 ---
 
-## **What is .abudhabi?**
+The **.abudhabi** domain is a geographic [new gTLD](/en/glossary/new-gtld/) built for one place: the Emirate of Abu Dhabi, the capital of the United Arab Emirates. Unlike a generic extension such as [.com](/en/tld/com/), it carries a built-in place name, so a `.abudhabi` address tells a visitor immediately that the site has a real connection to the emirate. Registration is not fully open: the registry expects registrants to show a genuine nexus to Abu Dhabi, which sets it apart from unrestricted extensions available to anyone, anywhere.
 
-The **.abudhabi** extension is a Geographic [Top-Level Domain](/en/glossary/tld/) (Geo-TLD) explicitly dedicated to the Emirate of Abu Dhabi, the capital of the United Arab Emirates. Launched as part of the [ICANN](/en/glossary/icann/) (Internet Corporation for Assigned Names and Numbers) [New gTLD](/en/glossary/new-gtld/) Program, this domain extension is managed by the Abu Dhabi Digital Authority (ADDA).
+This guide covers what `.abudhabi` actually is, who operates it, who can register one, how pricing works, and how it is perceived for SEO, reputation, and email, so you can judge whether it fits your organization.
 
-Its primary purpose is to create a distinct digital identity for the Emirate, promoting Abu Dhabi as a hub for tourism, culture, and business innovation. Unlike generic domains like [.com](/en/tld/com/) or [.net](/en/tld/net/), .abudhabi is designed to foster trust and authenticity, signaling to users that the website has a genuine connection to the region.
+## .abudhabi at a glance
 
-For businesses and investors, this TLD represents a strategic asset in the Middle East's growing digital economy. You can read more about the delegation of this TLD on the [ICANN delegation report](https://www.iana.org/domains/root/db/abudhabi.html).
+| Fact | Detail |
+| --- | --- |
+| TLD type | Geographic new gTLD |
+| Registry operator | Abu Dhabi Systems and Information Centre (ADSIC), the Emirate's government IT authority |
+| Year delegated | 2016 (delegated to the root zone on February 26, 2016) |
+| IDN support | Supported (varies by registrar) |
+| DNSSEC | Supported |
+| Registration restrictions | Nexus required — registrants need a genuine connection to Abu Dhabi |
+| Best for | Abu Dhabi government bodies, local businesses, and institutions with a real connection to the emirate |
 
-## **How People Are Using .abudhabi**
+## What is .abudhabi?
 
-The usage of .abudhabi is centered around establishing legitimacy and local presence. It is effectively used to categorize content and services relevant to the residents and visitors of the Emirate.
+"Abudhabi" is the name of the capital emirate of the United Arab Emirates, and as a domain suffix it means exactly that: a site tied to that specific place. According to its [IANA root-zone entry](https://www.iana.org/domains/root/db/abudhabi.html), `.abudhabi` was delegated to the DNS [root zone](/en/glossary/root-zone/) on February 26, 2016, as part of ICANN's New gTLD Program.
 
-*   **Government Services:** The primary usage currently involves government departments unifying their digital presence under a single, trustworthy banner.
-*   **Tourism and Hospitality:** Hotels, travel agencies, and cultural sites use the domain to highlight their specific location within the capital, distinguishing themselves from other Emirates like Dubai.
-*   **Local Enterprises:** Businesses operating within the Abu Dhabi Global Market (ADGM) or the wider city utilize the domain to target local customers and improve local SEO.
-*   **Innovation and Tech:** Startups wishing to align themselves with Abu Dhabi's "Smart City" initiatives often adopt this TLD to showcase their commitment to the region's technological future.
+The [registry](/en/glossary/registry/) is operated by the **Abu Dhabi Systems and Information Centre (ADSIC)**, the emirate government's own IT authority, so unlike many privately run geographic strings, `.abudhabi` is run directly by the government body it names. Operator information and policy details are published at [nic.abudhabi](https://nic.abudhabi).
 
-## **Notable Entities Using .abudhabi**
+Because it is a **geographic** [gTLD](/en/glossary/gtld/) rather than a [country-code TLD](/en/glossary/cctld/) like the UAE's `.ae`, it sits one level more specific: `.ae` covers the whole country, while `.abudhabi` names the capital emirate alone. Search engines do not treat every gTLD as geo-locked by default, but because `.abudhabi` is explicitly geographic, site owners can set explicit Abu Dhabi or UAE geotargeting in tools like Google Search Console, reinforcing the place signal the name already carries.
 
-Because .abudhabi is a specialized Geo-TLD, its most prominent adopters are entities that drive the Emirate's economy and governance.
+## History of .abudhabi
 
-*   **TAMM (tamm.abudhabi):** Perhaps the most famous example, TAMM is the unified system for Abu Dhabi government services. It serves as a one-stop shop for citizens and residents, proving the high-level security and trust associated with the extension.
-*   **Department of Culture and Tourism:** Various cultural initiatives utilize the extension to promote events, museums, and heritage sites specific to the capital.
-*   **Make it in the Emirates:** Initiatives often linked to the Abu Dhabi Department of Economic Development utilize the domain to attract foreign investment.
+`.abudhabi` came out of ICANN's 2012-round New gTLD Program, the expansion that added geographic strings alongside brand and generic extensions. Applicants for a geographic gTLD name generally needed government or public-authority backing, and here the connection is direct: the registry operator is the emirate's own government IT authority rather than a third party running the name on the government's behalf.
 
-While major multinational corporations often stick to legacy TLDs, we are seeing a shift where companies open localized portals (e.g., `brandname.abudhabi`) to serve their specific UAE client base.
+The TLD was delegated to the root zone on **February 26, 2016**. Since then, ADSIC has continued to run `.abudhabi` as part of the emirate's approach to organizing its digital presence, publishing registration policy and operator information at nic.abudhabi.
 
-## **Why Choose .abudhabi?**
+## How people use .abudhabi
 
-Choosing a .abudhabi domain offers specific advantages, particularly for entities physically located in or doing business with the UAE.
+Given the nexus requirement, real-world use of `.abudhabi` concentrates in two areas:
 
-*   **Geographic Credibility:** It instantly communicates to visitors that you are local, authorized, and relevant to the Abu Dhabi market. This builds immediate consumer trust.
-*   **Availability:** Compared to saturated markets like .com or [.ae](/en/tld/ae/), the .abudhabi namespace has high availability. This means you are more likely to secure short, memorable, and premium names without paying [aftermarket](/en/glossary/aftermarket/) prices.
-*   **Local SEO Benefits:** Search engines often prioritize local TLDs for geo-specific search queries. If someone searches for "luxury real estate in Abu Dhabi," a website ending in .abudhabi may have a relevance advantage.
-*   **Brand Protection:** For global brands, registering your [trademark](/en/glossary/trademark/) under .abudhabi prevents [cybersquatting](/en/glossary/cybersquatting/) and ensures your brand integrity remains intact in the Middle East region.
+- **Government bodies.** Emirate-level and municipal departments and agencies use `.abudhabi` addresses as part of the emirate's own digital footprint.
+- **Local businesses and institutions.** Companies, service providers, and institutions with an actual presence in Abu Dhabi use the suffix to state that connection directly, rather than relying on a generic `.com` or `.ae` address to imply it.
 
-## **Register Your .abudhabi Domain at Namefi**
+**Who it's not ideal for:** organizations with no real connection to Abu Dhabi, since the nexus requirement means the name isn't available on demand the way it would be with an open gTLD. It is also a weak fit for a brand that wants one global, placeless address; the entire point of `.abudhabi` is to say "this is Abu Dhabi," which does not suit businesses operating everywhere at once.
 
-Ready to establish your digital footprint in the UAE capital? **Namefi** makes it easier than ever to search for, register, and manage your domain names.
+## Notable sites using .abudhabi
 
-Unlike traditional registrars, Namefi is at the forefront of the [Web3](/en/glossary/web3/) revolution. We offer seamless integration that allows you to treat your domain as a true digital asset. Whether you are a local business owner, a domain investor looking for high-value Geo-TLDs, or a developer building the next [blockchain](/en/glossary/blockchain/) solution in the Middle East, we have you covered.
+Because registration expects a genuine Abu Dhabi connection, adoption is concentrated among the emirate's government bodies and local businesses and institutions rather than a single flagship consumer brand. This is typical of nexus-gated geographic gTLDs: the names in active use tend to belong to the government agencies and local organizations the suffix was built for, since a global brand with no Abu Dhabi presence would not clear the eligibility bar in the first place. Rather than point to one representative address, it is more accurate to describe the pattern: government departments and local institutions using the emirate's name as their own digital address.
 
-*   **ICANN Accredited:** Secure and compliant registration.
-*   **Web3 Ready:** Easily [tokenize](/en/glossary/tokenize/) your domains for enhanced [liquidity](/en/glossary/domain-liquidity/) and management.
-*   **Instant Setup:** Get your site running quickly.
+## .abudhabi vs other domains
 
-Don't wait until your preferred local keyword is taken. Secure your connection to Abu Dhabi today.
+| Feature | .abudhabi | [.com](/en/tld/com) | .ae | [.xyz](/en/tld/xyz) |
+| --- | --- | --- | --- | --- |
+| Type | Geographic new gTLD | Legacy gTLD | Country-code TLD (UAE) | New gTLD (generic) |
+| Restrictions | Nexus required (Abu Dhabi) | Open to all | Set by UAE policy | Open to all |
+| Geographic scope | One emirate | None | Whole country | None |
+| Best fit | Abu Dhabi government and local entities | Any brand, anywhere | UAE-wide presence | Generic or Web3-native brands |
 
-[**Register your .abudhabi domain at Namefi**](https://namefi.io)
+Choose `.com` when you want the broadest possible reach and no geographic tie at all. Choose `.ae` when you need to represent the whole United Arab Emirates rather than one emirate. Choose a generic new gTLD like [`.xyz`](/en/tld/xyz) when geography should play no part in your name. Choose `.abudhabi` when your organization has a real, provable connection to the emirate and you want the address to say so.
+
+## Why choose .abudhabi?
+
+- **Direct government link.** The registry is run by the emirate's own IT authority, not a third-party operator, so the suffix ties straight back to Abu Dhabi's administration.
+- **Built-in place signal.** The name itself tells visitors and search engines the site is about Abu Dhabi, something a generic `.com` address cannot do on its own.
+- **Availability.** As a newer, narrower namespace than `.com` or `.ae`, short and descriptive `.abudhabi` names are easier to secure.
+- **Nexus as a trust marker.** Because registration requires a genuine local connection, the suffix itself signals legitimacy to Abu Dhabi audiences.
+
+## Things to consider
+
+- **The nexus requirement is real.** You cannot register `.abudhabi` speculatively or defensively without a qualifying connection to the emirate; plan for an eligibility check, not an instant purchase.
+- **Lower general recognition than .com.** Outside the UAE, `.abudhabi` is far less familiar, so audiences unfamiliar with the region may need more context.
+- **Narrow by design.** The suffix only makes sense for Abu Dhabi-connected organizations; it is not a substitute for a national or global address.
+
+## Who can register a .abudhabi domain?
+
+**Registration restrictions: nexus required.** `.abudhabi` expects registrants to show a genuine connection to the Emirate of Abu Dhabi, for example a local business, institution, or government affiliation, under eligibility policy set by the registry operator, the **Abu Dhabi Systems and Information Centre (ADSIC)**. This is not an open, first-come-first-served namespace like `.com`; it is built for entities tied to the emirate.
+
+Current eligibility rules, application steps, and any sunrise or [trademark](/en/glossary/trademark/)-related provisions are published by the operator at [nic.abudhabi](https://nic.abudhabi). The authoritative technical record is the [IANA root-zone entry](https://www.iana.org/domains/root/db/abudhabi.html); as a live [ICANN](/en/glossary/icann/) new gTLD, the underlying contract also appears in ICANN's [registry agreements database](https://www.icann.org/en/registry-agreements/details/abudhabi).
+
+## .abudhabi pricing and value
+
+Because `.abudhabi` is a nexus-gated geographic gTLD rather than a mass-market extension, pricing dynamics differ somewhat from an open namespace:
+
+- **Eligibility comes before price.** You need to qualify under the nexus policy before a name is available to you at all, which narrows the buyer pool compared with open gTLDs.
+- **First-year and renewal pricing can differ.** As with most gTLDs, check the standard renewal rate, not just an introductory offer, before committing.
+- **Cost drivers** include the registrar you use and any name-specific classification the registry applies.
+
+This page intentionally quotes no figures, since prices and offers change across registrars and over time.
+
+## Reputation and email deliverability
+
+Because registration requires a genuine Abu Dhabi connection, `.abudhabi` is structurally less exposed to the bulk, speculative registration that drives spam reputation problems on wide-open, low-cost extensions. A gated namespace tends to see less abuse, since fewer registrants qualify in the first place.
+
+Deliverability still depends mainly on how you configure email, not on the suffix itself. Set up correct **SPF, DKIM, and DMARC** records, warm up any new sending domain gradually, and keep list hygiene tight. A newer or less familiar suffix can face slightly more spam-filter scrutiny at first, purely due to unfamiliarity, but a properly authenticated `.abudhabi` sender should deliver mail reliably.
+
+## Branding and naming tips
+
+- **Lead with the connection, not just the keyword.** Since eligibility already ties you to Abu Dhabi, use the second-level name to state what you do, such as `tourism.abudhabi` or `logistics.abudhabi`, rather than repeating the place name.
+- **Keep the left side short and clear**, since the suffix itself already carries meaning and length.
+- **Confirm your nexus early.** Check the registry operator's eligibility rules before you build a brand around the name.
+- **Pair defensively.** Organizations that also serve the wider UAE may want to hold a matching `.ae` or `.com` alongside `.abudhabi`.
+
+## How to register a .abudhabi domain at Namefi
+
+1. **Search** for your desired name on [Namefi](https://namefi.io) to check availability.
+2. **Confirm eligibility** against the registry's Abu Dhabi nexus requirement.
+3. **Register** and configure DNS. Namefi provides fast, reliable DNS management.
+
+Namefi is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) with transparent pricing, and it supports [Web3](/en/glossary/web3/) tokenization, so you can optionally [tokenize](/en/glossary/tokenize/) an eligible domain for easier transfer and on-chain management. [Search and register your .abudhabi domain at Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .abudhabi domain?
+
+Not without a connection to the emirate. Registration expects a genuine nexus to Abu Dhabi, such as a local business, institution, or government affiliation, under rules set by the registry operator. It is not an open, anyone-anywhere gTLD like `.com`.
+
+### Does a .abudhabi domain affect SEO?
+
+As a geographic gTLD, `.abudhabi` carries a built-in place signal for Abu Dhabi and UAE searches. Site owners can reinforce this with explicit geotargeting in tools like Google Search Console. Beyond that signal, normal ranking factors such as content and links still decide results.
+
+### Who operates the .abudhabi registry?
+
+The `.abudhabi` registry is operated by the Abu Dhabi Systems and Information Centre, the Emirate of Abu Dhabi government IT authority. It was delegated to the DNS root zone on February 26, 2016.
+
+### Who should register a .abudhabi domain?
+
+Government bodies, local businesses, and institutions with a genuine connection to Abu Dhabi. It suits organizations that want to signal a direct, verifiable link to the emirate rather than a generic global presence.
+
+## Related resources
+
+- [.com domain](/en/tld/com) — the legacy benchmark with no geographic tie.
+- [.xyz domain](/en/tld/xyz) — a generic new gTLD alternative with no nexus requirement.
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals of top-level domains.
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains/) — how Web3 domain ownership works.
+- [Glossary: registry](/en/glossary/registry/), [registrar](/en/glossary/registrar/), [ICANN](/en/glossary/icann/), and [DNS](/en/glossary/dns/).

--- a/content/tld/en/ac.md
+++ b/content/tld/en/ac.md
@@ -1,13 +1,22 @@
 ---
-title: 'Unlock Your Potential: What is the .ac TLD and Why Choose It?'
-date: '2025-12-10'
+title: "What Is the .ac Domain? Ascension Island's Global ccTLD"
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: 'Discover the hidden value of the .ac domain. From academic prestige to creative branding, learn why the .ac TLD is a smart choice for your next project. Register with Namefi today.'
-keywords: ['.ac domains', '.ac TLD', 'top-level domain .ac', 'what is .ac', 'why choose .ac', 'what is the .ac domain', 'why choose the .ac domain', 'Ascension Island domain', 'academic domains', 'domain investing', 'blockchain domains', 'tokenized domains', 'accounting domains', 'short link domains', 'Web3 domains']
+description: 'What is the .ac domain? Ascension Island''s open, worldwide ccTLD used for academic branding and domain hacks. Manager, eligibility, and pricing explained.'
+keywords: ['.ac domain', '.ac TLD', 'what is .ac', 'Ascension Island domain', 'academic domain extension', 'domain hack TLDs', 'generic ccTLD', 'register .ac domain']
+faqs:
+  - question: 'Can anyone register a .ac domain?'
+    answer: 'Yes. Although .ac is the country-code TLD for Ascension Island, registration carries no local-presence or residency requirement. Names are available first-come, first-served through any participating registrar, with no need for a genuine Ascension Island connection.'
+  - question: 'Does a .ac domain affect SEO?'
+    answer: 'No. Google lists .ac among the ccTLDs it treats as generic rather than geo-targeted, so a .ac site is not tied to Ascension Island search results and can rank for a global audience like a standard gTLD.'
+  - question: 'Why is .ac associated with academics?'
+    answer: '"AC" is the common abbreviation for "academic," and it echoes familiar university addresses such as .ac.uk and .ac.jp. Ascension Island''s registry leans into that association, which is why education and research projects gravitate to the extension.'
+  - question: 'Who should register a .ac domain?'
+    answer: 'Academic and education-related projects, research tools, and anyone building a domain hack around a word ending in "ac." It fits short, brandable names better than large consumer platforms with no academic or wordplay angle.'
 relatedArticles:
   - /en/blog/what-is-a-tld/
   - /en/blog/top-tlds-to-secure-for-your-accounting-firm/
@@ -28,53 +37,134 @@ relatedGlossary:
   - /en/glossary/web3/
 ---
 
-## **What is .ac?**
+The **.ac** domain is the [ccTLD](/en/glossary/cctld/) for **Ascension Island**, a remote territory in the South Atlantic, and one of the small set of country-code domains that search engines treat as generic rather than tied to one country. Open to anyone worldwide, with no local-presence requirement, it has become a go-to extension for academic-flavored branding and for domain hacks built around words ending in the letters "ac."
 
-The **.ac** domain is the **Country Code [Top-Level Domain](/en/glossary/tld/) ([ccTLD](/en/glossary/cctld/))** designated for **Ascension Island**, a remote British Overseas Territory located in the South Atlantic Ocean. Despite its geographic origins, the .ac TLD has transcended its physical borders to become a versatile and highly sought-after extension in the global digital landscape.
+This guide covers what .ac really is, who runs it, who can register one, how it is priced, and what to expect for SEO and email reputation.
 
-While it is technically a geographic domain, .ac is widely recognized and managed as an open [registry](/en/glossary/registry/). This means that anyone, regardless of their location, can register a .ac domain. It is managed by the [Internet Computer Bureau (ICB)](http://www.nic.ac/), ensuring a stable and reliable infrastructure.
+## .ac at a glance
 
-The domain has gained significant traction for two primary reasons:
-1.  **Academic Association:** "AC" is the universal abbreviation for "Academic" or "Academy."
-2.  **Branding Potential:** It serves as a perfect suffix for words ending in "ac" ([domain hacks](/en/blog/domain-hacks-explained/)) or abbreviations for "Account," "Activity," or "Action."
+| Fact | Detail |
+| --- | --- |
+| TLD type | Country-code TLD (ccTLD) for Ascension Island |
+| Registry operator | Internet Computer Bureau Limited (nic.ac) |
+| Year delegated | 1997 (December 19) |
+| Registration restrictions | Open to all — no local presence required |
+| Google treatment | Listed among the ccTLDs Google treats as generic, not geo-targeted |
+| Best for | Academic and education-adjacent projects, plus domain-hack branding |
 
-## **How People Are Using .ac**
+## What is .ac?
 
-Because of its dual nature as a geographic code and a meaningful abbreviation, the usage of .ac is incredibly diverse. Here is how modern businesses and developers are utilizing it:
+**.ac** is the country-code [Top-Level Domain](/en/glossary/tld/) assigned under the ISO 3166-1 system to **Ascension Island**, listed by the [Internet Assigned Numbers Authority (IANA)](https://www.iana.org/domains/root/db/ac.html) with **Internet Computer Bureau Limited** as the registry, operating the namespace through [nic.ac](https://www.nic.ac/).
 
-*   **Educational Institutions & EdTech:** While many universities use second-level domains like `.ac.uk` or `.ac.jp`, the standalone `.ac` is becoming popular for online academies, tutoring platforms, and educational startups looking for a shorter, cleaner URL.
-*   **Accounting and Fintech:** Financial firms and SaaS tools often use .ac as a shorthand for "Accounting" or "Account."
-*   **Creative Agencies & Portfolios:** Agencies focused on "Action" or "Activity" utilize the extension to create dynamic, energetic brand names.
-*   **URL Shorteners:** Due to the availability of two-letter and three-letter names, .ac is excellent for creating branded short links for social media.
-*   **Tech and Gaming:** Specifically in the gaming sector, "AC" is often associated with "Anti-Cheat" software or "Armor Class," making it a niche favorite for gaming communities.
+Unlike many ccTLDs that restrict registration to residents or local entities, .ac has been run as an open [registry](/en/glossary/registry/): anyone, anywhere, can register a second-level .ac name. That openness, combined with the fact that "AC" is the standard shorthand for "academic," is why the extension is marketed toward education and research projects — echoing the familiar look of academic addresses like `.ac.uk` or `.ac.jp` without the formal accreditation those actually require.
 
-## **Notable Entities Using .ac**
+Google includes .ac on its list of ccTLDs it [treats as generic rather than country-specific](https://developers.google.com/search/docs/crawling-indexing/manage-international-sites) for search purposes, so a .ac site is not boxed into Ascension Island results and can target a global audience.
 
-While .ac is often used as a backend infrastructure TLD (for shortening) or by niche startups, several categories of entities have adopted it to great effect:
+## History of .ac
 
-1.  **Academic Sub-domains:** The most famous usage of "ac" is actually within second-level domains. Prestigious institutions like the **University of Oxford** (`ox.ac.uk`) rely on the "ac" identifier for credibility. The standalone .ac TLD inherits this sense of trust and prestige.
-2.  **Tech Startups and SaaS:** Various URL shortening services and specialized software tools utilize .ac for its brevity. For example, legitimate security and anti-cheat software providers have utilized the extension to denote authority.
-3.  **Local Businesses on Ascension Island:** Naturally, local governmental and tourist entities on [Ascension Island](https://www.ascension.gov.ac/) utilize the domain to represent their territory online.
+The .ac ccTLD was delegated on **December 19, 1997**. Internet Computer Bureau Limited has managed the registry since, running registrations through nic.ac as an open namespace rather than restricting it to Ascension Island residents or businesses.
 
-## **Why Choose .ac?**
+Beyond the delegation record, IANA does not publish a detailed commercial history for .ac the way it does for larger, more actively marketed ccTLDs. What is clear from current registry practice is the open, worldwide registration policy and the academic and domain-hack use it has attracted as a result.
 
-If you are considering a new domain name, here is why .ac should be at the top of your list:
+## How people use .ac
 
-*   **Instant Credibility:** If you are in the education sector, .ac signals "Academy" immediately. It carries the weight of institutional trust without the strict requirements of a .edu domain.
-*   **Superior Availability:** Unlike [.com](/en/tld/com/) or [.net](/en/tld/net/), which are saturated, the .ac namespace still offers a vast selection of short, memorable, and premium names. You are more likely to get `YourName.ac` than `YourName.com`.
-*   **Professional Branding:** For accountants and consultants, it offers a professional abbreviation built right into the URL (e.g., `SmithCPA.ac`).
-*   **Domain Hacks:** It offers creative opportunities for brands ending in "ac" (e.g., `bivou.ac`, `tarm.ac`, or `mani.ac`), making your URL catchy and easy to remember.
-*   **Global Recognition:** According to [IANA](https://www.iana.org/domains/root/db/ac.html), the domain is standard and recognized globally, ensuring your site resolves correctly anywhere in the world.
+Two real patterns account for most .ac registrations:
 
-## **Register Your .ac Domain at Namefi**
+- **Academic and education-adjacent projects.** Research tools, online courses, and education startups use .ac for the instant "academic" cue, borrowing the credibility of `.ac.uk`-style addresses without needing an actual university affiliation.
+- **[Domain hacks](/en/blog/domain-hacks-explained/).** Because plenty of English words end in the letters "ac" (as in *almanac*, *cognac*, or *maniac*), short brand names can complete a word using the extension as the final syllable.
 
-Whether you are launching an online course, an accounting firm, or a sleek tech startup, **.ac** offers the perfect blend of availability and authority.
+**Who it's not ideal for:** brands with no academic or wordplay angle at all, where the "academic" connotation adds nothing, or buyers who assume a two-letter ccTLD guarantees the lowest possible price — some short or dictionary names still command a premium.
 
-At **Namefi**, we make securing your .ac domain seamless and future-proof. We are not just a traditional [registrar](/en/glossary/registrar/); we bridge the gap between Web2 and [Web3](/en/glossary/web3/).
-*   **[ICANN](/en/glossary/icann/) Accredited:** Trustworthy and secure registration.
-*   **[Tokenized Domains](/en/blog/what-are-tokenized-domains/):** When you register with Namefi, you have the option to mint your domain as an [NFT](/en/glossary/nft/), giving you true ownership and the ability to trade it easily on the blockchain.
-*   **Instant Setup:** Get your site running in minutes.
+## Notable sites using .ac
 
-Don't let your perfect domain name get snapped up by someone else. Take action today.
+We are not aware of a single dominant, widely recognized brand anchoring .ac the way certain other extensions have a flagship adopter. In practice, registrations skew toward smaller academic and research projects using the education cue, and toward domain-hack names completing a word ending in "ac," rather than large consumer platforms. If you are evaluating .ac, expect a namespace defined by its open availability and linguistic fit rather than by a marquee public example.
 
-[**Search and Register Your .ac Domain at Namefi**](https://namefi.io)
+## .ac vs other domains
+
+| Feature | .ac | [.com](/en/tld/com/) | [.co](/en/tld/co/) | [.io](/en/tld/io/) |
+| --- | --- | --- | --- | --- |
+| Type | ccTLD (treated as generic) | Legacy gTLD | ccTLD (used globally) | ccTLD (used globally) |
+| Core association | Academic cue, domain hacks | The default web standard | Generic, short alternative to .com | Tech / "Input-Output" |
+| Registration eligibility | Open worldwide | Open worldwide | Open worldwide | Open worldwide |
+| Availability of short names | Better than .com | Very poor | Poor | Moderate |
+
+Choose **.com** when the exact name is available — it remains the default choice for most audiences. Reach for **.ac** when an academic or research framing fits your brand, or when a domain hack ending in "ac" completes your name. **[.co](/en/tld/co/)** is a reasonable generic short alternative with no thematic association, and **[.io](/en/tld/io/)** suits developer- and infrastructure-focused tech brands.
+
+## Why choose .ac?
+
+- **Open worldwide.** No local-presence or residency requirement, unlike many other ccTLDs.
+- **Academic shorthand.** "AC" reads instantly as "academic," which suits education, research, and learning-adjacent projects.
+- **Domain-hack potential.** Words ending in "ac" can be completed cleanly by the extension.
+- **Treated as generic by Google.** Search visibility is not confined to Ascension Island.
+
+## Things to consider
+
+- **A ccTLD by nature.** Because .ac technically belongs to Ascension Island, its long-term rules are set by Internet Computer Bureau Limited under national policy, not by an [ICANN](/en/glossary/icann/) registry agreement.
+- **No marquee example.** Unlike some ccTLDs with a famous flagship adopter, .ac has no single well-known site that anchors the extension in the public mind — recognition rests on the string's own meaning.
+- **Niche connotation.** The academic association is a strength for education and research brands, but can feel mismatched for ventures with no learning or wordplay angle.
+
+## Who can register a .ac domain?
+
+**Registration restrictions: open to all.** There is **no local-presence, residency, or Ascension Island connection required** to register a second-level .ac domain. Registration is available to individuals and organizations anywhere in the world through any participating [registrar](/en/glossary/registrar/), on a first-come, first-served basis.
+
+Because .ac is a ccTLD, it is governed by Ascension Island's registry policy rather than an ICANN registry agreement — the authoritative sources for current management and eligibility details are the [IANA root-zone entry](https://www.iana.org/domains/root/db/ac.html) and the registry's own site, [nic.ac](https://www.nic.ac/).
+
+## .ac pricing and value
+
+This page intentionally quotes no numbers, but a few dynamics are worth knowing before you commit to a name:
+
+- **Premium classification is common across ccTLDs.** Check whether your specific name carries a premium price before assuming a standard rate applies.
+- **First-year pricing is often introductory.** As with most TLDs, a promotional first-year rate does not necessarily match the standard renewal fee — confirm both before registering.
+- **What drives cost.** Name length, dictionary-word desirability, and registry [wholesale pricing](/en/glossary/wholesale-pricing/) are the main factors that determine what a given .ac name costs to register and renew.
+
+For exact, current figures, check live pricing at registration time.
+
+## Reputation and email deliverability
+
+We are not aware of .ac carrying any negative bulk-mail or spam reputation. As with any TLD, email deliverability depends far more on **sending reputation, SPF/DKIM/DMARC authentication, and list hygiene** than on the suffix itself. A properly authenticated .ac sender should reach inboxes normally.
+
+The main practical caveat is fit: a business with no academic, research, or wordplay connection may find a .ac email address reads as slightly unusual to recipients unfamiliar with the extension.
+
+## Branding and naming tips
+
+- **Lean into the academic cue if it fits.** Education, research, and learning brands get real value from the "ac" association.
+- **Try a domain hack.** Look for a word ending in "ac" that your brand name can complete naturally.
+- **Keep it short.** Two-letter ccTLDs work best paired with equally short, punchy names.
+- **Check premium status first.** Confirm classification and renewal pricing before settling on a name.
+
+## How to register a .ac domain at Namefi
+
+1. **Search** for your desired name and the .ac extension.
+2. **Choose** an available name and confirm whether it is classified as premium.
+3. **Register** and configure DNS.
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for easier transfer and provable ownership.
+
+## Frequently asked questions
+
+### Can anyone register a .ac domain?
+
+Yes. Although .ac is the country-code TLD for Ascension Island, registration carries no local-presence or residency requirement. Names are available first-come, first-served through any participating registrar, with no need for a genuine Ascension Island connection.
+
+### Does a .ac domain affect SEO?
+
+No. Google lists .ac among the ccTLDs it treats as generic rather than geo-targeted, so a .ac site is not tied to Ascension Island search results and can rank for a global audience like a standard gTLD.
+
+### Why is .ac associated with academics?
+
+"AC" is the common abbreviation for "academic," and it echoes familiar university addresses such as .ac.uk and .ac.jp. Ascension Island's registry leans into that association, which is why education and research projects gravitate to the extension.
+
+### Who should register a .ac domain?
+
+Academic and education-related projects, research tools, and anyone building a domain hack around a word ending in "ac." It fits short, brandable names better than large consumer platforms with no academic or wordplay angle.
+
+## Related resources
+
+- [.com TLD guide](/en/tld/com/)
+- [.io TLD guide](/en/tld/io/)
+- [.co TLD guide](/en/tld/co/)
+- [What is a TLD?](/en/blog/what-is-a-tld/)
+- [Domain hacks explained](/en/blog/domain-hacks-explained/)
+- [Glossary: registrar](/en/glossary/registrar/)
+- [Glossary: ICANN](/en/glossary/icann/)
+- [Glossary: ccTLD](/en/glossary/cctld/)

--- a/content/tld/en/ac.md
+++ b/content/tld/en/ac.md
@@ -3,7 +3,7 @@ title: "What Is the .ac Domain? Ascension Island's Global ccTLD"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'What is the .ac domain? Ascension Island''s open, worldwide ccTLD used for academic branding and domain hacks. Manager, eligibility, and pricing explained.'

--- a/content/tld/en/accenture.md
+++ b/content/tld/en/accenture.md
@@ -3,7 +3,7 @@ title: "What Is .accenture? Accenture's Brand TLD Explained"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .accenture domain is Accenture''s closed brand TLD, not open to the public. Learn what it is, who runs it, why it exists, and what to register instead.'

--- a/content/tld/en/accenture.md
+++ b/content/tld/en/accenture.md
@@ -1,13 +1,22 @@
 ---
-title: "What is the .accenture TLD and What Does It Represent?"
-date: '2025-12-10'
+title: "What Is .accenture? Accenture's Brand TLD Explained"
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: "Explore the .accenture top-level domain. Understand the strategy behind Brand TLDs, why corporations use them, and how to find your own perfect domain at Namefi."
-keywords: [".accenture domains", ".accenture TLD", "top-level domain", "what is .accenture", "why choose .accenture", "what is the .accenture domain", "why choose the .accenture domain", "brand TLD", "domain investing", "blockchain domains", "tokenized domains", "corporate digital identity", "exclusive TLDs", "Accenture domain strategy", "Web3 domains"]
+description: 'The .accenture domain is Accenture''s closed brand TLD, not open to the public. Learn what it is, who runs it, why it exists, and what to register instead.'
+keywords: ['.accenture domain', 'what is .accenture', '.accenture TLD', 'Accenture brand domain', 'dot-brand TLD', 'Accenture registry operator', 'closed generic TLD', 'is .accenture available']
+faqs:
+  - question: 'Can anyone register a .accenture domain?'
+    answer: 'No. .accenture is a closed brand TLD delegated to Accenture plc. Only Accenture and parties it authorizes can hold a .accenture name, so it is not available to the general public through any registrar.'
+  - question: 'Who operates the .accenture registry?'
+    answer: 'Accenture plc is the registry operator, with Identity Digital providing the technical back-end. The TLD was delegated to the DNS root zone on April 30, 2015, under ICANN''s New gTLD Program.'
+  - question: 'What kind of company is Accenture?'
+    answer: 'Accenture plc is a global professional-services firm working in consulting, technology, and operations. Its .accenture domain is reserved for its own use, not for consulting clients or partners.'
+  - question: 'What can I register instead of .accenture?'
+    answer: 'Because .accenture is closed, choose an open extension for your own project. A matching .com, or a modern alternative like .io or .xyz, can be registered by anyone through an accredited registrar such as Namefi.'
 relatedArticles:
   - /en/blog/top-tlds-to-secure-for-your-accounting-firm/
   - /en/blog/what-is-a-tld/
@@ -28,51 +37,113 @@ relatedGlossary:
   - /en/glossary/dns/
 ---
 
-## **What is .accenture?**
+The **.accenture** domain is a **closed brand [top-level domain](/en/glossary/tld/)** operated by **Accenture plc**, the global professional-services firm. It is not a public extension: unlike [.com](/en/tld/com/) or [.io](/en/tld/io/), you cannot register a `.accenture` name for your own project, because the entire namespace belongs to one company.
 
-The **.accenture** [Top-Level Domain](/en/glossary/tld/) (TLD) is a specific type of extension known as a "Brand TLD" or "dot-brand." Unlike open extensions like [.com](/en/tld/com/) or [.net](/en/tld/net/), which are available for public registration, .accenture was applied for and delegated exclusively to **Accenture**, the global professional services company specializing in information technology services and consulting.
+If you searched for the ".accenture domain" hoping to buy one, the short answer is that you can't — but this page explains what `.accenture` is, who controls it, why a professional-services firm runs its own TLD, and what you can register instead.
 
-This TLD was created during [ICANN’s New gTLD Program](https://newgtlds.icann.org/en/about/program), which allowed organizations to apply for their own custom extensions. The primary purpose of .accenture is to serve as a trusted, verified digital namespace for the company's internal operations, client communications, and marketing initiatives. It represents a move toward total brand control in the digital infrastructure space.
+## .accenture at a glance
 
-## **How People Are Using .accenture**
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | Accenture plc (technical back-end by Identity Digital) |
+| Year delegated | 2015 |
+| IDN support | Not relevant — closed namespace |
+| DNSSEC | Supported |
+| Registration restrictions | **Closed** — restricted to Accenture plc and parties it authorizes; not available to the public |
+| Best for | Accenture's own corporate, consulting, and campaign websites |
 
-Because .accenture is a **closed [registry](/en/glossary/registry/)**, it is not available for general public registration. Instead, it is used strategically by the corporation itself. Here is how the domain is utilized within the digital ecosystem:
+## What is .accenture?
 
-*   **Corporate Identity & Trust:** By operating their own registry, Accenture ensures that any website ending in .accenture is an official corporate asset. This eliminates the risk of [phishing](/en/glossary/phishing/) or [cybersquatting](/en/glossary/cybersquatting/) on that specific extension.
-*   **Marketing Campaigns:** Companies with Brand TLDs often create memorable campaign links (e.g., `future.accenture` or `vision.accenture`) to drive traffic to specific landing pages.
-*   **Internal Infrastructure:** Large corporations often use these domains for employee portals, cloud infrastructure, and intranet systems, ensuring a secure environment for data exchange.
-*   **Client Deliverables:** Providing secure login portals for clients under a verified brand extension enhances professional perception and security.
+`.accenture` is a **[generic top-level domain](/en/glossary/gtld/)** that ICANN delegated to **Accenture plc** on **April 30, 2015**. Accenture is a global professional-services firm, working across consulting, technology, and operations for clients around the world.
 
-## **Notable Entities Using .accenture**
+`.accenture` is a **brand TLD** — a "dot-brand" — not an open extension anyone can buy into. The company applied for the string so that it, and only it, would control every domain ending in `.accenture`. You can confirm the delegation and operator on the authoritative [IANA root-zone record for .accenture](https://www.iana.org/domains/root/db/accenture.html).
 
-As a single-[registrant](/en/glossary/registrant/) TLD, the only entity using this extension is **Accenture PLC** and its subsidiaries. However, the usage of the domain highlights best practices in corporate branding.
+## History of .accenture
 
-While specific internal subdomains are private, the structure generally follows these patterns:
+`.accenture` was delegated to the DNS [root zone](/en/glossary/root-zone/) on **April 30, 2015**, with **Identity Digital** (the registry services provider formerly known as Afilias/Donuts) handling the technical operation on Accenture's behalf. Its registry agreement with [ICANN](/en/glossary/icann/) includes **Specification 13**, the contract clause that formally designates a TLD as a brand and lets the operator keep it closed.
 
-1.  **Corporate Portals:** Subdomains dedicated to specific geographic branches or service arms (e.g., `strategy.accenture` or `technology.accenture`).
-2.  **Recruitment:** Dedicated portals for talent acquisition, offering a streamlined path for potential employees.
-3.  **Thought Leadership:** Hubs for white papers, research, and Accenture’s "Point of View" articles.
+Accenture was one of many large firms that applied for their own company name as a TLD during ICANN's New gTLD Program, alongside dozens of other consultancies, banks, and manufacturers seeking the same kind of control over their online namespace. The `.accenture` record has remained active since delegation.
 
-*Note: As this is a private registry, specific live URLs are often strictly for internal or client-specific use.*
+## Is .accenture available to register?
 
-## **Why Choose .accenture?**
+**No.** `.accenture` is a **closed brand TLD**, so there is no open registration and no [registrar](/en/glossary/registrar/) — including Namefi — can sell you a `.accenture` name. Registrations are limited to Accenture plc and organizations it authorizes, such as subsidiaries or agencies acting on its behalf. This is by design: a dot-brand exists precisely so the trademark holder controls the whole namespace and no one else can register a confusing or malicious lookalike.
 
-While you cannot register a .accenture domain personally, understanding *why* a corporation chooses to invest in a Brand TLD offers valuable insights for domain investors and business owners selecting their own domains.
+If you have a genuine business relationship with Accenture and a legitimate need for a `.accenture` address, that request would go through Accenture's own corporate channels, not a commercial registrar.
 
-*   **Ultimate Authority:** A proprietary TLD signals to the world that the organization is forward-thinking and authoritative.
-*   **Enhanced Security:** Since the registry is closed, there is zero risk of bad actors registering a domain like `support.accenture` to scam customers.
-*   **SEO & Branding:** Search engines and users recognize the brand name immediately in the URL, reinforcing brand recall every time the link is seen.
-*   **Availability:** For the registry owner, "availability" is 100%. They can create any short, keyword-rich domain they want (e.g., `ai.accenture`) without checking if it is taken.
+## How Accenture uses .accenture
 
-## **Register Your Domain at Namefi**
+Brand TLDs give a company a private space to organize its web presence. Typical uses for a dot-brand like `.accenture` include:
 
-While **.accenture** is exclusive to the corporate giant, you can still build a powerful, secure, and memorable digital identity for your own project. Whether you are looking for a professional **.com**, a tech-savvy **[.io](/en/tld/io/)**, or an innovative **[.xyz](/en/tld/xyz/)**, finding the right TLD is the first step toward success.
+- **Service-line and practice sites** on clean, memorable addresses tied directly to the brand.
+- **Campaign and event pages** that are obviously official because only the company can create them.
+- **Internal tools and client portals** where a branded suffix signals a trusted, first-party destination.
 
-At **Namefi**, we make [domain ownership](/en/glossary/domain-ownership/) easier and more versatile than ever before.
-*   **[ICANN](/en/glossary/icann/)-Accredited:** We are a fully compliant and trusted [registrar](/en/glossary/registrar/).
-*   **Web3 Integration:** We specialize in **[tokenized domains](/en/blog/what-are-tokenized-domains/)**, allowing you to manage your Web2 domains with the ease and security of [blockchain](/en/glossary/blockchain/) technology.
-*   **Seamless Management:** Connect your traditional domains to the decentralized web instantly.
+**Who it's not for:** anyone outside Accenture. Because the namespace is closed, there is no scenario in which an independent consultant, competitor, or business can build on `.accenture`.
 
-Don't wait for the perfect name to disappear. Secure your brand's future today.
+## Notable sites using .accenture
 
-[**Register Your Domain at Namefi**](https://namefi.io)
+There are **no third-party sites** on `.accenture`, and there never will be while it stays a closed brand TLD — every `.accenture` address is controlled by Accenture plc. Accenture continues to run its main public presence from **accenture.com**, and uses the brand TLD selectively rather than as a wholesale replacement. Rather than point to a specific address that may change, the honest description is simple: `.accenture` is Accenture's private namespace, used only for the company's own properties.
+
+## What is a dot-brand TLD?
+
+A **dot-brand** (or brand TLD) is a top-level domain that a single company owns and operates for its exclusive use, secured through ICANN's [New gTLD Program](/en/glossary/new-gtld/). Hundreds were delegated — examples in this same alphabetical band include `.abb`, `.aetna`, and `.afl` — and they share a few defining traits:
+
+- **Closed registration.** Only the brand and its affiliates can hold names.
+- **Specification 13.** A registry-agreement addendum that formally recognizes the TLD as a brand and relaxes some rules that apply to open generics.
+- **Security and control.** The brand eliminates the risk of anyone else registering a `.accenture` lookalike, which strengthens resistance to [phishing](/en/glossary/phishing/) and impersonation.
+
+Some brands invest heavily in their TLD; others register it defensively and barely use it. A number of companies have even terminated their dot-brands after deciding the upkeep was not worth it.
+
+## .accenture vs open domain alternatives
+
+If your goal was a short, brandable name rather than the `.accenture` string specifically, an open extension is the right tool. Here is how a closed brand TLD compares with domains you can actually register:
+
+| Feature | .accenture | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.xyz](/en/tld/xyz/) |
+| --- | --- | --- | --- | --- |
+| Who can register | Accenture plc only | Anyone | Anyone | Anyone |
+| Type | Brand new gTLD (closed) | Legacy gTLD | ccTLD used generically | New gTLD |
+| Core use | Accenture's own sites | Universal default | Tech & startups | Generic / Web3 |
+| Available to you | No | Yes | Yes | Yes |
+
+For your own venture, a matching `.com` remains the safest default; [.io](/en/tld/io/) suits technical products; and [.xyz](/en/tld/xyz/) is a flexible, low-cost modern option.
+
+## Reputation and trust
+
+Ironically, the closed nature of `.accenture` is exactly what makes it trustworthy: because only Accenture can create these addresses, a `.accenture` link is verifiably official, which is why brand TLDs are considered strong against impersonation and email spoofing. That trust, however, benefits Accenture alone — it does not transfer to any name you might register, since you cannot register one. For your own project, deliverability and reputation will come from a well-configured domain on an open extension, not from a brand TLD you don't control.
+
+## Looking for an "accenture" name? Register an alternative at Namefi
+
+You can't buy a `.accenture` domain, but if you want a short name of your own, you can secure it on an open extension in minutes:
+
+1. **Search** your desired name across open TLDs like `.com`, `.io`, or `.xyz`.
+2. **Choose** the extension that fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can anyone register a .accenture domain?
+
+No. `.accenture` is a closed brand TLD delegated to Accenture plc. Only Accenture and parties it authorizes can hold a `.accenture` name, so it is not available to the general public through any registrar.
+
+### Who operates the .accenture registry?
+
+Accenture plc is the registry operator, with Identity Digital providing the technical back-end. The TLD was delegated to the DNS root zone on April 30, 2015, under ICANN's New gTLD Program.
+
+### What kind of company is Accenture?
+
+Accenture plc is a global professional-services firm working in consulting, technology, and operations. Its `.accenture` domain is reserved for its own use, not for consulting clients or partners.
+
+### What can I register instead of .accenture?
+
+Because `.accenture` is closed, choose an open extension for your own project. A matching `.com`, or a modern alternative like `.io` or `.xyz`, can be registered by anyone through an accredited registrar such as Namefi.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals behind top-level domains.
+- [How a TLD affects domain value](/en/blog/how-tld-affects-domain-value/) — why the extension matters.
+- [.com TLD guide](/en/tld/com/) — the open default to compare against.
+- [.io TLD guide](/en/tld/io/) and [.xyz TLD guide](/en/tld/xyz/) — modern open alternatives.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [registry](/en/glossary/registry/), [ICANN](/en/glossary/icann/).

--- a/content/tld/en/aco.md
+++ b/content/tld/en/aco.md
@@ -1,13 +1,22 @@
 ---
-title: 'Unlock Potential with the .aco TLD: What You Need to Know'
-date: '2025-12-10'
+title: "What Is .aco? ACO's Brand TLD Explained"
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: 'Discover the .aco TLD! Learn why this unique domain extension is gaining traction for businesses, healthcare, and Web3 portfolios. Secure your .aco at Namefi.'
-keywords: ['.aco domains', '.aco TLD', 'top-level domain .aco', 'what is .aco', 'why choose .aco', 'what is the .aco domain', 'why choose the .aco domain', 'buy .aco domain', 'domain investing', 'blockchain domains', 'tokenized domains', 'Web3 domains', 'healthcare domains', 'brand protection', 'new gTLD']
+description: 'The .aco domain is the closed brand TLD of German drainage maker ACO, not a healthcare extension. Learn what it is, who runs it, and what to register instead.'
+keywords: ['.aco domain', 'what is .aco', '.aco TLD', 'ACO brand domain', 'dot-brand TLD', 'ACO Severin Ahlmann registry', 'closed generic TLD', 'is .aco available', 'ACO drainage systems']
+faqs:
+  - question: 'Can anyone register a .aco domain?'
+    answer: 'No. .aco is a closed brand TLD delegated to ACO Severin Ahlmann GmbH & Co. KG. Only ACO and parties it authorizes can hold a .aco name, so it is not available to the general public through any registrar.'
+  - question: 'Who operates the .aco registry?'
+    answer: 'ACO Severin Ahlmann GmbH & Co. KG is the registry operator, with LEMARIT providing the technical back-end. The TLD was delegated to the DNS root zone on July 16, 2015, under ICANN''s New gTLD Program.'
+  - question: 'Does .aco stand for Accountable Care Organization?'
+    answer: 'No. The .aco domain belongs to ACO, a German maker of drainage and civil-engineering systems, not to any healthcare organization. Accountable Care Organizations have no claim on or use of the .aco namespace.'
+  - question: 'What can I register instead of .aco?'
+    answer: 'Because .aco is closed, choose an open extension for your own project. A matching .com, or a modern alternative like .io or .xyz, can be registered by anyone through an accredited registrar such as Namefi.'
 relatedArticles:
   - /en/blog/what-is-a-tld/
   - /en/blog/ai-vs-io-domain/
@@ -28,50 +37,115 @@ relatedGlossary:
   - /en/glossary/registry/
 ---
 
-## **What is .aco?**
+The **.aco** domain is a **closed brand [top-level domain](/en/glossary/tld/)** operated by **ACO Severin Ahlmann GmbH & Co. KG**, a German manufacturer of drainage and construction systems. It is not a public extension, and it is not a healthcare extension either: unlike [.com](/en/tld/com/) or [.io](/en/tld/io/), you cannot register a `.aco` name for your own project or organization, because the entire namespace belongs to one company.
 
-In the expanding universe of the internet, choosing the right digital identity is crucial. The **.aco** extension is a unique [Top-Level Domain](/en/glossary/tld/) (TLD) that has garnered attention for its brevity and specific branding utility. Originally delegated as a [generic Top-Level Domain (gTLD)](https://www.icann.org/resources/pages/tlds-2012-02-25-en) under [ICANN](/en/glossary/icann/)’s [New gTLD](/en/glossary/new-gtld/) Program, .aco represents a modern class of domains designed to move beyond the saturated [.com](/en/tld/com/) market.
+If you searched for the ".aco domain" expecting something related to Accountable Care Organizations, that association does not apply here. This page explains what `.aco` actually is, who controls it, why the company runs its own TLD, and what you can register instead.
 
-While .aco has roots as a "Brand TLD" managed by ACO Severin Ahlmann GmbH & Co. KG, the interest in this extension has grown within the domain investing and development communities due to its versatility. Acronyms drive the internet, and "ACO" is a powerful one. It is widely recognized in the medical field standing for **Accountable Care Organization**, and in the corporate world as a shorthand for "A Company" or "Associated Company."
+## .aco at a glance
 
-As we move toward a more decentralized web, TLDs like .aco are also being evaluated for their potential in **[tokenized domain](/en/blog/what-are-tokenized-domains/)** portfolios, where brevity and distinctiveness translate to higher value on the [blockchain](/en/glossary/blockchain/).
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | ACO Severin Ahlmann GmbH & Co. KG (technical back-end by LEMARIT) |
+| Year delegated | 2015 |
+| IDN support | Not relevant — closed namespace |
+| DNSSEC | Supported |
+| Registration restrictions | **Closed** — restricted to ACO Severin Ahlmann GmbH & Co. KG and parties it authorizes; not available to the public |
+| Best for | ACO's own corporate and product websites |
 
-## **How People Are Using .aco**
+## What is .aco?
 
-The .aco domain offers specific utility for distinct market sectors. Because it is short (only three letters), it is easy to type and remember. Here is how different groups are utilizing this extension:
+`.aco` is a **[generic top-level domain](/en/glossary/gtld/)** that ICANN delegated to **ACO Severin Ahlmann GmbH & Co. KG** on **July 16, 2015**. ACO is a German company that makes drainage systems and other construction and civil-engineering products, sold under the ACO brand worldwide.
 
-*   **Healthcare Networks:** The primary adoption comes from **Accountable Care Organizations**. Medical groups use .aco to signal their adherence to value-based care models, creating immediate trust with patients and insurers.
-*   **Corporate Branding:** Businesses with names ending in "aco" (e.g., Taco, Draco, Paco) or those using the acronym for "Associated Company" utilize the domain for clever [domain hacks](https://en.wikipedia.org/wiki/Domain_hack) and corporate portals.
-*   **[Web3](/en/glossary/web3/) and Tech Startups:** In the realm of domain investing and blockchain, short 3-letter TLDs are highly coveted. Developers are eyeing .aco for projects where "ACO" signifies "Autonomous" or "Algorithmic" operations.
-*   **Local Businesses:** Companies seeking a local feel often use it to differentiate themselves from global .com competitors, particularly if "ACO" resonates with their specific regional branding.
+`.aco` is a **brand TLD** — a "dot-brand" — not an open extension anyone can buy into. The company applied for the string so that it, and only it, would control every domain ending in `.aco`. You can confirm the delegation and operator on the authoritative [IANA root-zone record for .aco](https://www.iana.org/domains/root/db/aco.html).
 
-## **Notable Entities Using .aco**
+**A note on the acronym:** "ACO" is also used elsewhere as shorthand for "Accountable Care Organization," a US healthcare-coordination model. That usage has no connection to this TLD. `.aco` belongs entirely to the German drainage-systems company; no healthcare group registers or controls any part of the namespace.
 
-While .aco started as a restricted brand [registry](/en/glossary/registry/), its footprint serves as a case study for high-level corporate infrastructure.
+## History of .aco
 
-*   **ACO Group:** As the registry operator, the ACO Group (a world leader in drainage technology) utilizes the domain for its global digital infrastructure, ensuring distinct brand protection and security.
-*   **Healthcare Alliances (Hypothetical/Emerging):** Various healthcare alliances utilize the "ACO" acronym in their sub-branding. While many still sit on [.org](/en/tld/org/) or .com, the migration to exact-match TLDs is a growing trend in the industry.
-*   **Niche Portfolios:** Specialized domain investors hold generic keywords associated with the extension, anticipating future liberalization or tokenized wrapping of these assets.
+`.aco` was delegated to the DNS [root zone](/en/glossary/root-zone/) on **July 16, 2015**, with **LEMARIT** handling the technical operation on ACO's behalf. Its registry agreement with [ICANN](/en/glossary/icann/) includes **Specification 13**, the contract clause that formally designates a TLD as a brand and lets the operator keep it closed.
 
-## **Why Choose .aco?**
+ACO was one of many manufacturers that applied for their own company name as a TLD during ICANN's New gTLD Program. The `.aco` record has remained active since delegation.
 
-Selecting .aco for your next project or investment portfolio offers several distinct advantages:
+## Is .aco available to register?
 
-*   **Industry Authority:** If you are in the healthcare sector, specifically running an Accountable Care Organization, there is no better extension to establish immediate authority and relevance.
-*   **Availability:** Compared to legacy extensions like .com or [.net](/en/tld/net/), where almost every good name is taken, .aco offers a higher probability of securing short, premium keywords.
-*   **SEO Relevance:** For entities where "ACO" is part of the business name, having the keyword in the TLD can send positive signals to search engines regarding the site's relevance.
-*   **Memorability:** Three-letter extensions are inherently easier to remember. In the mobile-first era, shorter URLs improve user experience and click-through rates.
-*   **Asset Tokenization Ready:** At Namefi, we recognize that unique TLDs are excellent candidates for Real World Asset (RWA) tokenization. A rare or industry-specific domain holds intrinsic value that can be leveraged in the [DeFi](/en/glossary/defi/) space.
+**No.** `.aco` is a **closed brand TLD**, so there is no open registration and no [registrar](/en/glossary/registrar/) — including Namefi — can sell you a `.aco` name. Registrations are limited to ACO Severin Ahlmann GmbH & Co. KG and organizations it authorizes, such as subsidiaries or regional divisions. This is by design: a dot-brand exists precisely so the trademark holder controls the whole namespace and no one else can register a confusing or malicious lookalike.
 
-## **Register Your .aco Domain at Namefi**
+If you have a genuine business relationship with ACO and a legitimate need for a `.aco` address, that request would go through ACO's own corporate channels, not a commercial registrar.
 
-Ready to secure a domain that is short, professional, and industry-relevant? Whether you are building a healthcare network, a new tech startup, or expanding your domain investment portfolio, .aco helps you stand out.
+## How ACO uses .aco
 
-At **Namefi**, we make [domain ownership](/en/glossary/domain-ownership/) seamless. We are not just a [registrar](/en/glossary/registrar/); we are your bridge to the future of digital identity.
-*   **ICANN Accredited:** Safe, secure, and compliant registration.
-*   **Web3 Integration:** Mint your domain as an [NFT](/en/glossary/nft/), manage it via your [wallet](/en/glossary/wallet/), and enjoy the [liquidity](/en/glossary/domain-liquidity/) of the blockchain market.
-*   **Instant Setup:** seamless DNS management and easy transfers.
+Brand TLDs give a company a private space to organize its web presence. Typical uses for a dot-brand like `.aco` include:
 
-Don't let the perfect name slip away. Secure your digital identity today.
+- **Product and division sites** on clean, memorable addresses tied directly to the brand.
+- **Campaign and event pages** that are obviously official because only the company can create them.
+- **Internal tools and distributor portals** where a branded suffix signals a trusted, first-party destination.
 
-[**Search and Register Your Domain at Namefi**](https://namefi.io)
+**Who it's not for:** anyone outside ACO, and specifically not healthcare organizations. Because the namespace is closed and unrelated to the Accountable Care Organization model, no independent developer, insurer, or medical group can build on `.aco`.
+
+## Notable sites using .aco
+
+There are **no third-party sites** on `.aco`, and there never will be while it stays a closed brand TLD — every `.aco` address is controlled by ACO Severin Ahlmann GmbH & Co. KG. ACO runs its main public presence from **aco.com** and uses the brand TLD selectively. The honest description is simple: `.aco` is ACO's private namespace — not a healthcare directory, and not open to any Accountable Care Organization.
+
+## What is a dot-brand TLD?
+
+A **dot-brand** (or brand TLD) is a top-level domain that a single company owns and operates for its exclusive use, secured through ICANN's [New gTLD Program](/en/glossary/new-gtld/). Hundreds were delegated — examples in this same alphabetical band include `.abb`, `.accenture`, and `.aetna` — and they share a few defining traits:
+
+- **Closed registration.** Only the brand and its affiliates can hold names.
+- **Specification 13.** A registry-agreement addendum that formally recognizes the TLD as a brand and relaxes some rules that apply to open generics.
+- **Security and control.** The brand eliminates the risk of anyone else registering a `.aco` lookalike, which strengthens resistance to [phishing](/en/glossary/phishing/) and impersonation.
+
+Some brands invest heavily in their TLD; others register it defensively and barely use it. A number of companies have even terminated their dot-brands after deciding the upkeep was not worth it.
+
+## .aco vs open domain alternatives
+
+If your goal was a short, brandable name rather than the `.aco` string specifically, an open extension is the right tool. Here is how a closed brand TLD compares with domains you can actually register:
+
+| Feature | .aco | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.xyz](/en/tld/xyz/) |
+| --- | --- | --- | --- | --- |
+| Who can register | ACO Severin Ahlmann GmbH & Co. KG only | Anyone | Anyone | Anyone |
+| Type | Brand new gTLD (closed) | Legacy gTLD | ccTLD used generically | New gTLD |
+| Core use | ACO's own sites | Universal default | Tech & startups | Generic / Web3 |
+| Available to you | No | Yes | Yes | Yes |
+
+For your own venture, a matching `.com` remains the safest default; [.io](/en/tld/io/) suits technical products; and [.xyz](/en/tld/xyz/) is a flexible, low-cost modern option.
+
+## Reputation and trust
+
+Ironically, the closed nature of `.aco` is exactly what makes it trustworthy: because only ACO can create these addresses, a `.aco` link is verifiably official, which is why brand TLDs are considered strong against impersonation and email spoofing. That trust benefits ACO alone — it does not transfer to any name you might register, and it does not extend to any healthcare use of "ACO." For your own project, deliverability and reputation will come from a well-configured domain on an open extension, not from a brand TLD you don't control.
+
+## Looking for an "aco" name? Register an alternative at Namefi
+
+You can't buy a `.aco` domain, but if you want a short name — maybe an "aco" acronym of your own — you can secure it on an open extension in minutes:
+
+1. **Search** your desired name across open TLDs like `.com`, `.io`, or `.xyz`.
+2. **Choose** the extension that fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can anyone register a .aco domain?
+
+No. `.aco` is a closed brand TLD delegated to ACO Severin Ahlmann GmbH & Co. KG. Only ACO and parties it authorizes can hold a `.aco` name, so it is not available to the general public through any registrar.
+
+### Who operates the .aco registry?
+
+ACO Severin Ahlmann GmbH & Co. KG is the registry operator, with LEMARIT providing the technical back-end. The TLD was delegated to the DNS root zone on July 16, 2015, under ICANN's New gTLD Program.
+
+### Does .aco stand for Accountable Care Organization?
+
+No. The `.aco` domain belongs to ACO, a German maker of drainage and civil-engineering systems, not to any healthcare organization. Accountable Care Organizations have no claim on or use of the `.aco` namespace.
+
+### What can I register instead of .aco?
+
+Because `.aco` is closed, choose an open extension for your own project. A matching `.com`, or a modern alternative like `.io` or `.xyz`, can be registered by anyone through an accredited registrar such as Namefi.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals behind top-level domains.
+- [How a TLD affects domain value](/en/blog/how-tld-affects-domain-value/) — why the extension matters.
+- [.com TLD guide](/en/tld/com/) — the open default to compare against.
+- [.io TLD guide](/en/tld/io/) and [.xyz TLD guide](/en/tld/xyz/) — modern open alternatives.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [registry](/en/glossary/registry/), [ICANN](/en/glossary/icann/).

--- a/content/tld/en/aco.md
+++ b/content/tld/en/aco.md
@@ -3,7 +3,7 @@ title: "What Is .aco? ACO's Brand TLD Explained"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .aco domain is the closed brand TLD of German drainage maker ACO, not a healthcare extension. Learn what it is, who runs it, and what to register instead.'

--- a/content/tld/en/active.md
+++ b/content/tld/en/active.md
@@ -3,7 +3,7 @@ title: 'What Was the .active Domain? A Terminated Brand TLD'
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .active domain was a brand TLD for The Active Network that ICANN terminated in 2019. Learn its history, why it was removed, and what to register instead.'

--- a/content/tld/en/active.md
+++ b/content/tld/en/active.md
@@ -1,13 +1,22 @@
 ---
-title: 'What is the .active TLD and Why Choose It?'
-date: '2025-12-10'
+title: 'What Was the .active Domain? A Terminated Brand TLD'
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: 'Unlock the power of movement with the .active TLD. Perfect for fitness brands, lifestyle apps, and energetic startups. Learn more about .active domains here.'
-keywords: ['.active domains', '.active TLD', 'top-level domain', 'what is .active', 'why choose .active', 'what is the .active domain', 'why choose the .active domain', 'buy .active domain', 'fitness domain names', 'lifestyle TLD', 'domain investing', 'blockchain domains', 'tokenized domain', 'sports branding', 'Namefi']
+description: 'The .active domain was a brand TLD for The Active Network that ICANN terminated in 2019. Learn its history, why it was removed, and what to register instead.'
+keywords: ['.active domain', 'what is .active', '.active TLD', 'The Active Network domain', 'terminated TLD', 'discontinued gTLD', 'dot-brand TLD', 'is .active available']
+faqs:
+  - question: 'Can I register a .active domain?'
+    answer: 'No. .active was terminated in 2019 and removed from the DNS root zone, so it no longer exists as a working extension and cannot be registered through any registrar. Even before that, it was a closed brand TLD never open to the public.'
+  - question: 'What happened to .active?'
+    answer: 'ICANN removed .active from the root zone on 15 February 2019 after the registry agreement covering it ended. It had been delegated under five years earlier, in June 2014.'
+  - question: 'Was .active ever open to the public?'
+    answer: 'No. .active was always a closed brand TLD, meaning only The Active Network could ever register names under it. It was never sold to outside individuals or businesses.'
+  - question: 'Did anyone ever use a .active domain?'
+    answer: 'No public site of note. The Active Network made little to no public use of the extension before its registry agreement ended, so nothing was lost when the TLD was removed.'
 relatedArticles:
   - /en/blog/what-is-a-tld/
   - /en/blog/what-are-tokenized-domains/
@@ -28,50 +37,85 @@ relatedGlossary:
   - /en/glossary/registry/
 ---
 
-## **What is .active?**
+The **.active** domain was a **brand [top-level domain](/en/glossary/tld/)** created for **The Active Network, Inc.**, a company known for event, activity, and registration management software. It no longer exists: ICANN **removed `.active` from the DNS [root zone](/en/glossary/root-zone/) in 2019**, so the extension no longer resolves and cannot be registered.
 
-The **.active** extension is a part of the "[New gTLD](/en/glossary/new-gtld/)" (New [Generic Top-Level Domain](/en/glossary/gtld/)) program, an initiative managed by [ICANN](https://www.icann.org/) to expand the internet's namespace beyond the traditional [.com](/en/tld/com/), [.net](/en/tld/net/), and [.org](/en/tld/org/).
+If you searched for the ".active domain," this page explains what it was, why it disappeared, and what the story of a terminated dot-brand means for anyone choosing a domain today.
 
-Unlike generic domains that define a commercial entity or an organization, **.active** is an identity-focused [TLD](/en/glossary/tld/). It is designed specifically to represent movement, energy, lifestyle, and engagement. It serves as a digital beacon for businesses, communities, and individuals involved in sports, fitness, outdoor recreation, and health technology.
+## .active at a glance
 
-Originally applied for by The Active Network, Inc., this TLD falls under the category of domains that communicate a specific state of being. Whether for a decentralized fitness app (FiWeb3) or a local sports club, this extension tells the user exactly what to expect: action. You can verify the delegation details of this TLD via the [IANA Root Zone Database](https://www.iana.org/domains/root/db/active.html).
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | The Active Network, Inc. — agreement now terminated |
+| Year delegated | 2014 |
+| Year terminated | 2019 (removed from the root zone) |
+| Current status | **Terminated** — not present in the DNS root zone |
+| Registration restrictions | **Not available** — the TLD no longer exists |
 
-## **How People Are Using .active**
+## What was .active?
 
-Because ".active" is an adjective that implies vitality, its usage spans several dynamic industries. It is currently being adopted by:
+`.active` was a **closed brand [gTLD](/en/glossary/new-gtld/)**: a top-level domain reserved for a single company's exclusive use. The string itself is an ordinary English adjective for movement and energy, which is likely why people still search for it, but that everyday meaning never came with a public registration option. Only **The Active Network, Inc.**, the company that applied for the string, could ever hold names under it.
 
-*   **Fitness and Wellness Brands:** Gyms, yoga studios, and personal trainers are using it to create memorable URLs (e.g., `Get.active` or `YourCity.active`).
-*   **Health Tech & Wearables:** Developers creating apps for step tracking, heart rate monitoring, and bio-hacking are finding it relevant for product landing pages.
-*   **Outdoor and Adventure Companies:** Camping gear retailers and hiking tour guides use it to appeal to adventurous demographics.
-*   **Community Movements:** Non-profits and social groups focused on social activism and community engagement utilize it to mobilize members.
-*   **[Web3](/en/glossary/web3/) and Move-to-Earn Projects:** With the rise of [blockchain](/en/glossary/blockchain/) gaming and "Move-to-Earn" models, crypto projects are using .active to denote tokenized physical activity.
+Like other dot-brands, `.active` was never open to the public. You can confirm its status on the authoritative [IANA root-zone record for .active](https://www.iana.org/domains/root/db/active.html), which now shows the domain is not present in the root zone.
 
-## **Notable Entities Using .active**
+## History of .active
 
-While many TLDs are dominated by massive corporations, .active is often utilized for specific campaigns or niche branding.
+`.active` was **delegated on 19 June 2014** as part of ICANN's New gTLD Program, the 2012 expansion that let companies apply for their own brand as a suffix. The Active Network secured the string to match its own name and its business in event and activity registration software.
 
-1.  **The Active Network:** As the [registry](/en/glossary/registry/) applicant, they have utilized the namespace to consolidate their digital ecosystem surrounding event management and activity registrations.
-2.  **Lifestyle Blogs:** Various influencers in the "Healthy Living" niche adopt this TLD to differentiate themselves from standard `.com` blogs.
-3.  **Hypothetical Best Use Cases:**
-    *   *Sports Apparel:* A brand launching a new line called "Forever Active" could secure `forever.active`.
-    *   *Event Registration:* A marathon organizer using `register.active` for seamless sign-ups.
-    *   *Crypto-Fitness:* A dApp that rewards users with tokens for running could use `reward.active`.
+The brand never opened the TLD to outside registrants and made little to no public use of the extension. On **15 February 2019, ICANN removed `.active` from the root zone**, under five years after it was first delegated — one of many closed dot-brands whose owners chose not to keep the registry running.
 
-## **Why Choose .active?**
+## Why was .active discontinued?
 
-Choosing the right domain extension is critical for your brand's digital identity. Here is why **.active** stands out:
+A brand TLD only earns its keep if the company builds public-facing use on it, and running one carries ongoing [ICANN](/en/glossary/icann/) fees and technical maintenance regardless of how many names exist under it. When an owner decides that cost is not worth it, it can **voluntarily terminate** its registry agreement; ICANN then removes the TLD from the root zone, and the extension stops resolving worldwide.
 
-*   **Instant Semantic Relevance:** The word "active" is universally understood in English as positive, energetic, and healthy. It does the branding work for you before a user even visits the site.
-*   **Higher Availability:** Compared to the saturated `.com` market, it is significantly easier to find short, one-word, or two-word brand names on the `.active` extension.
-*   **Call to Action:** The extension itself functions as a verb or a state of being. A domain like `Be.active` or `Stay.active` serves as a subconscious Call to Action (CTA) for your customers.
-*   **Niche Authority:** For businesses in the sports and health sectors, using this TLD signals to search engines and users that your content is specifically relevant to that industry, potentially aiding in topical SEO authority.
+`.active` is one of many closed dot-brands retired this way. Because it was never open to the public, its termination affected no outside registrants — there were none — but it is still a reminder that a delegated TLD is not a permanent fixture of the internet.
 
-## **Register Your .active Domain at Namefi**
+## Can you register a .active domain?
 
-Ready to bring energy to your brand? Securing a **.active** domain is the first step toward building a dynamic online presence.
+**No.** `.active` no longer exists in the DNS, so there is nothing to register and no [registrar](/en/glossary/registrar/) can offer it. It was never available to the public even while it was active, because it was a closed brand namespace controlled by The Active Network.
 
-At **Namefi**, we go beyond traditional registration. As an [ICANN](/en/glossary/icann/)-accredited [registrar](/en/glossary/registrar/), we offer a seamless bridge between Web2 and Web3. When you register with us, you can easily mint your domain as an [NFT](/en/glossary/nft/), allowing for instant [liquidity](/en/glossary/domain-liquidity/), easy transfers, and integration with the decentralized web—all while maintaining standard DNS functionality.
+If a `.active` link ever appears again, it would only be because a company re-applies in a later ICANN round — there is no public path to owning one today.
 
-Don't let your perfect name sprint away.
+## What .active teaches about choosing a TLD
 
-**[Search for your .active domain at Namefi](https://namefi.io)** and start building your future today.
+The rise and removal of `.active` is a useful reminder for anyone picking a domain:
+
+- **Brand TLDs are private.** A dot-brand is never something an outside project can build on, no matter how generic or appealing the word behind it looks.
+- **Not every TLD is permanent.** Delegated strings can be handed back and removed, so long-term projects are safest on well-established, widely used extensions.
+- **Openness matters.** For your own venture, an open extension anyone can register and renew is far more dependable than a single-owner string.
+
+## What to register instead at Namefi
+
+Since `.active` is gone, choose a stable, open extension for your own name:
+
+1. **Search** your desired name across open TLDs such as [.com](/en/tld/com/), [.io](/en/tld/io/), or [.xyz](/en/tld/xyz/).
+2. **Choose** the extension that best fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can I register a .active domain?
+
+No. `.active` was terminated in 2019 and removed from the DNS root zone, so it no longer exists as a working extension and cannot be registered through any registrar. Even before that, it was a closed brand TLD never open to the public.
+
+### What happened to .active?
+
+ICANN removed `.active` from the root zone on 15 February 2019 after the registry agreement covering it ended. It had been delegated under five years earlier, in June 2014.
+
+### Was .active ever open to the public?
+
+No. `.active` was always a closed brand TLD, meaning only The Active Network could ever register names under it. It was never sold to outside individuals or businesses.
+
+### Did anyone ever use a .active domain?
+
+No public site of note. The Active Network made little to no public use of the extension before its registry agreement ended, so nothing was lost when the TLD was removed.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — how top-level domains work.
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains/) — owning a domain on-chain.
+- [How a TLD affects domain value](/en/blog/how-tld-affects-domain-value/) — why the extension matters.
+- [.com TLD guide](/en/tld/com/), [.io TLD guide](/en/tld/io/), and [.xyz TLD guide](/en/tld/xyz/) — open extensions you can actually register.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [ICANN](/en/glossary/icann/), [root zone](/en/glossary/root-zone/).

--- a/content/tld/en/ad.md
+++ b/content/tld/en/ad.md
@@ -1,14 +1,23 @@
 ---
-title: "What is the .ad Domain and Why Is It Perfect for Advertising?"
-date: '2025-12-10'
+title: "What Is the .ad Domain? Andorra's Restricted ccTLD"
+date: '2026-07-24'
 language: 'en'
 priority: P1
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: "Discover the .ad TLD: the country code for Andorra that doubles as the ultimate domain for the advertising industry. Learn why brands and agencies are choosing .ad."
-keywords: [".ad domains", ".ad TLD", ".ad top-level domain", "what is .ad", "why choose .ad", "what is the .ad domain", "why choose the .ad domain", "advertising domains", "marketing domain names", "Andorra country code", "domain hacks", "ad tech domains", "creative branding", "buy .ad domain", "tokenized domains"]
+description: 'What is the .ad domain? Andorra''s country-code TLD, generally restricted to local trademark or presence holders. Manager, eligibility, and pricing explained.'
+keywords: ['.ad domain', '.ad TLD', 'what is .ad', 'Andorra domain', 'restricted ccTLD', 'local presence requirement', 'Andorra Telecom registry', 'register .ad domain']
+faqs:
+  - question: 'Can anyone register a .ad domain?'
+    answer: 'Generally, no. .ad registration typically requires an Andorran trademark or a genuine local commercial presence in Andorra. It is not an open, global namespace the way some other ccTLDs are, so check current eligibility with the registry before planning a brand around it.'
+  - question: 'Does a .ad domain affect SEO?'
+    answer: 'Google geo-targets .ad to Andorra, so a .ad site is generally treated as relevant to Andorran search results rather than as a globally generic domain. That makes it well suited to an Andorra-based audience, but less useful for international SEO than a generic gTLD.'
+  - question: 'Is .ad really a domain for the word "advertising"?'
+    answer: '"Ad" is a common English abbreviation for "advertisement," but that coincidence has not turned .ad into an open, global namespace for ad-tech brands. Because eligibility is restricted to Andorran trademark or presence holders, .ad functions as Andorra''s national domain rather than a generic marketing extension.'
+  - question: 'Who should register a .ad domain?'
+    answer: 'Businesses, institutions, and organizations with a genuine trademark or commercial presence in Andorra. It is the right choice for establishing local Andorran identity online, not for buyers outside Andorra looking for a short, generic branding suffix.'
 relatedArticles:
   - /en/blog/what-is-a-tld/
   - /en/blog/ai-vs-io-domain/
@@ -29,63 +38,127 @@ relatedGlossary:
   - /en/glossary/registry/
 ---
 
-## **What is .ad?**
+The **.ad** domain is the [ccTLD](/en/glossary/cctld/) for the **Principality of Andorra**, and unlike some two-letter country codes that opened up to global registrants, it has stayed close to its original purpose: registration generally requires an Andorran trademark or a real commercial presence in the country. If you have seen .ad marketed elsewhere as a global "advertising" domain, that framing does not match how the registry actually runs today.
 
-The **.ad** domain extension is the **country code [Top-Level Domain](/en/glossary/tld/) ([ccTLD](/en/glossary/cctld/))** for the **Principality of Andorra**, a small, sovereign landlocked microstate on the Iberian Peninsula, bordered by France and Spain. Managed by [Andorra Telecom](https://www.andorratelecom.ad/), this extension was originally created to serve the local population and businesses of Andorra.
+This guide covers what .ad is, who runs it, the eligibility rule you need to know before you consider it, and how it is perceived for SEO and email.
 
-However, in the world of the internet, **.ad** holds a unique and powerful position due to its linguistic association. It is globally recognized as the standard abbreviation for **"Advertisement"** or **"Advertising."**
+## .ad at a glance
 
-For years, the [registry](/en/glossary/registry/) maintained strict restrictions, limiting registration primarily to entities with a physical presence or [trademark](/en/glossary/trademark/) in Andorra. However, recent liberalization efforts have made it more accessible to the global community, transforming it from a strictly local domain into a highly sought-after asset for marketing agencies, ad-tech platforms, and creative brands.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Country-code TLD (ccTLD) for Andorra |
+| Registry operator | Andorra Telecom (domini.ad) |
+| Year delegated | 1996 (January 9) |
+| Registration restrictions | Restricted — generally requires an Andorran trademark or local commercial presence |
+| Google treatment | Geo-targeted to Andorra |
+| Best for | Andorran businesses and institutions with a genuine local presence or trademark |
 
-According to the [Internet Assigned Numbers Authority (IANA)](https://www.iana.org/domains/root/db/ad.html), the domain has been active since 1996, but its relevance has surged in the 2020s as digital advertising dominates the global economy.
+## What is .ad?
 
-## **How People Are Using .ad**
+**.ad** is the country-code [Top-Level Domain](/en/glossary/tld/) assigned under the ISO 3166-1 system to **Andorra**, listed by [IANA](https://www.iana.org/domains/root/db/ad.html) with **Andorra Telecom** as the registry, operated through [domini.ad](https://www.domini.ad/).
 
-While it remains the primary digital identity for Andorran citizens, the global appeal of `.ad` lies in its ability to create short, memorable, and context-aware URLs. Here is how the digital world is utilizing this TLD:
+In English, "ad" is a familiar shorthand for "advertisement," and that coincidence has occasionally led marketing sites to pitch .ad as a global domain for the ad-tech and agency world. That framing does not reflect how the registry actually operates: .ad eligibility generally requires an **Andorran trademark or a genuine local commercial presence**, which keeps registration to entities actually connected to Andorra rather than opening the namespace globally. Google [geo-targets .ad to Andorra](https://developers.google.com/search/docs/crawling-indexing/manage-international-sites) accordingly, reinforcing that it functions as a national domain, not a generic one.
 
-*   **Advertising Agencies & Marketing Firms:**
-    Agencies use `.ad` to signal their industry instantly. A domain like `creative.ad` or `social.ad` tells a potential client exactly what the business does before the page even loads.
-*   **AdTech and SaaS Platforms:**
-    Software companies that specialize in programmatic advertising, SEO tools, or marketing analytics use `.ad` to brand their products efficiently.
-*   **Domain Hacks and Wordplay:**
-    Creative developers and brands utilize the extension to complete words ending in "ad." Examples include `re.ad` (read), `he.ad` (head), `nom.ad` (nomad), or `squ.ad` (squad).
-*   **Classifieds and Listings:**
-    Websites dedicated to classified listings often use the extension to represent individual "ads," making it a logical choice for buy-and-sell marketplaces.
-*   **Tourism and Local Business:**
-    Within Andorra, it remains the gold standard for trust, used by banks, ski resorts, and government entities to prove local authenticity.
+## History of .ad
 
-## **Notable Entities Using .ad**
+The .ad ccTLD was delegated on **January 9, 1996**, and has been managed by **Andorra Telecom** since. As Andorra's national telecommunications operator, Andorra Telecom runs the registry alongside the country's domestic phone and internet infrastructure, which is consistent with .ad's role as Andorra's official namespace rather than a globally marketed extension.
 
-Because `.ad` is a specialized ccTLD, it is less common among Fortune 500 giants for their *primary* corporate homepages compared to `.com`, but it is widely used for specialized campaigns and local authority.
+## How people use .ad
 
-*   **Visit Andorra (visitandorra.com / .ad):** The official tourism board utilizes the local extension to promote the country's world-famous ski resorts and shopping.
-*   **Andorra Telecom:** The registry and primary telecommunications provider operates strictly on `.ad`, setting the standard for local infrastructure.
-*   **Creative Agencies:** Numerous boutique marketing firms have adopted domains like `pop.ad` or `native.ad` to stand out in the crowded agency market.
-*   **Tech Startups:** Various startups in the [Web3](/en/glossary/web3/) and marketing space utilize `.ad` for URL shorteners to track campaign links (e.g., `brand.ad/promo`).
+Given the eligibility rule, .ad usage is concentrated in one clear category:
 
-## **Why Choose .ad?**
+- **Andorran businesses and institutions.** Companies, government-linked entities, and organizations with a registered trademark or commercial presence in Andorra use .ad to establish an official local identity online.
 
-If you are debating between a standard generic domain and `.ad`, here are compelling reasons to choose the latter, especially if you operate in the media or marketing sectors:
+**Who it's not ideal for:** international marketing agencies, ad-tech platforms, or anyone outside Andorra hoping to register .ad purely for its "advertisement" wordplay — the local-presence requirement rules that out for most applicants without an Andorran connection.
 
-*   **Instant Industry Recognition:**
-    If your business involves advertising, nothing is more descriptive than `.ad`. It saves you from having to add the word "agency" or "media" to your domain name (e.g., `Smith.ad` vs. `SmithAdvertisingAgency.com`).
-*   **Premium Availability:**
-    The `.com` namespace is saturated. Finding short, one-word, or two-letter names is nearly impossible or prohibitively expensive. With `.ad`, there is still significant inventory for high-value keywords and short names.
-*   **Short and Memorable:**
-    With only two letters, `.ad` helps keep your URL character count low. Shorter domains are easier to type on mobile devices, easier to remember, and look better on social media profiles.
-*   **Trust and Safety:**
-    Andorra is known for its stability and strict adherence to European standards. Domains under this registry are generally viewed as safe and spam-free compared to cheaper, unregulated TLDs.
+## Notable sites using .ad
 
-## **Register Your .ad Domain at Namefi**
+Because eligibility is tied to an Andorran trademark or commercial presence, .ad is used almost entirely by Andorran businesses and institutions establishing an official local presence, rather than by international brands, agencies, or domain-hack projects. We are not citing specific registrants here since none are pre-verified for this guide — the honest summary is that .ad functions as national infrastructure for Andorra, not as a global consumer or marketing namespace.
 
-Whether you are launching a new ad-tech platform, a creative design studio, or simply securing a clever [domain hack](/en/blog/domain-hacks-explained/) for your portfolio, `.ad` offers distinct branding advantages that are hard to ignore.
+## .ad vs other domains
 
-At **Namefi**, we make registering and managing these unique domains effortless.
+| Feature | .ad | [.com](/en/tld/com/) | [.co](/en/tld/co/) | [.org](/en/tld/org/) |
+| --- | --- | --- | --- | --- |
+| Type | ccTLD (national, restricted) | Legacy gTLD | ccTLD (used globally) | Legacy gTLD |
+| Core association | Andorra | The default web standard | Generic, short alternative to .com | Institutions and nonprofits |
+| Registration eligibility | Andorran trademark or local presence required | Open worldwide | Open worldwide | Open worldwide |
+| Availability of short names | N/A outside Andorra due to eligibility rule | Very poor | Poor | Moderate |
 
-*   **Seamless Ownership:** We handle the complexity of ccTLD registration for you.
-*   **Web3 Integration:** Namefi allows you to [tokenize](/en/glossary/tokenize/) your domains. This means you can hold your `.ad` domain in your crypto [wallet](/en/glossary/wallet/), trade it instantly on [NFT](/en/glossary/nft/) marketplaces, and manage DNS settings without bureaucratic hurdles.
-*   **[ICANN](/en/glossary/icann/) Accredited Standards:** Enjoy the security of a compliant, professional [registrar](/en/glossary/registrar/) built for the future of the internet.
+If you have no Andorran trademark or presence, .ad is not an option — choose **[.com](/en/tld/com/)** for the default global standard, **[.co](/en/tld/co/)** for a short, generic alternative, or **[.org](/en/tld/org/)** if you represent an institution or nonprofit. Reach for **.ad** only if your organization is genuinely established in Andorra.
 
-**Ready to boost your brand's visibility?**
+## Why choose .ad?
 
-[Register your .ad domain at Namefi](https://namefi.io) today and secure a name that truly advertises itself.
+- **Genuine local identity.** For Andorran businesses and institutions, .ad signals real, verifiable presence in the country.
+- **Short and memorable.** At two letters, it keeps a URL compact for anyone who does qualify.
+- **National trust.** As Andorra's official namespace, it is the natural choice for entities that want to be recognized as locally established.
+
+## Things to consider
+
+- **Eligibility comes first.** Before anything else, confirm whether your organization actually meets the Andorran trademark or local-presence requirement — most applicants outside Andorra will not.
+- **A ccTLD by nature.** Because .ad belongs to Andorra, its rules are set by Andorra Telecom under national policy, not by an [ICANN](/en/glossary/icann/) registry agreement.
+- **Not a global generic.** Despite the "advertisement" wordplay some marketing has built around it, .ad is not an open namespace for international ad-tech or agency branding.
+
+## Who can register a .ad domain?
+
+**Registration restrictions: generally restricted.** Eligibility typically requires an **Andorran trademark or a genuine commercial presence in Andorra**. This is the first thing to confirm — .ad is not first-come, first-served for the general public the way many other ccTLDs are.
+
+Because .ad is a ccTLD, it is governed by Andorra's registry policy rather than an ICANN registry agreement. The authoritative sources for current eligibility rules and application requirements are the [IANA root-zone entry](https://www.iana.org/domains/root/db/ad.html) and Andorra Telecom's own registry site, [domini.ad](https://www.domini.ad/).
+
+## .ad pricing and value
+
+This page intentionally quotes no numbers, but a few dynamics matter if you do qualify:
+
+- **Eligibility verification is a separate step from the fee itself.** Because registration requires proof of an Andorran trademark or presence, expect a documentation step beyond a standard domain purchase.
+- **First-year vs. renewal pricing can differ.** As with most TLDs, confirm the standard renewal rate rather than assuming an introductory rate continues.
+- **What drives cost.** Name desirability and registry wholesale pricing are the main factors, on top of whatever administrative cost the eligibility check involves.
+
+For exact, current figures, check live pricing and eligibility requirements directly with the registry at registration time.
+
+## Reputation and email deliverability
+
+We are not aware of .ad carrying any negative bulk-mail or spam reputation. As with any TLD, email deliverability depends far more on **sending reputation, SPF/DKIM/DMARC authentication, and list hygiene** than on the suffix itself.
+
+The main practical caveat is unfamiliarity: because .ad is a restricted national domain, recipients outside Andorra who do not recognize the extension may find a .ad email address unexpected, even though a properly authenticated sender should still reach inboxes normally.
+
+## Branding and naming tips
+
+- **Confirm eligibility first.** Do not build brand plans around .ad until you have verified your organization qualifies under Andorra Telecom's trademark or presence rule.
+- **Lean into local trust.** For Andorran entities, .ad signals genuine local identity in a way an international gTLD cannot.
+- **Keep it short.** A two-letter extension rewards a short, clear brand name.
+
+## How to register a .ad domain at Namefi
+
+1. **Confirm eligibility** — check whether your organization meets Andorra Telecom's trademark or local-presence requirement.
+2. **Search** for your desired name and the .ad extension.
+3. **Register** and configure DNS.
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for easier transfer and provable ownership.
+
+## Frequently asked questions
+
+### Can anyone register a .ad domain?
+
+Generally, no. .ad registration typically requires an Andorran trademark or a genuine local commercial presence in Andorra. It is not an open, global namespace the way some other ccTLDs are, so check current eligibility with the registry before planning a brand around it.
+
+### Does a .ad domain affect SEO?
+
+Google geo-targets .ad to Andorra, so a .ad site is generally treated as relevant to Andorran search results rather than as a globally generic domain. That makes it well suited to an Andorra-based audience, but less useful for international SEO than a generic gTLD.
+
+### Is .ad really a domain for the word "advertising"?
+
+"Ad" is a common English abbreviation for "advertisement," but that coincidence has not turned .ad into an open, global namespace for ad-tech brands. Because eligibility is restricted to Andorran trademark or presence holders, .ad functions as Andorra's national domain rather than a generic marketing extension.
+
+### Who should register a .ad domain?
+
+Businesses, institutions, and organizations with a genuine trademark or commercial presence in Andorra. It is the right choice for establishing local Andorran identity online, not for buyers outside Andorra looking for a short, generic branding suffix.
+
+## Related resources
+
+- [.com TLD guide](/en/tld/com/)
+- [.org TLD guide](/en/tld/org/)
+- [.co TLD guide](/en/tld/co/)
+- [What is a TLD?](/en/blog/what-is-a-tld/)
+- [Glossary: registrar](/en/glossary/registrar/)
+- [Glossary: ICANN](/en/glossary/icann/)
+- [Glossary: ccTLD](/en/glossary/cctld/)
+- [Glossary: trademark](/en/glossary/trademark/)

--- a/content/tld/en/ad.md
+++ b/content/tld/en/ad.md
@@ -4,7 +4,7 @@ date: '2026-07-24'
 language: 'en'
 priority: P1
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'What is the .ad domain? Andorra''s country-code TLD, generally restricted to local trademark or presence holders. Manager, eligibility, and pricing explained.'

--- a/content/tld/en/adac.md
+++ b/content/tld/en/adac.md
@@ -1,13 +1,22 @@
 ---
-title: 'What is .adac TLD and why choose it?'
-date: '2025-12-10'
+title: 'What Was the .adac Domain? A Terminated Brand TLD'
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: 'Discover the power of the .adac TLD. Learn about its origins, its significance in the automotive world, and how it represents trust and security in the domain industry.'
-keywords: ['.adac domains', '.adac TLD', 'top-level domain', 'what is .adac', 'why choose .adac', 'what is the .adac domain', 'why choose the .adac domain', 'ADAC registry', 'automotive domains', 'domain investing', 'blockchain domains', 'tokenized domain', 'brand TLD', 'German internet domains', 'secure domains']
+description: "The .adac domain was a brand TLD for Germany's ADAC motoring club that ICANN terminated in 2022. Learn its history, why it ended, and what to register instead."
+keywords: ['.adac domain', 'what is .adac', '.adac TLD', 'ADAC brand domain', 'terminated TLD', 'discontinued gTLD', 'dot-brand TLD', 'is .adac available']
+faqs:
+  - question: 'Can I register a .adac domain?'
+    answer: 'No. .adac was terminated in 2022 and removed from the DNS root zone, so it no longer exists as a working extension and cannot be registered through any registrar. Even before that, it was a closed brand TLD never open to the public.'
+  - question: 'What happened to .adac?'
+    answer: 'ICANN removed .adac from the root zone on 26 November 2022 after the registry agreement covering it ended. It had been delegated about seven years earlier, in November 2015.'
+  - question: 'Was .adac ever open to the public?'
+    answer: 'No. .adac was always a closed brand TLD, meaning only ADAC e.V. could ever register names under it. It was never sold to outside individuals or businesses.'
+  - question: 'Did anyone ever use a .adac domain?'
+    answer: 'No public site of note. ADAC never opened the namespace to outside registrants, so nothing was lost when the TLD was removed.'
 relatedArticles:
   - /en/blog/top-tlds-to-secure-for-your-accounting-firm/
   - /en/blog/what-is-a-tld/
@@ -28,55 +37,85 @@ relatedGlossary:
   - /en/glossary/registry/
 ---
 
-## **What is .adac?**
+The **.adac** domain was a **brand [top-level domain](/en/glossary/tld/)** created for **ADAC e.V.** (Allgemeiner Deutscher Automobil-Club), Germany's largest automobile and motoring club. It no longer exists: ICANN **removed `.adac` from the DNS [root zone](/en/glossary/root-zone/) in 2022**, so the extension no longer resolves and cannot be registered.
 
-The **.adac** [Top-Level Domain](/en/glossary/tld/) (TLD) is a specialized "Brand TLD" (dot-brand) delegated to the **Allgemeiner Deutscher Automobil-Club e.V. (ADAC)**, Europe's largest motoring association. Unlike generic extensions like [.com](/en/tld/com/) or [.net](/en/tld/net/), the .adac extension serves as a dedicated digital identity for the organization, offering a unique layer of trust, security, and brand verification.
+If you searched for the ".adac domain," this page explains what it was, why it disappeared, and what the story of a terminated dot-brand means for anyone choosing a domain today.
 
-Introduced during the expansion of the internet's namespace by **[ICANN](https://www.icann.org/)** (Internet Corporation for Assigned Names and Numbers), the .adac TLD was designed to centralize the diverse services offered by the club—ranging from roadside assistance to insurance and travel—under a unified, authentic digital banner.
+## .adac at a glance
 
-For domain investors and tech enthusiasts, .adac represents the evolution of the internet towards **verified digital identity**. In an era where [phishing](/en/glossary/phishing/) and domain spoofing are rampant, a closed Brand TLD like .adac signals to the user that they are interacting with a verified entity. While currently restricted primarily to the organization's use, observing how major entities utilize such TLDs provides valuable insight into the future of **[domain investing](https://namefi.io)** and corporate digital strategy.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | ADAC e.V. (Allgemeiner Deutscher Automobil-Club) — agreement now terminated |
+| Year delegated | 2015 |
+| Year terminated | 2022 (removed from the root zone) |
+| Current status | **Terminated** — not present in the DNS root zone |
+| Registration restrictions | **Not available** — the TLD no longer exists |
 
-## **How People Are Using .adac**
+## What was .adac?
 
-Because .adac is a Brand TLD, its usage is highly strategic and focused on user safety and service consolidation. Here is how the namespace is effectively utilized:
+`.adac` was a **closed brand [gTLD](/en/glossary/new-gtld/)**: a top-level domain reserved for a single organization's exclusive use. The string is the acronym of the **Allgemeiner Deutscher Automobil-Club e.V.**, Germany's largest automobile and motoring club. Only ADAC could ever hold names under the extension.
 
-*   **Verified Service Portals:** It is used to host secure login pages for members, ensuring that sensitive data regarding insurance and membership details is transmitted through an authenticated channel.
-*   **Emergency Response:** The TLD helps streamline digital entry points for roadside assistance and air rescue services, providing short, memorable URLs that are easy to recall in stressful situations.
-*   **Corporate Communications:** It serves as a hub for press releases, mobility studies, and automotive testing reports, reinforcing the authority of the content.
-*   **Travel and Mobility Guides:** The extension is used to categorize vast amounts of travel data, maps, and route planning tools distinctively under the club's brand.
+Like other dot-brands, `.adac` was never open to the public. You can confirm its status on the authoritative [IANA root-zone record for .adac](https://www.iana.org/domains/root/db/adac.html), which now shows the domain is not present in the root zone.
 
-## **Notable Entities Using .adac**
+## History of .adac
 
-As a restricted Brand TLD, the "entities" using this domain are primarily internal divisions of the ADAC ecosystem. However, these examples highlight the power of a dedicated TLD structure:
+`.adac` was **delegated on 20 November 2015** as part of ICANN's New gTLD Program, the 2012 expansion that let organizations worldwide apply for their own brand as a suffix. ADAC secured the string that matched its own name.
 
-1.  **ADAC e.V.** – The parent organization uses the TLD to anchor its primary digital presence and membership services.
-2.  **ADAC Luftrettung** – The charitable air rescue service utilizes the domain infrastructure to coordinate and inform regarding their helicopter fleet and emergency operations.
-3.  **ADAC Versicherung** – The insurance arm of the group uses the TLD to provide distinct, secure pathways for policyholders to manage their automotive and travel insurance.
+The club never opened the TLD to outside registrants. On **26 November 2022, ICANN removed `.adac` from the root zone**, about seven years after it was first delegated — one of many closed dot-brands whose owners chose not to keep the registry running long term.
 
-These examples demonstrate how a TLD can be used not just for a website, but as a structural component of a massive organization's digital architecture.
+## Why was .adac discontinued?
 
-## **Why Choose .adac?**
+A brand TLD only earns its keep if the organization builds public-facing use on it, and running one carries ongoing [ICANN](/en/glossary/icann/) fees and technical maintenance regardless of how many names exist under it. When an owner decides that cost is not worth it, it can **voluntarily terminate** its registry agreement; ICANN then removes the TLD from the root zone, and the extension stops resolving worldwide.
 
-While .adac is exclusive to the association, understanding its advantages highlights what you should look for when choosing your own high-value or Brand TLDs for your business or investment portfolio:
+`.adac` is one of many closed dot-brands retired this way. Because it was never open to the public, its termination affected no outside registrants — there were none — but it is still a reminder that a delegated TLD is not a permanent fixture of the internet.
 
-*   **Unmatched Trust and Security:** A domain ending in .adac acts as a seal of approval. Users know immediately that the site is official and not a fraudulent copycat.
-*   **SEO Authority:** Search engines value relevance. For queries related to German automotive services, mobility, and travel safety, the semantic relevance of the TLD reinforces the content's authority.
-*   **Branding Clarity:** It eliminates the need for long, hyphenated domain names (e.g., `adac-insurance-services.com` can simply become `insurance.adac`).
-*   **Control:** The [registry](/en/glossary/registry/) owner has complete control over who registers domains, effectively eliminating [cybersquatting](/en/glossary/cybersquatting/) within that namespace.
+## Can you register a .adac domain?
 
-## **Register Your .adac Domain at Namefi**
+**No.** `.adac` no longer exists in the DNS, so there is nothing to register and no [registrar](/en/glossary/registrar/) can offer it. It was never available to the public even while it was active, because it was a closed brand namespace controlled by the club.
 
-Are you interested in the world of specialized TLDs, domain investment, and [Web3](/en/glossary/web3/) integration?
+If a `.adac` link ever appears again, it would only be because ADAC re-applies in a later ICANN round — there is no public path to owning one today.
 
-While the .adac registry is currently restricted to the ADAC organization, the world of domains is vast. At **Namefi**, we specialize in helping you secure high-value domains and **[tokenized Web3 domains](https://namefi.io)** that offer similar benefits of trust, brevity, and branding power.
+## What .adac teaches about choosing a TLD
 
-Whether you are looking for available brandable domains, new gTLDs that fit your niche (like .auto, .car, or [.club](/en/tld/club/)), or want to [tokenize](/en/glossary/tokenize/) your existing portfolio for easier trading on the [blockchain](/en/glossary/blockchain/), Namefi is your premier partner.
+The rise and removal of `.adac` is a useful reminder for anyone picking a domain:
 
-**Why use Namefi?**
-*   **[ICANN](/en/glossary/icann/)-Accredited** [Registrar](/en/glossary/registrar/).
-*   Seamless integration of **Web2 DNS and Web3 capabilities**.
-*   Transparent pricing and advanced domain management tools.
+- **Brand TLDs are private.** A dot-brand is never something an outside project can build on, no matter how well known the parent organization is.
+- **Not every TLD is permanent.** Delegated strings can be handed back and removed, so long-term projects are safest on well-established, widely used extensions.
+- **Openness matters.** For your own venture, an open extension anyone can register and renew is far more dependable than a single-owner string.
 
-Don't wait for the perfect name to disappear. Secure your digital identity today.
+## What to register instead at Namefi
 
-**[Start your domain search at Namefi](https://namefi.io)**
+Since `.adac` is gone, choose a stable, open extension for your own name:
+
+1. **Search** your desired name across open TLDs such as [.com](/en/tld/com/), [.io](/en/tld/io/), or [.xyz](/en/tld/xyz/).
+2. **Choose** the extension that best fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can I register a .adac domain?
+
+No. `.adac` was terminated in 2022 and removed from the DNS root zone, so it no longer exists as a working extension and cannot be registered through any registrar. Even before that, it was a closed brand TLD never open to the public.
+
+### What happened to .adac?
+
+ICANN removed `.adac` from the root zone on 26 November 2022 after the registry agreement covering it ended. It had been delegated about seven years earlier, in November 2015.
+
+### Was .adac ever open to the public?
+
+No. `.adac` was always a closed brand TLD, meaning only ADAC e.V. could ever register names under it. It was never sold to outside individuals or businesses.
+
+### Did anyone ever use a .adac domain?
+
+No public site of note. ADAC never opened the namespace to outside registrants, so nothing was lost when the TLD was removed.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — how top-level domains work.
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains/) — owning a domain on-chain.
+- [How a TLD affects domain value](/en/blog/how-tld-affects-domain-value/) — why the extension matters.
+- [.com TLD guide](/en/tld/com/), [.io TLD guide](/en/tld/io/), and [.xyz TLD guide](/en/tld/xyz/) — open extensions you can actually register.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [ICANN](/en/glossary/icann/), [root zone](/en/glossary/root-zone/).

--- a/content/tld/en/adac.md
+++ b/content/tld/en/adac.md
@@ -3,7 +3,7 @@ title: 'What Was the .adac Domain? A Terminated Brand TLD'
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: "The .adac domain was a brand TLD for Germany's ADAC motoring club that ICANN terminated in 2022. Learn its history, why it ended, and what to register instead."

--- a/content/tld/en/ads.md
+++ b/content/tld/en/ads.md
@@ -3,7 +3,7 @@ title: "What Is .ads? Google's Closed Brand TLD Explained"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .ads domain is a closed brand TLD run by Google, not open to advertisers or the public. Learn what it is, who controls it, and what to register instead.'

--- a/content/tld/en/ads.md
+++ b/content/tld/en/ads.md
@@ -1,13 +1,22 @@
 ---
-title: 'What is the .ads TLD and Why Choose It?'
-date: '2025-12-10'
+title: "What Is .ads? Google's Closed Brand TLD Explained"
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: 'Discover the potential of the .ads domain extension for agencies, marketers, and ad-tech. Learn why .ads is the ultimate choice for digital advertising.'
-keywords: ['.ads domains', '.ads TLD', 'top-level domain', 'what is .ads', 'why choose .ads', 'what is the .ads domain', 'why choose the .ads domain', 'advertising domains', 'marketing domain names', 'digital marketing TLD', 'buy .ads domain', 'domain investing', 'blockchain domains', 'tokenized domains', 'adtech domains']
+description: 'The .ads domain is a closed brand TLD run by Google, not open to advertisers or the public. Learn what it is, who controls it, and what to register instead.'
+keywords: ['.ads domain', 'what is .ads', '.ads TLD', 'Google brand TLD', 'Charleston Road Registry', 'dot-brand TLD', 'closed generic TLD', 'is .ads available']
+faqs:
+  - question: 'Can anyone register a .ads domain?'
+    answer: 'No. .ads is a closed brand TLD delegated to Charleston Road Registry Inc., a Google entity. Only Google and parties it authorizes can hold a .ads name, so it is not available to advertisers, agencies, or the general public.'
+  - question: 'Who operates the .ads registry?'
+    answer: 'Charleston Road Registry Inc., a Google entity, is the registry operator, and Google runs the technical back-end itself. The TLD was delegated to the DNS root zone on February 5, 2015, under ICANN''s New gTLD Program.'
+  - question: 'Is .ads open to advertising agencies or adtech companies?'
+    answer: 'No. Despite the name, .ads is not an industry extension for advertising businesses. It is a closed brand TLD controlled entirely by Google, with no public registration path for agencies, adtech firms, or anyone else.'
+  - question: 'What can I register instead of .ads?'
+    answer: 'Because .ads is closed, choose an open extension for your own project. A matching .com, or a modern alternative like .io or .xyz, can be registered by anyone through an accredited registrar such as Namefi.'
 relatedArticles:
   - /en/blog/top-tlds-to-secure-for-your-startup/
   - /en/blog/what-is-a-tld/
@@ -28,51 +37,113 @@ relatedGlossary:
   - /en/glossary/registry/
 ---
 
-## **What is .ads?**
+The **.ads** domain is a **closed brand [top-level domain](/en/glossary/tld/)** operated by **Charleston Road Registry Inc.**, a Google entity. Despite the generic-sounding name, it is not an open extension for the advertising industry: unlike [.com](/en/tld/com/) or [.io](/en/tld/io/), you cannot register a `.ads` name for your agency, adtech product, or campaign, because the entire namespace belongs to Google.
 
-The **.ads** domain extension is a [generic Top-Level Domain](/en/glossary/gtld/) (gTLD) specifically designed for the advertising, marketing, and promotional industries. Introduced during the expansion of the internet's namespace by [ICANN](https://www.icann.org/), this [TLD](/en/glossary/tld/) provides a specialized digital identity for businesses and individuals whose primary focus is connecting brands with audiences.
+If you searched for the ".ads domain" hoping to build an advertising brand on it, the short answer is that you can't — but this page explains what `.ads` actually is, who controls it, and what you can register instead.
 
-Originally proposed and managed by Charleston Road Registry Inc. (a subsidiary of Google), **.ads** was created to serve as a trustworthy and instantly recognizable namespace. Unlike traditional extensions like [.com](/en/tld/com/) or [.net](/en/tld/net/), which cover broad categories, .ads signals immediate intent. It tells the user exactly what to expect: advertising services, marketing technology, or promotional content.
+## .ads at a glance
 
-As the digital marketing landscape evolves, the demand for specific, keyword-rich domains has grown. The .ads TLD caters to this need, offering a modern alternative for ad networks, creative agencies, and classified listings.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | Charleston Road Registry Inc. (a Google entity; Google runs the back-end) |
+| Year delegated | 2015 |
+| IDN support | Not relevant — closed namespace |
+| DNSSEC | Supported |
+| Registration restrictions | **Closed** — restricted to Google and parties it authorizes; not available to the public |
+| Best for | Google's own internal and product-related use |
 
-## **How People Are Using .ads**
+## What is .ads?
 
-The versatility of the .ads extension allows for a wide range of applications within the digital ecosystem. Here is how different sectors are utilizing this TLD:
+`.ads` is a **[generic top-level domain](/en/glossary/gtld/)** string that ICANN delegated to **Charleston Road Registry Inc.** on **February 5, 2015**. Charleston Road Registry is the entity Google uses to hold several of its dot-brand and generic TLD delegations.
 
-*   **Advertising Agencies:** Creative shops and media buying firms use .ads to shorten their URLs and create memorable brand identities (e.g., *Creative.ads* or *Global.ads*).
-*   **AdTech Companies:** Developers of software for programmatic advertising, PPC management, and analytics use the extension to highlight their technical specialization.
-*   **Marketing Campaigns:** Brands launch specific product campaigns using .ads domains for landing pages, keeping the campaign data separate and the URL catchy.
-*   **Classifieds and Listings:** Online marketplaces utilize .ads to categorize sections of their sites dedicated to buying and selling goods.
-*   **URL Shorteners:** Large platforms create custom URL shorteners ending in .ads to track click-through rates on social media content.
-*   **Domain Investors:** Forward-thinking investors are acquiring premium .ads keywords, anticipating the continued growth of the digital advertising market and the utility of [tokenized domains](https://namefi.io/blog).
+Even though "ads" is an ordinary English word, this is not an open industry extension. `.ads` is a **closed brand TLD**: Google applied for and controls the entire string, and no advertising agency, adtech vendor, or marketer can register a name on it. You can confirm the delegation and operator on the authoritative [IANA root-zone record for .ads](https://www.iana.org/domains/root/db/ads.html).
 
-## **Notable Entities Using .ads**
+## History of .ads
 
-While .ads is a highly specific TLD, it has been adopted by major players in the tech and marketing space to streamline their services.
+`.ads` was delegated to the DNS [root zone](/en/glossary/root-zone/) on **February 5, 2015**. Unlike many dot-brands that outsource technical operation to a registry-services provider, Google runs the back-end for `.ads` itself, publishing registry information for its TLD portfolio at **registry.google**.
 
-1.  **Google:** As the [registry operator](/en/glossary/registry/), Google has utilized the extension for various internal and external advertising documentation and registry information (e.g., via the [Google Registry](https://www.registry.google/)).
-2.  **AdTech Startups:** Numerous emerging SaaS platforms in the programmatic advertising space have adopted the TLD to differentiate themselves from general tech startups using [.io](/en/tld/io/) or [.ai](/en/tld/ai/).
-3.  **Marketing Portfolios:** Freelance media buyers and creative directors are increasingly moving away from generic domains to .ads to signal their professional niche immediately.
+Google applied for a wide range of strings during ICANN's New gTLD Program, from its own company name to generic terms tied to its business, and chose to keep `.ads` closed rather than open it to public registration. The `.ads` record has remained active since delegation.
 
-*Note: As this is a niche gTLD, many "category-killer" domains (like auto.ads or realestate.ads) represent the most valuable use cases, often held by domain investors or large marketing conglomerates.*
+## Is .ads available to register?
 
-## **Why Choose .ads?**
+**No.** `.ads` is a **closed brand TLD**, so there is no open registration and no [registrar](/en/glossary/registrar/) — including Namefi — can sell you a `.ads` name. Registrations are limited to Google and organizations it authorizes. This is by design: keeping the string closed means Google, not the public, decides how the "ads" namespace is used, and no one can register a confusing or malicious lookalike under it.
 
-Choosing the right domain extension is critical for your brand's digital strategy. Here is why .ads is a smart investment:
+If you work in advertising and want a short, keyword-rich domain, that name has to come from an open extension instead — `.ads` itself is not on the table.
 
-*   **Instant Recognition:** The extension clearly communicates your industry. Visitors know immediately that your site is related to advertising or marketing services.
-*   **Availability:** Compared to the saturated .com market, .ads offers a higher chance of securing short, single-word, or keyword-rich names that are essential for strong branding.
-*   **SEO Relevance:** While Google treats all new gTLDs equally, having a relevant keyword in your domain (like "mobile.ads") can improve click-through rates (CTR) because users perceive the link as highly relevant to their search query.
-*   **Memorable Branding:** For URL shorteners and print marketing, a domain like *agency.ads* is far easier to remember than *agency-advertising-services.com*.
-*   **Trust and Professionalism:** Using a dedicated industry TLD signals that you are an established player in the advertising ecosystem.
+## How Google uses .ads
 
-## **Register Your .ads Domain at Namefi**
+Brand TLDs give a company a private space to organize part of its web presence. For a closed, generic-word TLD like `.ads` that a company holds defensively or for narrow internal purposes, typical uses include:
 
-Ready to elevate your advertising brand? Securing your **.ads** domain is the first step toward a more powerful digital presence.
+- **Reserved namespace control**, so no outside party can register `.ads` names that might imply an official advertising product or service.
+- **Selective internal or product-linked addresses**, at Google's discretion, rather than broad public-facing use.
+- **Registry-information pages**, such as the listings Google maintains at registry.google for the TLDs it operates.
 
-At **Namefi**, we make domain registration seamless and future-proof. Whether you are a Web2 marketing agency or a [Web3](/en/glossary/web3/) developer building decentralized ad networks, Namefi offers the unique advantage of tokenized real-world assets. You can manage your [ICANN](/en/glossary/icann/)-accredited domains with the ease of [blockchain](/en/glossary/blockchain/) technology, ensuring instant transferability and enhanced security.
+**Who it's not for:** advertising agencies, adtech companies, publishers, or domain investors. Because the namespace is closed, none of the industry use cases the string might suggest are actually available to anyone but Google.
 
-Don't let your perfect domain name get snapped up by a competitor.
+## Notable sites using .ads
 
-**[Search for your .ads domain at Namefi today](https://namefi.io)** and start building a brand that clicks.
+There are **no third-party sites** on `.ads`, and there never will be while it stays a closed brand TLD — every `.ads` address is controlled by Google through Charleston Road Registry Inc. Google's own registry-operator information for its TLD portfolio, including `.ads`, is published at **registry.google**; this is a registry-information page, not a public advertising platform. Rather than point to a specific address that may change, the honest description is simple: `.ads` is Google's private namespace, held closed rather than opened to the advertising industry its name suggests.
+
+## What is a dot-brand TLD?
+
+A **dot-brand** (or brand TLD) is a top-level domain that a single company owns and operates for its exclusive use, secured through ICANN's [New gTLD Program](/en/glossary/new-gtld/). Hundreds were delegated, including strings that are ordinary words rather than company names — `.ads` is one such case — and they share a few defining traits:
+
+- **Closed registration.** Only the operator and its affiliates can hold names, regardless of what the string itself means.
+- **Specification 13.** A registry-agreement addendum that formally recognizes the TLD as a brand and relaxes some rules that apply to open generics.
+- **Security and control.** The operator eliminates the risk of anyone else registering a `.ads` lookalike, which strengthens resistance to [phishing](/en/glossary/phishing/) and impersonation.
+
+Some companies invest heavily in their dot-brand; others register it defensively and barely use it. `.ads` falls closer to the latter: a generic-sounding string kept closed rather than developed into a public product.
+
+## .ads vs open domain alternatives
+
+If your goal was a short, advertising-flavored name rather than the `.ads` string specifically, an open extension is the right tool. Here is how a closed brand TLD compares with domains you can actually register:
+
+| Feature | .ads | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.xyz](/en/tld/xyz/) |
+| --- | --- | --- | --- | --- |
+| Who can register | Google only | Anyone | Anyone | Anyone |
+| Type | Brand new gTLD (closed) | Legacy gTLD | ccTLD used generically | New gTLD |
+| Core use | Google's own, narrow use | Universal default | Tech & startups | Generic / Web3 |
+| Available to you | No | Yes | Yes | Yes |
+
+For an advertising or marketing brand, a matching `.com` remains the safest default; [.io](/en/tld/io/) suits ad-tech products; and [.xyz](/en/tld/xyz/) is a flexible, low-cost modern option.
+
+## Reputation and trust
+
+Ironically, the closed nature of `.ads` is exactly what makes any address on it trustworthy: because only Google can create these names, a `.ads` link is verifiably official, which is why brand TLDs are considered strong against impersonation and email spoofing. That trust, however, benefits Google alone — it does not transfer to any advertising business you run, since you cannot register a `.ads` name. For your own project, deliverability and reputation will come from a well-configured domain on an open extension, not from a brand TLD you don't control.
+
+## Looking for an "ads" name? Register an alternative at Namefi
+
+You can't buy a `.ads` domain, but if you want a short, advertising-flavored name of your own, you can secure it on an open extension in minutes:
+
+1. **Search** your desired name across open TLDs like `.com`, `.io`, or `.xyz`.
+2. **Choose** the extension that fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can anyone register a .ads domain?
+
+No. `.ads` is a closed brand TLD delegated to Charleston Road Registry Inc., a Google entity. Only Google and parties it authorizes can hold a `.ads` name, so it is not available to advertisers, agencies, or the general public.
+
+### Who operates the .ads registry?
+
+Charleston Road Registry Inc., a Google entity, is the registry operator, and Google runs the technical back-end itself. The TLD was delegated to the DNS root zone on February 5, 2015, under ICANN's New gTLD Program.
+
+### Is .ads open to advertising agencies or adtech companies?
+
+No. Despite the name, `.ads` is not an industry extension for advertising businesses. It is a closed brand TLD controlled entirely by Google, with no public registration path for agencies, adtech firms, or anyone else.
+
+### What can I register instead of .ads?
+
+Because `.ads` is closed, choose an open extension for your own project. A matching `.com`, or a modern alternative like `.io` or `.xyz`, can be registered by anyone through an accredited registrar such as Namefi.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals behind top-level domains.
+- [How a TLD affects domain value](/en/blog/how-tld-affects-domain-value/) — why the extension matters.
+- [.com TLD guide](/en/tld/com/) — the open default to compare against.
+- [.io TLD guide](/en/tld/io/) and [.xyz TLD guide](/en/tld/xyz/) — modern open alternatives.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [registry](/en/glossary/registry/), [ICANN](/en/glossary/icann/).

--- a/content/tld/en/adult.md
+++ b/content/tld/en/adult.md
@@ -1,13 +1,24 @@
 ---
-title: "What is the .adult TLD and Why Choose It for Your Brand?"
-date: '2025-12-10'
+title: 'What Is the .adult Domain? An Open Adult-Industry TLD'
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: "Explore the .adult TLD: A specialized, secure domain for the entertainment industry. Learn about its branding benefits, availability, and how to register yours."
-keywords: [".adult domains", ".adult TLD", "top-level domain", "what is .adult", "why choose .adult", "what is the .adult domain", "why choose the .adult domain", "adult industry branding", "domain investing", "digital identity", "regulated content domains", "tokenized domain", "blockchain domains", "secure adult domains", "buy .adult domain"]
+description: 'The .adult domain is an open gTLD for the adult-content industry, run by ICM Registry AD LLC. Learn who registers it and its email deliverability trade-offs.'
+keywords: ['.adult domain', 'what is .adult', '.adult TLD', 'adult industry domain names', 'ICM Registry AD LLC', 'GoDaddy Registry', 'adult content TLD', 'defensive domain registration']
+faqs:
+  - question: 'Can anyone register a .adult domain?'
+    answer: 'Yes. The .adult domain is an open generic TLD with no age-verification or industry-membership requirement to register, so anyone can hold one. Most registrants are either adult-content businesses or mainstream brands registering their own name defensively.'
+  - question: 'Does a .adult domain affect SEO?'
+    answer: 'Google treats .adult like any other generic TLD, with no built-in ranking boost or penalty. The suffix does affect click-through, since it tells visitors and filtering systems exactly what kind of content to expect before they load the page.'
+  - question: 'Does using a .adult domain hurt email deliverability?'
+    answer: 'It can. Many corporate firewalls, consumer filters, and security systems treat the adult-content category as a policy-level block, independent of the registrant own conduct. Good sender practices help but cannot fully remove that categorical filtering.'
+  - question: 'Who registers .adult domains?'
+    answer: 'Two main groups: adult-content businesses that want a domain stating their content plainly, and mainstream brands that register their own name in .adult purely to keep it out of someone else hands, without ever publishing a site there.'
+  - question: 'Who operates the .adult registry?'
+    answer: 'The .adult registry is operated by ICM Registry AD LLC, with GoDaddy Registry providing the technical back-end. It was delegated to the DNS root zone on November 26, 2014, and sits alongside the related .xxx, .porn, and .sex extensions.'
 relatedArticles:
   - /en/blog/top-tlds-to-secure-for-your-accounting-firm/
   - /en/blog/top-tlds-to-secure-for-your-business/
@@ -28,52 +39,132 @@ relatedGlossary:
   - /en/glossary/registry/
 ---
 
-## **What is .adult?**
+The **.adult** domain is an open [generic top-level domain](/en/glossary/gtld/) (gTLD) built for the adult entertainment industry. Anyone can register one — there is no age-verification or industry-membership requirement at the registration level — but the string's meaning is so specific that most registrants either run adult content or are mainstream brands protecting their name defensively. This page covers what `.adult` is, who runs it, how it is actually used, and the reputation and email-deliverability trade-offs that come with such an unambiguous suffix.
 
-The **.adult** [domain extension](/en/blog/what-is-a-tld/) is a [generic Top-Level Domain](/en/glossary/gtld/) (gTLD) specifically designed for the adult entertainment industry. Launched as part of [ICANN’s New gTLD Program](https://newgtlds.icann.org/en/about/program), this extension was introduced to provide a clear, dedicated, and responsible digital space for adult content creators, businesses, and service providers.
+## .adult at a glance
 
-Managed by major [registry](/en/glossary/registry/) operators (originally ICM Registry, now part of GoDaddy Registry), **.adult** serves a dual purpose: it allows content creators to clearly signal the nature of their content to search engines and users, while simultaneously helping internet users make informed choices about the links they click.
+| Fact | Detail |
+| --- | --- |
+| TLD type | New gTLD (generic) |
+| Registry operator | ICM Registry AD LLC; technical back-end by GoDaddy Registry |
+| Year launched | Delegated to the root zone November 26, 2014 |
+| Registry site | [nic.adult](https://nic.adult) |
+| Sibling extensions | Part of the same family as `.xxx`, `.porn`, and `.sex` |
+| Registration restrictions | Open to all — no age-verification or industry-membership requirement |
+| Best for | Adult-content businesses, and brands registering defensively to protect their name |
 
-Unlike the crowded [.com](/en/tld/com/) namespace, **.adult** offers a modern, semantic solution that categorizes content instantly. It is part of a suite of industry-specific domains (alongside .porn, .sex, and .xxx) intended to professionalize the sector and improve online safety protocols.
+## What is .adult?
 
-## **How People Are Using .adult**
+"Adult" is a plain-English word that, as a domain suffix, signals sexually explicit or age-restricted content immediately. `.adult` is a generic new gTLD delegated to the root zone on **November 26, 2014**, according to its [IANA root-zone entry](https://www.iana.org/domains/root/db/adult.html). It is operated by **ICM Registry AD LLC**, with **GoDaddy Registry** providing the technical back-end infrastructure, and the registry publishes its own policy site at [nic.adult](https://nic.adult).
 
-The **.adult** TLD is utilized by a wide spectrum of entities within the digital entertainment landscape. Its usage goes beyond simple websites, serving as a tool for branding, compliance, and asset management.
+Because it is a generic extension rather than a country-code one, Google applies no geographic bias to `.adult` — it can be geo-targeted like any other gTLD. What the string does signal clearly, to both users and filtering software, is subject matter: it is one of the most explicit content labels in the entire namespace, which is both its main selling point and the source of most of the caveats below.
 
-*   **Production Studios:** Established production companies use .adult to host their primary content hubs or specific niche networks, ensuring their branding is immediately recognizable.
-*   **Independent Creators & Influencers:** With the rise of the creator economy, individual performers use .adult to build personal brands (e.g., `FirstNameLastName.adult`) that are professional and easy to remember, directing traffic to their social platforms or subscription services.
-*   **Brand Protection:** Mainstream companies outside the adult industry frequently register their trademarks with the .adult extension defensively. This prevents third parties from using their brand name in association with adult content.
-*   **Review and Affiliate Sites:** Bloggers and marketers who review industry products or sites use the extension to signal relevance to their target audience immediately.
-*   **[Web3](/en/glossary/web3/) and Domain Investors:** Forward-thinking investors are registering premium .adult names as digital assets, anticipating future value in the [tokenized domain](/en/glossary/tokenized-domain/) market.
+## History of .adult
 
-## **Notable Entities Using .adult**
+`.adult` came out of ICANN's New gTLD Program alongside its sibling strings `.xxx`, `.porn`, and `.sex`. ICM Registry — the operator already running the adult-content sector's namespace — holds the AD LLC entity behind `.adult`, and the string was delegated to the DNS root zone on November 26, 2014. GoDaddy Registry now provides the technical back-end for the zone.
 
-While many major legacy sites still operate on early internet domains like .com, the .adult extension has seen adoption for specific campaigns, redirects, and new ventures.
+Together, `.xxx`, `.adult`, `.porn`, and `.sex` form a coordinated group of extensions meant to give the adult-content sector its own clearly labeled part of the namespace, distinct from generic space like [.com](/en/tld/com).
 
-*   **Defensive Registrations by Fortune 500s:** Major global brands, including Microsoft, Apple, and large consumer goods companies, have defensively registered their .adult counterparts to protect brand integrity.
-*   **Industry Leaders:** Major adult networks often register the .adult versions of their flagship properties to capture direct navigation traffic and redirect it to their main portals.
-*   **Modern Creators:** A significant portion of the "creator economy" in the adult sector has moved toward .adult and .sex domains because their preferred handles are usually taken on legacy TLDs.
+## How people use .adult
 
-## **Why Choose .adult?**
+Real use falls into two clear groups:
 
-For businesses and individuals operating in this vertical, choosing a **.adult** domain offers distinct strategic advantages over generic extensions.
+- **Adult-content businesses** — studios, platforms, and services that want a domain stating their content plainly, both for visitors and for content-filtering software to categorize correctly.
+- **Defensive brand registrations** — mainstream, non-adult companies that register their own name in `.adult` (often alongside `.xxx`, `.porn`, and `.sex`) purely to keep someone else from using their brand on an adult site. This is one of the most common reasons an unrelated brand ends up owning a `.adult` domain.
 
-*   **Transparency and Trust:** Using a .adult domain is a hallmark of responsible business. It clearly labels content, ensuring that visitors are not surprised by what they find. This transparency builds trust with users and payment processors alike.
-*   **Premium Availability:** Finding a short, memorable, strictly-matching .com domain is nearly impossible today without spending thousands of dollars. **.adult** offers a vast inventory of short, keyword-rich names that are still available for standard registration prices.
-*   **SEO Relevance:** Search engines prioritize user experience. A descriptive TLD like .adult helps search engine crawlers understand the context of the website immediately, which can be beneficial for niche-specific queries.
-*   **Safer Neighborhood:** The registry for .adult maintains strict abuse policies. This creates a "cleaner" neighborhood compared to unregulated spaces, reducing the likelihood of being associated with malware or spam-heavy domains.
+**Who it's not ideal for:** any brand that does not want association with adult content in any form, including defensively — some companies deliberately skip these registrations, since even an unused `.adult` domain can raise questions if discovered. It is also a weak fit for anyone who needs reliable inbox delivery for transactional or marketing email tied to the same domain — see the reputation section below.
 
-## **Register Your .adult Domain at Namefi**
+## Notable sites using .adult
 
-Whether you are a content creator looking to professionalize your brand, a business protecting your [trademark](/en/glossary/trademark/), or a domain investor seeking the next valuable asset, **.adult** is a powerful choice.
+The honest description here is behavioral rather than a named list: `.adult` sites are, almost by definition, adult-content platforms, so this page does not name or link to any. Beyond the content sites themselves, the second major registrant category is the defensive brand — a company that owns its `.adult` match but points it nowhere, only to keep the name out of circulation. Between those two groups, there is no mainstream public flagship `.adult` site comparable to a `.com` brand home page.
 
-At **Namefi**, we make the registration process seamless. As an innovative domain registrar, we offer the unique ability to **[tokenize](/en/glossary/tokenize/) your domain**. This means your .adult domain isn't just a web address—it can be minted as an NFT, allowing for instant transfers, enhanced security, and easy integration into the Web3 ecosystem.
+## .adult vs other domains
 
-**Why register with Namefi?**
-*   **Simple Management:** Easy DNS setup and management dashboard.
-*   **Web3 Ready:** Tokenize your domain for instant [liquidity](/en/glossary/domain-liquidity/) and [blockchain](/en/glossary/blockchain/) integration.
-*   **Transparent Pricing:** No hidden fees or surprise renewal hikes.
+| Feature | .adult | [.com](/en/tld/com) | `.xxx` |
+| --- | --- | --- | --- |
+| Type | New gTLD (generic) | Legacy gTLD | Sponsored gTLD (adult sector) |
+| Content signal | Explicit (adult) | None | Explicit (adult) |
+| Restrictions | Open to all | Open to all | Adult-sector sponsored |
+| Common registrant | Adult businesses; defensive brands | Everyone | Adult businesses |
 
-Secure your digital identity today.
+Choose `.com` when you want no content signal at all and the broadest general trust. Choose `.adult` (or its siblings `.xxx`, `.porn`, `.sex`) when you specifically want the domain to say "adult content" before anyone clicks, or when you are a non-adult brand taking the name off the table defensively.
 
-[**Register your .adult domain at Namefi**](https://namefi.io)
+## Why choose .adult?
+
+- **Instant content labeling.** The suffix tells visitors, filters, and search engines what the site contains before they load a page.
+- **Defensive coverage.** Owning your brand's `.adult` match keeps it out of the hands of someone who might use it to impersonate or embarrass you.
+- **Open registration.** No credential or membership process gates who can register, unlike a restricted sponsored TLD such as `.aero`.
+- **A clear niche.** Alongside `.xxx`, `.porn`, and `.sex`, it gives the adult sector a dedicated part of the namespace instead of competing in generic space.
+
+## Things to consider
+
+- **Reputation is unavoidable.** There is no way to use a `.adult` domain without the suffix itself signaling adult content — a feature for the target audience and a hard constraint for everyone else.
+- **Email and network filtering.** Covered in detail below — many corporate and consumer filters treat `.adult` and its sibling gTLDs with extra suspicion, or block them outright.
+- **Defensive cost adds up.** A brand that also wants `.xxx`, `.porn`, and `.sex` for the same protective reason is registering four domains, not one.
+
+## Who can register a .adult domain?
+
+**Registration restrictions: open to all.** According to its [IANA root-zone entry](https://www.iana.org/domains/root/db/adult.html), `.adult` is a generic gTLD operated by ICM Registry AD LLC with GoDaddy Registry as technical back-end — there is no published requirement to be part of the adult industry, verify your age, or hold any credential to register the name itself. Anyone, whether an adult-content business or an unrelated brand protecting its name, can register a `.adult` domain through an accredited [registrar](/en/glossary/registrar/). This is what makes it fundamentally different from a restricted sponsored TLD, which gates registration on proof of community membership.
+
+Standard new-gTLD rules otherwise apply: names went through sunrise and [trademark](/en/glossary/trademark/)-claims phases at launch, and normal length, [WHOIS](/en/glossary/whois/), and renewal rules follow your registrar's policies. The authoritative rules live in the [ICANN .adult registry agreement](https://www.icann.org/en/registry-agreements/details/adult).
+
+## .adult pricing and value
+
+`.adult` follows the same general dynamics as other 2012-round gTLDs, without a single flat legacy-style fee:
+
+- **Registry-set wholesale pricing.** Like most new gTLDs, the registry sets a wholesale price that registrars mark up, rather than a fixed legacy fee.
+- **First-year and renewal pricing differ.** An introductory rate is not a guarantee of the renewal cost — always check the standing renewal price before committing.
+- **Defensive-registration demand.** Because so many registrants buy the name purely to protect a brand rather than to publish adult content, demand is shaped as much by brand-protection buyers as by the adult industry itself.
+
+This page lists no figures, since prices and promotions change across registrars — check current rates at the point of purchase.
+
+## Reputation and email deliverability
+
+This is the section a `.adult` buyer most needs straight talk on. The suffix's explicit meaning means many corporate firewalls, consumer content filters, parental-control tools, and email security systems treat `.adult` and its sibling gTLDs as adult content by category, and block or restrict them by policy, independent of what an individual registrant does.
+
+Practically, this differs from a spam-driven reputation problem: it is largely categorical. Correct **SPF, DKIM, and DMARC** records, clean lists, and consistent sending patterns still matter and are worth doing properly, but they cannot fully undo a blanket, policy-based block that some networks apply to the entire `.adult` zone. If a project depends on transactional or marketing email reliably reaching every inbox, weigh that constraint before committing — a purely defensive registration that parks the name unused has no deliverability exposure at all, since it sends no mail.
+
+## Branding and naming tips
+
+- **Lead with the category, not a euphemism.** Visitors already expect explicit content from the suffix, so a clear, direct name serves them better than an evasive one.
+- **Register the defensive set together.** If protecting a brand, secure the same name across `.adult`, `.xxx`, `.porn`, and `.sex` at once rather than piecemeal.
+- **Keep primary brand email separate.** If your main brand's email lives on `.com`, do not route it through a `.adult` registration.
+- **Match the registry's own style.** The registry runs its policy site at a plain, direct address — a model worth following for your own name.
+
+## How to register a .adult domain at Namefi
+
+1. **Search** for your desired name on [Namefi](https://namefi.io) to check availability.
+2. **Choose** the exact `.adult` name, whether for content or a defensive registration.
+3. **Register** and configure DNS, or leave the name parked if the registration is purely defensive.
+
+Namefi is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) with transparent pricing, and it also supports [Web3](/en/glossary/web3/) tokenization, so you can optionally [tokenize](/en/glossary/tokenize/) a domain for easier transfer and management. [Search and register your .adult domain at Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .adult domain?
+
+Yes. The `.adult` domain is an open generic TLD with no age-verification or industry-membership requirement to register, so anyone can hold one. Most registrants are either adult-content businesses or mainstream brands registering their own name defensively.
+
+### Does a .adult domain affect SEO?
+
+Google treats `.adult` like any other generic TLD, with no built-in ranking boost or penalty. The suffix does affect click-through, since it tells visitors and filtering systems exactly what kind of content to expect before they load the page.
+
+### Does using a .adult domain hurt email deliverability?
+
+It can. Many corporate firewalls, consumer filters, and security systems treat the adult-content category as a policy-level block, independent of the registrant own conduct. Good sender practices help but cannot fully remove that categorical filtering.
+
+### Who registers .adult domains?
+
+Two main groups: adult-content businesses that want a domain stating their content plainly, and mainstream brands that register their own name in `.adult` purely to keep it out of someone else hands, without ever publishing a site there.
+
+### Who operates the .adult registry?
+
+The `.adult` registry is operated by ICM Registry AD LLC, with GoDaddy Registry providing the technical back-end. It was delegated to the DNS root zone on November 26, 2014, and sits alongside the related `.xxx`, `.porn`, and `.sex` extensions.
+
+## Related resources
+
+- [.com domain](/en/tld/com) — the general-purpose baseline to compare against.
+- [What is a TLD?](/en/blog/what-is-a-tld) — the fundamentals of top-level domains.
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains) — how domains become on-chain assets.
+- Compare TLDs: [.com](/en/tld/com), [.xyz](/en/tld/xyz)
+- Glossary: [registrar](/en/glossary/registrar), [ICANN](/en/glossary/icann), [DNS](/en/glossary/dns), [registry](/en/glossary/registry)

--- a/content/tld/en/adult.md
+++ b/content/tld/en/adult.md
@@ -3,7 +3,7 @@ title: 'What Is the .adult Domain? An Open Adult-Industry TLD'
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .adult domain is an open gTLD for the adult-content industry, run by ICM Registry AD LLC. Learn who registers it and its email deliverability trade-offs.'

--- a/content/tld/en/aero.md
+++ b/content/tld/en/aero.md
@@ -3,7 +3,7 @@ title: 'What Is the .aero Domain? A Restricted Aviation TLD'
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .aero domain is a restricted sponsored TLD for the aviation industry, run by SITA. Learn who qualifies for an aero ID and how it compares with .com.'

--- a/content/tld/en/aero.md
+++ b/content/tld/en/aero.md
@@ -1,13 +1,24 @@
 ---
-title: "What is the .aero TLD and Why Choose It?"
-date: '2025-12-10'
+title: 'What Is the .aero Domain? A Restricted Aviation TLD'
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: "Discover the power of the .aero TLD—the exclusive domain for the aviation industry. Learn about eligibility, benefits, and how this restricted extension builds immediate trust."
-keywords: [".aero domains", "TLD", "top-level domain", "what is .aero", "why choose .aero", "what is the .aero domain", "why choose the .aero domain", "aviation domains", "restricted TLD", "SITA registry", "domain investing", "blockchain domains", "tokenized domain", "aerospace web address", "airline branding"]
+description: 'The .aero domain is a restricted sponsored TLD for the aviation industry, run by SITA. Learn who qualifies for an aero ID and how it compares with .com.'
+keywords: ['.aero domain', 'what is .aero', '.aero TLD', 'SITA registry', 'aviation domain names', 'aero ID eligibility', 'sponsored TLD aviation', 'restricted gTLD']
+faqs:
+  - question: 'Who can register a .aero domain?'
+    answer: 'Only members of the aviation and air-transport community, such as airlines, airports, and aviation businesses and professionals. Registrants must obtain an aero ID from the registry verifying that eligibility before a name can be registered.'
+  - question: 'What is an aero ID?'
+    answer: 'An aero ID is the eligibility credential issued by the .aero registry that confirms a registrant belongs to the aviation and air-transport community. It must be obtained before a .aero domain name can be registered.'
+  - question: 'Does a .aero domain affect SEO?'
+    answer: 'Google treats .aero like any other top-level domain, with no automatic ranking boost or penalty. Its main practical effect is trust signaling, since visitors know the registrant cleared an industry eligibility check.'
+  - question: 'Who operates the .aero registry?'
+    answer: 'The .aero registry is sponsored and operated by SITA, with Identity Digital providing the technical back-end. It was delegated to the DNS root zone on December 21, 2001, making it one of the earliest sponsored top-level domains.'
+  - question: 'Is .aero better than .com for an airline?'
+    answer: 'They serve different purposes. A .com domain offers broad, unrestricted reach, while a .aero domain proves aviation-industry membership through its eligibility check. Many airlines and airports use both rather than choosing one.'
 relatedArticles:
   - /en/blog/what-is-a-tld/
   - /en/blog/top-tlds-to-secure-for-your-accounting-firm/
@@ -28,47 +39,126 @@ relatedGlossary:
   - /en/glossary/dns/
 ---
 
-## **What is .aero?**
+The **.aero** domain is a **sponsored top-level domain** (sTLD) reserved for the aviation and air-transport community — airlines, airports, and aviation businesses and professionals. Unlike an open gTLD such as [.com](/en/tld/com), `.aero` is **restricted**: you cannot just buy one, because the registry requires proof that you belong to the aviation sector before it will activate the name. This page covers what `.aero` is, who runs it, who is actually eligible to register one, and how it compares with an open extension.
 
-The **.aero** [Top-Level Domain (TLD)](/en/glossary/tld/) is the internet’s dedicated namespace for the aviation community. Unlike generic domains like [.com](/en/tld/com/) or [.net](/en/tld/net/), .aero is a **Sponsored Top-Level Domain (sTLD)**. This means it is managed by a specific agency representing the community it serves—in this case, [SITA (Société Internationale de Télécommunications Aéronautiques)](https://www.sita.aero/), a multinational information technology company providing IT and telecommunication services to the air transport industry.
+## .aero at a glance
 
-Established in 2002 as the first sTLD approved by [ICANN](https://www.icann.org/), .aero was designed to structure the internet presence of the aviation world efficiently. It is a "restricted" domain, meaning not just anyone can register one. Applicants must obtain an Aviation Community ID and prove their validity within the aerospace sector. This exclusivity transforms the extension from a simple web address into a digital badge of authenticity and professionalism.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Sponsored TLD (sTLD), restricted |
+| Sponsor / registry operator | SITA ([Société Internationale de Télécommunications Aéronautiques](https://www.sita.aero/)); technical back-end by Identity Digital |
+| Year launched | Delegated to the root zone December 21, 2001 — one of the earliest sponsored TLDs |
+| Registry site | [information.aero](https://information.aero) |
+| Registration restrictions | **Restricted** — registrant must belong to the aviation/air-transport community and hold a valid aero ID |
+| Best for | Airlines, airports, and aviation businesses and professionals |
 
-## **How People Are Using .aero**
+## What is .aero?
 
-Because .aero is strictly reserved for the aviation industry, its usage is highly specific and professional. It serves as a unifying digital umbrella for various stakeholders in the sky.
+"Aero" is short for aeronautical, and as a domain suffix it is reserved specifically for that industry. `.aero` is a sponsored top-level domain, a category distinct from an open generic gTLD, delegated to the DNS root zone on **December 21, 2001**, per its [IANA root-zone entry](https://www.iana.org/domains/root/db/aero.html) — one of the earliest sponsored TLDs in the namespace. It is sponsored and operated by **SITA**, an organization that provides IT and telecom services to the air-transport sector, with **Identity Digital** providing the technical back-end. The registry publishes its policy and eligibility information at [information.aero](https://information.aero).
 
-*   **Airlines and Commercial Carriers:** Used for corporate sites, cargo logistics portals, and ticketing gateways.
-*   **Airports and Aerodromes:** Local and international airports use .aero to distinguish official operational information from unofficial tourism guides.
-*   **Aerospace Manufacturers:** Companies building aircraft, engines, and avionics components use it to assert industry authority.
-*   **Pilots and Crews:** Individual professionals (pilots, air traffic controllers, and maintenance engineers) can register domains for digital portfolios or contracting services.
-*   **Unmanned Aviation (Drones):** With the rise of drone technology, UAV operators and software developers are increasingly adopting .aero to legitimize their businesses.
-*   **Air Sports and Clubs:** Flying clubs and air sports federations use it to manage memberships and events.
+Because a sponsor represents its community's interests to ICANN, `.aero`'s rules are set by SITA rather than opened to any registrant, which is the key structural difference from a generic gTLD like `.com` or an open new gTLD.
 
-## **Notable Entities Using .aero**
+## History of .aero
 
-While many airlines maintain a .com presence for general consumer ticket sales, the .aero extension is frequently used for corporate identity, industry-specific infrastructure, and governing bodies.
+`.aero` was delegated in December 2001, during an early wave of new TLDs ICANN approved after `.com`, `.net`, and `.org` — a group that introduced the sponsored-TLD model itself. Being sponsored means an organization representing a defined community, here SITA for aviation, sets and enforces eligibility policy, rather than the registry accepting any registrant the way an open gTLD would. `.aero` has operated on this restricted, community-verified basis since launch, with Identity Digital now providing the technical back-end behind SITA's sponsorship.
 
-*   **SITA (sita.aero):** The [registry](/en/glossary/registry/) manager itself uses the TLD, showcasing its central role in aviation IT.
-*   **World Air Sports Federation (fai.aero):** The Fédération Aéronautique Internationale, the world governing body for air sports, relies on this TLD.
-*   **KTM (ktm.aero):** Various regional airlines and logistics companies utilize the extension to signify their operational focus.
-*   **Aviation Safety Agencies:** Various national and international safety groups utilize the domain to disseminate critical regulatory information.
+## How people use .aero
 
-## **Why Choose .aero?**
+Because eligibility is enforced, real use is concentrated in one sector:
 
-If you qualify for this exclusive domain, securing a .aero address offers distinct advantages that generic TLDs cannot match.
+- **Airlines** running their official web presence and booking and service sites.
+- **Airports** publishing traveler information, operations, and logistics content.
+- **Aviation businesses and professionals** — manufacturers, service providers, associations, and individuals verified as part of the air-transport community.
 
-*   **Instant Credibility and Trust:** Because the domain requires validation of an Aviation Community ID, users visiting a .aero site immediately know the entity is legitimate. It creates a "clean" neighborhood free of cybersquatters and scammers.
-*   **Premium Availability:** Since the domain is restricted to a specific industry, the pool of registered names is smaller. This means you are much more likely to find short, memorable, and keyword-rich domain names (e.g., `jets.aero` or `cargo.aero`) compared to the saturated .com market.
-*   **Industry Branding:** It clearly categorizes your business. A startup with a .aero address is instantly recognized as an aviation technology player, which is vital for B2B relationships and investors.
-*   **Future-Proofing:** As the aviation industry digitizes—moving toward [blockchain](/en/glossary/blockchain/) integration for supply chains and ticketing—holding a specialized domain positions your brand at the forefront of this technological shift.
+**Who it's not ideal for:** anyone outside the aviation and air-transport sector. General businesses, hobbyist aviation fans, or enthusiasts without an industry affiliation cannot register one at all, since the aero ID check gates it. Anyone wanting an aviation-themed name without proving industry membership needs an open gTLD instead.
 
-## **Register Your .aero Domain at Namefi**
+## Notable sites using .aero
 
-Are you ready to claim your territory in the digital sky? If you are part of the aviation community, a .aero domain is a powerful asset for your brand's authority.
+Because registration is restricted to verified airlines, airports, and aviation businesses, the honest description is by category rather than by name: the visible footprint of `.aero` is airline and airport web presences, plus aviation-industry association and business sites. This page does not name a specific site, since none has been verified here — but the category itself is exactly what the restriction is designed to produce, a namespace where every registrant is a confirmed aviation-sector party.
 
-At **Namefi**, we make managing your digital assets seamless. Whether you are securing a .aero domain for your airline or building a portfolio of high-value industry domains, Namefi offers a next-generation experience. We combine [ICANN](/en/glossary/icann/)-accredited reliability with cutting-edge Web3 integration, allowing you to [tokenize](/en/glossary/tokenize/) your domains for easier transfer, enhanced security, and seamless management on the blockchain.
+## .aero vs other domains
 
-**Secure your aviation identity today.**
+| Feature | .aero | [.com](/en/tld/com) | [.org](/en/tld/org) |
+| --- | --- | --- | --- |
+| Type | Sponsored TLD, restricted | Legacy gTLD | Legacy gTLD |
+| Restrictions | Aviation community + aero ID required | Open to all | Open to all |
+| Trust signal | Verified industry membership | None built in | Association with nonprofits, by convention |
+| Audience | Airlines, airports, aviation professionals | Everyone | Nonprofits and communities |
 
-[**Search for your domain at Namefi**](https://namefi.io)
+Choose `.com` if you want the broadest possible reach and do not need, or cannot get, aviation-industry verification. Choose `.org` for a nonprofit aviation association that does not clear the `.aero` bar. Choose `.aero` when you are part of the aviation and air-transport sector and want a domain that itself proves industry membership — something no open gTLD can offer.
+
+## Why choose .aero?
+
+- **Built-in credibility.** Because registration requires verified industry membership, the domain itself functions as a trust signal — a `.aero` address tells visitors the registrant cleared an eligibility check.
+- **Clear industry fit.** The name is unambiguous: aviation and air transport, nothing else.
+- **Low namespace noise.** Because outsiders cannot register speculative or unrelated names, the zone stays focused on genuine aviation entities.
+- **Long track record.** Delegated in 2001, `.aero` has operated under the same sponsorship model for over two decades.
+
+## Things to consider
+
+- **You must qualify.** This is not a domain you can just buy — proving aviation-community membership and obtaining an aero ID is a prerequisite, which rules it out for anyone outside the sector.
+- **Verification takes process and time.** Expect an eligibility step before the name activates, unlike an instant open-gTLD purchase.
+- **Narrow by design.** A `.aero` domain makes no sense for a non-aviation use case, which is the entire point of a sponsored TLD.
+
+## Who can register a .aero domain?
+
+**Registration restrictions: restricted to the aviation community.** According to its [IANA root-zone entry](https://www.iana.org/domains/root/db/aero.html), `.aero` is a sponsored TLD, and SITA, the sponsoring organization, requires registrants to belong to the aviation and air-transport community and obtain an **aero ID** verifying that eligibility before a name can be registered. This stands in clear contrast to an open gTLD such as `.com`, which imposes no such check. Airlines, airports, and aviation businesses and professionals are the qualifying categories; general businesses and individual hobbyists outside the industry cannot register a `.aero` name at all. The authoritative eligibility rules and application process are published by the registry at [information.aero](https://information.aero), with the binding contract in the [ICANN .aero registry agreement](https://www.icann.org/en/registry-agreements/details/aero).
+
+## .aero pricing and value
+
+Because eligibility gates who may even attempt to register, `.aero`'s market dynamics differ from an open gTLD's:
+
+- **No speculative land rush.** Since only verified aviation-sector entities can register, `.aero` sees none of the defensive or speculative buying pressure that shapes demand on open extensions.
+- **Sector-specific tiering.** As with most sponsored and industry TLDs, pricing can vary by name type and use case rather than following one flat rate.
+- **First-year and renewal pricing still typically differ**, as with most registry-priced TLDs — confirm the renewal rate, not just an introductory offer, before committing.
+
+This page lists no figures. A registrar experienced with `.aero` and its eligibility process can quote current rates.
+
+## Reputation and email deliverability
+
+`.aero` carries essentially no spam or abuse reputation problem. The restricted, verified-registrant model that keeps outsiders from registering also keeps the zone free of the bulk-registration abuse that affects wide-open, low-cost gTLDs. From a filter's perspective, `.aero` reads as a narrow, industry-verified namespace rather than a generic or disposable one.
+
+For deliverability specifically, treat it like any legitimate, established domain: configure **SPF, DKIM, and DMARC** correctly and keep sending practices clean. Nothing about `.aero` itself works against inbox placement — if anything, its verified nature is a mild net positive for trust.
+
+## Branding and naming tips
+
+- **Use your real organizational name.** Since only verified aviation entities can register, there is no benefit to cryptic or speculative naming — visitors expect a real airline, airport, or aviation business behind the address.
+- **Keep it short where possible.** Codes, callsigns, or a clean company name all read naturally under `.aero`.
+- **Pair with `.com` if you also serve consumers broadly.** Many aviation businesses keep a `.com` for general public reach alongside `.aero` for industry-facing credibility.
+
+## How to register a .aero domain at Namefi
+
+1. **Confirm eligibility** — you will need to qualify as part of the aviation and air-transport community and obtain an aero ID before registration.
+2. **Search** for your desired name on [Namefi](https://namefi.io) to check availability once eligible.
+3. **Register** and configure DNS.
+
+Namefi is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) with transparent pricing, and it also supports [Web3](/en/glossary/web3/) tokenization, so you can optionally [tokenize](/en/glossary/tokenize/) an eligible domain for easier transfer and management. [Search and register your .aero domain at Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Who can register a .aero domain?
+
+Only members of the aviation and air-transport community, such as airlines, airports, and aviation businesses and professionals. Registrants must obtain an aero ID from the registry verifying that eligibility before a name can be registered.
+
+### What is an aero ID?
+
+An aero ID is the eligibility credential issued by the `.aero` registry that confirms a registrant belongs to the aviation and air-transport community. It must be obtained before a `.aero` domain name can be registered.
+
+### Does a .aero domain affect SEO?
+
+Google treats `.aero` like any other top-level domain, with no automatic ranking boost or penalty. Its main practical effect is trust signaling, since visitors know the registrant cleared an industry eligibility check.
+
+### Who operates the .aero registry?
+
+The `.aero` registry is sponsored and operated by SITA, with Identity Digital providing the technical back-end. It was delegated to the DNS root zone on December 21, 2001, making it one of the earliest sponsored top-level domains.
+
+### Is .aero better than .com for an airline?
+
+They serve different purposes. A `.com` domain offers broad, unrestricted reach, while a `.aero` domain proves aviation-industry membership through its eligibility check. Many airlines and airports use both rather than choosing one.
+
+## Related resources
+
+- [.com domain](/en/tld/com) — the unrestricted general-purpose baseline to compare against.
+- [.org domain](/en/tld/org) — a fit for aviation associations that do not clear the `.aero` bar.
+- [What is a TLD?](/en/blog/what-is-a-tld) — the fundamentals of top-level domains.
+- Glossary: [registry](/en/glossary/registry), [registrar](/en/glossary/registrar), [ICANN](/en/glossary/icann)

--- a/content/tld/en/aetna.md
+++ b/content/tld/en/aetna.md
@@ -3,7 +3,7 @@ title: "What Is .aetna? Aetna's Brand TLD Explained"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .aetna domain is health insurer Aetna''s closed brand TLD, not open to the public. Learn what it is, who runs it, why it exists, and what to register instead.'

--- a/content/tld/en/aetna.md
+++ b/content/tld/en/aetna.md
@@ -1,13 +1,22 @@
 ---
-title: "What is the .aetna TLD and Why Does It Matter?"
-date: '2025-12-10'
+title: "What Is .aetna? Aetna's Brand TLD Explained"
+date: '2026-07-24'
 language: 'en'
-tags: ['tld', 'brand domains', 'digital identity', 'domain investing']
+tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: "Everything you need to know about the .aetna TLD. Explore the purpose of this unique domain extension, its role in corporate branding, and the future of digital identity."
-keywords: [".aetna domains", "TLD", "top-level domain", "what is .aetna", "why choose .aetna", "what is the .aetna domain", "why choose the .aetna domain", "brand TLD", "corporate domain names", "domain investing", "blockchain domains", "tokenized domain", "secure web addresses", "insurance domains", "Namefi"]
+description: 'The .aetna domain is health insurer Aetna''s closed brand TLD, not open to the public. Learn what it is, who runs it, why it exists, and what to register instead.'
+keywords: ['.aetna domain', 'what is .aetna', '.aetna TLD', 'Aetna brand domain', 'dot-brand TLD', 'Aetna registry operator', 'closed generic TLD', 'is .aetna available']
+faqs:
+  - question: 'Can anyone register a .aetna domain?'
+    answer: 'No. .aetna is a closed brand TLD delegated to Aetna Life Insurance Company. Only Aetna and parties it authorizes can hold a .aetna name, so it is not available to the general public through any registrar.'
+  - question: 'Who operates the .aetna registry?'
+    answer: 'Aetna Life Insurance Company is the registry operator, with GoDaddy Registry providing the technical back-end. The TLD was delegated to the DNS root zone on April 21, 2016, under ICANN''s New gTLD Program.'
+  - question: 'Is Aetna part of CVS Health?'
+    answer: 'Yes. Aetna is a US health-insurance and managed-care company that is now part of CVS Health. The .aetna domain remains reserved for Aetna''s own use within that corporate structure.'
+  - question: 'What can I register instead of .aetna?'
+    answer: 'Because .aetna is closed, choose an open extension for your own project. A matching .com, or a modern alternative like .io or .xyz, can be registered by anyone through an accredited registrar such as Namefi.'
 relatedArticles:
   - /en/blog/top-tlds-to-secure-for-your-business/
   - /en/blog/what-is-a-tld/
@@ -28,54 +37,113 @@ relatedGlossary:
   - /en/glossary/registry/
 ---
 
-## **What is .aetna?**
+The **.aetna** domain is a **closed brand [top-level domain](/en/glossary/tld/)** operated by **Aetna Life Insurance Company**, a US health-insurance and managed-care company that is now part of CVS Health. It is not a public extension: unlike [.com](/en/tld/com/) or [.io](/en/tld/io/), you cannot register a `.aetna` name for your own project, because the entire namespace belongs to one company.
 
-The **.aetna** domain is a specialized [Top-Level Domain (TLD)](/en/glossary/tld/) categorized as a "Brand TLD." Unlike open generic TLDs (gTLDs) like [.com](/en/tld/com/), [.net](/en/tld/net/), or [.io](/en/tld/io/), which are available for public registration, .aetna was created exclusively for the use of the **Aetna Life Insurance Company** (now part of CVS Health).
+If you searched for the ".aetna domain" hoping to buy one, the short answer is that you can't — but this page explains what `.aetna` is, who controls it, why an insurer runs its own TLD, and what you can register instead.
 
-This TLD was established during [ICANN](/en/glossary/icann/)'s (Internet Corporation for Assigned Names and Numbers) expansion of the internet's namespace. The primary purpose of a Brand TLD is to provide a dedicated, secure, and authenticated digital space for a corporation. By owning the entire [registry](/en/glossary/registry/), a company can ensure that every website ending in **.aetna** is an official corporate asset, drastically reducing the risk of [phishing](/en/glossary/phishing/) and [cybersquatting](/en/glossary/cybersquatting/).
+## .aetna at a glance
 
-For more information on the delegation of this TLD, you can view the [IANA Delegation Record for .aetna](https://www.iana.org/domains/root/db/aetna.html).
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | Aetna Life Insurance Company (technical back-end by GoDaddy Registry) |
+| Year delegated | 2016 |
+| IDN support | Not relevant — closed namespace |
+| DNSSEC | Supported |
+| Registration restrictions | **Closed** — restricted to Aetna Life Insurance Company and parties it authorizes; not available to the public |
+| Best for | Aetna's own corporate and member-facing websites |
 
-## **How People Are Using .aetna**
+## What is .aetna?
 
-Because **.aetna** is a "closed registry," it is not used by the general public, freelance developers, or unrelated businesses. Instead, its usage is strategic and focused on corporate governance and customer security.
+`.aetna` is a **[generic top-level domain](/en/glossary/gtld/)** that ICANN delegated to **Aetna Life Insurance Company** on **April 21, 2016**. Aetna is a US health-insurance and managed-care company, now part of CVS Health.
 
-Here is how this specific TLD is utilized within the digital ecosystem:
+`.aetna` is a **brand TLD** — a "dot-brand" — not an open extension anyone can buy into. The company applied for the string so that it, and only it, would control every domain ending in `.aetna`. You can confirm the delegation and operator on the authoritative [IANA root-zone record for .aetna](https://www.iana.org/domains/root/db/aetna.html).
 
-*   **Corporate Identity & Security:** It serves as a verified stamp of approval. If a user sees a URL ending in .aetna, they know immediately that they are interacting with the genuine insurance provider, not a malicious actor.
-*   **Streamlined Navigation:** It allows the organization to create intuitive, memorable web addresses for specific portals (e.g., `member.aetna` or `careers.aetna`) rather than long, complicated subdirectories.
-*   **Marketing Campaigns:** Companies with Brand TLDs often use them for specific product launches or health initiatives, ensuring the branding remains cohesive and premium.
-*   **Digital Trust:** In an era where data privacy is paramount, particularly in healthcare and insurance, using a proprietary TLD signals a high level of infrastructure security.
+## History of .aetna
 
-## **Notable Entities Using .aetna**
+`.aetna` was delegated to the DNS [root zone](/en/glossary/root-zone/) on **April 21, 2016**, with **GoDaddy Registry** handling the technical operation on Aetna's behalf. Its registry agreement with [ICANN](/en/glossary/icann/) includes **Specification 13**, the contract clause that formally designates a TLD as a brand and lets the operator keep it closed.
 
-As a restricted Brand TLD, the "entities" using this domain are exclusively internal divisions and affiliates of the parent company.
+Aetna applied for its own company name as a TLD during ICANN's New gTLD Program, joining a number of insurers and healthcare companies that sought the same kind of control over their online namespace. The `.aetna` record has remained active since delegation, and it continues to sit within Aetna's structure as part of CVS Health.
 
-*   **Aetna Life Insurance Company:** The primary registry operator and user.
-*   **CVS Health:** As the parent company of Aetna, related digital health services may utilize the infrastructure associated with this TLD.
-*   **Aetna International:** Global branches of the healthcare provider often utilize the centralized trust of the brand TLD to maintain a unified global presence.
+## Is .aetna available to register?
 
-While you won't see third-party tech startups using this TLD, the strategy behind it serves as a powerful case study for **Domain Investors** and **[Web3](/en/glossary/web3/) Developers** analyzing the value of digital scarcity and verified [on-chain](/en/glossary/on-chain/) identity.
+**No.** `.aetna` is a **closed brand TLD**, so there is no open registration and no [registrar](/en/glossary/registrar/) — including Namefi — can sell you a `.aetna` name. Registrations are limited to Aetna Life Insurance Company and organizations it authorizes, such as affiliates within CVS Health. This is by design: a dot-brand exists precisely so the trademark holder controls the whole namespace and no one else can register a confusing or malicious lookalike — a meaningful concern for a health insurer whose domains may carry sensitive member communications.
 
-## **Why Choose .aetna?**
+If you have a genuine business relationship with Aetna and a legitimate need for a `.aetna` address, that request would go through Aetna's own corporate channels, not a commercial registrar.
 
-While the general public cannot choose to register a .aetna domain for personal use, understanding *why* a corporation chooses to operate one highlights the critical importance of domain strategy in the modern web.
+## How Aetna uses .aetna
 
-*   **Absolute Trust:** The primary advantage is the elimination of doubt. There is zero chance of a "copycat" site existing on the .aetna registry because the brand controls 100% of the allocations.
-*   **SEO Authority:** Search engines increasingly value user safety. A closed TLD can potentially signal a high-authority source for specific industry queries related to health and insurance.
-*   **Brand Protection:** It eliminates the need for defensive registrations. The company does not need to buy `aetna-scam-protection.com` or other variations to stop bad actors, as they own the root extension itself.
-*   **Innovation Ready:** Brand TLDs pave the way for future technologies. By controlling the namespace, companies can easily integrate new protocols or even [blockchain](/en/glossary/blockchain/)-based authentication systems internally without waiting for public registry support.
+Brand TLDs give a company a private space to organize its web presence. Typical uses for a dot-brand like `.aetna` include:
 
-## **Register Your Domain at Namefi**
+- **Member and plan-related sites** on clean, memorable addresses tied directly to the brand.
+- **Campaign and enrollment pages** that are obviously official because only the company can create them.
+- **Internal tools and secure portals** where a branded suffix signals a trusted, first-party destination — useful for a company handling health information.
 
-While **.aetna** is a restricted TLD reserved for the insurance giant, the power of a strong digital identity is available to everyone. Whether you are looking for a professional `.com`, a tech-savvy `.io`, or exploring the future of **tokenized domains** and **Web3**, Namefi is your gateway.
+**Who it's not for:** anyone outside Aetna and its CVS Health affiliates. Because the namespace is closed, there is no scenario in which an independent broker, provider, or business can build on `.aetna`.
 
-At **Namefi**, we simplify domain management by bridging the gap between traditional Web2 DNS and Web3 blockchain technology.
+## Notable sites using .aetna
 
-*   **ICANN-Accredited:** Secure, compliant, and trustworthy registration.
-*   **Web3 Integration:** Mint your domains as NFTs for easy transfer and [liquidity](/en/glossary/domain-liquidity/).
-*   **Smart Pricing:** Competitive rates on hundreds of open TLDs.
+There are **no third-party sites** on `.aetna`, and there never will be while it stays a closed brand TLD — every `.aetna` address is controlled by Aetna Life Insurance Company. Aetna continues to run its main public presence from **aetna.com**, and uses the brand TLD selectively rather than as a wholesale replacement. Rather than point to a specific address that may change, the honest description is simple: `.aetna` is Aetna's private namespace, used only for the company's own properties.
 
-Don't wait to secure your brand. Search for your perfect domain today and take ownership of your digital future.
+## What is a dot-brand TLD?
 
-[**Start Your Search at Namefi**](https://namefi.io)
+A **dot-brand** (or brand TLD) is a top-level domain that a single company owns and operates for its exclusive use, secured through ICANN's [New gTLD Program](/en/glossary/new-gtld/). Hundreds were delegated — examples in this same alphabetical band include `.abb`, `.accenture`, and `.aco` — and they share a few defining traits:
+
+- **Closed registration.** Only the brand and its affiliates can hold names.
+- **Specification 13.** A registry-agreement addendum that formally recognizes the TLD as a brand and relaxes some rules that apply to open generics.
+- **Security and control.** The brand eliminates the risk of anyone else registering a `.aetna` lookalike, which strengthens resistance to [phishing](/en/glossary/phishing/) and impersonation.
+
+Some brands invest heavily in their TLD; others register it defensively and barely use it. A number of companies have even terminated their dot-brands after deciding the upkeep was not worth it.
+
+## .aetna vs open domain alternatives
+
+If your goal was a short, brandable name rather than the `.aetna` string specifically, an open extension is the right tool. Here is how a closed brand TLD compares with domains you can actually register:
+
+| Feature | .aetna | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.xyz](/en/tld/xyz/) |
+| --- | --- | --- | --- | --- |
+| Who can register | Aetna Life Insurance Company only | Anyone | Anyone | Anyone |
+| Type | Brand new gTLD (closed) | Legacy gTLD | ccTLD used generically | New gTLD |
+| Core use | Aetna's own sites | Universal default | Tech & startups | Generic / Web3 |
+| Available to you | No | Yes | Yes | Yes |
+
+For your own venture, a matching `.com` remains the safest default; [.io](/en/tld/io/) suits technical products; and [.xyz](/en/tld/xyz/) is a flexible, low-cost modern option.
+
+## Reputation and trust
+
+Ironically, the closed nature of `.aetna` is exactly what makes it trustworthy: because only Aetna can create these addresses, a `.aetna` link is verifiably official, which is why brand TLDs are considered strong against impersonation and email spoofing — a real advantage for a health insurer that member communications depend on. That trust, however, benefits Aetna alone — it does not transfer to any name you might register, since you cannot register one. For your own project, deliverability and reputation will come from a well-configured domain on an open extension, not from a brand TLD you don't control.
+
+## Looking for an "aetna" name? Register an alternative at Namefi
+
+You can't buy a `.aetna` domain, but if you want a short name of your own, you can secure it on an open extension in minutes:
+
+1. **Search** your desired name across open TLDs like `.com`, `.io`, or `.xyz`.
+2. **Choose** the extension that fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can anyone register a .aetna domain?
+
+No. `.aetna` is a closed brand TLD delegated to Aetna Life Insurance Company. Only Aetna and parties it authorizes can hold a `.aetna` name, so it is not available to the general public through any registrar.
+
+### Who operates the .aetna registry?
+
+Aetna Life Insurance Company is the registry operator, with GoDaddy Registry providing the technical back-end. The TLD was delegated to the DNS root zone on April 21, 2016, under ICANN's New gTLD Program.
+
+### Is Aetna part of CVS Health?
+
+Yes. Aetna is a US health-insurance and managed-care company that is now part of CVS Health. The `.aetna` domain remains reserved for Aetna's own use within that corporate structure.
+
+### What can I register instead of .aetna?
+
+Because `.aetna` is closed, choose an open extension for your own project. A matching `.com`, or a modern alternative like `.io` or `.xyz`, can be registered by anyone through an accredited registrar such as Namefi.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals behind top-level domains.
+- [How a TLD affects domain value](/en/blog/how-tld-affects-domain-value/) — why the extension matters.
+- [.com TLD guide](/en/tld/com/) — the open default to compare against.
+- [.io TLD guide](/en/tld/io/) and [.xyz TLD guide](/en/tld/xyz/) — modern open alternatives.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [registry](/en/glossary/registry/), [ICANN](/en/glossary/icann/).

--- a/content/tld/en/af.md
+++ b/content/tld/en/af.md
@@ -3,7 +3,7 @@ title: "What Is the .af Domain? Afghanistan's Country-Code TLD"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'What is the .af domain? Afghanistan''s country-code TLD, managed by AFGNIC. Learn its history, eligibility, and how pricing works before you register.'

--- a/content/tld/en/af.md
+++ b/content/tld/en/af.md
@@ -1,13 +1,22 @@
 ---
-title: "What is the .af TLD and Why Choose It for Your Next Domain?"
-date: '2025-12-10'
+title: "What Is the .af Domain? Afghanistan's Country-Code TLD"
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: "Discover the .af top-level domain. From its origins as the Afghanistan ccTLD to its popularity for creative domain hacks and branding, learn why .af is a smart choice."
-keywords: [".af domains", ".af TLD", "top-level domain", "what is .af", "why choose .af", "what is the .af domain", "why choose the .af domain", "Afghanistan domain", "domain hacks", "creative branding", "domain investing", "buy .af domain", "tokenized domains", "blockchain domains", "Namefi"]
+description: 'What is the .af domain? Afghanistan''s country-code TLD, managed by AFGNIC. Learn its history, eligibility, and how pricing works before you register.'
+keywords: ['.af domain', '.af TLD', 'what is .af', 'Afghanistan domain', 'AFGNIC registry', 'country code top level domain', 'ccTLD registration', 'register .af domain']
+faqs:
+  - question: 'Can anyone register a .af domain?'
+    answer: 'The registry, AFGNIC, sets current eligibility rules for .af, and they can differ from an open global gTLD. Before planning a brand around .af, confirm current registration requirements directly with AFGNIC rather than assuming worldwide open registration.'
+  - question: 'Does a .af domain affect SEO?'
+    answer: 'Google geo-targets .af to Afghanistan, so a .af site is generally treated as relevant to Afghan search results rather than as a globally generic domain. That makes it a fit for an Afghanistan-focused audience more than for international SEO.'
+  - question: 'What does .af stand for?'
+    answer: '.af is the ISO country code assigned to Afghanistan, delegated to the Ministry of Communications and Information Technology, which operates the registry as AFGNIC. It functions as Afghanistan''s national top-level domain.'
+  - question: 'Who should register a .af domain?'
+    answer: 'Organizations, institutions, and individuals with a genuine connection to Afghanistan. It is best understood as Afghanistan''s national ccTLD, not as a globally marketed novelty extension.'
 relatedArticles:
   - /en/blog/what-is-a-tld/
   - /en/blog/ai-vs-io-domain/
@@ -28,61 +37,123 @@ relatedGlossary:
   - /en/glossary/web3/
 ---
 
-## **What is .af?**
+The **.af** domain is the [ccTLD](/en/glossary/cctld/) for **Afghanistan**, administered by the country's Ministry of Communications and Information Technology through the registry known as **AFGNIC**. It functions primarily as Afghanistan's national namespace, the role most ccTLDs play for their home country, rather than as a globally marketed generic extension.
 
-The **.af** extension is the **country code [Top-Level Domain](/en/glossary/tld/) ([ccTLD](/en/glossary/cctld/))** for **Afghanistan**. It was originally delegated in 1997 and is managed by the [Afghanistan Network Information Center (AFGNIC)](https://nic.af/). 
+This guide covers what .af really is, who runs it, what to check before registering, and how it is perceived for SEO.
 
-While its primary purpose was to serve entities, organizations, and individuals connected to Afghanistan, the .af domain has transcended its geographic borders to become a favorite among the global tech and creative communities. This is largely due to the serendipitous linguistic coincidence in internet slang where "AF" is an acronym for "as f***" (used to emphasize an adjective, e.g., "cool af"). 
+## .af at a glance
 
-Because of this dual nature—serving a nation while simultaneously offering unique branding opportunities—.af has seen a steady rise in registrations outside of its home region. It is a standard DNS domain, but like many unique extensions, it holds specific value for **domain investors** looking for short, memorable names that may not be available in saturated legacy TLDs like [.com](/en/tld/com/).
+| Fact | Detail |
+| --- | --- |
+| TLD type | Country-code TLD (ccTLD) for Afghanistan |
+| Registry operator | Ministry of Communications and Information Technology, operating as AFGNIC (nic.af) |
+| Year delegated | 1997 (October 16) |
+| Registration restrictions | Primarily national — confirm current eligibility directly with AFGNIC |
+| Google treatment | Geo-targeted to Afghanistan |
+| Best for | Organizations, institutions, and individuals with a genuine Afghanistan connection |
 
-## **How People Are Using .af**
+## What is .af?
 
-The usage of .af is distinctly divided into two categories: local utility and global creativity.
+**.af** is the country-code [Top-Level Domain](/en/glossary/tld/) assigned under the ISO 3166-1 system to **Afghanistan**, listed by [IANA](https://www.iana.org/domains/root/db/af.html) with the **Ministry of Communications and Information Technology** as the manager, operating the registry as [AFGNIC](https://nic.af/).
 
-*   **Creative Branding and ["Domain Hacks"](/en/blog/domain-hacks-explained/):**
-    This is currently the most popular use case on the global stage. Startups, agencies, and personal brands use .af to create phrases. For example, a fast delivery service might register `fast.af`, or a security firm might use `safe.af`. This usage is prevalent in the **[Web3](/en/glossary/web3/) and tech sectors**, where edgy, memorable branding is highly valued.
-*   **Local Businesses and NGOs:**
-    Within Afghanistan, the domain is used for government portals, educational institutions, and local commerce, serving as a digital identifier of Afghan origin.
-*   **Portfolio and Personal Sites:**
-    Designers and developers often use the extension to make a statement about their work ethic or style (e.g., `creative.af` or `smart.af`).
-*   **Domain Investing:**
-    Investors actively acquire short, premium, or dictionary-word .af domains, anticipating their value will increase as more companies look for catchy "domain hacks."
+.af functions primarily as Afghanistan's national ccTLD. Google [geo-targets .af to Afghanistan](https://developers.google.com/search/docs/crawling-indexing/manage-international-sites), consistent with a domain built for a national audience rather than a global, generic one. We are not treating .af here as a novelty or domain-hack extension the way some other two-letter ccTLDs have become — its primary role is representing Afghanistan online.
 
-## **Notable Entities Using .af**
+## History of .af
 
-While many major corporations stick to .com, the .af extension is dominated by agile startups, tech projects, and media platforms leveraging the "slang" aspect.
+The .af ccTLD was delegated on **October 16, 1997**. It has since been managed by Afghanistan's Ministry of Communications and Information Technology, which operates the registry under the name AFGNIC through [nic.af](https://nic.af/).
 
-1.  **Spot.af:** Often cited in [domain hack](/en/glossary/domain-hack/) lists, representing how common words are paired with the extension.
-2.  **Health.af:** Examples of generic dictionary words being registered to create authoritative-sounding, yet modern, category-defining websites.
-3.  **Tech Startups & URL Shorteners:** Many tech companies use .af domains for custom URL shorteners or marketing campaigns to emphasize speed or intensity.
+## How people use .af
 
-*Note: Due to the nature of domain hacks, many .af sites are agile landing pages or redirectors for major brands' marketing campaigns.*
+.af functions as Afghanistan's national online namespace — the same role most ccTLDs play for their home country. Registrants are organizations, institutions, and individuals with a genuine connection to Afghanistan, using the domain to establish an Afghan online identity, rather than international brands adopting it for its letters or as a domain hack.
 
-For more context on how ccTLDs function globally, you can refer to [ICANN's resources on country code domains](https://www.icann.org/resources/pages/cctlds-21-2012-02-25-en).
+**Who it's not ideal for:** buyers looking for a globally generic, open-registration extension, or for a domain-hack novelty name with no connection to Afghanistan — that is not the primary role .af plays.
 
-## **Why Choose .af?**
+## Notable sites using .af
 
-Choosing a .af domain comes with several distinct advantages, especially if you are looking to stand out in a crowded digital marketplace.
+We have no pre-verified examples to cite here. What can be said honestly is that .af serves the function most national ccTLDs serve: a namespace for entities connected to the country, rather than a namespace defined by a famous global brand or a viral domain-hack trend.
 
-*   **Memorability and Impact:**
-    Using .af allows you to complete a phrase with your URL. A domain like `bold.af` is instantly memorable and conveys a brand personality that is confident and modern.
-*   **High Availability:**
-    Compared to .com, [.net](/en/tld/net/), or [.io](/en/tld/io/), there is a much higher probability of finding short, one-word, or two-letter domain names available in the .af namespace.
-*   **SEO Potential:**
-    While .af is a ccTLD, search engines like Google generally understand the context of the website content. If your site is in English and targets a global audience, it can still rank well. However, it is excellent for branding, which indirectly boosts direct traffic.
-*   **Investment Value:**
-    Short, punchy domain names are digital assets. As the internet expands, "hackable" extensions like .af retain value for their uniqueness.
+## .af vs other domains
 
-## **Register Your .af Domain at Namefi**
+| Feature | .af | [.com](/en/tld/com/) | [.org](/en/tld/org/) | [.net](/en/tld/net/) |
+| --- | --- | --- | --- | --- |
+| Type | ccTLD (national, geo-targeted) | Legacy gTLD | Legacy gTLD | Legacy gTLD |
+| Core association | Afghanistan | The default web standard | Institutions and nonprofits | Networks and infrastructure |
+| Registration eligibility | Confirm directly with AFGNIC | Open worldwide | Open worldwide | Open worldwide |
+| Typical audience | Afghanistan-focused | Global | Global | Global |
 
-Whether you are launching a bold new startup, building a personal portfolio, or looking to invest in unique digital assets, a .af domain offers a perfect blend of availability and attitude.
+If your project targets a global audience with no specific Afghanistan connection, **[.com](/en/tld/com/)**, **[.org](/en/tld/org/)**, or **[.net](/en/tld/net/)** are the more natural defaults. Choose **.af** when your organization, institution, or project is genuinely tied to Afghanistan.
 
-At **Namefi**, we make the registration process seamless and future-proof.
-*   **Easy Management:** Manage your traditional DNS settings with ease.
-*   **Web3 Integration:** Namefi specializes in **tokenized domains**. When you register with us, you can mint your domain as an NFT, allowing for instant transfer, [fractional ownership](/en/glossary/fractional-ownership/), and integration with [blockchain](/en/glossary/blockchain/) applications.
-*   **Transparent Pricing:** No hidden fees, just straightforward access to the domains you need.
+## Why choose .af?
 
-Don't let your perfect domain hack get taken by someone else. Secure your brand's intensity today.
+- **National relevance.** For entities connected to Afghanistan, .af signals that connection directly.
+- **Short extension.** At two letters, it keeps a URL compact.
+- **Clear identity.** As Afghanistan's ccTLD, it is the natural namespace for representing the country online.
 
-**[Register your .af domain at Namefi](https://namefi.io)**
+## Things to consider
+
+- **Confirm eligibility first.** Because current registration requirements are set by AFGNIC and not detailed in globally standardized policy, check directly with the registry before committing to a name.
+- **A ccTLD by nature.** Because .af belongs to Afghanistan, its rules are set nationally, not by an [ICANN](/en/glossary/icann/) registry agreement.
+- **Not a global generic.** .af is best treated as a national ccTLD rather than a domain-hack or novelty extension marketed for its letters alone.
+
+## Who can register a .af domain?
+
+**Registration restrictions: primarily national.** .af functions mainly as Afghanistan's ccTLD. Because eligibility rules are set by AFGNIC rather than published as an open, globally standardized policy, the most reliable step before registering is to confirm current requirements directly with the registry.
+
+Because .af is a ccTLD, it is governed by national policy rather than an ICANN registry agreement. The authoritative sources for current management and eligibility details are the [IANA root-zone entry](https://www.iana.org/domains/root/db/af.html) and the registry's own site, [nic.af](https://nic.af/).
+
+## .af pricing and value
+
+This page intentionally quotes no numbers, but a few general dynamics apply to ccTLD registration:
+
+- **Confirm eligibility and process before price.** For a nationally administered ccTLD like .af, the registration process itself — not just the fee — is worth understanding up front.
+- **First-year vs. renewal pricing can differ.** As with most TLDs, do not assume an introductory rate continues at renewal.
+- **What drives cost.** Name desirability and registry wholesale pricing are the main factors that shape what a given name costs to register and keep.
+
+For exact, current figures and eligibility requirements, check directly with the registry at registration time.
+
+## Reputation and email deliverability
+
+We are not aware of .af carrying a specific bulk-mail or spam reputation. As with any TLD, email deliverability depends far more on **sending reputation, SPF/DKIM/DMARC authentication, and list hygiene** than on the suffix itself. A properly authenticated .af sender should reach inboxes normally.
+
+## Branding and naming tips
+
+- **Lead with genuine relevance.** .af works best for organizations and projects with a real Afghanistan connection.
+- **Confirm the process early.** Check AFGNIC's current registration requirements before finalizing a name.
+- **Keep it short and clear.** A two-letter ccTLD rewards a name that reads well without extra qualifiers.
+
+## How to register a .af domain at Namefi
+
+1. **Confirm eligibility** — check current AFGNIC registration requirements for your situation.
+2. **Search** for your desired name and the .af extension.
+3. **Register** and configure DNS.
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for easier transfer and provable ownership.
+
+## Frequently asked questions
+
+### Can anyone register a .af domain?
+
+The registry, AFGNIC, sets current eligibility rules for .af, and they can differ from an open global gTLD. Before planning a brand around .af, confirm current registration requirements directly with AFGNIC rather than assuming worldwide open registration.
+
+### Does a .af domain affect SEO?
+
+Google geo-targets .af to Afghanistan, so a .af site is generally treated as relevant to Afghan search results rather than as a globally generic domain. That makes it a fit for an Afghanistan-focused audience more than for international SEO.
+
+### What does .af stand for?
+
+.af is the ISO country code assigned to Afghanistan, delegated to the Ministry of Communications and Information Technology, which operates the registry as AFGNIC. It functions as Afghanistan's national top-level domain.
+
+### Who should register a .af domain?
+
+Organizations, institutions, and individuals with a genuine connection to Afghanistan. It is best understood as Afghanistan's national ccTLD, not as a globally marketed novelty extension.
+
+## Related resources
+
+- [.com TLD guide](/en/tld/com/)
+- [.org TLD guide](/en/tld/org/)
+- [.net TLD guide](/en/tld/net/)
+- [What is a TLD?](/en/blog/what-is-a-tld/)
+- [Glossary: registrar](/en/glossary/registrar/)
+- [Glossary: ICANN](/en/glossary/icann/)
+- [Glossary: ccTLD](/en/glossary/cctld/)
+- [Glossary: DNS](/en/glossary/dns/)

--- a/content/tld/en/afl.md
+++ b/content/tld/en/afl.md
@@ -3,7 +3,7 @@ title: "What Is .afl? The AFL's Brand TLD Explained"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .afl domain is the closed brand TLD of the Australian Football League, not open to the public. Learn what it is, who runs it, and what to register instead.'

--- a/content/tld/en/afl.md
+++ b/content/tld/en/afl.md
@@ -1,31 +1,22 @@
 ---
-title: 'What is the .afl TLD and Why Is It Unique?'
-date: '2025-12-10'
+title: "What Is .afl? The AFL's Brand TLD Explained"
+date: '2026-07-24'
 language: 'en'
-tags:
-  - 'tld'
-authors:
-  - 'namefiteam'
-editors:
-  - victor-zhou
+tags: ['tld']
+authors: ['namefiteam']
+editors: ['victor-zhou']
 draft: false
-description: 'Discover everything about the .afl top-level domain. Learn how the Australian Football League uses this unique Brand TLD and what it means for domain investing and digital identity.'
-keywords:
-  - '.afl domains'
-  - '.afl TLD'
-  - 'top-level domain'
-  - 'what is .afl'
-  - 'why choose .afl'
-  - 'what is the .afl domain'
-  - 'why choose the .afl domain'
-  - 'Australian Football League domain'
-  - 'brand TLDs'
-  - 'sports domains'
-  - 'domain investing'
-  - 'blockchain domains'
-  - 'tokenized domain'
-  - 'Namefi'
-  - 'restricted TLD'
+description: 'The .afl domain is the closed brand TLD of the Australian Football League, not open to the public. Learn what it is, who runs it, and what to register instead.'
+keywords: ['.afl domain', 'what is .afl', '.afl TLD', 'Australian Football League domain', 'AFL brand TLD', 'dot-brand TLD', 'closed generic TLD', 'is .afl available']
+faqs:
+  - question: 'Can anyone register a .afl domain?'
+    answer: 'No. .afl is a closed brand TLD delegated to the Australian Football League. Only the AFL and parties it authorizes can hold a .afl name, so it is not available to the general public through any registrar.'
+  - question: 'Who operates the .afl registry?'
+    answer: 'The Australian Football League is the registry operator, with CSC providing the technical back-end. The TLD was delegated to the DNS root zone on February 19, 2015, under ICANN''s New gTLD Program.'
+  - question: 'What does AFL stand for?'
+    answer: 'AFL stands for Australian Football League, the top professional competition in Australian-rules football. The .afl domain is reserved for the League''s own use, not for clubs, fans, or fantasy-league sites generally.'
+  - question: 'What can I register instead of .afl?'
+    answer: 'Because .afl is closed, choose an open extension for your own project. A matching .com, or a modern alternative like .io or .xyz, can be registered by anyone through an accredited registrar such as Namefi.'
 relatedArticles:
   - /en/blog/what-are-tokenized-domains/
   - /en/blog/what-is-a-tld/
@@ -46,55 +37,113 @@ relatedGlossary:
   - /en/glossary/dns/
 ---
 
-## **What is .afl?**
+The **.afl** domain is a **closed brand [top-level domain](/en/glossary/tld/)** operated by the **Australian Football League**, the top professional competition in Australian-rules football. It is not a public extension: unlike [.com](/en/tld/com/) or [.io](/en/tld/io/), you cannot register a `.afl` name for your own project, fan site, or fantasy league, because the entire namespace belongs to the League.
 
-The **.afl** extension is a specialized [Top-Level Domain (TLD)](/en/glossary/tld/) representing the **Australian Football League (AFL)**. Unlike generic extensions like `.com` or `.net`, `.afl` is categorized as a **Brand TLD** (or "dotBrand"). It was created during [ICANN's New gTLD Program](https://newgtlds.icann.org/en/about/program), which allowed organizations to apply for their own proprietary domain extensions.
+If you searched for the ".afl domain" hoping to buy one, the short answer is that you can't — but this page explains what `.afl` is, who controls it, why a sports league runs its own TLD, and what you can register instead.
 
-The intended purpose of `.afl` is to provide a dedicated, verified digital space for the Australian Football League, its clubs, and its massive fanbase. By operating its own registry, the AFL ensures that any website ending in `.afl` is an official, authorized source of information, stats, or media related to the sport.
+## .afl at a glance
 
-In the world of domain investing and [Web3](/en/glossary/web3/), Brand TLDs like `.afl` represent the pinnacle of digital asset ownership—where an entity doesn't just own the domain name (the string to the left of the dot), but the infrastructure of the extension itself.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | Australian Football League (technical back-end by CSC) |
+| Year delegated | 2015 |
+| IDN support | Not relevant — closed namespace |
+| DNSSEC | Supported |
+| Registration restrictions | **Closed** — restricted to the Australian Football League and parties it authorizes; not available to the public |
+| Best for | The AFL's own league, club, and event websites |
 
-## **How People Are Using .afl**
+## What is .afl?
 
-Because `.afl` is a restricted Brand TLD, it is not generally available for public registration like a standard `.com` or `.xyz`. Instead, it is used strategically by the League to unify its digital ecosystem.
+`.afl` is a **[generic top-level domain](/en/glossary/gtld/)** that ICANN delegated to the **Australian Football League** on **February 19, 2015**. The AFL is the top professional competition in Australian-rules football, and the letters are simply its own name.
 
-Here is how the extension is utilized:
-*   **Official League Communications:** Centralizing news, fixtures, and results under a unified namespace.
-*   **Club Affiliation:** Providing a standardized naming convention for the various clubs within the league, ensuring fans know they are visiting an official club site.
-*   **Marketing Campaigns:** Creating short, memorable URLs for specific seasons, finals, or promotional events (e.g., `finals.afl`).
-*   **Brand Protection:** By controlling the TLD, the AFL prevents cybersquatters or unauthorized third parties from registering misleading domains that could confuse fans.
+`.afl` is a **brand TLD** — a "dot-brand" — not an open extension anyone can buy into. The League applied for the string so that it, and only it, would control every domain ending in `.afl`. You can confirm the delegation and operator on the authoritative [IANA root-zone record for .afl](https://www.iana.org/domains/root/db/afl.html).
 
-## **Notable Entities Using .afl**
+## History of .afl
 
-As a closed registry, the "notable entities" are exclusively within the AFL ecosystem. However, this structure serves as a prime example of how major organizations manage digital identity.
+`.afl` was delegated to the DNS [root zone](/en/glossary/root-zone/) on **February 19, 2015**, with **CSC** handling the technical operation on the League's behalf. Its registry agreement with [ICANN](/en/glossary/icann/) includes **Specification 13**, the contract clause that formally designates a TLD as a brand and lets the operator keep it closed.
 
-*   **The Australian Football League:** The registry operator and primary user, utilizing the domain for corporate and fan-facing infrastructure.
-*   **AFL Clubs:** Professional clubs within the league (such as Collingwood, Richmond, or West Coast Eagles) benefit from the trust architecture provided by the TLD.
-*   **AFL Media:** The broadcasting and news arm of the league utilizes the domain to serve verified sports journalism.
+The AFL was one of a small number of sports organizations that applied for their own league name as a TLD during ICANN's New gTLD Program, alongside a handful of other leagues and federations seeking the same kind of control over their online namespace. The `.afl` record has remained active since delegation, and the registry publishes contact and policy information at **nic.afl**, the standard informational page ICANN requires of every new gTLD operator.
 
-*Note: While you may often see these entities use `.com.au` for legacy reasons, the `.afl` infrastructure operates in the background to secure their brand on the global DNS.*
+## Is .afl available to register?
 
-## **Why Choose .afl? (The Power of Brand TLDs)**
+**No.** `.afl` is a **closed brand TLD**, so there is no open registration and no [registrar](/en/glossary/registrar/) — including Namefi — can sell you a `.afl` name. Registrations are limited to the Australian Football League and organizations it authorizes, such as its clubs or commercial partners. This is by design: a dot-brand exists precisely so the League controls the whole namespace and no one else can register a confusing or malicious lookalike, including opportunistic fan sites or ticket scams.
 
-While `.afl` is restricted to the league, understanding its advantages highlights why choosing the right TLD is crucial for any business or investor, and why specific niche TLDs are highly valued in the domain market.
+If you have a genuine business relationship with the AFL and a legitimate need for a `.afl` address, that request would go through the League's own channels, not a commercial registrar.
 
-*   **Unmatched Trust and Security:** When a user visits a `.afl` site, they know immediately it is not a phishing site or a fake fan blog. The "dotBrand" acts as a seal of authenticity.
-*   **Short and Relevant:** Niche TLDs allow for shorter domain names. Instead of `australianfootballleague-stats.com`, the league can utilize `stats.afl`.
-*   **SEO Authority:** Search engines reward relevance. For searches related to Australian Football, a domain ending in `.afl` signals high relevance to the topic.
-*   **Asset Control:** In the context of **tokenized domains** and blockchain assets, owning a TLD (or a premium domain within one) provides total sovereignty over one's digital presence, similar to how the AFL controls their entire namespace.
+## How the AFL uses .afl
 
-## **Register Your Domain at Namefi**
+Brand TLDs give an organization a private space to organize its web presence. Typical uses for a dot-brand like `.afl` include:
 
-Whether you are looking for a sports-related domain, a geographical extension, or a brand-new gTLD to define your digital identity, securing the right name is the first step toward success.
+- **Competition and club-related sites** on clean, memorable addresses tied directly to the League.
+- **Campaign and event pages** that are obviously official because only the League can create them.
+- **Internal tools and partner portals** where a branded suffix signals a trusted, first-party destination.
 
-At **Namefi**, we revolutionize how you manage these digital assets. We are an ICANN-accredited [registrar](/en/glossary/registrar/) that bridges the gap between Web2 and Web3. When you register a domain with us, we wrap it in a seamless NFT envelop, allowing you to trade, transfer, and manage your domains with the ease of blockchain technology.
+**Who it's not for:** anyone outside the League and its authorized affiliates. Because the namespace is closed, there is no scenario in which an independent fan site, fantasy-league platform, or ticket reseller can build on `.afl`.
 
-While `.afl` is exclusive to the league, you can search for thousands of other available TLDs that suit your brand perfectly.
+## Notable sites using .afl
 
-*   **Seamless Web3 Integration:** Manage your DNS settings using your crypto wallet.
-*   **Instant Transfers:** no more waiting days for authorization codes; transfer ownership in seconds via blockchain.
-*   **Secure & Accredited:** Enjoy the safety of an ICANN-accredited partner.
+There are **no third-party sites** on `.afl`, and there never will be while it stays a closed brand TLD — every `.afl` address is controlled by the Australian Football League. The registry's own informational page for the namespace sits at **nic.afl**, the standard landing page every new gTLD operator must publish; it is not a fan destination. Rather than point to a specific consumer address that may change, the honest description is simple: `.afl` is the League's private namespace, used only for its own properties.
 
-**Ready to kick off your digital journey?**
+## What is a dot-brand TLD?
 
-[**Register Your Ideal Domain at Namefi**](https://namefi.io)
+A **dot-brand** (or brand TLD) is a top-level domain that a single organization owns and operates for its exclusive use, secured through ICANN's [New gTLD Program](/en/glossary/new-gtld/). Hundreds were delegated — examples in this same alphabetical band include `.abb`, `.accenture`, and `.aetna` — and they share a few defining traits:
+
+- **Closed registration.** Only the brand and its affiliates can hold names.
+- **Specification 13.** A registry-agreement addendum that formally recognizes the TLD as a brand and relaxes some rules that apply to open generics.
+- **Security and control.** The League eliminates the risk of anyone else registering a `.afl` lookalike, which strengthens resistance to [phishing](/en/glossary/phishing/) and impersonation — useful protection against fake ticket or merchandise sites.
+
+Some brands invest heavily in their TLD; others register it defensively and barely use it. A number of organizations have even terminated their dot-brands after deciding the upkeep was not worth it.
+
+## .afl vs open domain alternatives
+
+If your goal was a short, sports-flavored name rather than the `.afl` string specifically, an open extension is the right tool. Here is how a closed brand TLD compares with domains you can actually register:
+
+| Feature | .afl | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.xyz](/en/tld/xyz/) |
+| --- | --- | --- | --- | --- |
+| Who can register | Australian Football League only | Anyone | Anyone | Anyone |
+| Type | Brand new gTLD (closed) | Legacy gTLD | ccTLD used generically | New gTLD |
+| Core use | The AFL's own sites | Universal default | Tech & startups | Generic / Web3 |
+| Available to you | No | Yes | Yes | Yes |
+
+For a fan project, club community, or fantasy-league app, a matching `.com` remains the safest default; [.io](/en/tld/io/) suits app-style products; and [.xyz](/en/tld/xyz/) is a flexible, low-cost modern option.
+
+## Reputation and trust
+
+Ironically, the closed nature of `.afl` is exactly what makes it trustworthy: because only the League can create these addresses, a `.afl` link is verifiably official, which is why brand TLDs are considered strong against impersonation and email spoofing — a genuine benefit against ticket and merchandise scams that target fans. That trust, however, benefits the AFL alone — it does not transfer to any fan or club name you might register, since you cannot register one. For your own project, deliverability and reputation will come from a well-configured domain on an open extension, not from a brand TLD you don't control.
+
+## Looking for an "afl" name? Register an alternative at Namefi
+
+You can't buy a `.afl` domain, but if you want a short name for your own football-related project, you can secure it on an open extension in minutes:
+
+1. **Search** your desired name across open TLDs like `.com`, `.io`, or `.xyz`.
+2. **Choose** the extension that fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can anyone register a .afl domain?
+
+No. `.afl` is a closed brand TLD delegated to the Australian Football League. Only the AFL and parties it authorizes can hold a `.afl` name, so it is not available to the general public through any registrar.
+
+### Who operates the .afl registry?
+
+The Australian Football League is the registry operator, with CSC providing the technical back-end. The TLD was delegated to the DNS root zone on February 19, 2015, under ICANN's New gTLD Program.
+
+### What does AFL stand for?
+
+AFL stands for Australian Football League, the top professional competition in Australian-rules football. The `.afl` domain is reserved for the League's own use, not for clubs, fans, or fantasy-league sites generally.
+
+### What can I register instead of .afl?
+
+Because `.afl` is closed, choose an open extension for your own project. A matching `.com`, or a modern alternative like `.io` or `.xyz`, can be registered by anyone through an accredited registrar such as Namefi.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals behind top-level domains.
+- [How a TLD affects domain value](/en/blog/how-tld-affects-domain-value/) — why the extension matters.
+- [.com TLD guide](/en/tld/com/) — the open default to compare against.
+- [.io TLD guide](/en/tld/io/) and [.xyz TLD guide](/en/tld/xyz/) — modern open alternatives.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [registry](/en/glossary/registry/), [ICANN](/en/glossary/icann/).

--- a/content/tld/en/africa.md
+++ b/content/tld/en/africa.md
@@ -1,31 +1,22 @@
 ---
-title: 'Unlocking the Continent: What is the .africa TLD and Why Choose It?'
-date: '2025-12-10'
+title: 'What Is the .africa Domain? A Pan-African gTLD'
+date: '2026-07-24'
 language: 'en'
-tags:
-  - 'tld'
-authors:
-  - 'namefiteam'
-editors:
-  - victor-zhou
+tags: ['tld']
+authors: ['namefiteam']
+editors: ['victor-zhou']
 draft: false
-description: 'Discover the potential of the .africa domain. Learn how this TLD connects businesses to the African digital economy and why you should register it at Namefi.'
-keywords:
-  - '.africa domains'
-  - '.africa TLD'
-  - '.africa top-level domain'
-  - 'what is .africa'
-  - 'why choose .africa'
-  - 'what is the .africa domain'
-  - 'why choose the .africa domain'
-  - 'pan-African digital identity'
-  - 'investing in African domains'
-  - 'domain investing Africa'
-  - 'blockchain domains Africa'
-  - 'tokenized .africa domains'
-  - 'buy .africa domain'
-  - 'African tech startup branding'
-  - 'Namefi .africa registration'
+description: 'The .africa domain is a geographic gTLD representing the whole African continent. Learn who operates it, who can register, and how it fits pan-African branding.'
+keywords: ['.africa domains', '.africa TLD', 'what is .africa', 'pan-African domain name', 'geographic gTLD', 'African continent domain', 'Registry Africa', 'African business domain']
+faqs:
+  - question: 'Can anyone register a .africa domain?'
+    answer: 'Registration is broadly open but expects a connection to Africa. The registry has kept eligibility broad rather than narrowly gatekept, and the namespace has been adopted continent-wide by businesses, governments, media, and pan-African organizations.'
+  - question: 'Does a .africa domain affect SEO?'
+    answer: 'As a geographic gTLD, .africa carries a built-in continental signal. Site owners can add explicit geotargeting in tools such as Google Search Console to reinforce it. Beyond that, normal ranking factors like content and links still decide where a site ranks.'
+  - question: 'Who operates the .africa registry?'
+    answer: 'The .africa registry is operated by ZA Central Registry NPC, trading as Registry.Africa, with DNS Africa Ltd providing the technical back-end. It was delegated to the DNS root zone on February 11, 2017.'
+  - question: 'Who should register a .africa domain?'
+    answer: 'Businesses operating across multiple African countries, governments, media organizations, and pan-African associations. It suits anyone who wants one continent-wide address instead of managing separate country-code domains.'
 relatedArticles:
   - /en/blog/ai-vs-io-domain/
   - /en/blog/what-is-a-tld/
@@ -46,51 +37,134 @@ relatedGlossary:
   - /en/glossary/web3/
 ---
 
-## **What is .africa?**
+The **.africa** domain is a geographic [new gTLD](/en/glossary/new-gtld/) built to represent an entire continent rather than a single country. Where a business operating across several African nations would otherwise juggle separate [ccTLDs](/en/glossary/cctld/), such as `.za` for South Africa or `.ng` for Nigeria, `.africa` offers one shared address for a pan-African identity. Registration is broadly open, with an expectation of a genuine connection to Africa rather than a strict, hard-gated eligibility check.
 
-The **.africa** domain is a geographic [Top-Level Domain (geoTLD)](/en/glossary/tld/) specifically designed to represent the African continent. Unlike country-code TLDs (ccTLDs) such as `.za` for South Africa or `.ng` for Nigeria, which are tied to specific nations, **.africa** serves as a unified digital identity for all 54 countries within the continent.
+This guide covers what `.africa` is, who runs it, who can register one, how pricing works, and how it holds up for SEO, reputation, and email, so you can decide whether it fits your organization.
 
-Launched to the general public in 2017, the initiative was championed by the African Union to provide the continent with a distinct online presence. It is administered by the [Registry Africa (ZACR)](https://www.registry.africa/), ensuring that the domain remains a secure and reliable space for digital innovation.
+## .africa at a glance
 
-Today, .africa is more than just a web suffix; it is a symbol of the "Digital Renaissance" happening across the continent. It allows individuals and corporations to associate their products, services, and personal brands with the dynamism and growth of the African market.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Geographic new gTLD |
+| Registry operator | ZA Central Registry NPC, trading as Registry.Africa (technical back-end: DNS Africa Ltd) |
+| Year delegated | 2017 (delegated to the root zone on February 11, 2017) |
+| IDN support | Supported (varies by registrar) |
+| DNSSEC | Supported |
+| Registration restrictions | Broadly open — registrants are expected to have a connection to Africa |
+| Best for | Businesses, governments, media organizations, and pan-African associations |
 
-## **How People Are Using .africa**
+## What is .africa?
 
-As internet penetration rates across Africa continue to soar, the usage of the .africa TLD has diversified. It is currently being utilized by a wide array of sectors looking to establish a pan-African footprint:
+"Africa" names the continent itself, and as a domain suffix it works as a single shared identity for anything connected to it, a deliberate contrast to the dozens of individual country-code domains (`.za`, `.ng`, `.ke`, and the rest) that otherwise divide the continent's namespace by border. According to its [IANA root-zone entry](https://www.iana.org/domains/root/db/africa.html), `.africa` was delegated to the DNS [root zone](/en/glossary/root-zone/) on February 11, 2017, as part of ICANN's New gTLD Program.
 
-*   **Multinational Corporations:** Companies that operate in multiple African countries use the domain to consolidate their regional marketing under one umbrella (e.g., `brandname.africa` rather than managing 10 different country codes).
-*   **Tech Startups:** The "Silicon Savannah" and other tech hubs use .africa to signal that their innovative solutions—be it Fintech, Agritech, or Healthtech—are scalable across the continent.
-*   **Tourism and Travel:** Travel agencies and tour operators use the extension to market cross-border tourism packages and safaris.
-*   **NGOs and Non-Profits:** Humanitarian organizations use the TLD to highlight their continental reach and commitment to African development.
-*   **Cultural Portfolios:** Artists, musicians, and designers use it to showcase African creativity to a global audience.
+The [registry](/en/glossary/registry/) is operated by **ZA Central Registry NPC**, trading as **Registry.Africa**, with **DNS Africa Ltd** running the technical back-end. Operator information is published at [nic.africa](https://nic.africa).
 
-## **Notable Entities Using .africa**
+Because `.africa` is a **geographic** [gTLD](/en/glossary/gtld/) rather than a country-specific [ccTLD](/en/glossary/cctld/), it isn't tied to any one nation's policy. Search engines don't automatically geo-lock every gTLD, but since `.africa` is explicitly geographic, site owners can set continent-level geotargeting in tools like Google Search Console to reinforce the signal the name already carries.
 
-While many global giants protect their intellectual property by registering their names across all TLDs, .africa has seen adoption by organizations specifically focused on the continent's growth.
+## History of .africa
 
-*   **The African Union (AU):** As the primary backer of the TLD, the African Union and its affiliated bodies heavily promote its usage to foster digital unity.
-*   **Startups and SME Hubs:** Many incubators have adopted the TLD to represent the collective ecosystem of African innovation.
-*   **Registry Africa:** The registry itself operates on [registry.africa](https://www.registry.africa/), setting the standard for the domain's technical implementation.
-*   **Pan-African Banks:** Several financial institutions have secured .africa domains to facilitate the growing trend of cross-border digital banking and the [African Continental Free Trade Area (AfCFTA)](https://au.int/en/cfta) initiatives.
+`.africa` emerged from ICANN's 2012-round New gTLD Program as one of the relatively few **continental**, rather than national, geographic strings. It was delegated to the root zone on **February 11, 2017**.
 
-## **Why Choose .africa?**
+The registry contract is held by **ZA Central Registry NPC**, operating the namespace commercially as **Registry.Africa**, with **DNS Africa Ltd** handling the technical infrastructure that keeps the TLD resolving. Since delegation, the registry has positioned `.africa` as shared digital infrastructure for the continent rather than any single country's property.
 
-Choosing the right [domain extension](/en/blog/what-is-a-tld/) is critical for your brand's digital strategy. Here is why .africa is a compelling choice for investors and businesses alike:
+## How people use .africa
 
-*   **Geographic Authority and Trust:** Using .africa immediately signals to your audience that your business is relevant to the continent. It builds trust with local consumers who prefer engaging with regionally committed brands.
-*   **Superior Availability:** Compared to the overcrowded [.com](/en/tld/com/) or [.net](/en/tld/net/) spaces, .africa is relatively new. This means there is a much higher chance of securing short, memorable, and premium [keyword domain](/en/glossary/keyword-domain/) names that would otherwise be unavailable or prohibitively expensive.
-*   **SEO Benefits:** For businesses targeting the African market, using this TLD can send strong signals to search engines regarding your geographic relevance, potentially helping you rank higher in local search results.
-*   **Unified Branding:** It eliminates the administrative nightmare and cost of registering separate domains for every African country you operate in. One domain covers the entire continent.
-*   **Investment Potential:** As the African digital economy grows, the value of premium .africa domains is expected to rise. Securing a strong name now is a strategic move for domain investors.
+`.africa` has genuinely been adopted across the continent, spanning a few consistent categories:
 
-## **Register Your .africa Domain at Namefi**
+- **Businesses** operating in multiple African countries, using one `.africa` address instead of maintaining a separate ccTLD per market.
+- **Governments** and government-linked bodies using the suffix for continent-facing initiatives.
+- **Media organizations** publishing content aimed at a pan-African audience.
+- **Pan-African organizations and associations** whose mandate spans the continent rather than one country.
 
-Whether you are a developer building the next big Fintech dApp for Africa, or a business expanding your reach from Cairo to Cape Town, securing your .africa domain is the first step toward digital success.
+**Who it's not ideal for:** a business serving only a single African country, which may get a stronger local-SEO signal from that country's own ccTLD, or any brand with no African connection at all, since the name's entire value comes from that association.
 
-At **Namefi**, we make [domain ownership](/en/glossary/domain-ownership/) seamless and future-proof.
-*   **[ICANN](/en/glossary/icann/) Accredited:** We provide secure, compliant registration services.
-*   **[Web3](/en/glossary/web3/) Integrated:** Namefi allows you to [tokenize](/en/glossary/tokenize/) your domains. You can manage your .africa domain as an NFT, enabling easy transfer, collateralization, and integration into the blockchain ecosystem.
+## Notable sites using .africa
 
-Don't wait until the best names are taken. Establish your presence in one of the world's fastest-growing digital markets today.
+Adoption of `.africa` spans businesses, governments, media outlets, and pan-African organizations working across the continent, rather than concentrating around one flagship address. That spread reflects the TLD's purpose: it exists to give continent-facing entities a shared home, not to crown a single dominant site. Rather than point to one name that could change hands, it is more accurate to describe the pattern: organizations whose work or audience spans multiple African countries choosing one address over several separate ccTLDs.
 
-**[Register your .africa domain at Namefi](https://namefi.io)**
+## .africa vs other domains
+
+| Feature | .africa | [.com](/en/tld/com) | .za / .ng (national ccTLDs) | [.xyz](/en/tld/xyz) |
+| --- | --- | --- | --- | --- |
+| Type | Geographic new gTLD (continental) | Legacy gTLD | Country-code TLD | New gTLD (generic) |
+| Restrictions | Broadly open, African nexus expected | Open to all | Set by each country | Open to all |
+| Geographic scope | Whole continent | None | One country | None |
+| Best fit | Pan-African businesses and organizations | Any brand, anywhere | Single-country presence | Generic or Web3-native brands |
+
+Choose `.com` when you want the broadest global reach with no geographic association. Choose a national ccTLD like `.za` or `.ng` when your business serves one country specifically and local search relevance there matters most. Choose a generic new gTLD like [`.xyz`](/en/tld/xyz) when geography should play no role at all. Choose `.africa` when your audience or operations span the continent and you want one address instead of many.
+
+## Why choose .africa?
+
+- **One address, many countries.** `.africa` replaces the need to register and manage a separate ccTLD in every African market you operate in.
+- **Genuine continent-wide adoption.** Businesses, governments, media, and pan-African organizations across Africa already use the suffix, so it reads as an established choice rather than a novelty.
+- **Availability.** As a newer namespace than `.com`, short and descriptive `.africa` names are easier to find.
+- **Clear positioning.** The name states a pan-African scope at a glance, useful for any brand whose story is continental rather than local.
+
+## Things to consider
+
+- **It still implies a connection.** `.africa` is broadly open, but it carries an expectation of an African connection; it isn't a placeless brand name.
+- **Lower general recognition than .com.** Outside Africa-focused contexts, `.africa` is less familiar than legacy extensions.
+- **Continental, not local.** For a business that only serves one city or country, a national ccTLD may carry a stronger local-search signal than a continent-wide suffix.
+
+## Who can register a .africa domain?
+
+**Registration restrictions: broadly open.** `.africa` is not narrowly gatekept, but registrants are expected to have some connection to Africa. In practice, the registry, **ZA Central Registry NPC**, trading as **Registry.Africa**, has kept eligibility broad, and the namespace has been genuinely adopted across the continent by businesses, governments, media organizations, and pan-African bodies rather than restricted to a small approved list.
+
+Current eligibility rules and application details are published by the operator at [nic.africa](https://nic.africa). The authoritative technical record is the [IANA root-zone entry](https://www.iana.org/domains/root/db/africa.html); as a live [ICANN](/en/glossary/icann/) new gTLD, the underlying contract also appears in ICANN's [registry agreements database](https://www.icann.org/en/registry-agreements/details/africa).
+
+## .africa pricing and value
+
+`.africa` pricing follows patterns common to geographic new gTLDs:
+
+- **Broad eligibility doesn't mean uniform pricing.** Registrars may price differently based on demand for a given name.
+- **First-year and renewal pricing can differ.** Check the standard renewal rate before committing, not just an introductory offer.
+- **Cost drivers** include the registrar you choose and any premium classification the registry applies to high-demand names.
+
+This page intentionally quotes no figures, since prices and promotions change across registrars and over time.
+
+## Reputation and email deliverability
+
+`.africa`'s reputation benefits from genuine, visible adoption: businesses, governments, media, and pan-African organizations actually use it for real operations, a different profile from extensions known mainly for cheap bulk registration. That real-world use pattern works against a spammy or throwaway perception.
+
+Deliverability still comes down mainly to configuration rather than the suffix. Set up correct **SPF, DKIM, and DMARC** records, warm up new sending domains gradually, and maintain good list hygiene. A properly authenticated `.africa` sender should deliver mail as reliably as any other gTLD.
+
+## Branding and naming tips
+
+- **Lead with continental scope.** `.africa` works best when your name or message is explicitly pan-African, such as `trade.africa` or `startups.africa`, rather than tied to one city.
+- **Keep the left side short**, since the suffix already communicates scope and meaning.
+- **Check country-specific alternatives first.** If your business is genuinely single-country, compare against that country's ccTLD before committing to a continental suffix.
+- **Pair defensively where it matters.** Organizations active in a specific African market may want to hold both `.africa` and that country's ccTLD.
+
+## How to register a .africa domain at Namefi
+
+1. **Search** for your desired name on [Namefi](https://namefi.io) to check availability.
+2. **Choose** the `.africa` name that fits your business, initiative, or organization.
+3. **Register** and configure DNS. Namefi provides fast, reliable DNS management.
+
+Namefi is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) with transparent pricing, and it supports [Web3](/en/glossary/web3/) tokenization, so you can optionally [tokenize](/en/glossary/tokenize/) your domain for easier transfer and on-chain management. [Search and register your .africa domain at Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .africa domain?
+
+Registration is broadly open but expects a connection to Africa. The registry has kept eligibility broad rather than narrowly gatekept, and the namespace has been adopted continent-wide by businesses, governments, media, and pan-African organizations.
+
+### Does a .africa domain affect SEO?
+
+As a geographic gTLD, `.africa` carries a built-in continental signal. Site owners can add explicit geotargeting in tools such as Google Search Console to reinforce it. Beyond that, normal ranking factors like content and links still decide where a site ranks.
+
+### Who operates the .africa registry?
+
+The `.africa` registry is operated by ZA Central Registry NPC, trading as Registry.Africa, with DNS Africa Ltd providing the technical back-end. It was delegated to the DNS root zone on February 11, 2017.
+
+### Who should register a .africa domain?
+
+Businesses operating across multiple African countries, governments, media organizations, and pan-African associations. It suits anyone who wants one continent-wide address instead of managing separate country-code domains.
+
+## Related resources
+
+- [.com domain](/en/tld/com) — the legacy benchmark with no geographic tie.
+- [.xyz domain](/en/tld/xyz) — a generic new gTLD alternative with no nexus expectation.
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals of top-level domains.
+- [AI vs .io domain](/en/blog/ai-vs-io-domain/) — a look at how newer gTLDs get chosen.
+- [Glossary: registry](/en/glossary/registry/), [registrar](/en/glossary/registrar/), [ICANN](/en/glossary/icann/), and [Web3](/en/glossary/web3/).

--- a/content/tld/en/africa.md
+++ b/content/tld/en/africa.md
@@ -3,7 +3,7 @@ title: 'What Is the .africa Domain? A Pan-African gTLD'
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .africa domain is a geographic gTLD representing the whole African continent. Learn who operates it, who can register, and how it fits pan-African branding.'

--- a/content/tld/en/ag.md
+++ b/content/tld/en/ag.md
@@ -3,7 +3,7 @@ title: "What Is the .ag Domain? Antigua and Barbuda's Global ccTLD"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'What is the .ag domain? Antigua and Barbuda''s open ccTLD, known for German AG corporate branding and domain hacks. Manager, eligibility, and pricing.'

--- a/content/tld/en/ag.md
+++ b/content/tld/en/ag.md
@@ -1,13 +1,22 @@
 ---
-title: 'Unlock the Potential of .ag: What is the .ag TLD and Why Choose It?'
-date: '2025-12-10'
+title: "What Is the .ag Domain? Antigua and Barbuda's Global ccTLD"
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: 'Discover the versatility of the .ag domain. From Antigua and Barbuda to German corporations (Aktiengesellschaft) and AgTech, learn why .ag is a smart choice for your next web address.'
-keywords: ['.ag domains', '.ag TLD', '.ag top-level domain', 'what is .ag', 'why choose .ag', 'what is the .ag domain', 'why choose the .ag domain', 'Antigua and Barbuda domain', 'German AG companies', 'Aktiengesellschaft domain', 'AgTech domains', 'silver investment domains', 'domain investing', 'tokenized domains', 'blockchain domains']
+description: 'What is the .ag domain? Antigua and Barbuda''s open ccTLD, known for German AG corporate branding and domain hacks. Manager, eligibility, and pricing.'
+keywords: ['.ag domain', '.ag TLD', 'what is .ag', 'Antigua and Barbuda domain', 'Aktiengesellschaft domain', 'agriculture domain extension', 'domain hack TLDs', 'register .ag domain']
+faqs:
+  - question: 'Can anyone register a .ag domain?'
+    answer: 'Yes. .ag is Antigua and Barbuda''s ccTLD, but it has been open to registrants worldwide for years, with no local-presence requirement. Registration is first-come, first-served through any participating registrar.'
+  - question: 'Does a .ag domain affect SEO?'
+    answer: 'No, not inherently. Google lists .ag among the ccTLDs it treats as generic rather than geo-targeted, so a .ag site is not confined to Antigua and Barbuda search results and can rank for a global audience.'
+  - question: 'Why do German companies use .ag domains?'
+    answer: 'In Germany, Austria, and Switzerland, "AG" is the abbreviation for Aktiengesellschaft, meaning a public stock corporation. That linguistic overlap with Antigua and Barbuda''s country code has made .ag a recognizable extension for German-market corporate branding.'
+  - question: 'Who should register a .ag domain?'
+    answer: 'Businesses incorporated as an Aktiengesellschaft in German-speaking markets, agriculture and AgTech ventures, and anyone building a domain hack around a word ending in "ag." It is open to registrants worldwide.'
 relatedArticles:
   - /en/blog/top-tlds-to-secure-for-your-business/
   - /en/blog/top-tlds-to-secure-for-your-accounting-firm/
@@ -28,55 +37,131 @@ relatedGlossary:
   - /en/glossary/web3/
 ---
 
-## **What is .ag?**
+The **.ag** domain is the [ccTLD](/en/glossary/cctld/) for **Antigua and Barbuda**, and it has become one of the more versatile two-letter extensions on the market: open to anyone worldwide, and carrying a built-in meaning for German-speaking business markets, where "AG" is the standard abbreviation for a stock corporation. Add in a natural fit for agriculture-related branding and a domain-hack ending, and .ag serves several distinct audiences at once.
 
-The **.ag** [domain extension](/en/blog/what-is-a-tld/) is the country code [Top-Level Domain (ccTLD)](/en/glossary/tld/) officially assigned to **Antigua and Barbuda**, a twin-island country in the Americas. Managed by the University of Health Sciences Antigua via Nic.ag, it was originally created to serve entities connected to this Caribbean nation.
+This guide covers what .ag really is, who runs it, who can register one, how it is priced, and how it is perceived for SEO and email.
 
-However, like many versatile ccTLDs, the intended purpose of .ag has expanded significantly beyond its geographic borders. The domain has found a unique and high-value niche in the global market due to two linguistic coincidences:
+## .ag at a glance
 
-1.  **Corporate Status:** In German-speaking countries (Germany, Austria, Switzerland), "AG" stands for *Aktiengesellschaft*, which translates to "stock corporation" or "public limited company."
-2.  **Science and Commodities:** In the periodic table of elements, **Ag** is the symbol for Silver (Argentum).
-3.  **Agriculture:** It is widely used as an abbreviation for the agricultural industry ("Ag").
+| Fact | Detail |
+| --- | --- |
+| TLD type | Country-code TLD (ccTLD) for Antigua and Barbuda |
+| Registry operator | UHSA School of Medicine, operating as nic.ag |
+| Year delegated | 1991 (September 3) |
+| Registration restrictions | Open to all — no local presence required |
+| Google treatment | Listed among the ccTLDs Google treats as generic, not geo-targeted |
+| Best for | German-market corporate branding, agriculture/AgTech, and domain-hack names |
 
-Because of these associations, .ag has become a sought-after digital asset for major corporations, commodity traders, and agricultural tech startups. You can verify the delegation details on the [IANA .ag Delegation Record](https://www.iana.org/domains/root/db/ag.html).
+## What is .ag?
 
-## **How People Are Using .ag**
+**.ag** is the country-code [Top-Level Domain](/en/glossary/tld/) assigned under the ISO 3166-1 system to **Antigua and Barbuda**, listed by [IANA](https://www.iana.org/domains/root/db/ag.html) with the **UHSA School of Medicine** as the registry manager, operating through [nic.ag](https://www.nic.ag/).
 
-The usage of .ag is incredibly diverse, bridging the gap between tropical tourism and serious corporate finance. Here is how different sectors are utilizing this TLD:
+.ag has been run as an **open registry** with no local-presence requirement, and that openness combined with a linguistic coincidence has driven most of its adoption outside Antigua and Barbuda: in Germany, Austria, and Switzerland, "AG" is the standard abbreviation for *Aktiengesellschaft*, a public stock corporation. The letters also read naturally as short for "agriculture." Google includes .ag on its list of ccTLDs it [treats as generic rather than country-specific](https://developers.google.com/search/docs/crawling-indexing/manage-international-sites), so a .ag site is not tied to Antigua and Barbuda search results.
 
-*   **German-Speaking Corporations:** Large companies in the DACH region utilize .ag to denote their legal corporate status online (e.g., `CompanyName.ag`), signaling trust and stability to investors.
-*   **The Agriculture Industry (AgTech):** Startups and established companies in farming, sustainability, and food technology use .ag as a short, relevant industry identifier.
-*   **Silver and Mining Traders:** Jewelry designers, silver miners, and commodity trading platforms use the domain due to the chemical symbol association.
-*   **[Domain Hacks](/en/blog/domain-hacks-explained/):** Creative brands use it to finish words ending in "ag," such as `sw.ag`, `br.ag`, or `b.ag`.
-*   **Local Businesses:** Tourism operators, hotels, and local services within Antigua and Barbuda use it to highlight their local presence.
+## History of .ag
 
-## **Notable Entities Using .ag**
+The .ag ccTLD was delegated on **September 3, 1991**. It is managed by the **UHSA School of Medicine**, which operates the registry through nic.ag as an open, worldwide namespace rather than restricting registration to local entities.
 
-While many domains are held privately for brand protection, several high-profile entities and industries utilize the .ag extension effectively:
+## How people use .ag
 
-*   **Volkswagen:** The automotive giant has utilized `volkswagen.ag` for corporate communications, aligning with its status as an *Aktiengesellschaft*.
-*   **Mercedes-Benz:** Similarly, `mercedes-benz.ag` is often secured to protect the corporate identity of the group.
-*   **Siemens:** Major industrial manufacturing companies secure their exact corporate match to prevent [phishing](/en/glossary/phishing/) and maintain brand authority.
-*   **Süddeutsche Zeitung:** One of Germany's largest daily newspapers uses `sz-magazin.ag` for specific digital properties.
+Because of its open registration policy and the German corporate meaning of the letters, .ag draws a mix of registrants:
 
-*Note: Many of these domains are used for corporate reporting sites or redirected to primary [.com](/en/tld/com/) or .de domains to capture traffic.*
+- **German-market corporate branding.** Businesses incorporated as an *Aktiengesellschaft* in Germany, Austria, or Switzerland use .ag to signal that legal status directly in the domain.
+- **Agriculture and AgTech.** The letters read naturally as short for "agriculture," making the extension a fit for farming, food-tech, and sustainability projects.
+- **[Domain hacks](/en/blog/domain-hacks-explained/).** Words ending in "ag" (as in *swag*, *brag*, or *drag*) can be completed cleanly by the extension.
 
-## **Why Choose .ag?**
+**Who it's not ideal for:** brands with no German-market, agriculture, or wordplay angle, where none of .ag's built-in associations add anything, or buyers who need the absolute cheapest possible extension regardless of desirability tier.
 
-If you are debating which extension to choose for your next project, .ag offers several compelling advantages:
+## Notable sites using .ag
 
-*   **Instant Corporate Credibility:** For businesses targeting Germany, Austria, or Switzerland, having a .ag domain immediately identifies you as a serious, incorporated entity (*Aktiengesellschaft*).
-*   **Short and Memorable:** Two-letter domains are snappy and easy to type.
-*   **Keyword Relevance:** If you are in the **Ag**riculture sector or the Silver market, this TLD acts as a built-in keyword, potentially aiding in niche SEO efforts.
-*   **Availability:** While premium one-word .com domains are often taken or prohibitively expensive, you may find excellent, short brandable names available in the .ag namespace.
-*   **Safe and Stable:** The [registry](/en/glossary/registry/) is well-established, ensuring a stable environment for your digital identity.
+We have no pre-verified examples to cite here. In practice, the open registration policy and the *Aktiengesellschaft* association mean .ag registrations skew toward German-market corporate names, agriculture and AgTech projects, and domain-hack brands completing a word ending in "ag," rather than toward one dominant, widely recognized site.
 
-## **Register Your .ag Domain at Namefi**
+## .ag vs other domains
 
-Whether you are launching a cutting-edge AgTech startup, incorporating a business in the DACH region, or simply want a short, memorable web address, the .ag TLD is a powerful choice.
+| Feature | .ag | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.co](/en/tld/co/) |
+| --- | --- | --- | --- | --- |
+| Type | ccTLD (used globally) | Legacy gTLD | ccTLD (used globally) | ccTLD (used globally) |
+| Core association | German corporate status, agriculture, domain hacks | The default web standard | Tech / "Input-Output" | Generic, short alternative to .com |
+| Registration eligibility | Open worldwide | Open worldwide | Open worldwide | Open worldwide |
+| Availability of short names | Better than .com | Very poor | Moderate | Poor |
 
-At **Namefi**, we make managing your digital assets easier than ever. We combine the reliability of traditional [ICANN](/en/glossary/icann/)-accredited registration with the innovation of [Web3](/en/glossary/web3/). When you register with us, you enjoy seamless management, transparent pricing, and the ability to [tokenize](/en/glossary/tokenize/) your domain for easier transfers and enhanced security.
+Choose **.com** when the exact name is available — it remains the default for most audiences. Reach for **.ag** when a German corporate identity, an agriculture angle, or a domain hack ending in "ag" fits your brand. **[.io](/en/tld/io/)** suits developer- and infrastructure-focused tech brands, and **[.co](/en/tld/co/)** works as a generic short alternative with no thematic association.
 
-**Ready to secure your digital identity?**
+## Why choose .ag?
 
-[**Register your .ag domain at Namefi today**](https://namefi.io) and join the future of [domain ownership](/en/glossary/domain-ownership/).
+- **Open worldwide.** No local-presence requirement, unlike many other ccTLDs.
+- **Built-in corporate meaning.** Reads instantly as *Aktiengesellschaft* for German-speaking business audiences.
+- **Agriculture fit.** A natural short form for farming and AgTech branding.
+- **Domain-hack potential.** Words ending in "ag" complete cleanly with the extension.
+
+## Things to consider
+
+- **A ccTLD by nature.** Because .ag technically belongs to Antigua and Barbuda, its long-term rules are set by the UHSA School of Medicine under national policy, not by an [ICANN](/en/glossary/icann/) registry agreement.
+- **Mixed audiences share the namespace.** Corporate, agricultural, and domain-hack registrants all use .ag for different reasons, so the extension carries no single dominant connotation.
+- **No marquee example.** There is no single, widely recognized site anchoring .ag the way some extensions have a famous flagship adopter.
+
+## Who can register a .ag domain?
+
+**Registration restrictions: open to all.** There is **no local-presence or Antigua and Barbuda residency requirement** to register a second-level .ag domain. Registration is available to individuals and organizations anywhere in the world through any participating [registrar](/en/glossary/registrar/), on a first-come, first-served basis.
+
+Because .ag is a ccTLD, it is governed by Antigua and Barbuda's registry policy rather than an ICANN registry agreement. The authoritative sources for current management details are the [IANA root-zone entry](https://www.iana.org/domains/root/db/ag.html) and the registry's own site, [nic.ag](https://www.nic.ag/).
+
+## .ag pricing and value
+
+This page intentionally quotes no numbers, but a few dynamics are worth knowing:
+
+- **Premium classification is common across ccTLDs.** Check whether your specific name carries a premium price before assuming a standard rate applies.
+- **First-year vs. renewal pricing can differ.** As with most TLDs, confirm the standard renewal rate rather than assuming an introductory rate continues.
+- **What drives cost.** Name length, corporate or agricultural keyword relevance, and registry [wholesale pricing](/en/glossary/wholesale-pricing/) are the main factors shaping cost.
+
+For exact, current figures, check live pricing at registration time.
+
+## Reputation and email deliverability
+
+We are not aware of .ag carrying any negative bulk-mail or spam reputation. As with any TLD, email deliverability depends far more on **sending reputation, SPF/DKIM/DMARC authentication, and list hygiene** than on the suffix itself. A properly authenticated .ag sender should reach inboxes normally.
+
+The main practical caveat is fit: a business with no German-market, agriculture, or wordplay connection may find a .ag email address reads as unexpected to some recipients.
+
+## Branding and naming tips
+
+- **Lean into the corporate cue for German markets.** If your business is an *Aktiengesellschaft*, .ag states that plainly.
+- **Use the agriculture association if relevant.** Farming and AgTech brands get a built-in keyword fit.
+- **Try a domain hack.** Look for a word ending in "ag" that your brand name can complete naturally.
+- **Check premium status first.** Confirm classification and renewal pricing before settling on a name.
+
+## How to register a .ag domain at Namefi
+
+1. **Search** for your desired name and the .ag extension.
+2. **Choose** an available name and confirm whether it is classified as premium.
+3. **Register** and configure DNS.
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for easier transfer and provable ownership.
+
+## Frequently asked questions
+
+### Can anyone register a .ag domain?
+
+Yes. .ag is Antigua and Barbuda's ccTLD, but it has been open to registrants worldwide for years, with no local-presence requirement. Registration is first-come, first-served through any participating registrar.
+
+### Does a .ag domain affect SEO?
+
+No, not inherently. Google lists .ag among the ccTLDs it treats as generic rather than geo-targeted, so a .ag site is not confined to Antigua and Barbuda search results and can rank for a global audience.
+
+### Why do German companies use .ag domains?
+
+In Germany, Austria, and Switzerland, "AG" is the abbreviation for Aktiengesellschaft, meaning a public stock corporation. That linguistic overlap with Antigua and Barbuda's country code has made .ag a recognizable extension for German-market corporate branding.
+
+### Who should register a .ag domain?
+
+Businesses incorporated as an Aktiengesellschaft in German-speaking markets, agriculture and AgTech ventures, and anyone building a domain hack around a word ending in "ag." It is open to registrants worldwide.
+
+## Related resources
+
+- [.com TLD guide](/en/tld/com/)
+- [.io TLD guide](/en/tld/io/)
+- [.co TLD guide](/en/tld/co/)
+- [What is a TLD?](/en/blog/what-is-a-tld/)
+- [Domain hacks explained](/en/blog/domain-hacks-explained/)
+- [Glossary: registrar](/en/glossary/registrar/)
+- [Glossary: ICANN](/en/glossary/icann/)
+- [Glossary: ccTLD](/en/glossary/cctld/)

--- a/content/tld/en/agakhan.md
+++ b/content/tld/en/agakhan.md
@@ -3,7 +3,7 @@ title: "What Is .agakhan? The Aga Khan Foundation's Brand TLD"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .agakhan domain is the closed brand TLD of the Aga Khan Foundation, not open to the public. Learn what it is, who runs it, and what to register instead.'

--- a/content/tld/en/agakhan.md
+++ b/content/tld/en/agakhan.md
@@ -1,13 +1,22 @@
 ---
-title: 'What is the .agakhan TLD and Why is it Significant?'
-date: '2025-12-10'
+title: "What Is .agakhan? The Aga Khan Foundation's Brand TLD"
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: 'Discover the purpose of the .agakhan TLD, a unique domain extension for the AKDN. Learn about Brand TLDs, digital trust, and domain identity.'
-keywords: ['.agakhan domains', '.agakhan TLD', 'top-level domain', 'what is .agakhan', 'why choose .agakhan', 'what is the .agakhan domain', 'why choose the .agakhan domain', 'brand TLD', 'Aga Khan Development Network', 'domain investing', 'blockchain domains', 'tokenized domain', 'digital identity', 'secure domains', 'NGO domains']
+description: 'The .agakhan domain is the closed brand TLD of the Aga Khan Foundation, not open to the public. Learn what it is, who runs it, and what to register instead.'
+keywords: ['.agakhan domain', 'what is .agakhan', '.agakhan TLD', 'Aga Khan Foundation domain', 'Fondation Aga Khan', 'dot-brand TLD', 'closed generic TLD', 'is .agakhan available']
+faqs:
+  - question: 'Can anyone register a .agakhan domain?'
+    answer: 'No. .agakhan is a closed brand TLD delegated to Fondation Aga Khan, the Aga Khan Foundation. Only the Foundation and parties it authorizes can hold a .agakhan name, so it is not available to the general public through any registrar.'
+  - question: 'Who operates the .agakhan registry?'
+    answer: 'Fondation Aga Khan, the Aga Khan Foundation, is the registry operator, with Afilias providing the technical back-end. The TLD was delegated to the DNS root zone on March 31, 2016, under ICANN''s New gTLD Program.'
+  - question: 'What is the Aga Khan Foundation?'
+    answer: 'The Aga Khan Foundation is a non-profit international development organization. Its .agakhan domain is reserved for its own use and is separate from the similarly named .akdn TLD held by the wider Aga Khan Development Network.'
+  - question: 'What can I register instead of .agakhan?'
+    answer: 'Because .agakhan is closed, choose an open extension for your own project. A matching .com, or a modern alternative like .io or .xyz, can be registered by anyone through an accredited registrar such as Namefi.'
 relatedArticles:
   - /en/blog/top-tlds-to-secure-for-your-accounting-firm/
   - /en/blog/what-is-a-tld/
@@ -28,53 +37,115 @@ relatedGlossary:
   - /en/glossary/registrar/
 ---
 
-## **What is .agakhan?**
+The **.agakhan** domain is a **closed brand [top-level domain](/en/glossary/tld/)** operated by **Fondation Aga Khan**, known publicly as the **Aga Khan Foundation**, a non-profit international development organization. It is not a public extension: unlike [.com](/en/tld/com/) or [.io](/en/tld/io/), you cannot register a `.agakhan` name for your own project, because the entire namespace belongs to the Foundation.
 
-The **.agakhan** extension is a unique and specialized generic [Top-Level Domain (gTLD)](/en/glossary/tld/). Unlike standard open domains like [.com](/en/tld/com/) or [.net](/en/tld/net/), **.agakhan** falls under the category of a **Brand TLD** (or registry-closed TLD). It was established to serve the specific digital infrastructure needs of the **Aga Khan Development Network (AKDN)** and its associated agencies.
+If you searched for the ".agakhan domain" hoping to buy one, the short answer is that you can't — but this page explains what `.agakhan` is, who controls it, why a non-profit runs its own TLD, and what you can register instead.
 
-Delegated through the Internet Corporation for Assigned Names and Numbers ([ICANN](/en/glossary/icann/)) [New gTLD](/en/glossary/new-gtld/) Program, this extension allows the organization to create a unified, secure, and authoritative namespace on the internet. By operating its own [registry](/en/glossary/registry/), the organization ensures that any website ending in **.agakhan** is verified, authentic, and directly affiliated with the institution.
+## .agakhan at a glance
 
-For more technical details on the delegation, you can view the [IANA Delegation Record for .agakhan](https://www.iana.org/domains/root/db/agakhan.html).
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | Fondation Aga Khan / Aga Khan Foundation (technical back-end by Afilias) |
+| Year delegated | 2016 |
+| IDN support | Not relevant — closed namespace |
+| DNSSEC | Supported |
+| Registration restrictions | **Closed** — restricted to Fondation Aga Khan and parties it authorizes; not available to the public |
+| Best for | The Foundation's own institutional and program websites |
 
-## **How People Are Using .agakhan**
+## What is .agakhan?
 
-Because **.agakhan** is a Brand TLD, its usage is strategically focused on organizational identity rather than public commercial use. Usage trends for this TLD highlight the future of corporate and institutional digital presence:
+`.agakhan` is a **[generic top-level domain](/en/glossary/gtld/)** that ICANN delegated to **Fondation Aga Khan** on **March 31, 2016**. The registrant operates publicly as the **Aga Khan Foundation**, a non-profit organization working in international development.
 
-*   **Digital Unification:** It creates a cohesive digital thread connecting diverse agencies operating in health, education, culture, and rural development across the globe.
-*   **Brand Protection:** By controlling the entire namespace, the organization prevents [cybersquatting](/en/glossary/cybersquatting/) and [phishing](/en/glossary/phishing/) attempts that might exploit their name.
-*   **Trust Anchors:** It is used to signal to donors, partners, and beneficiaries that a website is an official channel of the Imamat or the Development Network.
+`.agakhan` is a **brand TLD** — a "dot-brand" — not an open extension anyone can buy into. The Foundation applied for the string so that it, and only it, would control every domain ending in `.agakhan`. You can confirm the delegation and operator on the authoritative [IANA root-zone record for .agakhan](https://www.iana.org/domains/root/db/agakhan.html).
 
-## **Notable Entities Using .agakhan**
+**A related but separate TLD:** the wider network the Foundation belongs to, the Aga Khan Development Network, holds its own sibling dot-brand, `.akdn`. The two are related but distinct delegations, each closed to its own registrant.
 
-The ecosystem of the Aga Khan Development Network is vast, and the **.agakhan** TLD is designed to encompass its various pillars. While specific public-facing URLs may vary as digital strategies evolve, the TLD is intended for entities such as:
+## History of .agakhan
 
-*   **The Aga Khan Foundation (AKF):** Focusing on long-term solutions to problems of poverty, hunger, illiteracy, and ill-health.
-*   **Aga Khan University (AKU):** A distinct global university with campuses in Asia, Africa, and the UK.
-*   **The Aga Khan Museum:** Dedicated to the presentation of Islamic arts and culture.
-*   **Aga Khan Health Services:** Providing quality health care to millions of people annually.
+`.agakhan` was delegated to the DNS [root zone](/en/glossary/root-zone/) on **March 31, 2016**, with **Afilias** handling the technical operation on the Foundation's behalf. Its registry agreement with [ICANN](/en/glossary/icann/) includes **Specification 13**, the contract clause that formally designates a TLD as a brand and lets the operator keep it closed.
 
-By utilizing this specific TLD, these entities reinforce their connection to the central mission of the network.
+Fondation Aga Khan applied for its own name as a TLD during ICANN's New gTLD Program, one of a small number of non-profit and institutional registrants to do so alongside the far more common corporate applicants. The `.agakhan` record has remained active since delegation.
 
-## **Why Choose .agakhan?**
+## Is .agakhan available to register?
 
-While this TLD is restricted to specific affiliates, analyzing "why it was chosen" offers valuable lessons for any entity or investor looking at premium or Brand TLDs:
+**No.** `.agakhan` is a **closed brand TLD**, so there is no open registration and no [registrar](/en/glossary/registrar/) — including Namefi — can sell you a `.agakhan` name. Registrations are limited to Fondation Aga Khan and organizations it authorizes. This is by design: a dot-brand exists precisely so the registrant controls the whole namespace and no one else can register a confusing or malicious lookalike.
 
-*   **Unquestionable Authenticity:** A domain ending in **.agakhan** acts as a digital seal of approval. Users immediately know the site is legitimate.
-*   **Enhanced Security:** Since the registry is closed, bad actors cannot register confusingly similar domains within that extension.
-*   **SEO & Branding Authority:** Search engines and users increasingly value authoritative sources. A dedicated TLD signals high relevance to the organization's specific keywords and mission.
-*   **Future-Proofing:** Owning the TLD allows for unlimited [subdomain](/en/glossary/subdomain/) creation and flexibility in a [Web3](/en/glossary/web3/) and digital-first world.
+If you have a genuine institutional relationship with the Aga Khan Foundation and a legitimate need for a `.agakhan` address, that request would go through the Foundation's own channels, not a commercial registrar.
 
-## **Register Your .agakhan Domain at Namefi**
+## How the Foundation uses .agakhan
 
-Understanding the power of a distinct Top-Level Domain like **.agakhan** highlights the importance of securing the right digital identity for your own project. Whether you are looking for specific availability, interested in [premium domain](/en/glossary/premium-domain/) investment, or seeking to [tokenize](/en/glossary/tokenize/) real-world assets (RWA) on the [blockchain](/en/glossary/blockchain/), the right domain is your starting point.
+Brand TLDs give an organization a private space to organize its web presence. Typical uses for a dot-brand like `.agakhan` include:
 
-At **Namefi**, we specialize in bridging the gap between traditional Web2 DNS and the Web3 ecosystem. We offer:
-*   **Seamless Management:** Easy registration and management of your domains.
-*   **Web3 Integration:** The ability to tokenize your domains for easier trading and [liquidity](/en/glossary/domain-liquidity/).
-*   **ICANN Accreditation:** Trustworthy service backed by industry standards.
+- **Program and institutional sites** on clean, memorable addresses tied directly to the Foundation.
+- **Campaign and initiative pages** that are obviously official because only the Foundation can create them.
+- **Internal tools and partner portals** where a branded suffix signals a trusted, first-party destination.
 
-While strict Brand TLDs are managed privately, you can search for thousands of available TLDs that perfectly match your brand, business, or investment goals today.
+**Who it's not for:** anyone outside Fondation Aga Khan. Because the namespace is closed, there is no scenario in which an independent charity, developer, or business can build on `.agakhan`.
 
-[**Search for your perfect domain at Namefi**](https://namefi.io)
+## Notable sites using .agakhan
 
-**Don’t leave your digital identity to chance—secure your domain with Namefi today.**
+There are **no third-party sites** on `.agakhan`, and there never will be while it stays a closed brand TLD — every `.agakhan` address is controlled by Fondation Aga Khan. The Foundation's parent network runs its main public presence from **akdn.org**, and uses the brand TLD selectively rather than as a wholesale replacement. Rather than point to a specific address that may change, the honest description is simple: `.agakhan` is the Foundation's private namespace, used only for its own properties.
+
+## What is a dot-brand TLD?
+
+A **dot-brand** (or brand TLD) is a top-level domain that a single organization owns and operates for its exclusive use, secured through ICANN's [New gTLD Program](/en/glossary/new-gtld/). Hundreds were delegated — examples in this same alphabetical band include `.abb`, `.accenture`, and `.aetna` — and they share a few defining traits:
+
+- **Closed registration.** Only the registrant and its affiliates can hold names.
+- **Specification 13.** A registry-agreement addendum that formally recognizes the TLD as a brand and relaxes some rules that apply to open generics.
+- **Security and control.** The Foundation eliminates the risk of anyone else registering a `.agakhan` lookalike, which strengthens resistance to [phishing](/en/glossary/phishing/) and impersonation — a real concern for an organization that solicits donations and works with beneficiaries worldwide.
+
+Most brands are corporations, but institutional and non-profit registrants like Fondation Aga Khan show the same closed-registry model applies outside the commercial world.
+
+## .agakhan vs open domain alternatives
+
+If your goal was a short, brandable name rather than the `.agakhan` string specifically, an open extension is the right tool. Here is how a closed brand TLD compares with domains you can actually register:
+
+| Feature | .agakhan | [.com](/en/tld/com/) | [.org](/en/tld/org/) | [.io](/en/tld/io/) |
+| --- | --- | --- | --- | --- |
+| Who can register | Fondation Aga Khan only | Anyone | Anyone | Anyone |
+| Type | Brand new gTLD (closed) | Legacy gTLD | Legacy gTLD (non-profit heritage) | ccTLD used generically |
+| Core use | The Foundation's own sites | Universal default | Non-profits & institutions | Tech & startups |
+| Available to you | No | Yes | Yes | Yes |
+
+For a non-profit or institutional project, [.org](/en/tld/org/) is the traditional choice; a matching `.com` remains the universal default; and [.io](/en/tld/io/) suits a more modern, tech-forward program.
+
+## Reputation and trust
+
+Ironically, the closed nature of `.agakhan` is exactly what makes it trustworthy: because only the Foundation can create these addresses, a `.agakhan` link is verifiably official, which is why brand TLDs are considered strong against impersonation and email spoofing — useful for an organization that depends on donor and partner trust. That trust, however, benefits Fondation Aga Khan alone — it does not transfer to any name you might register, since you cannot register one. For your own project, deliverability and reputation will come from a well-configured domain on an open extension, not from a brand TLD you don't control.
+
+## Looking for an "agakhan" name? Register an alternative at Namefi
+
+You can't buy a `.agakhan` domain, but if you want a name for your own non-profit or institutional project, you can secure it on an open extension in minutes:
+
+1. **Search** your desired name across open TLDs like `.com`, `.org`, or `.io`.
+2. **Choose** the extension that fits your mission and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can anyone register a .agakhan domain?
+
+No. `.agakhan` is a closed brand TLD delegated to Fondation Aga Khan, the Aga Khan Foundation. Only the Foundation and parties it authorizes can hold a `.agakhan` name, so it is not available to the general public through any registrar.
+
+### Who operates the .agakhan registry?
+
+Fondation Aga Khan, the Aga Khan Foundation, is the registry operator, with Afilias providing the technical back-end. The TLD was delegated to the DNS root zone on March 31, 2016, under ICANN's New gTLD Program.
+
+### What is the Aga Khan Foundation?
+
+The Aga Khan Foundation is a non-profit international development organization. Its `.agakhan` domain is reserved for its own use and is separate from the similarly named `.akdn` TLD held by the wider Aga Khan Development Network.
+
+### What can I register instead of .agakhan?
+
+Because `.agakhan` is closed, choose an open extension for your own project. A matching `.com`, or a modern alternative like `.io` or `.xyz`, can be registered by anyone through an accredited registrar such as Namefi.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals behind top-level domains.
+- [How a TLD affects domain value](/en/blog/how-tld-affects-domain-value/) — why the extension matters.
+- [.com TLD guide](/en/tld/com/) — the open default to compare against.
+- [.org TLD guide](/en/tld/org/) and [.io TLD guide](/en/tld/io/) — alternatives for non-profits and tech projects.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [registry](/en/glossary/registry/), [ICANN](/en/glossary/icann/).

--- a/content/tld/en/aig.md
+++ b/content/tld/en/aig.md
@@ -1,13 +1,22 @@
 ---
-title: "Unlock the Future of Tech with the .aig TLD"
-date: '2025-12-10'
+title: "What Is the .aig Domain? AIG's Brand TLD Explained"
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: "Discover the .aig TLD, the emerging domain choice for Artificial Intelligence and Generative tech. Learn why .aig is the smart choice for your next innovative project."
-keywords: [".aig domains", ".aig TLD", "top-level domain .aig", "what is .aig", "why choose .aig", "what is the .aig domain", "why choose the .aig domain", "artificial intelligence domains", "blockchain domains", "tokenized domains", "generative AI domains", "tech startup branding", "domain investing", "Web3 domains", "AI gaming"]
+description: 'The .aig domain is the closed brand TLD of American International Group (AIG), a global insurer, not open to the public. Learn who runs it and what to register instead.'
+keywords: ['.aig domain', 'what is .aig', '.aig TLD', 'AIG brand domain', 'dot-brand TLD', 'AIG registry operator', 'closed generic TLD', 'is .aig available']
+faqs:
+  - question: 'Can anyone register a .aig domain?'
+    answer: 'No. .aig is a closed brand TLD delegated to American International Group, Inc. Only AIG and parties it authorizes can hold a .aig name, so it is not available to the general public through any registrar.'
+  - question: 'Who operates the .aig registry?'
+    answer: 'American International Group, Inc. is the registry operator, with GoDaddy Registry providing the technical back-end. The TLD was delegated to the DNS root zone in 2015 under ICANN''s New gTLD Program.'
+  - question: 'What does AIG stand for?'
+    answer: 'AIG stands for American International Group, a global insurance and financial-services company.'
+  - question: 'What can I register instead of .aig?'
+    answer: 'Because .aig is closed, choose an open extension for your own project. A matching .com, or a modern alternative like .io or .xyz, can be registered by anyone through an accredited registrar such as Namefi.'
 relatedArticles:
   - /en/blog/ai-vs-io-domain/
   - /en/blog/why-are-io-domains-expensive/
@@ -28,46 +37,113 @@ relatedGlossary:
   - /en/glossary/registry/
 ---
 
-## **What is .aig?**
+The **.aig** domain is a **closed brand [top-level domain](/en/glossary/tld/)** operated by **American International Group, Inc. (AIG)**, a global insurance and financial-services company. It is not a public extension: unlike [.com](/en/tld/com/) or [.io](/en/tld/io/), you cannot register a `.aig` name for your own project, because the entire namespace belongs to one company.
 
-The digital landscape is constantly evolving, and with the explosive growth of technology, the demand for specific, relevant domain extensions has never been higher. The **.aig** [Top-Level Domain (TLD)](/en/glossary/tld/) is emerging as a powerful designation specifically curated for the intersection of **A**rtificial **I**ntelligence and **G**enerative technologies (or **G**aming).
+If you searched for the ".aig domain" hoping to buy one, the short answer is that you can't — but this page explains exactly what `.aig` is, who controls it, why a company runs its own TLD, and what you can register instead.
 
-While country-code TLDs like [.ai (Anguilla)](https://en.wikipedia.org/wiki/.ai) became the standard for the first wave of AI startups, the market has become incredibly saturated. The .aig extension offers a fresh territory for the next generation of innovators. It is designed to signal advanced capability, typically associating a brand with Generative AI, AI Governance, or AI-driven Gaming.
+## .aig at a glance
 
-Whether utilized in a traditional DNS setting or bridged on the [blockchain](/en/glossary/blockchain/) as a [tokenized domain](https://namefi.io), .aig represents the cutting edge of the modern web.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | American International Group, Inc. (technical back-end by GoDaddy Registry) |
+| Year delegated | 2015 |
+| IDN support | Not relevant — closed namespace |
+| DNSSEC | Supported |
+| Registration restrictions | **Closed** — restricted to AIG and parties it authorizes; not available to the public |
+| Best for | AIG's own corporate, product, and campaign websites |
 
-## **How People Are Using .aig**
+## What is .aig?
 
-Because of its strong association with future-tech, the .aig TLD is attracting a specific, high-value demographic. Here is how it is currently being utilized:
+`.aig` is a **[generic top-level domain](/en/glossary/gtld/)** that ICANN delegated to **American International Group, Inc.** as part of its New gTLD Program. The three letters are the company's own name: **AIG** is short for **American International Group**, a global insurance and financial-services company.
 
-*   **Generative AI Platforms:** Startups building Large Language Models (LLMs) or image generation tools use .aig to distinguish themselves from general AI aggregators.
-*   **AI Gaming Studios:** Developers creating non-player characters (NPCs) powered by machine learning are adopting .aig to blend "AI" and "Gaming."
-*   **Automated Investment Groups:** Fintech companies using algorithms for trading are leveraging the acronym for trust and modernity.
-*   **[Web3](/en/glossary/web3/) and DAO Governance:** Decentralized Autonomous Organizations focused on AI safety and governance are securing .aig domains to [tokenize](/en/glossary/tokenize/) their brand identity on the blockchain.
+But `.aig` is a **brand TLD** — often called a "dot-brand" — not an open extension anyone can buy into. The company applied for the string specifically so that it, and only it, would control every domain ending in `.aig`. You can confirm the delegation and operator on the authoritative [IANA root-zone record for .aig](https://www.iana.org/domains/root/db/aig.html).
 
-## **Notable Entities Using .aig**
+## History of .aig
 
-As a newer entrant to the domain space compared to legacy extensions like [.com](/en/tld/com/) or [.net](/en/tld/net/), .aig is currently a "land of opportunity" rather than a museum of established giants. However, adoption is accelerating among niche tech sectors:
+`.aig` was **delegated to the DNS [root zone](/en/glossary/root-zone/) on April 9, 2015**, during the same wave of ICANN's New gTLD Program that brought hundreds of corporate names into the domain system. **GoDaddy Registry** runs the technical back-end on AIG's behalf, operating the infrastructure that keeps the namespace resolving and secure, while American International Group, Inc. remains the registry operator of record.
 
-1.  **Generative Art Collectives:** Several decentralized artist communities are migrating to .aig to showcase algorithmic artwork.
-2.  **Next-Gen Tech Incubators:** Forward-thinking accelerators are using the extension to host portfolio sites for their AI-native cohorts.
-3.  **Strategic Domain Investors:** recognizing the scarcity of short [.ai](/en/tld/ai/) domains, investors are securing premium .aig keywords (e.g., *chat.aig*, *draw.aig*, *play.aig*) anticipating the next boom in tech naming conventions.
+Its registry agreement with [ICANN](/en/glossary/icann/) includes **Specification 13**, the contract clause that formally designates a TLD as a brand and lets the operator keep it closed. The record has stayed active since delegation, unlike several brand TLDs that were later handed back and removed from the root.
 
-*Note: As this TLD grows, early adopters have the unique advantage of defining the namespace before major corporations dominate the [registry](/en/glossary/registry/).*
+## Is .aig available to register?
 
-## **Why Choose .aig?**
+**No.** `.aig` is a **closed brand TLD**, so there is no open registration and no [registrar](/en/glossary/registrar/) — including Namefi — can sell you a `.aig` name. Registrations are limited to AIG and organizations it authorizes, such as subsidiaries or partners. This is by design: a dot-brand exists precisely so the trademark holder controls the whole namespace and no one else can register a confusing or malicious lookalike.
 
-Choosing the right domain name is critical for SEO, branding, and user trust. Here is why you should consider registering a .aig domain:
+If you have a genuine business relationship with AIG and a legitimate need for a `.aig` address, that request would go through AIG's own corporate channels, not a commercial registrar.
 
-*   **Availability:** Unlike .com or .ai, where most dictionary words and short names are taken or prohibitively expensive, .aig offers a wide selection of premium, short, and memorable names.
-*   **Targeted Branding:** It immediately tells your audience that you are involved in high-tech, specifically Generative AI or smart gaming. It filters your audience automatically to those interested in innovation.
-*   **Investment Potential:** As the "Generative" aspect of AI becomes the industry standard, owning a relevant .aig domain could yield significant ROI, especially when managed as a digital asset.
-*   **Modern Appeal:** It signals that your business is native to the era of 2025 and beyond, separating you from legacy competitors stuck on older TLDs.
+## How AIG uses .aig
 
-## **Register Your .aig Domain at Namefi**
+Brand TLDs give a company a private space to organize its web presence. Typical uses for a dot-brand like `.aig` include:
 
-Ready to secure your brand's future in the age of artificial intelligence? Don’t wait until the best names are gone. At **Namefi**, we make domain registration seamless, offering you the unique ability to manage your standard domains with the flexibility of Web3 technology.
+- **Product and division sites** on clean, memorable addresses tied directly to the brand.
+- **Campaign and event pages** that are obviously official because only the company can create them.
+- **Internal tools and portals** where a branded suffix signals a trusted, first-party destination.
 
-Whether you are a developer launching a new app, a domain investor scouting for the next big trend, or a business rebranding for the AI era, Namefi is your trusted partner.
+**Who it's not for:** anyone outside AIG. Because the namespace is closed, there is no scenario in which an independent developer, investor, or business can build on `.aig`.
 
-**[Register your .aig domain with Namefi today](https://namefi.io)** and own a piece of the future internet.
+## Notable sites using .aig
+
+There are **no third-party sites** on `.aig`, and there never will be while it stays a closed brand TLD — every `.aig` address is controlled by American International Group, Inc. AIG continues to run its public presence from its long-established [.com](/en/tld/com/) domain, aig.com, and uses the brand TLD selectively rather than as a wholesale replacement. Rather than point to a specific address that may change, the honest description is simple: `.aig` is AIG's private namespace, used only for the company's own properties.
+
+## What is a dot-brand TLD?
+
+A **dot-brand** (or brand TLD) is a top-level domain that a single company owns and operates for its exclusive use, secured through ICANN's [New gTLD Program](/en/glossary/new-gtld/). Financial and insurance groups were among the many large corporations that applied for their own name as a TLD, and dot-brands share a few defining traits:
+
+- **Closed registration.** Only the brand and its affiliates can hold names.
+- **Specification 13.** A registry-agreement addendum that formally recognizes the TLD as a brand and relaxes some rules that apply to open generics.
+- **Security and control.** The brand eliminates the risk of anyone else registering a `.aig` lookalike, which strengthens resistance to [phishing](/en/glossary/phishing/) and impersonation.
+
+Some brands invest heavily in their TLD; others register it defensively and barely use it. A number of companies have even terminated their dot-brands after deciding the upkeep was not worth it.
+
+## .aig vs open domain alternatives
+
+If your goal was a short, brandable name rather than the `.aig` string specifically, an open extension is the right tool. Here is how a closed brand TLD compares with domains you can actually register:
+
+| Feature | .aig | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.xyz](/en/tld/xyz/) |
+| --- | --- | --- | --- | --- |
+| Who can register | AIG only | Anyone | Anyone | Anyone |
+| Type | Brand new gTLD (closed) | Legacy gTLD | ccTLD used generically | New gTLD |
+| Core use | AIG's own sites | Universal default | Tech & startups | Generic / Web3 |
+| Available to you | No | Yes | Yes | Yes |
+
+For your own venture, a matching `.com` remains the safest default; [.io](/en/tld/io/) suits technical products; and [.xyz](/en/tld/xyz/) is a flexible, low-cost modern option.
+
+## Reputation and trust
+
+Ironically, the closed nature of `.aig` is exactly what makes it trustworthy: because only AIG can create these addresses, a `.aig` link is verifiably official, which is why brand TLDs are considered strong against impersonation and email spoofing — a meaningful benefit for a financial-services brand that scammers regularly try to imitate. That trust, however, benefits AIG alone — it does not transfer to any name you might register, since you cannot register one. For your own project, deliverability and reputation will come from a well-configured domain on an open extension, not from a brand TLD you don't control.
+
+## Looking for an "aig" name? Register an alternative at Namefi
+
+You can't buy a `.aig` domain, but if you want a short name — maybe an "aig" acronym of your own — you can secure it on an open extension in minutes:
+
+1. **Search** your desired name across open TLDs like `.com`, `.io`, or `.xyz`.
+2. **Choose** the extension that fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can anyone register a .aig domain?
+
+No. `.aig` is a closed brand TLD delegated to American International Group, Inc. Only AIG and parties it authorizes can hold a `.aig` name, so it is not available to the general public through any registrar.
+
+### Who operates the .aig registry?
+
+American International Group, Inc. is the registry operator, with GoDaddy Registry providing the technical back-end. The TLD was delegated to the DNS root zone in 2015 under ICANN's New gTLD Program.
+
+### What does AIG stand for?
+
+AIG stands for American International Group, a global insurance and financial-services company.
+
+### What can I register instead of .aig?
+
+Because `.aig` is closed, choose an open extension for your own project. A matching `.com`, or a modern alternative like `.io` or `.xyz`, can be registered by anyone through an accredited registrar such as Namefi.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals behind top-level domains.
+- [How a TLD affects domain value](/en/blog/how-tld-affects-domain-value/) — why the extension matters.
+- [.com TLD guide](/en/tld/com/) — the open default to compare against.
+- [.io TLD guide](/en/tld/io/) and [.xyz TLD guide](/en/tld/xyz/) — modern open alternatives.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [registry](/en/glossary/registry/), [ICANN](/en/glossary/icann/).

--- a/content/tld/en/aig.md
+++ b/content/tld/en/aig.md
@@ -3,7 +3,7 @@ title: "What Is the .aig Domain? AIG's Brand TLD Explained"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .aig domain is the closed brand TLD of American International Group (AIG), a global insurer, not open to the public. Learn who runs it and what to register instead.'

--- a/content/tld/en/aigo.md
+++ b/content/tld/en/aigo.md
@@ -1,13 +1,22 @@
 ---
-title: "What is the .aigo TLD and Why Choose It for Your Next Big Idea?"
-date: '2025-12-11'
+title: 'What Was the .aigo Domain? A Terminated Brand TLD'
+date: '2026-07-24'
 language: 'en'
-tags: ['tld', 'domain-investing', 'branding', 'web3', 'ai']
+tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: "Discover the potential of the .aigo domain extension. Learn what .aigo is, why it's perfect for AI and tech innovators, and how to register yours with Namefi."
-keywords: [".aigo domains", ".aigo TLD", "top-level domain", "what is .aigo", "why choose .aigo", "what is the .aigo domain", "why choose the .aigo domain", "domain investing", "blockchain domains", "tokenized domain", "AI domain names", "tech branding", "buy .aigo domain", "Namefi domains", "new gTLD"]
+description: 'The .aigo domain was a brand TLD for the Chinese electronics brand aigo that ICANN terminated in 2020. Learn its history and what to register instead.'
+keywords: ['.aigo domain', 'what is .aigo', '.aigo TLD', 'aigo brand domain', 'terminated TLD', 'discontinued gTLD', 'dot-brand TLD', 'is .aigo available']
+faqs:
+  - question: 'Can I register a .aigo domain?'
+    answer: 'No. .aigo was terminated in 2020 and removed from the DNS root zone, so it no longer exists as a working extension and cannot be registered through any registrar. Even before that, it was a closed brand TLD never open to the public.'
+  - question: 'What happened to .aigo?'
+    answer: 'ICANN removed .aigo from the root zone on 27 June 2020 after the registry agreement covering it ended. It had been delegated under four years earlier, in August 2016.'
+  - question: 'Was .aigo ever open to the public?'
+    answer: 'No. .aigo was always a closed brand TLD, meaning only the aigo brand could ever register names under it. It was never sold to outside individuals or businesses.'
+  - question: 'Did anyone ever use a .aigo domain?'
+    answer: 'No public site of note. aigo never opened the namespace to outside registrants, so nothing was lost when the TLD was removed.'
 relatedArticles:
   - /en/blog/ai-vs-io-domain/
   - /en/blog/what-is-a-tld/
@@ -28,60 +37,85 @@ relatedGlossary:
   - /en/glossary/dns/
 ---
 
-## **What is .aigo?**
+The **.aigo** domain was a **brand [top-level domain](/en/glossary/tld/)** created for **aigo**, a Chinese consumer-electronics brand based in Beijing. It no longer exists: ICANN **removed `.aigo` from the DNS [root zone](/en/glossary/root-zone/) in 2020**, so the extension no longer resolves and cannot be registered.
 
-The digital landscape is constantly evolving, and with the explosion of artificial intelligence and [Web3](/en/glossary/web3/) technologies, the demand for relevant, snappy domain extensions has never been higher. Enter **.aigo**.
+If you searched for the ".aigo domain," this page explains what it was, why it disappeared, and what the story of a terminated dot-brand means for anyone choosing a domain today.
 
-The **.aigo** [Top-Level Domain (TLD)](/en/glossary/tld/) is a specialized [domain extension](/en/blog/what-is-a-tld/) designed to cater to the intersection of **Artificial Intelligence (AI)** and dynamic movement ("Go"). While "Aigo" is culturally recognized in parts of Asia as an expressive interjection, in the tech world, it is rapidly gaining traction as a shorthand for "AI on the Go" or "AI Governance."
+## .aigo at a glance
 
-Unlike traditional legacy domains like [.com](/en/tld/com/) or [.net](/en/tld/net/), .aigo falls under the category of **New gTLDs** (generic Top-Level Domains) or, in some contexts, alternative root domains bridged to the mainstream web. It was introduced to solve the overcrowding of traditional namespaces and to provide a dedicated digital identity for innovators, developers, and forward-thinking enterprises.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | aigo (Chinese consumer-electronics brand) — agreement now terminated |
+| Year delegated | 2016 |
+| Year terminated | 2020 (removed from the root zone) |
+| Current status | **Terminated** — not present in the DNS root zone |
+| Registration restrictions | **Not available** — the TLD no longer exists |
 
-For more context on how new gTLDs function within the global internet infrastructure, you can visit the [ICANN (Internet Corporation for Assigned Names and Numbers)](https://www.icann.org/) website.
+## What was .aigo?
 
-## **How People Are Using .aigo**
+`.aigo` was a **closed brand [gTLD](/en/glossary/new-gtld/)**: a top-level domain reserved for a single company's exclusive use. The string matched the name of **aigo**, a consumer-electronics brand based in Beijing. Only aigo could ever hold names under the extension — it was never a shared or open namespace.
 
-Because of its unique phonetic appeal and tech-forward connotation, the usage of .aigo is diverse yet concentrated in innovation sectors. Here is how individuals and businesses are currently utilizing this TLD:
+Like other dot-brands, `.aigo` was never open to the public. You can confirm its status on the authoritative [IANA root-zone record for .aigo](https://www.iana.org/domains/root/db/aigo.html), which now shows the domain is not present in the root zone.
 
-*   **AI Startups and SaaS:** Companies building machine learning models, chatbots, or automation tools use .aigo to signal their industry immediately (e.g., *chat.aigo*, *vision.aigo*).
-*   **Mobile Tech Applications:** "Go" implies mobility. App developers are using the extension for mobile-first AI solutions.
-*   **Web3 and Blockchain Projects:** Given the crossover between AI and [blockchain](/en/glossary/blockchain/) (DePIN, AI agents), developers use .aigo for decentralized identifiers (DIDs) and [wallet](/en/glossary/wallet/) naming.
-*   **Strategy Gaming:** Playing on the ancient strategy game "Go," gaming communities and AI researchers focused on game theory utilize this domain for forums and educational hubs.
-*   **Personal Portfolios:** Developers and data scientists are registering *firstname.aigo* to showcase their resume and coding projects.
+## History of .aigo
 
-## **Notable Entities Using .aigo**
+`.aigo` was **delegated on 4 August 2016** as part of ICANN's New gTLD Program, the 2012 expansion that let companies worldwide apply for their own brand as a suffix. aigo secured the string that matched its own name.
 
-As a relatively fresh contender in the namespace market (as of late 2025), .aigo offers a "blue ocean" of availability. While massive Fortune 500 adoption is still in its early stages, the TLD is popular among specific verticals:
+The brand never opened the TLD to outside registrants. On **27 June 2020, ICANN removed `.aigo` from the root zone**, under four years after it was first delegated — a short run even by the standards of closed dot-brands, many of which were wound down within their first decade.
 
-1.  **Next-Gen AI Labs:** Boutique research firms specializing in Generative AI are migrating to .aigo to differentiate themselves from the saturated [.ai](/en/tld/ai/) market.
-2.  **Tech Edu-Tubers:** Content creators focusing on Python, coding, and AI tutorials are using .aigo domains as memorable redirect links to their channels or course materials.
-3.  **Decentralized Autonomous Organizations (DAOs):** Governance groups focusing on AI ethics have begun adopting .aigo to signify "AI Governance."
+## Why was .aigo discontinued?
 
-*Note: As this is a rapidly emerging TLD, the "best" names are still largely available, making it a prime target for domain investors looking for the next trend similar to the rise of [.io](/en/tld/io/) or [.xyz](/en/tld/xyz/).*
+A brand TLD only earns its keep if the company builds public-facing use on it, and running one carries ongoing [ICANN](/en/glossary/icann/) fees and technical maintenance regardless of how many names exist under it. When an owner decides that cost is not worth it, it can **voluntarily terminate** its registry agreement; ICANN then removes the TLD from the root zone, and the extension stops resolving worldwide.
 
-## **Why Choose .aigo?**
+`.aigo` is one of many closed dot-brands retired this way. Because it was never open to the public, its termination affected no outside registrants — there were none — but it is still a reminder that a delegated TLD is not a permanent fixture of the internet.
 
-Choosing the right domain extension is critical for your brand's first impression. Here is why you should choose the .aigo domain for your next project:
+## Can you register a .aigo domain?
 
-*   **Brand Availability:** finding a short, one-word domain on .com is nearly impossible or prohibitively expensive. With .aigo, you can still register premium, short keywords (e.g., *write.aigo* or *fast.aigo*).
-*   **Industry Relevance:** It immediately signals to visitors and search engines that your site is related to modern technology, AI, or innovation.
-*   **Memorability:** It is short (4 letters), easy to pronounce, and has a rhythmic quality that sticks in the mind.
-*   **SEO Potential:** Search engines are increasingly treating new gTLDs as equal to legacy domains. A relevant keyword combined with .aigo can perform excellently in niche search results.
-*   **Future-Proofing:** As the web transitions from Web2 to Web3, having a distinct, modern TLD positions your brand as a future-ready entity.
+**No.** `.aigo` no longer exists in the DNS, so there is nothing to register and no [registrar](/en/glossary/registrar/) can offer it. It was never available to the public even while it was active, because it was a closed brand namespace controlled by aigo.
 
-For more insights on how domain extensions impact SEO, authoritative resources like [Search Engine Journal](https://www.searchenginejournal.com/) offer excellent deep dives.
+If a `.aigo` link ever appears again, it would only be because a company re-applies in a later ICANN round — there is no public path to owning one today.
 
-## **Register Your .aigo Domain at Namefi**
+## What .aigo teaches about choosing a TLD
 
-Ready to secure your digital identity? Don't wait until the best names are taken.
+The rise and removal of `.aigo` is a useful reminder for anyone picking a domain:
 
-At **Namefi**, we make domain registration seamless, secure, and ready for the future of the internet. We aren't just a standard [registrar](/en/glossary/registrar/); we are bridging the gap between Web2 and Web3. When you register a domain with us, you enjoy:
+- **Brand TLDs are private.** A dot-brand is never something an outside project can build on, however catchy the string looks.
+- **Not every TLD is permanent.** Delegated strings can be handed back and removed, so long-term projects are safest on well-established, widely used extensions.
+- **Openness matters.** For your own venture, an open extension anyone can register and renew is far more dependable than a single-owner string.
 
-*   **ICANN-Accredited Security:** Trustworthy management of your digital assets.
-*   **Seamless Web3 Integration:** The ability to [tokenize](/en/glossary/tokenize/) your domain, making transfers and management as easy as sending a crypto transaction.
-*   **Transparent Pricing:** No hidden fees or surprise renewal hikes.
+## What to register instead at Namefi
 
-**Secure your brand today.**
+Since `.aigo` is gone, choose a stable, open extension for your own name:
 
-[**Register your .aigo domain at Namefi**](https://namefi.io)
+1. **Search** your desired name across open TLDs such as [.com](/en/tld/com/), [.io](/en/tld/io/), or [.xyz](/en/tld/xyz/).
+2. **Choose** the extension that best fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
 
-Whether you are launching the next big AI tool or simply want a cool personal domain, .aigo is the smart choice for 2025 and beyond.
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can I register a .aigo domain?
+
+No. `.aigo` was terminated in 2020 and removed from the DNS root zone, so it no longer exists as a working extension and cannot be registered through any registrar. Even before that, it was a closed brand TLD never open to the public.
+
+### What happened to .aigo?
+
+ICANN removed `.aigo` from the root zone on 27 June 2020 after the registry agreement covering it ended. It had been delegated under four years earlier, in August 2016.
+
+### Was .aigo ever open to the public?
+
+No. `.aigo` was always a closed brand TLD, meaning only the aigo brand could ever register names under it. It was never sold to outside individuals or businesses.
+
+### Did anyone ever use a .aigo domain?
+
+No public site of note. aigo never opened the namespace to outside registrants, so nothing was lost when the TLD was removed.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — how top-level domains work.
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains/) — owning a domain on-chain.
+- [How a TLD affects domain value](/en/blog/how-tld-affects-domain-value/) — why the extension matters.
+- [.com TLD guide](/en/tld/com/), [.io TLD guide](/en/tld/io/), and [.xyz TLD guide](/en/tld/xyz/) — open extensions you can actually register.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [ICANN](/en/glossary/icann/), [root zone](/en/glossary/root-zone/).

--- a/content/tld/en/aigo.md
+++ b/content/tld/en/aigo.md
@@ -3,7 +3,7 @@ title: 'What Was the .aigo Domain? A Terminated Brand TLD'
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .aigo domain was a brand TLD for the Chinese electronics brand aigo that ICANN terminated in 2020. Learn its history and what to register instead.'

--- a/content/tld/en/airbus.md
+++ b/content/tld/en/airbus.md
@@ -1,13 +1,22 @@
 ---
-title: 'What is the .airbus TLD and Why Does It Matter?'
-date: '2025-12-10'
+title: "What Is the .airbus Domain? Airbus's Brand TLD Explained"
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: 'Discover the power of the .airbus Top-Level Domain. Learn about its exclusive usage, brand authority in aviation, and how to secure premium domains with Namefi.'
-keywords: ['.airbus domains', '.airbus TLD', 'top-level domain', 'what is .airbus', 'why choose .airbus', 'what is the .airbus domain', 'why choose the .airbus domain', 'brand TLD', 'aviation domains', 'domain investing', 'blockchain', 'tokenized domain', 'corporate identity', 'Namefi Web3 domains', 'secure domain registration']
+description: 'The .airbus domain is the closed brand TLD of Airbus S.A.S., the European aerospace manufacturer, not open to the public. Learn who runs it and what to register instead.'
+keywords: ['.airbus domain', 'what is .airbus', '.airbus TLD', 'Airbus brand domain', 'dot-brand TLD', 'Airbus registry operator', 'closed generic TLD', 'is .airbus available']
+faqs:
+  - question: 'Can anyone register a .airbus domain?'
+    answer: 'No. .airbus is a closed brand TLD delegated to Airbus S.A.S. Only Airbus and parties it authorizes can hold a .airbus name, so it is not available to the general public through any registrar.'
+  - question: 'Who operates the .airbus registry?'
+    answer: 'Airbus S.A.S. is the registry operator, with Identity Digital providing the technical back-end. The TLD was delegated to the DNS root zone in 2016 under ICANN''s New gTLD Program.'
+  - question: 'What kind of company is Airbus?'
+    answer: 'Airbus S.A.S. is the European aerospace and commercial-aircraft manufacturer behind the .airbus domain.'
+  - question: 'What can I register instead of .airbus?'
+    answer: 'Because .airbus is closed, choose an open extension for your own project. A matching .com, or a modern alternative like .io or .xyz, can be registered by anyone through an accredited registrar such as Namefi.'
 relatedArticles:
   - /en/blog/what-are-tokenized-domains/
   - /en/blog/what-is-a-tld/
@@ -28,50 +37,113 @@ relatedGlossary:
   - /en/glossary/registry/
 ---
 
-## **What is .airbus?**
+The **.airbus** domain is a **closed brand [top-level domain](/en/glossary/tld/)** operated by **Airbus S.A.S.**, the European aerospace and commercial-aircraft manufacturer. It is not a public extension: unlike [.com](/en/tld/com/) or [.io](/en/tld/io/), you cannot register a `.airbus` name for your own project, because the entire namespace belongs to one company.
 
-The **.airbus** extension is a specialized [Top-Level Domain (TLD)](/en/glossary/tld/) falling under the category of a "Brand TLD." Unlike open extensions like [.com](/en/tld/com/) or [.net](/en/tld/net/), **.airbus** was created specifically for **Airbus S.A.S.**, the European multinational aerospace corporation. It was established as part of [ICANN's new gTLD program](https://newgtlds.icann.org/en/about/program), which allowed organizations to apply for their own branded domain endings to increase digital security and brand visibility.
+If you searched for the ".airbus domain" hoping to buy one, the short answer is that you can't — but this page explains exactly what `.airbus` is, who controls it, why a company runs its own TLD, and what you can register instead.
 
-As a Brand TLD, .airbus represents the pinnacle of corporate digital identity. It allows the company to operate a closed ecosystem, ensuring that every website ending in this extension is authentically owned and verified by the aerospace giant. For domain investors and developers, observing the deployment of TLDs like .airbus offers critical insight into the future of the internet, where specific industries and corporations move away from crowded legacy domains toward dedicated, verified namespaces.
+## .airbus at a glance
 
-## **How People Are Using .airbus**
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | Airbus S.A.S. (technical back-end by Identity Digital) |
+| Year delegated | 2016 |
+| IDN support | Not relevant — closed namespace |
+| DNSSEC | Supported |
+| Registration restrictions | **Closed** — restricted to Airbus and parties it authorizes; not available to the public |
+| Best for | Airbus's own corporate, product, and campaign websites |
 
-Because .airbus is a restricted Brand TLD, its usage is strategic and focused on corporate governance, product differentiation, and partner ecosystems. It is not generally used by the public for personal blogs, but rather serves as a digital infrastructure tool for the aviation industry.
+## What is .airbus?
 
-*   **Digital Authenticity:** The primary use is to guarantee trust. When a user sees a URL ending in .airbus, they know immediately it is an official channel, mitigating the risk of [phishing](/en/glossary/phishing/) or [cybersquatting](/en/glossary/cybersquatting/).
-*   **Product Showcases:** It is used to highlight specific aircraft families or technological innovations within the Airbus group.
-*   **Internal Infrastructure:** Large corporations use proprietary TLDs for employee portals, cloud systems, and internal developer tools, streamlining their network architecture.
-*   **Partner Portals:** Secure gateways for suppliers and airlines to interact with Airbus logistics and data services.
+`.airbus` is a **[generic top-level domain](/en/glossary/gtld/)** that ICANN delegated to **Airbus S.A.S.** as part of its New gTLD Program. The string is the company's own name: **Airbus**, the European aerospace and commercial-aircraft manufacturer.
 
-## **Notable Entities Using .airbus**
+But `.airbus` is a **brand TLD** — often called a "dot-brand" — not an open extension anyone can buy into. The company applied for the string specifically so that it, and only it, would control every domain ending in `.airbus`. You can confirm the delegation and operator on the authoritative [IANA root-zone record for .airbus](https://www.iana.org/domains/root/db/airbus.html).
 
-As this is a closed [registry](/en/glossary/registry/), the "notable entities" are exclusively divisions and initiatives within the Airbus ecosystem. However, this strategy highlights how major players utilize domain names to assert authority.
+## History of .airbus
 
-*   **Airbus Official Registry:** The core management of the domain infrastructure is handled by Airbus's IT and legal divisions to ensure total compliance.
-*   **nic.airbus:** Often used as the network information center for the TLD, providing technical details about the namespace.
-*   **Campaign Specific Sites:** While specific live URLs change based on marketing campaigns, the TLD allows for clean, intuitive naming conventions like `careers.airbus` or `innovation.airbus` (hypothetical examples of standard Brand TLD usage).
+`.airbus` was **delegated to the DNS [root zone](/en/glossary/root-zone/) on May 26, 2016**, later in the New gTLD Program's rollout than many of the first-wave dot-brands. **Identity Digital** runs the technical back-end on Airbus's behalf, operating the infrastructure that keeps the namespace resolving and secure, while Airbus S.A.S. remains the registry operator of record.
 
-For a broader look at how major corporations manage their internet resources, you can check the [IANA Delegation Record for .airbus](https://www.iana.org/domains/root/db/airbus.html).
+Its registry agreement with [ICANN](/en/glossary/icann/) includes **Specification 13**, the contract clause that formally designates a TLD as a brand and lets the operator keep it closed. The record has stayed active since delegation, unlike several brand TLDs that were later handed back and removed from the root.
 
-## **Why Choose .airbus?**
+## Is .airbus available to register?
 
-While the .airbus TLD is exclusive to the corporation, the *concept* behind it illustrates why choosing the right niche or Brand TLD is vital for any business or investor. Here is why high-value, specific TLDs are a superior choice:
+**No.** `.airbus` is a **closed brand TLD**, so there is no open registration and no [registrar](/en/glossary/registrar/) — including Namefi — can sell you a `.airbus` name. Registrations are limited to Airbus and organizations it authorizes, such as subsidiaries or partners. This is by design: a dot-brand exists precisely so the trademark holder controls the whole namespace and no one else can register a confusing or malicious lookalike.
 
-*   **Unmatched Trust:** A specialized TLD signals to users that the website is legitimate. For .airbus, this means zero tolerance for counterfeit sites.
-*   **SEO and Branding:** Search engines and users alike appreciate short, relevant URLs. A domain that matches the brand name exactly improves recall and click-through rates.
-*   **Security:** Brand TLDs often implement stricter security protocols (like mandatory [DNSSEC](/en/glossary/dnssec/)), ensuring the safety of user data.
-*   **Availability:** For businesses looking at other new gTLDs (like [.tech](/en/tld/tech/), [.xyz](/en/tld/xyz/), or .fly), the availability of short, premium keywords is significantly higher than in the saturated .com market.
+If you have a genuine business relationship with Airbus and a legitimate need for a `.airbus` address, that request would go through Airbus's own corporate channels, not a commercial registrar.
 
-## **Register Your .airbus Domain at Namefi**
+## How Airbus uses .airbus
 
-Are you looking to secure a high-value domain name that offers the same level of prestige and authority as .airbus? While the .airbus registry is currently restricted to the corporation, **Namefi** is your gateway to registering thousands of other premium TLDs and aviation-related domains that define your brand.
+Brand TLDs give a company a private space to organize its web presence. Typical uses for a dot-brand like `.airbus` include:
 
-At Namefi, we are revolutionizing domain registration by bridging the gap between Web2 and [Web3](/en/glossary/web3/).
+- **Product and division sites** on clean, memorable addresses tied directly to the brand.
+- **Campaign and event pages** that are obviously official because only the company can create them.
+- **Internal tools and portals** where a branded suffix signals a trusted, first-party destination.
 
-*   **Seamless Integration:** We are an ICANN-accredited [registrar](/en/glossary/registrar/) that allows you to manage traditional domains with the ease of [blockchain](/en/glossary/blockchain/) technology.
-*   **Tokenized Domains:** When you register a domain with Namefi, you can mint it as an [NFT](/en/glossary/nft/), giving you true ownership, easy transferability, and [liquidity](/en/glossary/domain-liquidity/) for domain investing.
-*   **Bulk Search & AI Tools:** Use our advanced tools to find the perfect alternative to .airbus for your aerospace, travel, or tech business.
+**Who it's not for:** anyone outside Airbus. Because the namespace is closed, there is no scenario in which an independent developer, investor, or business can build on `.airbus`.
 
-Don't let your perfect name fly away. Secure your digital real estate today with the most innovative registrar in the market.
+## Notable sites using .airbus
 
-[**Register your domain at Namefi today**](https://namefi.io)
+There are **no third-party sites** on `.airbus`, and there never will be while it stays a closed brand TLD — every `.airbus` address is controlled by Airbus S.A.S. Airbus continues to run its public presence from its long-established [.com](/en/tld/com/) domain, airbus.com, and uses the brand TLD selectively rather than as a wholesale replacement. Rather than point to a specific address that may change, the honest description is simple: `.airbus` is Airbus's private namespace, used only for the company's own properties.
+
+## What is a dot-brand TLD?
+
+A **dot-brand** (or brand TLD) is a top-level domain that a single company owns and operates for its exclusive use, secured through ICANN's [New gTLD Program](/en/glossary/new-gtld/). Large industrial and manufacturing groups were among the many corporations that applied for their own name as a TLD, and dot-brands share a few defining traits:
+
+- **Closed registration.** Only the brand and its affiliates can hold names.
+- **Specification 13.** A registry-agreement addendum that formally recognizes the TLD as a brand and relaxes some rules that apply to open generics.
+- **Security and control.** The brand eliminates the risk of anyone else registering a `.airbus` lookalike, which strengthens resistance to [phishing](/en/glossary/phishing/) and impersonation.
+
+Some brands invest heavily in their TLD; others register it defensively and barely use it. A number of companies have even terminated their dot-brands after deciding the upkeep was not worth it.
+
+## .airbus vs open domain alternatives
+
+If your goal was a short, brandable name rather than the `.airbus` string specifically, an open extension is the right tool. Here is how a closed brand TLD compares with domains you can actually register:
+
+| Feature | .airbus | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.xyz](/en/tld/xyz/) |
+| --- | --- | --- | --- | --- |
+| Who can register | Airbus only | Anyone | Anyone | Anyone |
+| Type | Brand new gTLD (closed) | Legacy gTLD | ccTLD used generically | New gTLD |
+| Core use | Airbus's own sites | Universal default | Tech & startups | Generic / Web3 |
+| Available to you | No | Yes | Yes | Yes |
+
+For your own venture, a matching `.com` remains the safest default; [.io](/en/tld/io/) suits technical products; and [.xyz](/en/tld/xyz/) is a flexible, low-cost modern option.
+
+## Reputation and trust
+
+Ironically, the closed nature of `.airbus` is exactly what makes it trustworthy: because only Airbus can create these addresses, a `.airbus` link is verifiably official, which is why brand TLDs are considered strong against impersonation and email spoofing — a meaningful benefit for an aerospace supplier whose partner and procurement communications are frequent phishing targets. That trust, however, benefits Airbus alone — it does not transfer to any name you might register, since you cannot register one. For your own project, deliverability and reputation will come from a well-configured domain on an open extension, not from a brand TLD you don't control.
+
+## Looking for an "airbus" name? Register an alternative at Namefi
+
+You can't buy a `.airbus` domain, but if you want a short, aviation-flavored name of your own, you can secure it on an open extension in minutes:
+
+1. **Search** your desired name across open TLDs like `.com`, `.io`, or `.xyz`.
+2. **Choose** the extension that fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can anyone register a .airbus domain?
+
+No. `.airbus` is a closed brand TLD delegated to Airbus S.A.S. Only Airbus and parties it authorizes can hold a `.airbus` name, so it is not available to the general public through any registrar.
+
+### Who operates the .airbus registry?
+
+Airbus S.A.S. is the registry operator, with Identity Digital providing the technical back-end. The TLD was delegated to the DNS root zone in 2016 under ICANN's New gTLD Program.
+
+### What kind of company is Airbus?
+
+Airbus S.A.S. is the European aerospace and commercial-aircraft manufacturer behind the `.airbus` domain.
+
+### What can I register instead of .airbus?
+
+Because `.airbus` is closed, choose an open extension for your own project. A matching `.com`, or a modern alternative like `.io` or `.xyz`, can be registered by anyone through an accredited registrar such as Namefi.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals behind top-level domains.
+- [How a TLD affects domain value](/en/blog/how-tld-affects-domain-value/) — why the extension matters.
+- [.com TLD guide](/en/tld/com/) — the open default to compare against.
+- [.io TLD guide](/en/tld/io/) and [.xyz TLD guide](/en/tld/xyz/) — modern open alternatives.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [registry](/en/glossary/registry/), [ICANN](/en/glossary/icann/).

--- a/content/tld/en/airbus.md
+++ b/content/tld/en/airbus.md
@@ -3,7 +3,7 @@ title: "What Is the .airbus Domain? Airbus's Brand TLD Explained"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .airbus domain is the closed brand TLD of Airbus S.A.S., the European aerospace manufacturer, not open to the public. Learn who runs it and what to register instead.'

--- a/content/tld/en/airforce.md
+++ b/content/tld/en/airforce.md
@@ -1,13 +1,24 @@
 ---
-title: What is the .airforce TLD and Why Choose It?
-date: '2025-12-10'
+title: 'What Is the .airforce Domain? An Open, Non-Military TLD'
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: Explore the strategic advantages of the .airforce domain. Perfect for recruitment, veterans, and aviation tech. Register your .airforce TLD with Namefi today.
-keywords: [.airforce domains, .airforce TLD, .airforce top-level domain, what is .airforce, why choose .airforce, what is the .airforce domain, why choose the .airforce domain, military domain names, aviation industry domains, tokenized military domains, blockchain domain assets, buy .airforce domain, defense technology domains, domain investing airforce, Namefi domains]
+description: 'The .airforce domain is an open gTLD run by Dog Beach, LLC (Identity Digital), not tied to any air force. Learn who actually uses it and who can register.'
+keywords: ['.airforce domain', 'what is .airforce', '.airforce TLD', 'Dog Beach registry', 'Identity Digital TLD', 'military-themed domain names', 'veteran community domain', 'aviation enthusiast domain']
+faqs:
+  - question: 'Can anyone register a .airforce domain?'
+    answer: 'Yes. The .airforce domain is an open generic TLD with no military, veteran, or government affiliation required to register. Any individual or organization can register one through an accredited registrar.'
+  - question: 'Is .airforce affiliated with any actual air force or the military?'
+    answer: 'No. The .airforce domain is not run by, endorsed by, or restricted to any air force or military branch. It is operated by Dog Beach, LLC, an Identity Digital company, purely as an open generic top-level domain.'
+  - question: 'Does a .airforce domain affect SEO?'
+    answer: 'Google treats .airforce like any other generic TLD, with no geographic bias and no automatic ranking boost or penalty. Rankings still come down to content, links, and user experience.'
+  - question: 'Who typically uses .airforce domains?'
+    answer: 'Military veterans and enthusiasts, aviation hobbyists, gaming and e-sports clans, and airsoft or paintball groups are the main real-world users, alongside general enthusiast sites drawn to the short, aviation-flavored name.'
+  - question: 'Who operates the .airforce registry?'
+    answer: 'The .airforce registry is operated by Dog Beach, LLC, a company under Identity Digital. It was delegated to the DNS root zone on April 17, 2014, and sits alongside the sibling extensions .army and .navy.'
 relatedArticles:
   - /en/blog/what-is-a-tld/
   - /en/blog/what-are-tokenized-domains/
@@ -28,53 +39,131 @@ relatedGlossary:
   - /en/glossary/web3/
 ---
 
-## **What is .airforce?**
+The **.airforce** domain is an open [generic top-level domain](/en/glossary/gtld/) built around a military-sounding word — but despite the tone of authority, it is not run by, affiliated with, or restricted to any actual air force or military branch. Anyone can register one. This page explains who actually runs `.airforce`, who genuinely uses it, and why the gap between how the name sounds and who is allowed to hold it is the single most important thing to understand before you buy.
 
-The **.airforce** domain is a specialized New Generic [Top-Level Domain](/en/glossary/tld/) ([new gTLD](/en/glossary/new-gtld/)) explicitly designed to serve the global air force community. Unlike the traditional `.com` or `.org`, which are broad and crowded, .airforce provides a dedicated digital namespace for active service members, veterans, recruitment agencies, aerospace suppliers, and aviation enthusiasts.
+## .airforce at a glance
 
-Launched as part of [ICANN’s](https://www.icann.org/) program to expand the internet's namespace, the .airforce TLD is managed by the [registry](/en/glossary/registry/) **Identity Digital** (formerly Donuts). It was created to allow organizations and individuals associated with air defense and aviation to establish a clear, authoritative, and instantly recognizable online identity.
+| Fact | Detail |
+| --- | --- |
+| TLD type | New gTLD (generic) |
+| Registry operator | Dog Beach, LLC (an [Identity Digital](https://www.identity.digital/) company) |
+| Year launched | Delegated to the root zone April 17, 2014 |
+| Military affiliation | **None** — not run by, endorsed by, or restricted to any air force or military body |
+| Sibling extensions | Part of the same family as `.army` and `.navy` |
+| Registration restrictions | Open to all — no military, veteran, or government affiliation required |
+| Best for | Veterans and enthusiasts, aviation hobbyists, gaming/e-sports clans, airsoft and paintball groups |
 
-While it carries a tone of official authority, it is generally open for registration, making it a versatile asset for anyone looking to build a community, sell equipment, or honor history within this specific sector.
+## What is .airforce?
 
-## **How People Are Using .airforce**
+"Air force" evokes national military aviation, but as a domain suffix `.airforce` carries no institutional backing. It is a generic new gTLD delegated to the root zone on **April 17, 2014**, per its [IANA root-zone entry](https://www.iana.org/domains/root/db/airforce.html), and it is operated by **Dog Beach, LLC**, a company under [Identity Digital](https://www.identity.digital/). The string traces back to the former United TLD / Rightside portfolio, one of the groups of 2012-round new-gTLD applicants that later consolidated into today's Identity Digital.
 
-The .airforce TLD is being utilized across various verticals to signal relevance and specific intent. Here is how different sectors are leveraging this extension:
+Because it is generic rather than a country code, Google applies no geographic bias to `.airforce` — it can rank and be geo-targeted anywhere, the same as any other gTLD.
 
-*   **Recruitment and Careers:** Recruitment centers and career blogs use the extension to create memorable URLs for aspiring pilots and service members (e.g., `careers.airforce` or `join.airforce`).
-*   **Veteran Support Networks:** Non-profits and community groups dedicated to supporting retired personnel use the domain to create safe, recognizable hubs for counseling, reunions, and benefits assistance.
-*   **Aerospace and Defense Contractors:** Businesses that supply technology, parts, or logistics to air forces worldwide use the TLD to highlight their specialization and industry focus.
-*   **History and Museums:** Aviation museums and historical archives utilize the domain to host digital exhibitions regarding military aviation history.
-*   **Gaming and Simulation:** Flight simulator communities and military-themed gaming clans adopt the domain to brand their squadrons and servers.
+## History of .airforce
 
-## **Notable Entities Using .airforce**
+`.airforce` was part of the 2012-round New gTLD Program wave that produced many single-word, evocative strings. It came out of the United TLD / Rightside applicant portfolio and was delegated to the DNS root zone on April 17, 2014. Rightside's TLD contracts were later absorbed into Identity Digital's portfolio, where Dog Beach, LLC now holds the registry agreement. `.airforce` sits next to two sibling strings built on the same idea — `.army` and `.navy` — none of which carry any actual service-branch affiliation.
 
-Because .airforce is a niche TLD, it is often used for specific campaigns or community sites rather than by massive consumer conglomerates. However, its usage is impactful within the industry.
+## How people use .airforce
 
-*   **Recruitment Portals:** various regional recruitment initiatives utilize the extension to separate their landing pages from general government sites, making marketing campaigns more effective.
-*   **Aerospace Suppliers:** Niche manufacturers of drone technology and avionics have adopted the TLD to improve their B2B visibility within the defense sector.
-*   **Veteran Communities:** Several localized support groups and "friends of the air force" foundations utilize the domain to build trust immediately upon a user seeing the URL.
+Because registration is open and unaffiliated with any real military body, real use skews toward enthusiast and community space rather than official channels:
 
-*If you are a developer or a brand in the defense tech space, you have a unique opportunity to define this namespace. Since many "premium" keywords are still available, a new startup could easily become a notable entity by securing a category-defining domain like `drone.airforce` or `security.airforce`.*
+- **Veterans and military enthusiasts** building personal, memorial, or community sites.
+- **Aviation hobbyists** using the name for flight-sim, spotting, or airshow-related projects.
+- **Gaming and e-sports clans** adopting a military-sounding handle for a team or guild site.
+- **Airsoft and paintball groups**, where "air force"-style branding fits the activity.
+- **General enthusiast sites** that want a short, punchy, aviation-flavored name.
 
-## **Why Choose .airforce?**
+**Who it's not ideal for:** anyone hoping the domain itself will confer, imply, or verify an official military or government connection — it does not, and using it in a way that suggests otherwise risks misleading visitors. It is also not the pick for a mainstream commercial brand with no aviation or military theme, since the name reads as specific to that niche.
 
-Choosing the right TLD is crucial for your digital identity. Here is why .airforce is a superior choice for relevant projects:
+## Notable sites using .airforce
 
-*   **Instant Credibility:** The word "airforce" commands respect. Using this TLD immediately signals discipline, authority, and industry relevance to your visitors.
-*   **High Availability:** Unlike `.com`, where most short and meaningful names were taken decades ago, .airforce still has a vast inventory of short, memorable, and keyword-rich domain names available.
-*   **Targeted Branding:** It removes ambiguity. When a user sees a link ending in .airforce, they know exactly what the content entails, which can improve click-through rates (CTR) from the right audience.
-*   **SEO Relevance:** While Google treats most TLDs equally, having keywords in your domain name (like "tactical.airforce") can assist in relevancy signals for niche search queries related to aviation and defense.
-*   **Domain Investment Potential:** As the aerospace and defense sectors continue to digitize, and as [Web3](/en/glossary/web3/) intersects with real-world assets, owning specific keyword domains within this TLD represents a forward-thinking digital asset strategy.
+No official air force or government body operates on `.airforce` — no registry-level restriction exists to produce one, and no verified list of official users exists either. In practice, its visible footprint matches the enthusiast pattern above: veteran and hobbyist community sites, aviation-fan projects, and gaming-clan pages rather than any institutional flagship. This page does not name a specific site, since none has been verified as a leading example.
 
-## **Register Your .airforce Domain at Namefi**
+## .airforce vs other domains
 
-Whether you are launching a veteran support blog, an aerospace startup, or simply investing in valuable digital real estate, the .airforce domain offers a runway for success.
+| Feature | .airforce | [.com](/en/tld/com) | `.army` |
+| --- | --- | --- | --- |
+| Type | New gTLD (generic) | Legacy gTLD | New gTLD (generic) |
+| Military affiliation | None | None | None |
+| Restrictions | Open to all | Open to all | Open to all |
+| Best fit | Aviation/military-themed hobby, veteran, and gaming-clan sites | General purpose | Land-forces-themed hobby and community sites |
 
-At **Namefi**, we make securing your digital identity seamless and future-proof. We are not just a [registrar](/en/glossary/registrar/); we are bridging the gap between Web2 and Web3. When you register with us, you enjoy:
-*   **ICANN-Accredited Security:** Trustworthy and compliant registration.
-*   **Web3 Integration:** The unique ability to ["tokenize"](/en/glossary/tokenize/) your domain, turning it into a transferable asset on the [blockchain](/en/glossary/blockchain/) for easier trading and management.
-*   **Transparent Pricing:** No hidden fees, just straightforward management of your portfolio.
+Choose `.com` for a general-purpose brand with no need for a themed suffix. Choose `.airforce` when the aviation/military theme is itself the point — a hobby, fan, veteran-community, or gaming-clan project that wants a short, evocative name, with the clear understanding that it implies no official status. Its sibling `.army` follows the identical model for land-forces-themed projects.
 
-Don't let your perfect domain fly under the radar. Secure your namespace today.
+## Why choose .airforce?
 
-[**Register your .airforce domain at Namefi**](https://namefi.io)
+- **Thematic clarity for hobby and community projects.** It signals an aviation/military theme instantly.
+- **Open registration.** No credential, veteran-status, or government affiliation is required.
+- **Available short names.** Less competition than `.com` for punchy, single-word military and aviation terms.
+- **Part of a recognizable set.** Sitting alongside `.army` and `.navy` gives it a coherent, memorable family.
+
+## Things to consider
+
+- **It implies no official status.** This is the single biggest thing to get right: `.airforce` is not run by, endorsed by, or restricted to any real air force, and using it in a way that suggests government or military affiliation would be misleading.
+- **Niche audience.** Outside aviation, military-enthusiast, or gaming-clan contexts, the name may not read as relevant to visitors.
+- **Lower mainstream recognition** than `.com` or `.org`.
+
+## Who can register a .airforce domain?
+
+**Registration restrictions: open to all.** According to its [IANA root-zone entry](https://www.iana.org/domains/root/db/airforce.html), `.airforce` is an unrestricted generic gTLD operated by Dog Beach, LLC. There is no requirement to be a veteran, service member, government body, or aviation professional — any individual or organization may register a `.airforce` name through an accredited [registrar](/en/glossary/registrar/). This openness is exactly why the name carries no official weight: unlike a sponsored, community-gated string, nothing about the registration process verifies any connection to an actual air force.
+
+Standard new-gTLD rules otherwise apply, including sunrise and [trademark](/en/glossary/trademark/)-claims phases at launch and normal renewal and [WHOIS](/en/glossary/whois/) rules through your registrar. The authoritative rules live in the [ICANN .airforce registry agreement](https://www.icann.org/en/registry-agreements/details/airforce).
+
+## .airforce pricing and value
+
+- **Standard new-gTLD pricing structure**, set by the registry and marked up by registrars, rather than a flat legacy fee.
+- **First-year and renewal pricing typically differ**, as with most new gTLDs — check the renewal rate, not just the introductory offer.
+- **Demand is enthusiast-driven** rather than commercial, which tends to keep short, generic terms attainable compared with a saturated `.com` namespace.
+
+This page lists no figures, since prices and promotions change across registrars — check current rates at the point of purchase.
+
+## Reputation and email deliverability
+
+`.airforce` carries no adult, spam, or abuse-driven reputation baggage in the way some budget gTLDs do — its typical content, military and aviation hobby or community material, is not itself a filter trigger. The real reputation issue is different: because the name suggests an official body that is not actually behind it, an organization using the domain should be careful not to let it imply a government or military affiliation it does not have.
+
+For deliverability specifically, treat it like any other newer gTLD: configure **SPF, DKIM, and DMARC** correctly, warm up sending gradually, and keep list hygiene tight. Nothing about `.airforce` itself works against inbox placement.
+
+## Branding and naming tips
+
+- **Be upfront about being unofficial** if your project could be mistaken for a government or service branch — a short note that you are not affiliated with any air force or ministry of defense protects both you and your visitors.
+- **Lean into the community angle** for veteran, hobbyist, or clan projects, where the name reads most naturally.
+- **Keep names short.** The suffix already carries weight, so the left side can be a single word or handle.
+- **Consider pairing with `.com`** if you plan a commercial storefront alongside a hobby or community site.
+
+## How to register a .airforce domain at Namefi
+
+1. **Search** for your desired name on [Namefi](https://namefi.io) to check availability.
+2. **Choose** the exact `.airforce` name for your community, hobby, or gaming project.
+3. **Register** and configure DNS.
+
+Namefi is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) with transparent pricing, and it also supports [Web3](/en/glossary/web3/) tokenization, so you can optionally [tokenize](/en/glossary/tokenize/) a domain for easier transfer and management. [Search and register your .airforce domain at Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .airforce domain?
+
+Yes. The `.airforce` domain is an open generic TLD with no military, veteran, or government affiliation required to register. Any individual or organization can register one through an accredited registrar.
+
+### Is .airforce affiliated with any actual air force or the military?
+
+No. The `.airforce` domain is not run by, endorsed by, or restricted to any air force or military branch. It is operated by Dog Beach, LLC, an Identity Digital company, purely as an open generic top-level domain.
+
+### Does a .airforce domain affect SEO?
+
+Google treats `.airforce` like any other generic TLD, with no geographic bias and no automatic ranking boost or penalty. Rankings still come down to content, links, and user experience.
+
+### Who typically uses .airforce domains?
+
+Military veterans and enthusiasts, aviation hobbyists, gaming and e-sports clans, and airsoft or paintball groups are the main real-world users, alongside general enthusiast sites drawn to the short, aviation-flavored name.
+
+### Who operates the .airforce registry?
+
+The `.airforce` registry is operated by Dog Beach, LLC, a company under Identity Digital. It was delegated to the DNS root zone on April 17, 2014, and sits alongside the sibling extensions `.army` and `.navy`.
+
+## Related resources
+
+- [.com domain](/en/tld/com) — the general-purpose baseline to compare against.
+- [.org domain](/en/tld/org) — a fit for nonprofit veteran and community organizations.
+- [What is a TLD?](/en/blog/what-is-a-tld) — the fundamentals of top-level domains.
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains) — how domains become on-chain assets.
+- Glossary: [registrar](/en/glossary/registrar), [ICANN](/en/glossary/icann), [registry](/en/glossary/registry), [TLD](/en/glossary/tld)

--- a/content/tld/en/airforce.md
+++ b/content/tld/en/airforce.md
@@ -3,7 +3,7 @@ title: 'What Is the .airforce Domain? An Open, Non-Military TLD'
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .airforce domain is an open gTLD run by Dog Beach, LLC (Identity Digital), not tied to any air force. Learn who actually uses it and who can register.'

--- a/content/tld/en/airtel.md
+++ b/content/tld/en/airtel.md
@@ -3,7 +3,7 @@ title: "What Is the .airtel Domain? Airtel's Brand TLD Explained"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .airtel domain is the closed brand TLD of Bharti Airtel, a major Indian telecom company, not open to the public. Learn who runs it and what to register instead.'

--- a/content/tld/en/airtel.md
+++ b/content/tld/en/airtel.md
@@ -1,13 +1,22 @@
 ---
-title: 'What is the .airtel TLD and Why is it Significant?'
-date: '2025-12-10'
+title: "What Is the .airtel Domain? Airtel's Brand TLD Explained"
+date: '2026-07-24'
 language: 'en'
-tags: ['tld', 'brand-tld', 'domain-investing', 'airtel']
+tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: 'Discover the .airtel Top-Level Domain: a specialized TLD for the telecom giant. Learn about Brand TLDs, their security benefits, and the future of domain naming.'
-keywords: ['.airtel domains', '.airtel TLD', 'top-level domain', 'what is .airtel', 'why choose .airtel', 'what is the .airtel domain', 'why choose the .airtel domain', 'Bharti Airtel domain', 'brand TLD', 'domain investing', 'blockchain domains', 'tokenized domain', 'new gTLD', 'telecom domains', 'Web3 domains']
+description: 'The .airtel domain is the closed brand TLD of Bharti Airtel, a major Indian telecom company, not open to the public. Learn who runs it and what to register instead.'
+keywords: ['.airtel domain', 'what is .airtel', '.airtel TLD', 'Airtel brand domain', 'dot-brand TLD', 'Bharti Airtel registry', 'closed generic TLD', 'is .airtel available']
+faqs:
+  - question: 'Can anyone register a .airtel domain?'
+    answer: 'No. .airtel is a closed brand TLD delegated to Bharti Airtel Limited. Only Airtel and parties it authorizes can hold a .airtel name, so it is not available to the general public through any registrar.'
+  - question: 'Who operates the .airtel registry?'
+    answer: 'Bharti Airtel Limited is the registry operator, with GoDaddy Registry providing the technical back-end. The TLD was delegated to the DNS root zone in 2015 under ICANN''s New gTLD Program.'
+  - question: 'What kind of company is Airtel?'
+    answer: 'Bharti Airtel Limited is a major Indian telecommunications company, and .airtel is its own dedicated brand top-level domain.'
+  - question: 'What can I register instead of .airtel?'
+    answer: 'Because .airtel is closed, choose an open extension for your own project. A matching .com, or a modern alternative like .io or .xyz, can be registered by anyone through an accredited registrar such as Namefi.'
 relatedArticles:
   - /en/blog/what-is-a-tld/
   - /en/blog/top-tlds-to-secure-for-your-business/
@@ -28,49 +37,113 @@ relatedGlossary:
   - /en/glossary/registry/
 ---
 
-## **What is .airtel?**
+The **.airtel** domain is a **closed brand [top-level domain](/en/glossary/tld/)** operated by **Bharti Airtel Limited**, a major Indian telecommunications company. It is not a public extension: unlike [.com](/en/tld/com/) or [.io](/en/tld/io/), you cannot register a `.airtel` name for your own project, because the entire namespace belongs to one company.
 
-The **.airtel** extension is a specialized [Top-Level Domain (TLD)](/en/glossary/tld/) categorized as a **Brand TLD** (or .brand). Unlike generic extensions like [.com](/en/tld/com/) or [.net](/en/tld/net/) which are open for public registration, the .airtel TLD was created specifically for **Bharti Airtel**, one of the world's leading telecommunications companies with operations in countries across Asia and Africa.
+If you searched for the ".airtel domain" hoping to buy one, the short answer is that you can't — but this page explains exactly what `.airtel` is, who controls it, why a company runs its own TLD, and what you can register instead.
 
-Introduced during [ICANN's New gTLD Program](https://newgtlds.icann.org/en/about/program), this domain extension allows the company to create a secure, branded digital ecosystem. By operating their own [registry](/en/glossary/registry/), Airtel moves away from relying on third-party extensions, asserting total control over their web presence. This move signifies a shift towards a more fragmented but trustworthy internet, where large corporations manage their own digital real estate.
+## .airtel at a glance
 
-## **How People Are Using .airtel**
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | Bharti Airtel Limited (technical back-end by GoDaddy Registry) |
+| Year delegated | 2015 |
+| IDN support | Not relevant — closed namespace |
+| DNSSEC | Supported |
+| Registration restrictions | **Closed** — restricted to Airtel and parties it authorizes; not available to the public |
+| Best for | Airtel's own corporate, product, and campaign websites |
 
-Because .airtel is a proprietary Brand TLD, its usage is currently restricted primarily to the entity itself and its affiliates. It is not typically used by the general public for personal blogs or unrelated e-commerce. However, understanding its usage provides valuable insight into the future of corporate web infrastructure:
+## What is .airtel?
 
-*   **Service Unification:** The domain is used to unify various services under one trustworthy umbrella (e.g., banking, streaming, and mobile services).
-*   **Customer Security:** By using a closed TLD, the company ensures that any website ending in `.airtel` is legitimate, drastically reducing the risk of [phishing](/en/glossary/phishing/) attacks.
-*   **Internal Infrastructure:** It serves as a backbone for employee portals, intranet systems, and developer environments within the telecom giant’s network.
-*   **Marketing Campaigns:** Short, memorable domains are used for specific marketing pushes or product launches.
+`.airtel` is a **[generic top-level domain](/en/glossary/gtld/)** that ICANN delegated to **Bharti Airtel Limited** as part of its New gTLD Program. The string is the company's own brand name: **Airtel**, a major Indian telecommunications company.
 
-## **Notable Entities Using .airtel**
+But `.airtel` is a **brand TLD** — often called a "dot-brand" — not an open extension anyone can buy into. The company applied for the string specifically so that it, and only it, would control every domain ending in `.airtel`. You can confirm the delegation and operator on the authoritative [IANA root-zone record for .airtel](https://www.iana.org/domains/root/db/airtel.html).
 
-As a restricted Brand TLD, the "notable entities" are exclusively departments, subsidiaries, or specific services within the Bharti Airtel ecosystem. Examples of how this namespace is utilized include:
+## History of .airtel
 
-1.  **Airtel India & Africa:** Regional divisions utilizing the TLD to route local traffic and manage customer accounts specific to the region.
-2.  **Airtel Payments Bank:** Financial services often utilize the TLD to provide a verified, secure environment for digital transactions.
-3.  **Xstream & Wynk:** Entertainment and media subdivisions of the company may utilize specific `.airtel` subdomains to host content or manage user subscriptions securely.
+`.airtel` was **delegated to the DNS [root zone](/en/glossary/root-zone/) on June 18, 2015**, during the same wave of ICANN's New gTLD Program that brought hundreds of corporate names into the domain system. **GoDaddy Registry** runs the technical back-end on Airtel's behalf, operating the infrastructure that keeps the namespace resolving and secure, while Bharti Airtel Limited remains the registry operator of record.
 
-## **Why Choose .airtel?**
+Its registry agreement with [ICANN](/en/glossary/icann/) includes **Specification 13**, the contract clause that formally designates a TLD as a brand and lets the operator keep it closed. The record has stayed active since delegation, unlike several brand TLDs that were later handed back and removed from the root.
 
-While public registration is restricted, the *existence* and *strategy* behind the .airtel TLD offer compelling reasons for why Brand TLDs are becoming the gold standard for major enterprises. If you are interacting with a `.airtel` domain, here are the advantages:
+## Is .airtel available to register?
 
-*   **Unmatched Trust & Security:** Because only Bharti Airtel can register domains in this extension, users can trust that a `.airtel` site is authentic and free from cybersquatters or scammers.
-*   **Brand Authority:** It signals technological leadership. Moving away from a generic `.com` to a proprietary extension demonstrates innovation.
-*   **Short and Memorable:** With total control over the registry, the company can create short, keyword-rich URLs (e.g., `shop.airtel` or `pay.airtel`) that are great for SEO and user recall.
-*   **Next-Gen Tech Integration:** Brand TLDs are often at the forefront of integrating new web technologies, including potential future use cases involving **[tokenized domains](/en/blog/what-are-tokenized-domains/)** and [blockchain](/en/glossary/blockchain/) identity verification.
+**No.** `.airtel` is a **closed brand TLD**, so there is no open registration and no [registrar](/en/glossary/registrar/) — including Namefi — can sell you a `.airtel` name. Registrations are limited to Airtel and organizations it authorizes, such as subsidiaries or partners. This is by design: a dot-brand exists precisely so the trademark holder controls the whole namespace and no one else can register a confusing or malicious lookalike.
 
-## **Register Your Domain at Namefi**
+If you have a genuine business relationship with Airtel and a legitimate need for a `.airtel` address, that request would go through Airtel's own corporate channels, not a commercial registrar.
 
-Whether you are looking for specific industry TLDs, generic extensions, or exploring the world of **[Web3](/en/glossary/web3/) domains**, securing your digital identity is the first step toward success.
+## How Airtel uses .airtel
 
-At **Namefi**, we simplify the domain management process. We are an [ICANN](/en/glossary/icann/)-accredited [registrar](/en/glossary/registrar/) that bridges the gap between traditional Web2 DNS and the decentralized Web3 world.
+Brand TLDs give a company a private space to organize its web presence. Typical uses for a dot-brand like `.airtel` include:
 
-*   **Seamless Integration:** Manage your domains with the ease of blockchain technology.
-*   **Tokenized Assets:** Turn your [domain portfolio](/en/glossary/domain-portfolio/) into liquid assets.
-*   **Instant Setup:** Search, buy, and configure in minutes.
+- **Product and division sites** on clean, memorable addresses tied directly to the brand.
+- **Campaign and event pages** that are obviously official because only the company can create them.
+- **Internal tools and portals** where a branded suffix signals a trusted, first-party destination.
 
-While `.airtel` is a restricted brand registry, you can find thousands of other high-impact domains to build your own brand authority.
+**Who it's not for:** anyone outside Airtel. Because the namespace is closed, there is no scenario in which an independent developer, investor, or business can build on `.airtel`.
 
-**Ready to start?**
-[**Secure your domain today at Namefi**](https://namefi.io)
+## Notable sites using .airtel
+
+There are **no third-party sites** on `.airtel`, and there never will be while it stays a closed brand TLD — every `.airtel` address is controlled by Bharti Airtel Limited. Airtel continues to run its public presence from its long-established primary site, airtel.in — notably a country-code domain rather than a `.com` — and uses the brand TLD selectively rather than as a wholesale replacement. Rather than point to a specific address that may change, the honest description is simple: `.airtel` is Airtel's private namespace, used only for the company's own properties.
+
+## What is a dot-brand TLD?
+
+A **dot-brand** (or brand TLD) is a top-level domain that a single company owns and operates for its exclusive use, secured through ICANN's [New gTLD Program](/en/glossary/new-gtld/). Telecommunications companies were among the many large corporations that applied for their own name as a TLD, and dot-brands share a few defining traits:
+
+- **Closed registration.** Only the brand and its affiliates can hold names.
+- **Specification 13.** A registry-agreement addendum that formally recognizes the TLD as a brand and relaxes some rules that apply to open generics.
+- **Security and control.** The brand eliminates the risk of anyone else registering a `.airtel` lookalike, which strengthens resistance to [phishing](/en/glossary/phishing/) and impersonation.
+
+Some brands invest heavily in their TLD; others register it defensively and barely use it. A number of companies have even terminated their dot-brands after deciding the upkeep was not worth it.
+
+## .airtel vs open domain alternatives
+
+If your goal was a short, brandable name rather than the `.airtel` string specifically, an open extension is the right tool. Here is how a closed brand TLD compares with domains you can actually register:
+
+| Feature | .airtel | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.xyz](/en/tld/xyz/) |
+| --- | --- | --- | --- | --- |
+| Who can register | Airtel only | Anyone | Anyone | Anyone |
+| Type | Brand new gTLD (closed) | Legacy gTLD | ccTLD used generically | New gTLD |
+| Core use | Airtel's own sites | Universal default | Tech & startups | Generic / Web3 |
+| Available to you | No | Yes | Yes | Yes |
+
+For your own venture, a matching `.com` remains the safest default; [.io](/en/tld/io/) suits technical products; and [.xyz](/en/tld/xyz/) is a flexible, low-cost modern option.
+
+## Reputation and trust
+
+Ironically, the closed nature of `.airtel` is exactly what makes it trustworthy: because only Airtel can create these addresses, a `.airtel` link is verifiably official, which is why brand TLDs are considered strong against impersonation and email spoofing — a meaningful benefit for a telecom brand whose billing and recharge messages are a common phishing lure. That trust, however, benefits Airtel alone — it does not transfer to any name you might register, since you cannot register one. For your own project, deliverability and reputation will come from a well-configured domain on an open extension, not from a brand TLD you don't control.
+
+## Looking for an "airtel" name? Register an alternative at Namefi
+
+You can't buy a `.airtel` domain, but if you want a short, telecom- or connectivity-flavored name of your own, you can secure it on an open extension in minutes:
+
+1. **Search** your desired name across open TLDs like `.com`, `.io`, or `.xyz`.
+2. **Choose** the extension that fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can anyone register a .airtel domain?
+
+No. `.airtel` is a closed brand TLD delegated to Bharti Airtel Limited. Only Airtel and parties it authorizes can hold a `.airtel` name, so it is not available to the general public through any registrar.
+
+### Who operates the .airtel registry?
+
+Bharti Airtel Limited is the registry operator, with GoDaddy Registry providing the technical back-end. The TLD was delegated to the DNS root zone in 2015 under ICANN's New gTLD Program.
+
+### What kind of company is Airtel?
+
+Bharti Airtel Limited is a major Indian telecommunications company, and `.airtel` is its own dedicated brand top-level domain.
+
+### What can I register instead of .airtel?
+
+Because `.airtel` is closed, choose an open extension for your own project. A matching `.com`, or a modern alternative like `.io` or `.xyz`, can be registered by anyone through an accredited registrar such as Namefi.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals behind top-level domains.
+- [How a TLD affects domain value](/en/blog/how-tld-affects-domain-value/) — why the extension matters.
+- [.com TLD guide](/en/tld/com/) — the open default to compare against.
+- [.io TLD guide](/en/tld/io/) and [.xyz TLD guide](/en/tld/xyz/) — modern open alternatives.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [registry](/en/glossary/registry/), [ICANN](/en/glossary/icann/).

--- a/content/tld/en/akdn.md
+++ b/content/tld/en/akdn.md
@@ -1,13 +1,22 @@
 ---
-title: "What is the .akdn TLD? Understanding the Aga Khan Development Network Domain"
-date: '2025-12-10'
+title: "What Is the .akdn Domain? AKDN's Brand TLD Explained"
+date: '2026-07-24'
 language: 'en'
-tags: ['tld', 'brand-tld', 'domain-industry']
+tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: "Discover the purpose of the .akdn TLD, its role in the Aga Khan Development Network, and how exclusive Brand TLDs function in the domain industry."
-keywords: [".akdn domains", ".akdn TLD", "top-level domain", "what is .akdn", "why choose .akdn", "what is the .akdn domain", "why choose the .akdn domain", "Aga Khan Development Network", "brand TLD", "restricted domain registration", "domain investing", "blockchain domains", "tokenized domain", "ICANN new gTLDs", "non-profit domains"]
+description: 'The .akdn domain is the closed brand TLD of the Aga Khan Development Network, not open to the public. Learn who runs it and what to register instead.'
+keywords: ['.akdn domain', 'what is .akdn', '.akdn TLD', 'AKDN brand domain', 'dot-brand TLD', 'Aga Khan Development Network domain', 'closed generic TLD', 'is .akdn available']
+faqs:
+  - question: 'Can anyone register a .akdn domain?'
+    answer: 'No. .akdn is a closed brand TLD delegated to the Fondation Aga Khan for the Aga Khan Development Network. Only AKDN entities and parties they authorize can hold a .akdn name, so it is not available to the general public through any registrar.'
+  - question: 'Who operates the .akdn registry?'
+    answer: 'Fondation Aga Khan is the registry operator, with Afilias providing the technical back-end. The TLD was delegated to the DNS root zone in 2016 under ICANN''s New gTLD Program.'
+  - question: 'What does AKDN stand for?'
+    answer: 'AKDN stands for the Aga Khan Development Network, a group of international development agencies. The .akdn domain is operated by the Fondation Aga Khan on the network''s behalf.'
+  - question: 'What can I register instead of .akdn?'
+    answer: 'Because .akdn is closed, choose an open extension for your own project. A matching .com, or a modern alternative like .io or .xyz, can be registered by anyone through an accredited registrar such as Namefi.'
 relatedArticles:
   - /en/blog/what-is-a-tld/
   - /en/blog/what-are-tokenized-domains/
@@ -28,66 +37,113 @@ relatedGlossary:
   - /en/glossary/registry/
 ---
 
-## **What is .akdn?**
+The **.akdn** domain is a **closed brand [top-level domain](/en/glossary/tld/)** operated by the **Fondation Aga Khan** for the **Aga Khan Development Network (AKDN)**, a group of international development agencies. It is not a public extension: unlike [.com](/en/tld/com/) or [.io](/en/tld/io/), you cannot register a `.akdn` name for your own project, because the entire namespace belongs to one network.
 
-The **.akdn** [Top-Level Domain (TLD)](/en/glossary/tld/) is a unique extension in the internet's namespace. Unlike generic domains like [.com](/en/tld/com/) or [.net](/en/tld/net/), **.akdn** is a "Brand TLD" delegated specifically to the **Aga Khan Development Network (AKDN)**.
+If you searched for the ".akdn domain" hoping to buy one, the short answer is that you can't — but this page explains exactly what `.akdn` is, who controls it, why a network runs its own TLD, and what you can register instead.
 
-Launched during [ICANN's](/en/glossary/icann/) expansion of the internet's [domain name system](/en/glossary/dns/), this TLD serves as a dedicated digital infrastructure for one of the world's largest private development agencies. The primary purpose of .akdn is to consolidate the various agencies, institutions, and programs of the network under a single, trusted, and verified digital umbrella.
+## .akdn at a glance
 
-Because it is a **restricted Brand TLD**, it is not available for public registration. Instead, it serves as a prime example of how major organizations use custom TLDs to enhance digital security and brand identity.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | Fondation Aga Khan, for AKDN (technical back-end by Afilias) |
+| Year delegated | 2016 |
+| IDN support | Not relevant — closed namespace |
+| DNSSEC | Supported |
+| Registration restrictions | **Closed** — restricted to AKDN entities and parties they authorize; not available to the public |
+| Best for | AKDN agencies' own institutional and program websites |
 
-*   **Registry Operator:** Imara IP Co. Limited (affiliated with AKDN).
-*   **Type:** [Generic Top-Level Domain](/en/glossary/gtld/) (gTLD) - Brand Category.
-*   **Status:** Active / Restricted.
+## What is .akdn?
 
-For more technical details on the delegation, you can view the [IANA Delegation Record for .akdn](https://www.iana.org/domains/root/db/akdn.html).
+`.akdn` is a **[generic top-level domain](/en/glossary/gtld/)** that ICANN delegated to the **Fondation Aga Khan** as part of its New gTLD Program. The string is an initialism for the **Aga Khan Development Network**, a group of international development agencies operating in the fields the network covers.
 
-## **How People Are Using .akdn**
+But `.akdn` is a **brand TLD** — often called a "dot-brand" — not an open extension anyone can buy into. The Fondation Aga Khan applied for the string specifically so that it, and only it, would control every domain ending in `.akdn`. You can confirm the delegation and operator on the authoritative [IANA root-zone record for .akdn](https://www.iana.org/domains/root/db/akdn.html).
 
-Since .akdn is a closed ecosystem, "usage" is defined strictly by the internal governance of the Aga Khan Development Network. It is used to create a unified digital presence for agencies operating in over 30 countries.
+## History of .akdn
 
-Here is how the namespace is utilized:
-*   **Digital Identity Consolidation:** It brings together diverse entities—ranging from universities to hospitals and cultural trusts—under one verified extension.
-*   **Philanthropic Verification:** In an era of online scams, seeing a URL ending in `.akdn` assures donors and partners that the site is legitimately affiliated with the organization.
-*   **Internal Infrastructure:** It is likely used for internal staff portals, secure communication channels, and developer sandboxes within the organization's IT structure.
+`.akdn` was **delegated to the DNS [root zone](/en/glossary/root-zone/) on March 31, 2016**, part of the same New gTLD Program that let hundreds of organizations apply for their own name as a TLD. **Afilias** ran the technical back-end on the network's behalf, operating the infrastructure that keeps the namespace resolving and secure, while the Fondation Aga Khan remains the registry operator of record. The network also operates a sibling brand TLD, `.agakhan`, delegated separately.
 
-You can learn more about the organization behind the domain at the [official AKDN website](https://www.akdn.org).
+Its registry agreement with [ICANN](/en/glossary/icann/) includes **Specification 13**, the contract clause that formally designates a TLD as a brand and lets the operator keep it closed. The record has stayed active since delegation, unlike several brand TLDs that were later handed back and removed from the root.
 
-## **Notable Entities Using .akdn**
+## Is .akdn available to register?
 
-Because this TLD is specific to one global network, the "notable entities" are the agencies within that network. While the main public-facing site often remains `akdn.org` for historical SEO reasons, the TLD allows for specific segmentations.
+**No.** `.akdn` is a **closed brand TLD**, so there is no open registration and no [registrar](/en/glossary/registrar/) — including Namefi — can sell you a `.akdn` name. Registrations are limited to AKDN agencies and organizations the network authorizes. This is by design: a dot-brand exists precisely so the trademark holder controls the whole namespace and no one else can register a confusing or malicious lookalike.
 
-Entities that operate within this digital sphere include:
+If you have a genuine affiliation with the Aga Khan Development Network and a legitimate need for a `.akdn` address, that request would go through the network's own governance channels, not a commercial registrar.
 
-1.  **The Aga Khan Foundation (AKF):** Focusing on rural development, health, and education.
-2.  **The Aga Khan University (AKU):** An international university with campuses in Asia, Africa, and the UK.
-3.  **The Aga Khan Agency for Habitat (AKAH):** Focusing on disaster preparedness and safe habitats.
-4.  **Aga Khan Trust for Culture (AKTC):** Known for the Aga Khan Award for Architecture.
+## How AKDN uses .akdn
 
-*Note: While many of these entities use standard gTLDs for public traffic, the .akdn infrastructure secures their backend and future-proofs their intellectual property.*
+Brand TLDs give an organization a private space to organize its web presence. Typical uses for a dot-brand like `.akdn` include:
 
-## **Why Choose .akdn? (The Power of Brand TLDs)**
+- **Agency and program sites** on clean, memorable addresses tied directly to the network.
+- **Campaign and event pages** that are obviously official because only the network can create them.
+- **Internal tools and portals** where a branded suffix signals a trusted, first-party destination.
 
-While you cannot register a .akdn domain unless you are part of the Aga Khan Development Network, understanding *why* they chose to acquire this TLD offers valuable lessons for domain investors and business owners regarding the future of naming.
+**Who it's not for:** anyone outside AKDN. Because the namespace is closed, there is no scenario in which an independent developer, investor, or business can build on `.akdn`.
 
-Here are the advantages of a closed Brand TLD:
+## Notable sites using .akdn
 
-*   **Unquestionable Trust:** There is zero risk of [phishing](/en/glossary/phishing/) or [cybersquatting](/en/glossary/cybersquatting/). If a domain ends in .akdn, the user knows 100% it belongs to the official organization.
-*   **Total Control:** The registry sets the rules. They do not have to compete for keywords or worry about availability—they own the entire list.
-*   **Security:** By restricting who can register a domain, the organization reduces vulnerabilities associated with third-party registrars or hijacked subdomains.
-*   **Branding Prestige:** Owning a TLD signals a high level of technological sophistication and organizational maturity.
+There are **no third-party sites** on `.akdn`, and there never will be while it stays a closed brand TLD — every `.akdn` address is controlled by the Fondation Aga Khan. AKDN continues to run its public presence from its long-established [.org](/en/tld/org/) domain, akdn.org, and uses the brand TLD selectively rather than as a wholesale replacement. Rather than point to a specific address that may change, the honest description is simple: `.akdn` is the network's private namespace, used only for its own properties.
 
-## **Register Your Domain at Namefi**
+## What is a dot-brand TLD?
 
-While **.akdn** is reserved for the Aga Khan Development Network, you can still secure a powerful, trustworthy, and memorable domain name for your own project.
+A **dot-brand** (or brand TLD) is a top-level domain that a single organization owns and operates for its exclusive use, secured through ICANN's [New gTLD Program](/en/glossary/new-gtld/). Not every dot-brand belongs to a for-profit corporation — non-profit networks and foundations applied too — and dot-brands share a few defining traits:
 
-At **Namefi**, we make [domain ownership](/en/glossary/domain-ownership/) easier and more advanced than ever before. Whether you are looking for a standard `.com`, a tech-focused `.io`, or exploring new [Web3](/en/glossary/web3/)-ready extensions, we have you covered.
+- **Closed registration.** Only the network and its affiliated agencies can hold names.
+- **Specification 13.** A registry-agreement addendum that formally recognizes the TLD as a brand and relaxes some rules that apply to open generics.
+- **Security and control.** The closed namespace eliminates the risk of anyone else registering a `.akdn` lookalike, which strengthens resistance to [phishing](/en/glossary/phishing/) and impersonation — a real concern for a network that solicits donations and manages sensitive institutional relationships.
 
-**Why register with Namefi?**
-*   **ICANN Accredited:** We are a fully compliant and trusted [registrar](/en/glossary/registrar/).
-*   **Web3 Integration:** We allow you to ["tokenize"](/en/glossary/tokenize/) your domain, effectively bridging the gap between traditional Web2 DNS and Web3 [blockchain](/en/glossary/blockchain/) assets.
-*   **Bulk Search & Management:** Perfect for investors and developers managing large portfolios.
+Some brands invest heavily in their TLD; others register it defensively and barely use it. A number of organizations have even terminated their dot-brands after deciding the upkeep was not worth it.
 
-Don't leave your brand identity to chance. Secure your perfect domain name today.
+## .akdn vs open domain alternatives
 
-[**Start Your Domain Search at Namefi**](https://namefi.io)
+If your goal was a short, brandable name rather than the `.akdn` string specifically, an open extension is the right tool. Here is how a closed brand TLD compares with domains you can actually register:
+
+| Feature | .akdn | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.xyz](/en/tld/xyz/) |
+| --- | --- | --- | --- | --- |
+| Who can register | AKDN only | Anyone | Anyone | Anyone |
+| Type | Brand new gTLD (closed) | Legacy gTLD | ccTLD used generically | New gTLD |
+| Core use | AKDN's own sites | Universal default | Tech & startups | Generic / Web3 |
+| Available to you | No | Yes | Yes | Yes |
+
+For your own venture, a matching `.com` remains the safest default; [.io](/en/tld/io/) suits technical products; and [.xyz](/en/tld/xyz/) is a flexible, low-cost modern option.
+
+## Reputation and trust
+
+Ironically, the closed nature of `.akdn` is exactly what makes it trustworthy: because only the Fondation Aga Khan can create these addresses, a `.akdn` link is verifiably official, which is why brand TLDs are considered strong against impersonation and email spoofing — a meaningful benefit for a development network whose donors and partners need to trust that a communication is genuine. That trust, however, benefits AKDN alone — it does not transfer to any name you might register, since you cannot register one. For your own project, deliverability and reputation will come from a well-configured domain on an open extension, not from a brand TLD you don't control.
+
+## Looking for an "akdn" name? Register an alternative at Namefi
+
+You can't buy a `.akdn` domain, but if you want a short name for your own organization or project, you can secure it on an open extension in minutes:
+
+1. **Search** your desired name across open TLDs like `.com`, `.io`, or `.xyz`.
+2. **Choose** the extension that fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can anyone register a .akdn domain?
+
+No. `.akdn` is a closed brand TLD delegated to the Fondation Aga Khan for the Aga Khan Development Network. Only AKDN entities and parties they authorize can hold a `.akdn` name, so it is not available to the general public through any registrar.
+
+### Who operates the .akdn registry?
+
+Fondation Aga Khan is the registry operator, with Afilias providing the technical back-end. The TLD was delegated to the DNS root zone in 2016 under ICANN's New gTLD Program.
+
+### What does AKDN stand for?
+
+AKDN stands for the Aga Khan Development Network, a group of international development agencies. The `.akdn` domain is operated by the Fondation Aga Khan on the network's behalf.
+
+### What can I register instead of .akdn?
+
+Because `.akdn` is closed, choose an open extension for your own project. A matching `.com`, or a modern alternative like `.io` or `.xyz`, can be registered by anyone through an accredited registrar such as Namefi.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals behind top-level domains.
+- [How a TLD affects domain value](/en/blog/how-tld-affects-domain-value/) — why the extension matters.
+- [.com TLD guide](/en/tld/com/) — the open default to compare against.
+- [.io TLD guide](/en/tld/io/) and [.xyz TLD guide](/en/tld/xyz/) — modern open alternatives.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [registry](/en/glossary/registry/), [ICANN](/en/glossary/icann/).

--- a/content/tld/en/akdn.md
+++ b/content/tld/en/akdn.md
@@ -3,7 +3,7 @@ title: "What Is the .akdn Domain? AKDN's Brand TLD Explained"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .akdn domain is the closed brand TLD of the Aga Khan Development Network, not open to the public. Learn who runs it and what to register instead.'

--- a/content/tld/en/al.md
+++ b/content/tld/en/al.md
@@ -3,7 +3,7 @@ title: "What Is the .al Domain? Albania's Two-Tier ccTLD"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'What is the .al domain? Albania''s country-code TLD, open at the third level but restricted at second-level. Manager, eligibility, and pricing explained.'

--- a/content/tld/en/al.md
+++ b/content/tld/en/al.md
@@ -1,13 +1,22 @@
 ---
-title: "Unlock Your Potential: What is the .al TLD and Why Choose It?"
-date: '2025-12-10'
+title: "What Is the .al Domain? Albania's Two-Tier ccTLD"
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: "Discover the versatility of the .al domain extension. From establishing a presence in Albania to creating clever domain hacks like 'digit.al', learn why the .al TLD is a prime choice for modern branding."
-keywords: [".al domains", ".al TLD", "top-level domain", "what is .al", "why choose .al", "what is the .al domain", "why choose the .al domain", "Albania domain registration", "domain hacks", "creative branding", "buy .al domain", "domain investing", "blockchain domains", "tokenized assets", "Web3 domains"]
+description: 'What is the .al domain? Albania''s country-code TLD, open at the third level but restricted at second-level. Manager, eligibility, and pricing explained.'
+keywords: ['.al domain', '.al TLD', 'what is .al', 'Albania domain', 'domain hack TLDs', 'local presence requirement', 'com.al third level domain', 'register .al domain']
+faqs:
+  - question: 'Can anyone register a .al domain?'
+    answer: 'Second-level .al domains (yourname.al) generally require a local presence or a registered entity in Albania. Third-level domains such as yourname.com.al are more open. Check current requirements with AKEP, the registry, before choosing which tier fits your situation.'
+  - question: 'Does a .al domain affect SEO?'
+    answer: 'Google geo-targets .al to Albania, so a .al site is generally treated as relevant to Albanian search results rather than as a globally generic domain. It suits an Albania-focused audience more than international SEO.'
+  - question: 'What is the difference between .al and com.al?'
+    answer: 'yourname.al is a second-level domain, which typically requires a local presence or registered Albanian entity. yourname.com.al is a third-level domain under the .al namespace and is generally more accessible, making it the more open option for registrants without an Albanian presence.'
+  - question: 'Who should register a .al domain?'
+    answer: 'Businesses and institutions with a registered presence in Albania are the natural fit for second-level .al names. Others should look at the third-level com.al space, which carries fewer restrictions.'
 relatedArticles:
   - /en/blog/ai-vs-io-domain/
   - /en/blog/what-is-a-tld/
@@ -28,55 +37,125 @@ relatedGlossary:
   - /en/glossary/web3/
 ---
 
-## **What is .al?**
+The **.al** domain is the [ccTLD](/en/glossary/cctld/) for the **Republic of Albania**, and it works on two tiers: second-level names (`yourname.al`) generally require a local presence or a registered Albanian entity, while third-level names under a category like `.com.al` are more accessible. Understanding that split matters more than any other single fact if you are weighing .al for a brand.
 
-The **.al** extension is the **Country Code [Top-Level Domain](/en/glossary/tld/) ([ccTLD](/en/glossary/cctld/))** for the **Republic of Albania**. It acts as the digital identity for individuals and businesses connected to this Southeastern European nation. The [registry](/en/glossary/registry/) is managed by **AKEP** (Authority of Electronic and Postal Communications).
+This guide covers what .al really is, who runs it, the eligibility split between its two tiers, and how it is perceived for SEO and email.
 
-While originally intended exclusively for Albanian entities, the regulations governing .al have evolved. Today, second-level domains (e.g., `yourname.al`) can be registered by individuals and companies worldwide without a local presence requirement. This deregulation has transformed .al from a strictly local utility into a globally recognized asset for creative branding.
+## .al at a glance
 
-For technical specifications and registry information, you can view the [IANA Delegation Record for .al](https://www.iana.org/domains/root/db/al.html).
+| Fact | Detail |
+| --- | --- |
+| TLD type | Country-code TLD (ccTLD) for Albania |
+| Registry operator | Electronic and Postal Communications Authority (AKEP), akep.al |
+| Year delegated | 1992 (April 21) |
+| Registration restrictions | Second-level generally requires local presence or a registered entity; third-level (e.g. com.al) is more open |
+| Google treatment | Geo-targeted to Albania |
+| Best for | Albania-based businesses and institutions, plus third-level registrants without a local presence |
 
-### **A Brief History and Current Trends**
-Launched in the early 1990s, .al was historically difficult to register due to strict bureaucratic processes. However, modernization efforts in recent years have streamlined registration. Currently, the trend for .al usage is twofold:
-1.  **National Identity:** It remains the gold standard for businesses operating within Tirana and the broader Albanian market.
-2.  **Creative ["Domain Hacks"](/en/blog/domain-hacks-explained/):** Because thousands of English words end in the letters "al" (e.g., *digital, capital, social*), this TLD has become a favorite among startups and marketers looking for short, memorable URLs.
+## What is .al?
 
-## **How People Are Using .al**
+**.al** is the country-code [Top-Level Domain](/en/glossary/tld/) assigned under the ISO 3166-1 system to **Albania**, listed by [IANA](https://www.iana.org/domains/root/db/al.html) with the **Electronic and Postal Communications Authority (AKEP)** as the manager, operating the registry through [akep.al](https://www.akep.al/).
 
-The versatility of the .al domain allows it to serve distinct purposes across different sectors:
+.al is not a single flat namespace. Second-level registrations (a name directly before `.al`) generally require a **local presence or a registered entity in Albania**, while third-level registrations under categories such as `com.al` are **more open**. Google [geo-targets .al to Albania](https://developers.google.com/search/docs/crawling-indexing/manage-international-sites), consistent with a domain built primarily for a national audience.
 
-*   **Tech Startups and SaaS:** Many technology companies utilize the extension to complete words, creating a seamless brand name (e.g., `rent.al` or `sign.al`).
-*   **Local Albanian Businesses:** From tourism agencies promoting the Albanian Riviera to e-commerce shops in Tirana, local businesses use it to signal trust and local relevance to Albanian customers.
-*   **Creative Portfolios:** Designers and artists often use it for clever wordplay, such as `visu.al` or `surre.al`, to make their portfolios stand out.
-*   **Crypto and [Web3](/en/glossary/web3/) Projects:** Given the rise of "Decentralized" (ending in -al) and "Digital" entities, the extension is finding a niche within the [blockchain](/en/glossary/blockchain/) community for projects looking for distinct branding.
+## History of .al
 
-## **Notable Entities Using .al**
+The .al ccTLD was delegated on **April 21, 1992**. It is managed by AKEP, Albania's electronic and postal communications regulator, which runs the two-tier structure — a more restricted second level and a more open third level — through akep.al.
 
-While many .al domains are owned by local giants, the global stage has seen an uptake in "domain hacks."
+## How people use .al
 
-1.  **Gjeje.al:** One of the most popular local search and listing platforms in Albania, demonstrating the authority of the TLD within the country.
-2.  **MerrJep.al:** A dominant [marketplace](/en/glossary/marketplace/) for buying and selling goods in the region, similar to eBay or Craigslist, relying heavily on the trust of the local extension.
-3.  **Domain Hack Examples:** While specific startups change rapidly, high-value generic terms like `propos.al`, `referr.al`, and `capit.al` are highly coveted by investors and developers. These domains often redirect to major platforms or are used for specific marketing campaigns by international brands.
+Because of the eligibility split between tiers, .al usage falls into two clear categories:
 
-## **Why Choose .al?**
+- **Albania-based businesses and institutions**, which use second-level `yourname.al` names to establish an official local identity, generally backed by a registered entity in the country.
+- **Registrants without a local presence**, who use the more open third-level structure (such as `yourname.com.al`) when a second-level name is not available to them.
 
-Whether you are targeting the Balkan market or building a global brand, there are compelling reasons to choose this TLD:
+**Who it's not ideal for:** buyers outside Albania hoping to register a short second-level `.al` name purely for a domain hack — that tier generally requires the local-presence or registered-entity condition first.
 
-*   **Exceptional Availability:** Compared to the saturated [.com](/en/tld/com/) and [.net](/en/tld/net/) markets, .al offers a higher chance of securing short, premium, single-word names.
-*   **Branding Genius (Domain Hacks):** It is one of the best TLDs for wordplay in the English language. Names like `festiv.al` or `arriv.al` are memorable, easy to type, and look great on marketing materials.
-*   **Local SEO Dominance:** If your business targets Albania, having a .al domain is a critical ranking factor for local search results on Google.
-*   **Short and Concise:** The extension is only two letters, keeping your URL short—a vital factor for mobile users and social media sharing.
-*   **Investment Potential:** As good .com names disappear, the value of clever ccTLD hacks continues to rise in the domain [aftermarket](/en/glossary/aftermarket/).
+## Notable sites using .al
 
-## **Register Your .al Domain at Namefi**
+We have no pre-verified examples to cite here. What can be said honestly is that .al's two-tier structure shapes who registers where: local Albanian entities at the second level, and a broader set of registrants at the more open third level, rather than one dominant brand defining the extension.
 
-Ready to secure your digital identity? Whether you are launching a startup named "Digit**al**" or opening a cafe in Durrës, the .al domain is a powerful choice.
+## .al vs other domains
 
-At **Namefi**, we make domain registration seamless. We bridge the gap between traditional [domain ownership](/en/glossary/domain-ownership/) and the future of the internet. When you register with us, you benefit from:
-*   **Instant Ownership:** Secure your name in minutes.
-*   **Web3 Integration:** We provide the option to [tokenize](/en/glossary/tokenize/) your domain, allowing you to manage it as a Real World Asset (RWA) on the blockchain.
-*   **Transparent Pricing:** No hidden fees, just great domains.
+| Feature | .al | [.com](/en/tld/com/) | [.co](/en/tld/co/) | [.xyz](/en/tld/xyz/) |
+| --- | --- | --- | --- | --- |
+| Type | ccTLD (two-tier: restricted second level, open third level) | Legacy gTLD | ccTLD (used globally) | New gTLD |
+| Core association | Albania | The default web standard | Generic, short alternative to .com | Generic / modern |
+| Registration eligibility | Second level restricted; third level open | Open worldwide | Open worldwide | Open worldwide |
+| Typical audience | Albania-focused (second level) | Global | Global | Global |
 
-Don't let your perfect name get snapped up by someone else.
+If you have no Albanian presence and want a short, open name, **[.com](/en/tld/com/)**, **[.co](/en/tld/co/)**, or **[.xyz](/en/tld/xyz/)** are more straightforward than trying for a second-level `.al` name. Reach for **.al** at the second level only if you have a genuine Albanian registered entity, or consider the third-level `com.al` space for a more open option.
 
-**[Register your .al domain at Namefi today](https://namefi.io)** and start building your legacy.
+## Why choose .al?
+
+- **Clear Albanian identity.** Second-level .al names signal genuine local presence to Albanian audiences.
+- **A more open alternative exists.** The third-level structure (such as com.al) offers a path for registrants without a local entity.
+- **Short extension.** At two letters, it keeps a URL compact.
+
+## Things to consider
+
+- **Know which tier you are registering.** Second-level and third-level .al names carry different eligibility rules — confirm which applies before committing to a name.
+- **A ccTLD by nature.** Because .al belongs to Albania, its rules are set by AKEP under national policy, not by an [ICANN](/en/glossary/icann/) registry agreement.
+- **Not a flat, globally open namespace.** Unlike some two-letter ccTLDs, .al's most desirable tier (second level) is not first-come, first-served for the general public worldwide.
+
+## Who can register a .al domain?
+
+**Registration restrictions: mixed by tier.** Second-level `.al` domains generally require a **local presence or a registered entity in Albania**. Third-level domains, such as those under `com.al`, are **more open** and the more practical route for registrants without an Albanian presence.
+
+Because .al is a ccTLD, it is governed by AKEP's registry policy rather than an ICANN registry agreement. The authoritative sources for current eligibility rules at each tier are the [IANA root-zone entry](https://www.iana.org/domains/root/db/al.html) and the registry's own site, [akep.al](https://www.akep.al/).
+
+## .al pricing and value
+
+This page intentionally quotes no numbers, but a few dynamics matter:
+
+- **Tier affects process, not just price.** A second-level name may involve an eligibility or documentation step that a third-level name does not.
+- **First-year vs. renewal pricing can differ.** As with most TLDs, confirm the standard renewal rate rather than assuming an introductory rate continues.
+- **What drives cost.** Name desirability, tier, and registry wholesale pricing are the main factors shaping what a given .al name costs.
+
+For exact, current figures and eligibility requirements, check directly with the registry at registration time.
+
+## Reputation and email deliverability
+
+We are not aware of .al carrying any negative bulk-mail or spam reputation. As with any TLD, email deliverability depends far more on **sending reputation, SPF/DKIM/DMARC authentication, and list hygiene** than on the suffix itself. A properly authenticated .al sender should reach inboxes normally.
+
+## Branding and naming tips
+
+- **Confirm your tier first.** Decide whether a second-level or third-level name fits your eligibility before settling on a brand.
+- **Lean into local identity if you qualify.** Second-level .al names read as genuinely Albanian to local audiences.
+- **Keep it short and clear.** A two-letter ccTLD rewards a name that stands on its own.
+
+## How to register a .al domain at Namefi
+
+1. **Confirm eligibility** — check whether a second-level or third-level .al name fits your situation.
+2. **Search** for your desired name at the appropriate tier.
+3. **Register** and configure DNS.
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for easier transfer and provable ownership.
+
+## Frequently asked questions
+
+### Can anyone register a .al domain?
+
+Second-level .al domains (yourname.al) generally require a local presence or a registered entity in Albania. Third-level domains such as yourname.com.al are more open. Check current requirements with AKEP, the registry, before choosing which tier fits your situation.
+
+### Does a .al domain affect SEO?
+
+Google geo-targets .al to Albania, so a .al site is generally treated as relevant to Albanian search results rather than as a globally generic domain. It suits an Albania-focused audience more than international SEO.
+
+### What is the difference between .al and com.al?
+
+yourname.al is a second-level domain, which typically requires a local presence or registered Albanian entity. yourname.com.al is a third-level domain under the .al namespace and is generally more accessible, making it the more open option for registrants without an Albanian presence.
+
+### Who should register a .al domain?
+
+Businesses and institutions with a registered presence in Albania are the natural fit for second-level .al names. Others should look at the third-level com.al space, which carries fewer restrictions.
+
+## Related resources
+
+- [.com TLD guide](/en/tld/com/)
+- [.co TLD guide](/en/tld/co/)
+- [.xyz TLD guide](/en/tld/xyz/)
+- [What is a TLD?](/en/blog/what-is-a-tld/)
+- [Glossary: registrar](/en/glossary/registrar/)
+- [Glossary: ICANN](/en/glossary/icann/)
+- [Glossary: ccTLD](/en/glossary/cctld/)

--- a/content/tld/en/alfaromeo.md
+++ b/content/tld/en/alfaromeo.md
@@ -3,7 +3,7 @@ title: 'What Was the .alfaromeo Domain? A Terminated Brand TLD'
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .alfaromeo domain was a brand TLD for the Italian car marque Alfa Romeo that ICANN terminated in 2023. Learn its history and what to register instead.'

--- a/content/tld/en/alfaromeo.md
+++ b/content/tld/en/alfaromeo.md
@@ -1,13 +1,22 @@
 ---
-title: 'What is the .alfaromeo TLD and Why is it Unique?'
-date: '2025-12-10'
+title: 'What Was the .alfaromeo Domain? A Terminated Brand TLD'
+date: '2026-07-24'
 language: 'en'
-tags: ['tld', 'brand-tld', 'automotive', 'domain-investing']
+tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: 'Discover the .alfaromeo TLD: a dedicated domain extension for the iconic Italian automotive brand. Learn about brand TLDs, their usage, and domain trends.'
-keywords: ['.alfaromeo domains', 'TLD', 'top-level domain', 'what is .alfaromeo', 'why choose .alfaromeo', 'what is the .alfaromeo domain', 'why choose the .alfaromeo domain', 'automotive domains', 'brand TLD', 'domain investing', 'tokenized domain', 'blockchain domains', 'luxury car domains', 'Namefi domains', 'buy .alfaromeo domain']
+description: 'The .alfaromeo domain was a brand TLD for the Italian car marque Alfa Romeo that ICANN terminated in 2023. Learn its history and what to register instead.'
+keywords: ['.alfaromeo domain', 'what is .alfaromeo', '.alfaromeo TLD', 'Alfa Romeo brand domain', 'terminated TLD', 'discontinued gTLD', 'dot-brand TLD', 'is .alfaromeo available']
+faqs:
+  - question: 'Can I register a .alfaromeo domain?'
+    answer: 'No. .alfaromeo was terminated in 2023 and removed from the DNS root zone, so it no longer exists as a working extension and cannot be registered through any registrar. Even before that, it was a closed brand TLD never open to the public.'
+  - question: 'What happened to .alfaromeo?'
+    answer: 'ICANN removed .alfaromeo from the root zone on 5 June 2023 after Stellantis ended the registry agreement. The sister marque .abarth was withdrawn on the same day, part of Stellantis stepping back from its dot-brand TLDs.'
+  - question: 'Was .alfaromeo ever open to the public?'
+    answer: 'No. .alfaromeo was always a closed brand TLD, meaning only the Alfa Romeo marque and its parent group could ever register names under it. It was never sold to outside individuals or businesses.'
+  - question: 'Did anyone ever use a .alfaromeo domain?'
+    answer: 'No public site of note. Alfa Romeo never opened the namespace to outside registrants, so nothing was lost when the TLD was removed.'
 relatedArticles:
   - /en/blog/top-tlds-to-secure-for-your-business/
   - /en/blog/what-are-tokenized-domains/
@@ -28,53 +37,85 @@ relatedGlossary:
   - /en/glossary/web3/
 ---
 
-## **What is .alfaromeo?**
+The **.alfaromeo** domain was a **brand [top-level domain](/en/glossary/tld/)** created for **Alfa Romeo**, the Italian car marque within the Fiat group (now part of Stellantis). It is no longer active: ICANN **removed `.alfaromeo` from the DNS [root zone](/en/glossary/root-zone/) in 2023**, so the extension no longer resolves and cannot be registered.
 
-The **.alfaromeo** domain is a specialized [Top-Level Domain (TLD)](/en/glossary/tld/) belonging to the category of **Brand TLDs** (new gTLDs). Unlike open extensions like [.com](/en/tld/com/) or [.net](/en/tld/net/), .alfaromeo was created specifically for **Fiat Chrysler Automobiles (now Stellantis)** to represent the iconic Italian luxury car manufacturer, Alfa Romeo.
+If you searched for the ".alfaromeo domain," this page explains what it was, why it disappeared, and what the story of a terminated dot-brand means for anyone choosing a domain today.
 
-Introduced during [ICANN’s new gTLD program](https://newgtlds.icann.org/en/about/program), this extension serves as a digital seal of authenticity. It allows the brand to consolidate its digital presence under a unified, secure, and instantly recognizable namespace. While traditional TLDs indicate a commercial entity or a network, .alfaromeo indicates a specific affiliation with the high-performance automotive world.
+## .alfaromeo at a glance
 
-For domain investors and developers interested in the **[Web3](/en/glossary/web3/)** and **[tokenized domain](/en/blog/what-are-tokenized-domains/)** space, understanding Brand TLDs like .alfaromeo is crucial. It highlights the shift from generic internet real estate to hyper-specific, branded digital assets.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | Alfa Romeo marque (Fiat / Stellantis) — agreement now terminated |
+| Year delegated | 2016 |
+| Year terminated | 2023 (removed from the root zone) |
+| Current status | **Terminated** — not present in the DNS root zone |
+| Registration restrictions | **Not available** — the TLD no longer exists |
 
-## **How People Are Using .alfaromeo**
+## What was .alfaromeo?
 
-Because .alfaromeo is a "closed" [registry](/en/glossary/registry/) intended primarily for the brand owner and its affiliates, its usage is highly strategic and focused on corporate identity rather than public registration.
+`.alfaromeo` was a **closed brand [gTLD](/en/glossary/new-gtld/)**: a top-level domain reserved for a single company's exclusive use. The string is the name of **Alfa Romeo**, the Italian car marque. Its parent, Fiat, became part of **Stellantis** in 2021.
 
-*   **Official Brand Presence:** The primary use is hosting official regional websites and campaign landing pages that require immediate trust.
-*   **Dealer Networks:** It creates a verified ecosystem where authorized dealerships might utilize subdomains to prove their legitimacy to customers.
-*   **Product Launches:** Marketing teams use specific product names combined with the TLD (e.g., `stelvio.alfaromeo`) for immersive digital brochures.
-*   **Internal Infrastructure:** Corporations often use these TLDs for secure back-end employee portals and intranets, reducing the risk of [phishing](/en/glossary/phishing/) attacks.
+Like other dot-brands, `.alfaromeo` was never open to the public. Only the brand could create names under it, and the point of holding the TLD was brand control rather than public registration. You can confirm its status on the authoritative [IANA root-zone record for .alfaromeo](https://www.iana.org/domains/root/db/alfaromeo.html), which now shows the domain is not present in the root zone.
 
-## **Notable Entities Using .alfaromeo**
+## History of .alfaromeo
 
-As a proprietary extension, the entities using this TLD are exclusively within the corporate hierarchy of the manufacturer.
+`.alfaromeo` was **delegated on 21 July 2016** as part of ICANN's New gTLD Program, the 2012 expansion that let hundreds of companies apply for their own brand as a suffix. Fiat's group secured `.alfaromeo` alongside several other automotive brand strings, including its sibling marque `.abarth`.
 
-1.  **Alfa Romeo Global:** The headquarters utilizes the domain to direct traffic to specific regional configurations and global press releases.
-2.  **Stellantis Group:** As the parent company, Stellantis leverages the TLD to manage the brand's intellectual property and digital architecture.
-3.  **Authorized Service Centers:** While less visible publicly, the infrastructure supporting authorized repairs and parts catalogs often resides on these verified domains to ensure supply chain security.
+In practice, the brand made little public use of the extension. On **5 June 2023, ICANN removed `.alfaromeo` from the root zone** after the registry agreement was ended — the same day it withdrew the sister marque `.abarth`. Both removals reflected **Stellantis** stepping back from the dot-brand TLDs it had inherited, a common pattern across the industry as owners weighed the cost of running a namespace they barely used.
 
-*Note: As this is a Brand TLD, you will not typically find third-party blogs or unrelated businesses hosting content on a .alfaromeo domain.*
+## Why was .alfaromeo discontinued?
 
-## **Why Choose .alfaromeo?**
+Stellantis inherited `.alfaromeo` along with a small portfolio of other automotive dot-brands, including `.abarth`. Running each of those namespaces still meant ongoing [ICANN](/en/glossary/icann/) fees and technical upkeep, regardless of how little the public ever used them. Stellantis chose to voluntarily terminate the registry agreements for both marques together, and ICANN removed both TLDs from the root zone on the same day.
 
-While public registration is restricted, understanding the *value proposition* of such a TLD is essential for anyone analyzing domain trends or considering a **Brand TLD** strategy for their own enterprise.
+`.alfaromeo` is one of dozens of dot-brands retired this way across the industry. Because it was closed, its termination affected no public registrants — there were none — but it does show that even a delegated TLD is not guaranteed to last forever.
 
-*   **Unmatched Trust & Security:** A .alfaromeo link guarantees the user is interacting with the official brand. There is zero risk of [cybersquatting](/en/glossary/cybersquatting/) or phishing on the root domain because the registry is closed.
-*   **Premium SEO Relevance:** Search engines recognize the exact match of the TLD with the brand name, signaling high authority for automotive and luxury queries.
-*   **Brand Protection:** By owning the entire registry, the company eliminates the need to buy defensive domains (like `alfaromeo-cars.net` or `alfaromeo-official.com`), saving costs in the long run.
-*   **Short and Memorable URLs:** It allows for clean, concise marketing URLs without the clutter of slashes and subdirectories found in traditional domain structures.
+## Can you register a .alfaromeo domain?
 
-## **Register Your .alfaromeo Domain at Namefi**
+**No.** `.alfaromeo` no longer exists in the DNS, so there is nothing to register and no [registrar](/en/glossary/registrar/) can offer it. It was never available to the public even when it was active, because it was a closed brand namespace controlled by the marque.
 
-Are you looking to secure a [premium domain](/en/glossary/premium-domain/) name for your automotive business, portfolio, or next Web3 project? While .alfaromeo is exclusive to the brand, **Namefi** offers access to millions of other premium TLDs and the ability to mint them as NFTs for seamless trading and management.
+If a `.alfaromeo` link ever appears in the future, it would only be because the brand re-applies in a later ICANN round — there is no public path to owning one.
 
-At Namefi, we bridge the gap between Web2 and Web3.
-*   **ICANN-Accredited:** We are a fully compliant and trusted [registrar](/en/glossary/registrar/).
-*   **Tokenized Assets:** Your domains are minted on the [blockchain](/en/glossary/blockchain/), giving you true ownership and ease of transfer.
-*   **[DeFi](/en/glossary/defi/) Ready:** Use your domain assets within the decentralized finance ecosystem.
+## What .alfaromeo teaches about choosing a TLD
 
-Whether you are looking for automotive-themed domains like `.car`, `.auto`, or looking to invest in the next big keyword, start your search with us.
+The rise and removal of `.alfaromeo` is a useful reminder for anyone picking a domain:
 
-[**Search for your perfect domain at Namefi**](https://namefi.io)
+- **Brand TLDs are private.** A dot-brand like `.alfaromeo` or its sibling `.abarth` is never something an outside project can build on.
+- **Not every TLD is permanent.** Delegated strings can be handed back and removed, so long-term projects are safest on well-established, widely used extensions.
+- **Openness matters.** For your own venture, an open extension anyone can register and renew is far more dependable than a niche or single-owner string.
 
-**Don’t wait until your ideal name is taken. Secure your digital identity today with Namefi.**
+## What to register instead at Namefi
+
+Since `.alfaromeo` is gone, choose a stable, open extension for your own name:
+
+1. **Search** your desired name across open TLDs such as [.com](/en/tld/com/), [.io](/en/tld/io/), or [.xyz](/en/tld/xyz/).
+2. **Choose** the extension that best fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can I register a .alfaromeo domain?
+
+No. `.alfaromeo` was terminated in 2023 and removed from the DNS root zone, so it no longer exists as a working extension and cannot be registered through any registrar. Even before that, it was a closed brand TLD never open to the public.
+
+### What happened to .alfaromeo?
+
+ICANN removed `.alfaromeo` from the root zone on 5 June 2023 after Stellantis ended the registry agreement. The sister marque `.abarth` was withdrawn on the same day, part of Stellantis stepping back from its dot-brand TLDs.
+
+### Was .alfaromeo ever open to the public?
+
+No. `.alfaromeo` was always a closed brand TLD, meaning only the Alfa Romeo marque and its parent group could ever register names under it. It was never sold to outside individuals or businesses.
+
+### Did anyone ever use a .alfaromeo domain?
+
+No public site of note. Alfa Romeo never opened the namespace to outside registrants, so nothing was lost when the TLD was removed.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — how top-level domains work.
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains/) — owning a domain on-chain.
+- [How a TLD affects domain value](/en/blog/how-tld-affects-domain-value/) — why the extension matters.
+- [.com TLD guide](/en/tld/com/), [.io TLD guide](/en/tld/io/), and [.xyz TLD guide](/en/tld/xyz/) — open extensions you can actually register.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [ICANN](/en/glossary/icann/), [root zone](/en/glossary/root-zone/).

--- a/content/tld/en/alibaba.md
+++ b/content/tld/en/alibaba.md
@@ -1,13 +1,22 @@
 ---
-title: What is the .alibaba TLD and what does it mean for digital commerce?
-date: '2025-12-10'
+title: "What Is the .alibaba Domain? Alibaba's Brand TLD Explained"
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: Explore the .alibaba TLD, a dedicated brand domain that represents security and authority in e-commerce. Learn how it impacts domain investing and digital identity.
-keywords: ['alibaba domains', '.alibaba TLD', 'top-level domain', 'what is .alibaba', 'why choose .alibaba', 'what is the .alibaba domain', 'why choose the .alibaba domain', 'brand TLD', 'domain investing', 'blockchain domains', 'tokenized domain', 'ecommerce domains', 'digital identity', 'Namefi', 'Web3 domains']
+description: 'The .alibaba domain is the closed brand TLD of Alibaba Group, a Chinese e-commerce and technology group, not open to the public. Learn what to register instead.'
+keywords: ['.alibaba domain', 'what is .alibaba', '.alibaba TLD', 'Alibaba brand domain', 'dot-brand TLD', 'Alibaba Group registry', 'closed generic TLD', 'is .alibaba available']
+faqs:
+  - question: 'Can anyone register a .alibaba domain?'
+    answer: 'No. .alibaba is a closed brand TLD delegated to Alibaba Group Holding Limited. Only Alibaba Group and parties it authorizes can hold a .alibaba name, so it is not available to the general public through any registrar.'
+  - question: 'Who operates the .alibaba registry?'
+    answer: 'Alibaba Group Holding Limited is the registry operator, running the technical back-end itself through Alibaba Cloud. The TLD was delegated to the DNS root zone in 2016 under ICANN''s New gTLD Program.'
+  - question: 'What kind of company is Alibaba?'
+    answer: 'Alibaba Group Holding Limited is the Chinese e-commerce and technology group behind the .alibaba domain.'
+  - question: 'What can I register instead of .alibaba?'
+    answer: 'Because .alibaba is closed, choose an open extension for your own project. A matching .com, or a modern alternative like .io or .xyz, can be registered by anyone through an accredited registrar such as Namefi.'
 relatedArticles:
   - /en/blog/top-tlds-to-secure-for-your-business/
   - /en/blog/top-tlds-to-secure-for-your-fashion-brand/
@@ -28,49 +37,113 @@ relatedGlossary:
   - /en/glossary/web3/
 ---
 
-## **What is .alibaba?**
+The **.alibaba** domain is a **closed brand [top-level domain](/en/glossary/tld/)** operated by **Alibaba Group Holding Limited**, the Chinese e-commerce and technology group. It is not a public extension: unlike [.com](/en/tld/com/) or [.io](/en/tld/io/), you cannot register a `.alibaba` name for your own project, because the entire namespace belongs to one company.
 
-The **.alibaba** domain is a specific type of [Top-Level Domain (TLD)](/en/glossary/tld/) known as a "Brand TLD" or "dot-brand." Unlike generic TLDs like [.com](/en/tld/com/) or [.io](/en/tld/io/) that are open to the public, .alibaba was created exclusively for the **Alibaba Group**, one of the world's largest e-commerce and technology conglomerates.
+If you searched for the ".alibaba domain" hoping to buy one, the short answer is that you can't — but this page explains exactly what `.alibaba` is, who controls it, why a company runs its own TLD, and what you can register instead.
 
-Launched following [ICANN’s New gTLD Program](https://newgtlds.icann.org/en/about/program), the .alibaba extension allows the company to create a unified, secure, and authenticated digital ecosystem. It represents a shift in how major corporations manage their online presence, moving away from third-party platforms to a fully owned and operated namespace. For domain investors and developers, understanding the .alibaba TLD provides insight into the future of corporate digital identity and the high value placed on proprietary namespaces.
+## .alibaba at a glance
 
-## **How People Are Using .alibaba**
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | Alibaba Group Holding Limited (technical back-end by Alibaba Cloud) |
+| Year delegated | 2016 |
+| IDN support | Not relevant — closed namespace |
+| DNSSEC | Supported |
+| Registration restrictions | **Closed** — restricted to Alibaba Group and parties it authorizes; not available to the public |
+| Best for | Alibaba Group's own corporate, product, and campaign websites |
 
-Because .alibaba is a closed [Registry](/en/glossary/registry/), "usage" is currently defined by how the Alibaba Group and its affiliates utilize the extension to streamline their massive digital infrastructure.
+## What is .alibaba?
 
-*   **Brand Verification**: It serves as a hallmark of trust. A URL ending in .alibaba guarantees the user that they are interacting with a legitimate entity of the Alibaba Group, mitigating the risk of [phishing](/en/glossary/phishing/).
-*   **Infrastructure Management**: Developers within the ecosystem use the TLD for internal routing, cloud resource management, and backend services that require secure, recognizable naming conventions.
-*   **Marketing Campaigns**: Specific product launches or corporate communications can utilize short, memorable .alibaba links that reinforce brand recall.
-*   **Digital Innovation**: As the web evolves toward [Web3](/en/glossary/web3/), entities like Alibaba are positioned to use their TLDs for digital identities and verified endpoints within their proprietary networks.
+`.alibaba` is a **[generic top-level domain](/en/glossary/gtld/)** that ICANN delegated to **Alibaba Group Holding Limited** as part of its New gTLD Program. The string is the company's own name: **Alibaba**, the Chinese e-commerce and technology group.
 
-## **Notable Entities Using .alibaba**
+But `.alibaba` is a **brand TLD** — often called a "dot-brand" — not an open extension anyone can buy into. The company applied for the string specifically so that it, and only it, would control every domain ending in `.alibaba`. You can confirm the delegation and operator on the authoritative [IANA root-zone record for .alibaba](https://www.iana.org/domains/root/db/alibaba.html).
 
-While the TLD is restricted, it covers a wide array of services within the conglomerate’s portfolio. Usage typically revolves around these core sectors:
+## History of .alibaba
 
-1.  **Alibaba Cloud**: As a major cloud service provider, the TLD infrastructure supports various backend services and verified API endpoints.
-2.  **E-commerce Logistics**: Internal tracking and logistics systems (Cainiao) may utilize the namespace for secure data transmission.
-3.  **Corporate Governance**: Portals for investor relations and corporate news often leverage the primary brand TLD to distinguish themselves from consumer-facing .com retail sites.
+`.alibaba` was **delegated to the DNS [root zone](/en/glossary/root-zone/) on January 8, 2016**, part of the same wave of ICANN's New gTLD Program that brought hundreds of corporate names into the domain system. Unlike dot-brands that hire an outside registry services provider, Alibaba Group runs the technical back-end itself through **Alibaba Cloud**, its own cloud-computing division, while remaining the registry operator of record.
 
-You can view the official delegation details on the [IANA .alibaba Delegation Record](https://www.iana.org/domains/root/db/alibaba.html).
+Its registry agreement with [ICANN](/en/glossary/icann/) includes **Specification 13**, the contract clause that formally designates a TLD as a brand and lets the operator keep it closed. The record has stayed active since delegation, unlike several brand TLDs that were later handed back and removed from the root.
 
-## **Why Choose .alibaba?**
+## Is .alibaba available to register?
 
-While the general public cannot currently register .alibaba domains, understanding "why" a company chooses to operate its own TLD highlights the immense value of [domain ownership](/en/glossary/domain-ownership/).
+**No.** `.alibaba` is a **closed brand TLD**, so there is no open registration and no [registrar](/en/glossary/registrar/) — including Namefi — can sell you a `.alibaba` name. Registrations are limited to Alibaba Group and organizations it authorizes, such as subsidiaries or partners. This is by design: a dot-brand exists precisely so the trademark holder controls the whole namespace and no one else can register a confusing or malicious lookalike.
 
-*   **Ultimate Trust and Security**: The primary advantage is security. Since the registry is closed, there is zero chance of [cybersquatting](/en/glossary/cybersquatting/) or [typosquatting](/en/glossary/typosquatting/). Users know that *any* site ending in .alibaba is official.
-*   **SEO and Brand Authority**: Search engines recognize the authority of a Brand TLD. It signals a verified entity, which can indirectly boost ranking signals for transactional queries within that ecosystem.
-*   **Availability of Short Names**: In a public TLD like .com, a name like `cloud.com` is incredibly expensive or unavailable. In a Brand TLD, the owner has instant access to premium, single-word domains like `cloud.alibaba` or `pay.alibaba` without competition.
-*   **Future-Proofing**: Owning the TLD gives the brand complete control over policy, pricing, and technical implementation, which is crucial for integrating with future technologies like [blockchain](/en/glossary/blockchain/) and tokenized assets.
+If you have a genuine business relationship with Alibaba Group and a legitimate need for a `.alibaba` address, that request would go through the company's own corporate channels, not a commercial registrar.
 
-## **Register Your .alibaba Domain at Namefi**
+## How Alibaba Group uses .alibaba
 
-Are you looking to secure a domain name that carries the same level of authority and trust as major corporate TLDs? While the .alibaba extension is currently exclusive to the Alibaba Group, the principles of securing a strong, brand-defining domain apply to everyone—from solo developers to growing enterprises.
+Brand TLDs give a company a private space to organize its web presence. Typical uses for a dot-brand like `.alibaba` include:
 
-At **Namefi**, we specialize in helping you secure high-value domains and seamlessly bridging them into the Web3 world.
-*   **ICANN-Accredited**: We provide a secure, compliant platform for all your registration needs.
-*   **Tokenized Domains**: Namefi allows you to [tokenize](/en/glossary/tokenize/) your domains, making them tradeable and easier to manage as digital assets on the blockchain.
-*   **Smart Search**: Find available alternatives and premium names that give your project the "dot-brand" feel.
+- **Product and division sites** on clean, memorable addresses tied directly to the brand.
+- **Campaign and event pages** that are obviously official because only the company can create them.
+- **Internal tools and portals** where a branded suffix signals a trusted, first-party destination.
 
-Don't wait for your perfect name to be taken. Secure your digital identity today.
+**Who it's not for:** anyone outside Alibaba Group. Because the namespace is closed, there is no scenario in which an independent developer, investor, or business can build on `.alibaba`.
 
-[**Search for your domain at Namefi**](https://namefi.io)
+## Notable sites using .alibaba
+
+There are **no third-party sites** on `.alibaba`, and there never will be while it stays a closed brand TLD — every `.alibaba` address is controlled by Alibaba Group Holding Limited. The group continues to run its corporate presence from its long-established [.com](/en/tld/com/) domain, alibabagroup.com, and uses the brand TLD selectively rather than as a wholesale replacement. Rather than point to a specific address that may change, the honest description is simple: `.alibaba` is the group's private namespace, used only for its own properties.
+
+## What is a dot-brand TLD?
+
+A **dot-brand** (or brand TLD) is a top-level domain that a single company owns and operates for its exclusive use, secured through ICANN's [New gTLD Program](/en/glossary/new-gtld/). Large e-commerce and technology groups were among the many corporations that applied for their own name as a TLD, and dot-brands share a few defining traits:
+
+- **Closed registration.** Only the brand and its affiliates can hold names.
+- **Specification 13.** A registry-agreement addendum that formally recognizes the TLD as a brand and relaxes some rules that apply to open generics.
+- **Security and control.** The brand eliminates the risk of anyone else registering a `.alibaba` lookalike, which strengthens resistance to [phishing](/en/glossary/phishing/) and impersonation.
+
+Some brands invest heavily in their TLD; others register it defensively and barely use it. A number of companies have even terminated their dot-brands after deciding the upkeep was not worth it.
+
+## .alibaba vs open domain alternatives
+
+If your goal was a short, brandable name rather than the `.alibaba` string specifically, an open extension is the right tool. Here is how a closed brand TLD compares with domains you can actually register:
+
+| Feature | .alibaba | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.xyz](/en/tld/xyz/) |
+| --- | --- | --- | --- | --- |
+| Who can register | Alibaba Group only | Anyone | Anyone | Anyone |
+| Type | Brand new gTLD (closed) | Legacy gTLD | ccTLD used generically | New gTLD |
+| Core use | Alibaba Group's own sites | Universal default | Tech & startups | Generic / Web3 |
+| Available to you | No | Yes | Yes | Yes |
+
+For your own venture, a matching `.com` remains the safest default; [.io](/en/tld/io/) suits technical products; and [.xyz](/en/tld/xyz/) is a flexible, low-cost modern option.
+
+## Reputation and trust
+
+Ironically, the closed nature of `.alibaba` is exactly what makes it trustworthy: because only Alibaba Group can create these addresses, a `.alibaba` link is verifiably official, which is why brand TLDs are considered strong against impersonation and email spoofing — a meaningful benefit for an e-commerce group whose checkout and payment pages are a frequent phishing target. That trust, however, benefits Alibaba Group alone — it does not transfer to any name you might register, since you cannot register one. For your own project, deliverability and reputation will come from a well-configured domain on an open extension, not from a brand TLD you don't control.
+
+## Looking for an "alibaba" name? Register an alternative at Namefi
+
+You can't buy a `.alibaba` domain, but if you want a short, marketplace- or trade-flavored name of your own, you can secure it on an open extension in minutes:
+
+1. **Search** your desired name across open TLDs like `.com`, `.io`, or `.xyz`.
+2. **Choose** the extension that fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can anyone register a .alibaba domain?
+
+No. `.alibaba` is a closed brand TLD delegated to Alibaba Group Holding Limited. Only Alibaba Group and parties it authorizes can hold a `.alibaba` name, so it is not available to the general public through any registrar.
+
+### Who operates the .alibaba registry?
+
+Alibaba Group Holding Limited is the registry operator, running the technical back-end itself through Alibaba Cloud. The TLD was delegated to the DNS root zone in 2016 under ICANN's New gTLD Program.
+
+### What kind of company is Alibaba?
+
+Alibaba Group Holding Limited is the Chinese e-commerce and technology group behind the `.alibaba` domain.
+
+### What can I register instead of .alibaba?
+
+Because `.alibaba` is closed, choose an open extension for your own project. A matching `.com`, or a modern alternative like `.io` or `.xyz`, can be registered by anyone through an accredited registrar such as Namefi.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals behind top-level domains.
+- [How a TLD affects domain value](/en/blog/how-tld-affects-domain-value/) — why the extension matters.
+- [.com TLD guide](/en/tld/com/) — the open default to compare against.
+- [.io TLD guide](/en/tld/io/) and [.xyz TLD guide](/en/tld/xyz/) — modern open alternatives.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [registry](/en/glossary/registry/), [ICANN](/en/glossary/icann/).

--- a/content/tld/en/alibaba.md
+++ b/content/tld/en/alibaba.md
@@ -3,7 +3,7 @@ title: "What Is the .alibaba Domain? Alibaba's Brand TLD Explained"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .alibaba domain is the closed brand TLD of Alibaba Group, a Chinese e-commerce and technology group, not open to the public. Learn what to register instead.'

--- a/content/tld/en/alipay.md
+++ b/content/tld/en/alipay.md
@@ -1,13 +1,22 @@
 ---
-title: "What is the .alipay TLD and How Does It Impact Digital Trust?"
-date: '2025-12-10'
+title: "What Is the .alipay Domain? Alipay's Brand TLD Explained"
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: "Discover the purpose behind the .alipay TLD. Learn how this unique Brand TLD enhances security in fintech and what it means for the future of domain investing."
-keywords: [".alipay domains", ".alipay TLD", "top-level domain", "what is .alipay", "why choose .alipay", "what is the .alipay domain", "why choose the .alipay domain", "fintech domains", "brand TLD", "Alibaba Group domains", "blockchain domains", "tokenized domains", "domain investing", "digital payment security", "Namefi"]
+description: 'The .alipay domain is the closed brand TLD tied to Alibaba Group and its Alipay payments platform, not open to the public. Learn who runs it and what to register instead.'
+keywords: ['.alipay domain', 'what is .alipay', '.alipay TLD', 'Alipay brand domain', 'dot-brand TLD', 'Alibaba Group registry', 'closed generic TLD', 'is .alipay available']
+faqs:
+  - question: 'Can anyone register a .alipay domain?'
+    answer: 'No. .alipay is a closed brand TLD delegated to Alibaba Group Holding Limited for the Alipay payments platform. Only Alibaba Group and parties it authorizes can hold a .alipay name, so it is not available to the public through any registrar.'
+  - question: 'Who operates the .alipay registry?'
+    answer: 'Alibaba Group Holding Limited is the registry operator, with Afilias providing the technical back-end. The TLD was delegated to the DNS root zone on January 8, 2016 under ICANN''s New gTLD Program.'
+  - question: 'What does the .alipay domain represent?'
+    answer: 'The string combines Ali, from Alibaba, with pay, for payments. It represents Alipay, the digital-payments platform associated with Ant Group and the wider Alibaba ecosystem, rather than an open word anyone can register.'
+  - question: 'What can I register instead of .alipay?'
+    answer: 'Because .alipay is closed, choose an open extension for your own project. A matching .com, or a modern alternative like .io or .xyz, can be registered by anyone through an accredited registrar such as Namefi.'
 relatedArticles:
   - /en/blog/top-tlds-to-secure-for-your-accounting-firm/
   - /en/blog/what-are-tokenized-domains/
@@ -28,55 +37,113 @@ relatedGlossary:
   - /en/glossary/registry/
 ---
 
-## **What is .alipay?**
+The **.alipay** domain is a **closed brand [top-level domain](/en/glossary/tld/)** operated by **Alibaba Group Holding Limited** for **Alipay**, the digital-payments platform associated with Ant Group and the wider Alibaba ecosystem. It is not a public extension: unlike [.com](/en/tld/com/) or [.io](/en/tld/io/), you cannot register a `.alipay` name for your own project, because the entire namespace belongs to one company.
 
-The **.alipay** extension is a specialized **generic [Top-Level Domain (gTLD)](/en/glossary/tld/)** that falls under the category of a "Brand TLD." Unlike standard open domains like [.com](/en/tld/com/) or [.io](/en/tld/io/), the .alipay TLD was applied for and secured by the **Alibaba Group** specifically for its digital payment arm, Alipay.
+If you searched for the ".alipay domain" hoping to buy one, the short answer is that you can't — but this page explains exactly what `.alipay` is, who controls it, why a company runs its own TLD, and what you can register instead.
 
-Introduced during [ICANN](/en/glossary/icann/)'s massive expansion of the [domain name system](/en/glossary/dns/), the primary purpose of .alipay is to provide a dedicated, secure, and authenticated namespace for one of the world's largest mobile payment platforms. By operating its own [registry](/en/glossary/registry/), Alipay ensures that every domain ending in .alipay is legitimate, significantly reducing the risk of [phishing](/en/glossary/phishing/) and fraud.
+## .alipay at a glance
 
-Currently, this TLD serves as a hallmark of digital trust within the fintech sector, representing a move away from shared public spaces toward fortified digital ecosystems.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | Alibaba Group Holding Limited (technical back-end by Afilias) |
+| Year delegated | 2016 |
+| IDN support | Not relevant — closed namespace |
+| DNSSEC | Supported |
+| Registration restrictions | **Closed** — restricted to Alibaba Group and parties it authorizes; not available to the public |
+| Best for | Alipay's own payment, platform, and campaign sites |
 
-*For more information on Brand TLDs, visit the [ICANN New gTLD Program](https://newgtlds.icann.org/en/about/program).*
+## What is .alipay?
 
-## **How People Are Using .alipay**
+`.alipay` is a **[generic top-level domain](/en/glossary/gtld/)** that ICANN delegated to **Alibaba Group Holding Limited**. The string reads as "Ali" plus "pay" — a direct reference to Alipay, the digital-payments platform that sits within the Ant Group and Alibaba ecosystem.
 
-Because .alipay is a **closed registry** (a "dot brand"), it is currently used exclusively by the Alipay organization and its affiliates rather than the general public. However, its usage sets a gold standard for how financial institutions utilize domain names:
+`.alipay` is a **brand TLD**, often called a "dot-brand," not an open extension anyone can buy into. Alibaba Group applied for the string so that it, and only it, would control every domain ending in `.alipay`. You can confirm the delegation and operator on the authoritative [IANA root-zone record for .alipay](https://www.iana.org/domains/root/db/alipay.html).
 
-*   **Security Infrastructure:** It allows the company to host critical payment gateways on a domain extension that cannot be spoofed by third parties.
-*   **Marketing Campaigns:** Short, memorable domains are used for specific promotions (e.g., `global.alipay` or `merchant.alipay`) to direct users to verified landing pages.
-*   **Trust Verification:** When a user sees a URL ending in .alipay, they receive immediate assurance that they are interacting with the official entity, which is crucial for transaction security.
-*   **Brand Protection:** By owning the entire registry, Alipay prevents cybersquatters from registering misleading domain names that could harm their reputation.
+## History of .alipay
 
-## **Notable Entities Using .alipay**
+The `.alipay` string was delegated to the DNS [root zone](/en/glossary/root-zone/) on **January 8, 2016**, following an application under [ICANN](/en/glossary/icann/)'s New gTLD Program. **Afilias** handled the technical registry operation on Alibaba's behalf. Its registry agreement includes Specification 13, the contract clause that formally designates a TLD as a brand and lets the operator keep it closed.
 
-As a restricted Brand TLD, the "notable entities" are strictly internal to the parent company. However, the ecosystem covers massive sectors of the digital economy:
+The record has remained active since delegation, unlike several brand TLDs that were later handed back and removed from the root.
 
-1.  **Ant Group (Alipay):** The primary [registrant](/en/glossary/registrant/) and operator, using the extension for core financial services infrastructure.
-2.  **Alibaba Group Affiliates:** Various e-commerce and logistics branches that integrate directly with the Alipay payment system may utilize subdomains within this namespace.
-3.  **Cross-Border Payment Solutions:** The domain is utilized to streamline international gateways, ensuring merchants worldwide recognize the authenticity of the payment interface.
+## Is .alipay available to register?
 
-*To understand the scale of the entity behind this TLD, you can read more at [Alibaba Group's Official Site](https://www.alibabagroup.com).*
+**No.** `.alipay` is a **closed brand TLD**, so there is no open registration and no [registrar](/en/glossary/registrar/) — including Namefi — can sell you a `.alipay` name. Registrations are limited to Alibaba Group Holding Limited and organizations it authorizes, such as Alipay and Ant Group affiliates. This is by design: a dot-brand exists precisely so the trademark holder controls the whole namespace and no one else can register a confusing or malicious lookalike.
 
-## **Why Choose .alipay?**
+If you have a genuine business relationship with Alibaba Group or Alipay and a legitimate need for a `.alipay` address, that request would go through the company's own corporate channels, not a commercial registrar.
 
-While general registration is restricted, understanding the *value* of the .alipay TLD is essential for domain investors and developers looking at the future of **fintech** and **[Web3](/en/glossary/web3/)** naming conventions. The advantages demonstrated by .alipay include:
+## How Alibaba uses .alipay
 
-*   **Unparalleled Trust:** In the financial sector, trust is the currency. A Brand TLD signals maximum security credentials.
-*   **Zero Phishing Risk:** Because only the brand owner can create domains, users are protected from "[typosquatting](/en/glossary/typosquatting/)" attacks (e.g., `alipay-login.com`).
-*   **SEO Authority:** Search engines increasingly recognize Brand TLDs as authoritative sources for queries related to that specific company.
-*   **Short & Memorable Names:** Without public competition, the registry can utilize premium keywords (like `pay.alipay` or `help.alipay`) without worrying about availability.
+Brand TLDs give a company a private space to organize its web presence. Typical uses for a dot-brand like `.alipay` include:
 
-## **Register Your .alipay Domain at Namefi**
+- **Payment and platform sites** on clean, memorable addresses tied directly to the brand.
+- **Campaign and event pages** that are obviously official because only the company can create them.
+- **Internal tools and portals** where a branded suffix signals a trusted, first-party destination.
 
-Are you looking to secure high-value domains for your fintech startup, [blockchain](/en/glossary/blockchain/) project, or investment portfolio?
+**Who it's not for:** anyone outside Alibaba Group. Because the namespace is closed, there is no scenario in which an independent developer, merchant, or business can build on `.alipay`.
 
-While **.alipay** is currently a restricted Brand TLD reserved for the Alibaba Group, the landscape of domains is evolving rapidly. At **Namefi**, we specialize in identifying and securing the most valuable digital assets available, including premium fintech domains and Web3-ready identities.
+## Notable sites using .alipay
 
-**Why use Namefi?**
-*   **Seamless Web3 Integration:** We allow you to mint your DNS domains as NFTs, giving you instant [liquidity](/en/glossary/domain-liquidity/) and easy transferability.
-*   **ICANN Accredited:** We bridge the gap between traditional Web2 compliance and Web3 innovation.
-*   **Future-Ready:** Be the first to know if restricted TLDs open up or if new, relevant financial TLDs hit the market.
+There are **no third-party sites** on `.alipay`, and there never will be while it stays a closed brand TLD — every `.alipay` address is controlled by Alibaba Group Holding Limited. The company's main public presence runs from [alibabagroup.com](https://www.alibabagroup.com), and it uses the brand TLD selectively rather than as a wholesale replacement. Rather than point to a specific address that may change, the honest description is simple: `.alipay` is Alibaba's private namespace, reserved for Alipay's own properties.
 
-Don't leave your brand identity to chance. Secure a powerful domain that commands trust and authority today.
+## What is a dot-brand TLD?
 
-**[Register Your Domain at Namefi](https://namefi.io)**
+A **dot-brand** (or brand TLD) is a top-level domain that a single company owns and operates for its exclusive use, secured through ICANN's [New gTLD Program](/en/glossary/new-gtld/). Hundreds were delegated during the same application round, and they share a few defining traits:
+
+- **Closed registration.** Only the brand and its affiliates can hold names.
+- **Specification 13.** A registry-agreement addendum that formally recognizes the TLD as a brand and relaxes some rules that apply to open generics.
+- **Security and control.** The brand eliminates the risk of anyone else registering a `.alipay` lookalike, which strengthens resistance to [phishing](/en/glossary/phishing/) and impersonation.
+
+Some brands invest heavily in their TLD; others register it defensively and barely use it. A number of companies have even terminated their dot-brands after deciding the upkeep was not worth it.
+
+## .alipay vs open domain alternatives
+
+If your goal was a short, brandable name rather than the `.alipay` string specifically, an open extension is the right tool. Here is how a closed brand TLD compares with domains you can actually register:
+
+| Feature | .alipay | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.xyz](/en/tld/xyz/) |
+| --- | --- | --- | --- | --- |
+| Who can register | Alibaba Group only | Anyone | Anyone | Anyone |
+| Type | Brand new gTLD (closed) | Legacy gTLD | ccTLD used generically | New gTLD |
+| Core use | Alipay's own sites | Universal default | Tech & startups | Generic / Web3 |
+| Available to you | No | Yes | Yes | Yes |
+
+For your own venture, a matching `.com` remains the safest default; [.io](/en/tld/io/) suits technical products; and [.xyz](/en/tld/xyz/) is a flexible, low-cost modern option.
+
+## Reputation and trust
+
+Ironically, the closed nature of `.alipay` is exactly what makes it trustworthy: because only Alibaba Group can create these addresses, a `.alipay` link is verifiably official, which is why brand TLDs are considered strong against impersonation and email spoofing. That trust, however, benefits Alibaba and Alipay alone — it does not transfer to any name you might register, since you cannot register one. For your own project, deliverability and reputation will come from a well-configured domain on an open extension, not from a brand TLD you don't control.
+
+## Looking for an "alipay"-style name? Register an alternative at Namefi
+
+You can't buy a `.alipay` domain, but if you want a short payments- or fintech-flavored name of your own, you can secure it on an open extension in minutes:
+
+1. **Search** your desired name across open TLDs like `.com`, `.io`, or `.xyz`.
+2. **Choose** the extension that fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can anyone register a .alipay domain?
+
+No. `.alipay` is a closed brand TLD delegated to Alibaba Group Holding Limited for the Alipay payments platform. Only Alibaba Group and parties it authorizes can hold a `.alipay` name, so it is not available to the public through any registrar.
+
+### Who operates the .alipay registry?
+
+Alibaba Group Holding Limited is the registry operator, with Afilias providing the technical back-end. The TLD was delegated to the DNS root zone on January 8, 2016 under ICANN's New gTLD Program.
+
+### What does the .alipay domain represent?
+
+The string combines "Ali," from Alibaba, with "pay," for payments. It represents Alipay, the digital-payments platform associated with Ant Group and the wider Alibaba ecosystem, rather than an open word anyone can register.
+
+### What can I register instead of .alipay?
+
+Because `.alipay` is closed, choose an open extension for your own project. A matching `.com`, or a modern alternative like `.io` or `.xyz`, can be registered by anyone through an accredited registrar such as Namefi.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals behind top-level domains.
+- [How a TLD affects domain value](/en/blog/how-tld-affects-domain-value/) — why the extension matters.
+- [.com TLD guide](/en/tld/com/) — the open default to compare against.
+- [.io TLD guide](/en/tld/io/) and [.xyz TLD guide](/en/tld/xyz/) — modern open alternatives.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [registry](/en/glossary/registry/), [ICANN](/en/glossary/icann/).

--- a/content/tld/en/alipay.md
+++ b/content/tld/en/alipay.md
@@ -3,7 +3,7 @@ title: "What Is the .alipay Domain? Alipay's Brand TLD Explained"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .alipay domain is the closed brand TLD tied to Alibaba Group and its Alipay payments platform, not open to the public. Learn who runs it and what to register instead.'

--- a/content/tld/en/allstate.md
+++ b/content/tld/en/allstate.md
@@ -1,13 +1,22 @@
 ---
-title: "What is .allstate TLD and why choose it?"
-date: '2025-12-10'
+title: "What Is the .allstate Domain? Allstate's Brand TLD Explained"
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: "Discover the purpose behind the .allstate TLD. Learn about Brand TLDs, how they enhance security and trust, and how you can secure your own powerful domain strategy with Namefi."
-keywords: ['.allstate domains', '.allstate TLD', 'top-level domain', 'what is .allstate', 'why choose .allstate', 'what is the .allstate domain', 'why choose the .allstate domain', 'domain investing', 'blockchain domains', 'tokenized domains', 'brand TLD', 'insurance domains', 'corporate domain strategy', 'Web3 domains', 'Namefi']
+description: 'The .allstate domain is the closed brand TLD of insurer Allstate, not open to the public. Learn what it is, who runs it, why it exists, and what to register instead.'
+keywords: ['.allstate domain', 'what is .allstate', '.allstate TLD', 'Allstate brand domain', 'dot-brand TLD', 'Allstate registry operator', 'closed generic TLD', 'is .allstate available']
+faqs:
+  - question: 'Can anyone register a .allstate domain?'
+    answer: 'No. .allstate is a closed brand TLD delegated to Allstate. Only Allstate and parties it authorizes can hold a .allstate name, so it is not available to the general public through any registrar.'
+  - question: 'Who operates the .allstate registry?'
+    answer: 'Allstate Fire and Casualty Insurance Company is the registry operator, with Afilias providing the technical back-end. The TLD was delegated to the DNS root zone on February 5, 2016 under ICANN''s New gTLD Program.'
+  - question: 'Why does Allstate have its own domain extension?'
+    answer: 'Allstate is a large United States insurance company that applied for its own brand name as a top-level domain so it alone controls every address ending in .allstate, closing off the string to cybersquatters and impersonators.'
+  - question: 'What can I register instead of .allstate?'
+    answer: 'Because .allstate is closed, choose an open extension for your own project. A matching .com, or a modern alternative like .io or .xyz, can be registered by anyone through an accredited registrar such as Namefi.'
 relatedArticles:
   - /en/blog/what-is-a-tld/
   - /en/blog/what-are-tokenized-domains/
@@ -28,56 +37,113 @@ relatedGlossary:
   - /en/glossary/registry/
 ---
 
-## **What is .allstate?**
+The **.allstate** domain is a **closed brand [top-level domain](/en/glossary/tld/)** operated by **Allstate**, the large United States insurance company. It is not a public extension: unlike [.com](/en/tld/com/) or [.io](/en/tld/io/), you cannot register a `.allstate` name for your own project, because the entire namespace belongs to one company.
 
-The **.allstate** extension is a specialized type of [Top-Level Domain (TLD)](/en/glossary/tld/) known as a **Brand TLD** (or "dot brand"). Unlike open extensions like [.com](/en/tld/com/) or [.net](/en/tld/net/), which are available for general public registration, .allstate was created specifically for the **Allstate Insurance Company**.
+If you searched for the ".allstate domain" hoping to buy one, the short answer is that you can't — but this page explains exactly what `.allstate` is, who controls it, why a company runs its own TLD, and what you can register instead.
 
-Introduced during [ICANN’s New gTLD Program](https://newgtlds.icann.org/en/about/program), this domain extension allows the corporation to create a trusted, dedicated digital environment. By owning the entire [registry](/en/glossary/registry/), Allstate ensures that every domain ending in `.allstate` is an authentic property of the company, providing a high level of security against [phishing](/en/glossary/phishing/) and brand impersonation.
+## .allstate at a glance
 
-While most internet users are familiar with Country Code TLDs (ccTLDs like .uk or .ca) or generic TLDs (gTLDs like [.org](/en/tld/org/)), .allstate represents the evolution of corporate digital identity, moving away from shared spaces to a wholly-owned digital ecosystem.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | Allstate Fire and Casualty Insurance Company (technical back-end by Afilias) |
+| Year delegated | 2016 |
+| IDN support | Not relevant — closed namespace |
+| DNSSEC | Supported |
+| Registration restrictions | **Closed** — restricted to Allstate and parties it authorizes; not available to the public |
+| Best for | Allstate's own corporate, product, and campaign sites |
 
-## **How People Are Using .allstate**
+## What is .allstate?
 
-Because .allstate is a **closed registry**, it is not used by the general public for personal blogs or unrelated e-commerce sites. Instead, its usage is strategic and focused on corporate governance and customer trust.
+`.allstate` is a **[generic top-level domain](/en/glossary/gtld/)** that ICANN delegated to **Allstate Fire and Casualty Insurance Company**, part of the Allstate group, one of the large insurance companies in the United States. The string is simply the company's own name — "All" plus "State" — read as a single brand, not a description of geographic coverage.
 
-Here is how the TLD is effectively utilized:
-*   **Customer Assurance:** When a customer sees a URL ending in `.allstate`, they know immediately that they are interacting with the official insurance provider, not a scam site.
-*   **Marketing Campaigns:** It allows for intuitive, memorable campaign links (e.g., `auto.allstate` or `claims.allstate`) rather than long, complicated subdirectories.
-*   **Internal Infrastructure:** Large corporations use proprietary TLDs to organize internal portals, employee resources, and developer environments securely.
-*   **Brand Authority:** It signals technological leadership and a forward-thinking approach to digital asset management.
+`.allstate` is a **brand TLD**, often called a "dot-brand," not an open extension anyone can buy into. Allstate applied for the string so that it, and only it, would control every domain ending in `.allstate`. You can confirm the delegation and operator on the authoritative [IANA root-zone record for .allstate](https://www.iana.org/domains/root/db/allstate.html).
 
-## **Notable Entities Using .allstate**
+## History of .allstate
 
-As a Brand TLD, the exclusive user of this extension is **The Allstate Corporation** and its subsidiaries.
+The `.allstate` string was delegated to the DNS [root zone](/en/glossary/root-zone/) on **February 5, 2016**, following an application under [ICANN](/en/glossary/icann/)'s New gTLD Program. **Afilias** handled the technical registry operation on Allstate's behalf. Its registry agreement includes Specification 13, the contract clause that formally designates a TLD as a brand and lets the operator keep it closed.
 
-*   **Allstate Insurance:** The primary entity utilizing the domain for product offerings, insurance quotes, and policy management.
-*   **Allstate Financial Services:** Leveraging the domain for secure financial interactions.
-*   **Esurance / Encompass:** While these are separate brands, they fall under the corporate umbrella that benefits from the technological infrastructure pioneered by the parent TLD strategy.
+The record has remained active since delegation, unlike several brand TLDs that were later handed back and removed from the root.
 
-*Note: You can view the delegation details on the [IANA Root Zone Database](https://www.iana.org/domains/root/db/allstate.html).*
+## Is .allstate available to register?
 
-## **Why Choose .allstate?**
+**No.** `.allstate` is a **closed brand TLD**, so there is no open registration and no [registrar](/en/glossary/registrar/) — including Namefi — can sell you a `.allstate` name. Registrations are limited to Allstate and organizations it authorizes, such as subsidiaries or partners. This is by design: a dot-brand exists precisely so the trademark holder controls the whole namespace and no one else can register a confusing or malicious lookalike.
 
-While you cannot register a `.allstate` domain unless you are an administrator for the Allstate corporation, understanding *why* they chose this path offers valuable lessons for domain investors, developers, and business owners looking for their own domains (like .insurance, [.finance](/en/tld/finance/), or their own brand name).
+If you have a genuine business relationship with Allstate and a legitimate need for a `.allstate` address, that request would go through Allstate's own corporate channels, not a commercial registrar.
 
-The advantages of a dedicated or industry-specific TLD include:
+## How Allstate uses .allstate
 
-*   **Unmatched Trust:** A closed or highly regulated TLD eliminates the risk of [cybersquatting](/en/glossary/cybersquatting/). Users trust the domain implies a verified identity.
-*   **SEO Relevance:** Search engines increasingly understand the semantic value of TLDs. A domain that exactly matches the brand or industry can improve click-through rates (CTR).
-*   **Security:** With full control over the registry, the organization can implement stricter security protocols (such as mandatory [DNSSEC](/en/glossary/dnssec/)) across all domains in the namespace.
-*   **Short and Memorable:** Without the overcrowding of .com, a specialized TLD offers access to premium, single-word domain names (e.g., `pay.allstate` vs. `allstate-payment-portal.com`).
+Brand TLDs give a company a private space to organize its web presence. Typical uses for a dot-brand like `.allstate` include:
 
-## **Register Your .allstate Domain at Namefi**
+- **Product and policy sites** on clean, memorable addresses tied directly to the brand.
+- **Campaign and event pages** that are obviously official because only the company can create them.
+- **Internal tools and portals** where a branded suffix signals a trusted, first-party destination.
 
-Are you inspired by the security and branding power of the .allstate TLD? While `.allstate` is restricted to the corporation, you can build your own powerful digital identity with **Namefi**.
+**Who it's not for:** anyone outside Allstate. Because the namespace is closed, there is no scenario in which an independent agent, policyholder, or business can build on `.allstate`.
 
-Whether you are looking for industry-specific domains like **.insurance**, **.finance**, or **[.xyz](/en/tld/xyz/)**, or building a portfolio of investment-grade domains, Namefi creates a bridge between traditional Web2 DNS and the [Web3](/en/glossary/web3/) future.
+## Notable sites using .allstate
 
-**Why Register with Namefi?**
-*   **Tokenized Domains:** We treat domains as real-world assets (RWA), allowing you to mint them as NFTs for easier trading and [liquidity](/en/glossary/domain-liquidity/).
-*   **Seamless Web3 Integration:** Connect your [wallet](/en/glossary/wallet/) and manage your DNS records with the security of [blockchain](/en/glossary/blockchain/) technology.
-*   **Instant Transfers:** Say goodbye to long [escrow](/en/glossary/escrow/) periods. With Namefi, transferring [domain ownership](/en/glossary/domain-ownership/) is as fast as sending a token.
+There are **no third-party sites** on `.allstate`, and there never will be while it stays a closed brand TLD — every `.allstate` address is controlled by Allstate. The company's main public presence runs from [allstate.com](https://www.allstate.com), and it uses the brand TLD selectively rather than as a wholesale replacement. Rather than point to a specific address that may change, the honest description is simple: `.allstate` is Allstate's private namespace, used only for the company's own properties.
 
-Don't wait for the perfect name to disappear. Secure your brand's future today.
+## What is a dot-brand TLD?
 
-[**Start Your Search at Namefi**](https://namefi.io)
+A **dot-brand** (or brand TLD) is a top-level domain that a single company owns and operates for its exclusive use, secured through ICANN's [New gTLD Program](/en/glossary/new-gtld/). Hundreds were delegated during the same application round, and they share a few defining traits:
+
+- **Closed registration.** Only the brand and its affiliates can hold names.
+- **Specification 13.** A registry-agreement addendum that formally recognizes the TLD as a brand and relaxes some rules that apply to open generics.
+- **Security and control.** The brand eliminates the risk of anyone else registering a `.allstate` lookalike, which strengthens resistance to [phishing](/en/glossary/phishing/) and impersonation.
+
+Some brands invest heavily in their TLD; others register it defensively and barely use it. A number of companies have even terminated their dot-brands after deciding the upkeep was not worth it.
+
+## .allstate vs open domain alternatives
+
+If your goal was a short, brandable name rather than the `.allstate` string specifically, an open extension is the right tool. Here is how a closed brand TLD compares with domains you can actually register:
+
+| Feature | .allstate | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.xyz](/en/tld/xyz/) |
+| --- | --- | --- | --- | --- |
+| Who can register | Allstate only | Anyone | Anyone | Anyone |
+| Type | Brand new gTLD (closed) | Legacy gTLD | ccTLD used generically | New gTLD |
+| Core use | Allstate's own sites | Universal default | Tech & startups | Generic / Web3 |
+| Available to you | No | Yes | Yes | Yes |
+
+For your own venture, a matching `.com` remains the safest default; [.io](/en/tld/io/) suits technical products; and [.xyz](/en/tld/xyz/) is a flexible, low-cost modern option.
+
+## Reputation and trust
+
+Ironically, the closed nature of `.allstate` is exactly what makes it trustworthy: because only Allstate can create these addresses, a `.allstate` link is verifiably official, which is why brand TLDs are considered strong against impersonation and email spoofing. That trust, however, benefits Allstate alone — it does not transfer to any name you might register, since you cannot register one. For your own project, deliverability and reputation will come from a well-configured domain on an open extension, not from a brand TLD you don't control.
+
+## Looking for an "allstate"-style name? Register an alternative at Namefi
+
+You can't buy a `.allstate` domain, but if you want a short, insurance- or finance-flavored name of your own, you can secure it on an open extension in minutes:
+
+1. **Search** your desired name across open TLDs like `.com`, `.io`, or `.xyz`.
+2. **Choose** the extension that fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can anyone register a .allstate domain?
+
+No. `.allstate` is a closed brand TLD delegated to Allstate. Only Allstate and parties it authorizes can hold a `.allstate` name, so it is not available to the general public through any registrar.
+
+### Who operates the .allstate registry?
+
+Allstate Fire and Casualty Insurance Company is the registry operator, with Afilias providing the technical back-end. The TLD was delegated to the DNS root zone on February 5, 2016 under ICANN's New gTLD Program.
+
+### Why does Allstate have its own domain extension?
+
+Allstate is a large United States insurance company that applied for its own brand name as a top-level domain so it alone controls every address ending in `.allstate`, closing off the string to cybersquatters and impersonators.
+
+### What can I register instead of .allstate?
+
+Because `.allstate` is closed, choose an open extension for your own project. A matching `.com`, or a modern alternative like `.io` or `.xyz`, can be registered by anyone through an accredited registrar such as Namefi.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals behind top-level domains.
+- [How a TLD affects domain value](/en/blog/how-tld-affects-domain-value/) — why the extension matters.
+- [.com TLD guide](/en/tld/com/) — the open default to compare against.
+- [.io TLD guide](/en/tld/io/) and [.xyz TLD guide](/en/tld/xyz/) — modern open alternatives.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [registry](/en/glossary/registry/), [ICANN](/en/glossary/icann/).

--- a/content/tld/en/allstate.md
+++ b/content/tld/en/allstate.md
@@ -3,7 +3,7 @@ title: "What Is the .allstate Domain? Allstate's Brand TLD Explained"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .allstate domain is the closed brand TLD of insurer Allstate, not open to the public. Learn what it is, who runs it, why it exists, and what to register instead.'

--- a/content/tld/en/ally.md
+++ b/content/tld/en/ally.md
@@ -1,13 +1,22 @@
 ---
-title: "Unlock the Power of Partnership: What is .ally TLD and why choose it?"
-date: '2025-12-10'
+title: "What Is the .ally Domain? Ally Financial's TLD Explained"
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: "Discover the .ally TLD: The perfect domain for partnerships, communities, and inclusive brands. Learn why .ally is the future of collaborative digital identity."
-keywords: [".ally domains", ".ally TLD", "top-level domain", "what is .ally", "why choose .ally", "what is the .ally domain", "why choose the .ally domain", "domain investing", "blockchain domains", "tokenized domain", "Web3 identity", "community domains", "brand partnership", "digital ally", "buy .ally domain"]
+description: 'The .ally domain is the closed brand TLD of Ally Financial, not open to the public despite the common word. Learn who runs it and what to register instead.'
+keywords: ['.ally domain', 'what is .ally', '.ally TLD', 'Ally Financial domain', 'dot-brand TLD', 'Ally Financial registry', 'closed generic TLD', 'is .ally available']
+faqs:
+  - question: 'Can anyone register a .ally domain?'
+    answer: 'No. .ally is a closed brand TLD delegated to Ally Financial Inc. Only Ally Financial and parties it authorizes can hold a .ally name, so it is not available to the general public through any registrar.'
+  - question: 'Who operates the .ally registry?'
+    answer: 'Ally Financial Inc. is the registry operator, with GoDaddy Registry providing the technical back-end. The TLD was delegated to the DNS root zone on October 22, 2015 under ICANN''s New gTLD Program.'
+  - question: 'Is .ally open because ally is a common word?'
+    answer: 'No. Ally is an ordinary English word, but the .ally domain is a closed dot-brand controlled by Ally Financial Inc., a United States digital financial-services company. That everyday meaning does not make the TLD open to the public.'
+  - question: 'What can I register instead of .ally?'
+    answer: 'Because .ally is closed, choose an open extension for your own project. A matching .com, or a modern alternative like .io or .xyz, can be registered by anyone through an accredited registrar such as Namefi.'
 relatedArticles:
   - /en/blog/what-are-tokenized-domains/
   - /en/blog/what-is-a-tld/
@@ -28,52 +37,113 @@ relatedGlossary:
   - /en/glossary/dns/
 ---
 
-## **What is .ally?**
+The **.ally** domain is a **closed brand [top-level domain](/en/glossary/tld/)** operated by **Ally Financial Inc.**, the United States digital financial-services company. It is not a public extension: unlike [.com](/en/tld/com/) or [.io](/en/tld/io/), you cannot register a `.ally` name for your own project, because the entire namespace belongs to one company — even though "ally" is also an ordinary English word.
 
-In the rapidly expanding universe of the internet, finding a domain name that speaks directly to your values and mission is crucial. The **.ally** [Top-Level Domain (TLD)](/en/glossary/tld/) is a unique and resonant extension designed for those who prioritize partnership, support, and community. Unlike generic domains like [.com](/en/tld/com/) or [.net](/en/tld/net/), **.ally** carries an inherent message of inclusivity and collaboration.
+If you searched for the ".ally domain" hoping to buy one, perhaps for a community, partnership, or advocacy project, the short answer is that you can't — but this page explains exactly what `.ally` is, who controls it, why a company runs its own TLD, and what you can register instead.
 
-While not originally part of the early internet infrastructure, niche and descriptive TLDs have grown significantly following [ICANN’s New gTLD Program](https://newgtlds.icann.org/en/about/program). The .ally domain falls into the category of "identity-based" or "descriptive" TLDs. It serves a specific purpose: to signal to the world that a website belongs to a partner, a supporter, or a collaborative entity.
+## .ally at a glance
 
-In the context of the evolving [Web3](/en/glossary/web3/) landscape, .ally is also gaining traction among Decentralized Autonomous Organizations (DAOs) and community-driven projects that operate on the principles of mutual assistance and shared governance.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | Ally Financial Inc. (technical back-end by GoDaddy Registry) |
+| Year delegated | 2015 |
+| IDN support | Not relevant — closed namespace |
+| DNSSEC | Supported |
+| Registration restrictions | **Closed** — restricted to Ally Financial and parties it authorizes; not available to the public |
+| Best for | Ally Financial's own banking, product, and campaign sites |
 
-## **How People Are Using .ally**
+## What is .ally?
 
-The versatility of the word "ally" allows this TLD to be used across a variety of sectors, from social justice to corporate B2B services. Here is how different groups are leveraging this extension:
+`.ally` is a **[generic top-level domain](/en/glossary/gtld/)** that ICANN delegated to **Ally Financial Inc.**, an online bank and digital financial-services company based in the United States. "Ally" is a common English word meaning a partner or supporter, but that everyday meaning is not why this TLD exists: Ally Financial applied for the string as its own corporate name, the same way any company might secure its brand as a domain extension.
 
-*   **Non-Profits and Advocacy Groups:** Organizations dedicated to social causes, LGBTQ+ rights, and mental health support use .ally to create safe, welcoming digital spaces.
-*   **B2B Service Providers:** Companies that position themselves as partners rather than just vendors (e.g., `marketing.ally` or `tech.ally`) use it to emphasize a supportive business relationship.
-*   **Gaming and Guilds:** In the gaming world, an "ally" is a teammate. Gaming clans and eSports teams utilize the domain to build community hubs.
-*   **Web3 and Blockchain Communities:** As the internet moves toward tokenization, DAOs and protocol "alliances" use the domain to signify [on-chain](/en/glossary/on-chain/) cooperation and governance participation.
-*   **Personal Portfolios:** Consultants and coaches use it to brand themselves as reliable partners in their clients' success stories.
+`.ally` is a **brand TLD**, often called a "dot-brand," not an open extension anyone can buy into. Ally Financial applied for the string so that it, and only it, would control every domain ending in `.ally`. You can confirm the delegation and operator on the authoritative [IANA root-zone record for .ally](https://www.iana.org/domains/root/db/ally.html).
 
-## **Notable Entities Using .ally**
+## History of .ally
 
-While .ally is a growing namespace, it is rapidly being adopted by forward-thinking brands and communities. While some specific usage data is proprietary to registries, we observe the following archetypes dominating the space:
+The `.ally` string was delegated to the DNS [root zone](/en/glossary/root-zone/) on **October 22, 2015**, following an application under [ICANN](/en/glossary/icann/)'s New gTLD Program. **GoDaddy Registry** handled the technical registry operation on Ally Financial's behalf. Its registry agreement includes Specification 13, the contract clause that formally designates a TLD as a brand and lets the operator keep it closed.
 
-1.  **Diversity & Inclusion Initiatives:** Major corporate sub-domains dedicated to internal Diversity, Equity, and Inclusion (DEI) initiatives often utilize `pride.ally` or `network.ally` for internal resource hubs.
-2.  **Tech Support Platforms:** Emerging SaaS platforms that act as "sidekicks" or assistants to main workflows are adopting the name to signify utility and helpfulness.
-3.  **Educational Coalitions:** Collaborative networks of schools or educational resources sharing a common goal are moving toward .ally to represent their unified front.
-4.  **Web3 Protocols:** innovative blockchain projects focusing on interoperability (working together) are securing these domains to [tokenize](/en/glossary/tokenize/) their brand identity.
+The record has remained active since delegation, unlike several brand TLDs that were later handed back and removed from the root.
 
-## **Why Choose .ally?**
+## Is .ally available to register?
 
-Selecting the right domain extension is about more than just availability; it is about branding strategy and SEO. Here is why .ally is a smart choice for your next venture:
+**No.** `.ally` is a **closed brand TLD**, so there is no open registration and no [registrar](/en/glossary/registrar/) — including Namefi — can sell you a `.ally` name. This holds regardless of the word's friendly, everyday meaning: registrations are limited to Ally Financial Inc. and organizations it authorizes, such as subsidiaries or partners. A dot-brand exists precisely so the trademark holder controls the whole namespace and no one else can register a confusing or malicious lookalike.
 
-*   **Instant Trust and Positivity:** The word "ally" has universally positive connotations. It implies friendship, help, and reliability. This builds immediate trust with visitors before they even click the link.
-*   **High Availability:** Compared to the saturated .com market, .ally offers a vast inventory of short, one-word, and memorable names. You are more likely to get `yourbrand.ally` than `yourbrand.com`.
-*   **Semantic SEO:** Search engines are getting smarter at understanding context. If your business revolves around support services, consulting, or community building, the domain name itself reinforces your relevance to those keywords.
-*   **Web3 Ready:** For those in the blockchain space, .ally signals a move away from competitive Web2 dynamics toward collaborative Web3 ecosystems.
+If you have a genuine business relationship with Ally Financial and a legitimate need for a `.ally` address, that request would go through the company's own corporate channels, not a commercial registrar.
 
-## **Register Your .ally Domain at Namefi**
+## How Ally Financial uses .ally
 
-Ready to position your brand as a trusted partner and leader in your community? Securing your **.ally** domain is the first step toward building a digital identity rooted in collaboration and trust.
+Brand TLDs give a company a private space to organize its web presence. Typical uses for a dot-brand like `.ally` include:
 
-At **Namefi**, we make domain registration effortless and future-proof. Whether you are a Web2 business looking for a catchy URL or a Web3 developer looking to mint a **[tokenized domain](/en/glossary/tokenized-domain/)**, our platform bridges the gap.
+- **Banking and product sites** on clean, memorable addresses tied directly to the brand.
+- **Campaign and event pages** that are obviously official because only the company can create them.
+- **Internal tools and portals** where a branded suffix signals a trusted, first-party destination.
 
-*   **Seamless Integration:** Manage your domains with traditional ease or via blockchain wallets.
-*   **Transparent Pricing:** No hidden fees, just great domains.
-*   **Instant Ownership:** When you register with Namefi, you truly own your digital asset.
+**Who it's not for:** anyone outside Ally Financial. Because the namespace is closed, there is no scenario in which an independent community group, advocacy organization, or developer can build on `.ally` — however well the name would fit a partnership-themed project.
 
-Don't wait for your perfect partnership name to be taken. Join the alliance of forward-thinking creators today.
+## Notable sites using .ally
 
-[**Secure your .ally domain at Namefi today**](https://namefi.io)
+There are **no third-party sites** on `.ally`, and there never will be while it stays a closed brand TLD — every `.ally` address is controlled by Ally Financial Inc. The company's main public presence runs from [ally.com](https://www.ally.com), and it uses the brand TLD selectively rather than as a wholesale replacement. Rather than point to a specific address that may change, the honest description is simple: `.ally` is Ally Financial's private namespace, used only for the company's own properties — not a shared space for third parties who identify with the word "ally."
+
+## What is a dot-brand TLD?
+
+A **dot-brand** (or brand TLD) is a top-level domain that a single company owns and operates for its exclusive use, secured through ICANN's [New gTLD Program](/en/glossary/new-gtld/). Hundreds were delegated during the same application round, and they share a few defining traits:
+
+- **Closed registration.** Only the brand and its affiliates can hold names.
+- **Specification 13.** A registry-agreement addendum that formally recognizes the TLD as a brand and relaxes some rules that apply to open generics.
+- **Security and control.** The brand eliminates the risk of anyone else registering a `.ally` lookalike, which strengthens resistance to [phishing](/en/glossary/phishing/) and impersonation.
+
+Some brands invest heavily in their TLD; others register it defensively and barely use it. A number of companies have even terminated their dot-brands after deciding the upkeep was not worth it.
+
+## .ally vs open domain alternatives
+
+If your goal was a short, brandable name built around the word "ally" rather than the `.ally` string specifically, an open extension is the right tool. Here is how a closed brand TLD compares with domains you can actually register:
+
+| Feature | .ally | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.xyz](/en/tld/xyz/) |
+| --- | --- | --- | --- | --- |
+| Who can register | Ally Financial only | Anyone | Anyone | Anyone |
+| Type | Brand new gTLD (closed) | Legacy gTLD | ccTLD used generically | New gTLD |
+| Core use | Ally Financial's own sites | Universal default | Tech & startups | Generic / Web3 |
+| Available to you | No | Yes | Yes | Yes |
+
+For your own venture, a matching `.com` remains the safest default; [.io](/en/tld/io/) suits technical products; and [.xyz](/en/tld/xyz/) is a flexible, low-cost modern option.
+
+## Reputation and trust
+
+Ironically, the closed nature of `.ally` is exactly what makes it trustworthy: because only Ally Financial can create these addresses, a `.ally` link is verifiably official, which is why brand TLDs are considered strong against impersonation and email spoofing. That trust, however, benefits Ally Financial alone — it does not transfer to any name you might register, since you cannot register one. For your own project, deliverability and reputation will come from a well-configured domain on an open extension, not from a brand TLD you don't control.
+
+## Looking for an "ally" name? Register an alternative at Namefi
+
+You can't buy a `.ally` domain, but if you want a name built around partnership, support, or community, you can secure it on an open extension in minutes:
+
+1. **Search** your desired name across open TLDs like `.com`, `.io`, or `.xyz`.
+2. **Choose** the extension that fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can anyone register a .ally domain?
+
+No. `.ally` is a closed brand TLD delegated to Ally Financial Inc. Only Ally Financial and parties it authorizes can hold a `.ally` name, so it is not available to the general public through any registrar.
+
+### Who operates the .ally registry?
+
+Ally Financial Inc. is the registry operator, with GoDaddy Registry providing the technical back-end. The TLD was delegated to the DNS root zone on October 22, 2015 under ICANN's New gTLD Program.
+
+### Is .ally open because ally is a common word?
+
+No. "Ally" is an ordinary English word, but the `.ally` domain is a closed dot-brand controlled by Ally Financial Inc., a United States digital financial-services company. That everyday meaning does not make the TLD open to the public.
+
+### What can I register instead of .ally?
+
+Because `.ally` is closed, choose an open extension for your own project. A matching `.com`, or a modern alternative like `.io` or `.xyz`, can be registered by anyone through an accredited registrar such as Namefi.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals behind top-level domains.
+- [How a TLD affects domain value](/en/blog/how-tld-affects-domain-value/) — why the extension matters.
+- [.com TLD guide](/en/tld/com/) — the open default to compare against.
+- [.io TLD guide](/en/tld/io/) and [.xyz TLD guide](/en/tld/xyz/) — modern open alternatives.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [registry](/en/glossary/registry/), [ICANN](/en/glossary/icann/).

--- a/content/tld/en/ally.md
+++ b/content/tld/en/ally.md
@@ -3,7 +3,7 @@ title: "What Is the .ally Domain? Ally Financial's TLD Explained"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .ally domain is the closed brand TLD of Ally Financial, not open to the public despite the common word. Learn who runs it and what to register instead.'

--- a/content/tld/en/alsace.md
+++ b/content/tld/en/alsace.md
@@ -1,13 +1,24 @@
 ---
-title: 'Unlocking Local Identity: What is the .alsace Domain and Why Choose It?'
-date: '2025-12-10'
+title: 'What Is the .alsace Domain? A Geo-TLD for the Alsace Region'
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: 'Discover the power of the .alsace TLD for regional branding and SEO. Learn why businesses, investors, and Web3 developers are choosing .alsace at Namefi.'
-keywords: ['.alsace domains', '.alsace TLD', '.alsace top-level domain', 'what is .alsace', 'why choose .alsace', 'what is the .alsace domain', 'why choose the .alsace domain', 'register .alsace domain', 'Alsace regional domain', 'French GeoTLD', 'domain investing', 'tokenized domains', 'Web3 domains', 'Alsace business domains', 'blockchain domain registration']
+description: 'The .alsace domain is a geographic gTLD for the Alsace region of eastern France. Learn who runs it, who can register, and how it suits local branding.'
+keywords: ['.alsace domains', '.alsace TLD', 'what is .alsace', 'Alsace region domain', 'geographic gTLD', 'French regional domain', 'Alsace wine domain', 'Region Grand Est']
+faqs:
+  - question: 'Can anyone register a .alsace domain?'
+    answer: 'Registration expects a link to the Alsace region, such as a local business, residence, or institution. It is not a fully open, anyone-anywhere gTLD like .com, but a suffix built specifically for Alsace-connected registrants.'
+  - question: 'Does a .alsace domain affect SEO?'
+    answer: 'As a geographic gTLD, .alsace carries a built-in regional signal for Alsace-focused searches. Site owners can reinforce this with explicit geotargeting in tools like Google Search Console. Content, links, and user experience still decide most of the ranking outcome.'
+  - question: 'Who operates the .alsace registry?'
+    answer: 'The .alsace registry is operated by Région Grand Est, with AFNIC, the operator of France''s .fr domain, providing the technical back-end. It was delegated to the DNS root zone on September 18, 2014.'
+  - question: 'Who should register a .alsace domain?'
+    answer: 'Alsace businesses, tourism and hospitality operators, wine and gastronomy producers, and local institutions. It suits anyone who wants a name that signals a genuine connection to the region.'
+  - question: 'Is .alsace the same as .fr?'
+    answer: 'No. .fr is France''s national country-code domain, open broadly to European registrants. .alsace is a narrower geographic gTLD for one French region, sharing AFNIC as its technical back-end but run under its own regional eligibility policy.'
 relatedArticles:
   - /en/blog/ai-vs-io-domain/
   - /en/blog/what-is-a-tld/
@@ -28,49 +39,138 @@ relatedGlossary:
   - /en/glossary/web3/
 ---
 
-## **What is .alsace?**
+The **.alsace** domain is a geographic [new gTLD](/en/glossary/new-gtld/) built for one French region: Alsace, in eastern France, on the border with Germany and near Switzerland. Unlike a generic extension such as [.com](/en/tld/com/), the name itself carries the region's identity, and registration expects a genuine link to Alsace rather than being open to anyone, anywhere.
 
-The **.alsace** extension is a geographic [Top-Level Domain (GeoTLD)](/en/glossary/tld/) dedicated specifically to the Alsace region of France. Unlike generic extensions like [.com](/en/tld/com/) or [.net](/en/tld/net/), or country codes like .fr, .alsace falls under the category of "new gTLDs" designed to highlight regional identity, culture, and economic activity.
+This guide covers what `.alsace` is, who runs it, who can register one, how pricing works, and how it holds up for SEO, reputation, and email, so you can decide whether it suits your brand.
 
-Launched in 2015, this TLD was created to foster a distinct digital ecosystem for individuals, companies, and organizations linked to the Alsace territory. It is managed by the Région Grand Est with technical operations often supported by [AFNIC](https://www.afnic.fr/en/), the same [registry](/en/glossary/registry/) that manages the .fr domain.
+## .alsace at a glance
 
-The primary purpose of .alsace is to allow entities to showcase their "Alsatian identity" online. It serves as a digital label of origin, instantly communicating to visitors that the website is connected to the linguistic, cultural, or economic landscape of this famous European region. You can learn more about the delegation of this TLD on the [ICANN wiki](https://icannwiki.org/.alsace).
+| Fact | Detail |
+| --- | --- |
+| TLD type | Geographic new gTLD |
+| Registry operator | Région Grand Est (technical back-end: AFNIC, operator of France's `.fr` registry) |
+| Year delegated | 2014 (delegated to the root zone on September 18, 2014) |
+| IDN support | Supported (varies by registrar) |
+| DNSSEC | Supported |
+| Registration restrictions | Local nexus expected — registrants should have a link to Alsace |
+| Best for | Alsace businesses, tourism and hospitality, wine and gastronomy producers, and local institutions |
 
-## **How People Are Using .alsace**
+## What is .alsace?
 
-The .alsace domain has become a powerful tool for establishing local authority and trust. Here is how various sectors are utilizing this extension:
+"Alsace" names the historic region in eastern France, and as a domain suffix it means exactly that: a site tied to that specific region. According to its [IANA root-zone entry](https://www.iana.org/domains/root/db/alsace.html), `.alsace` was delegated to the DNS [root zone](/en/glossary/root-zone/) on September 18, 2014, as part of ICANN's New gTLD Program.
 
-*   **Tourism and Hospitality:** Hotels, bed and breakfasts, and tour operators use it to signal their location immediately to tourists searching for authentic experiences in Strasbourg, Colmar, or Mulhouse.
-*   **Gastronomy and Viticulture:** Alsace is world-renowned for its wine. Wineries and food producers use .alsace to certify the origin of their products, which is crucial for branding in the export market.
-*   **Local Small Businesses (SMEs):** Artisans and service providers use the extension to improve local SEO ([Search Engine Optimization](/en/glossary/seo/)), making it easier for local customers to find them.
-*   **Public Institutions and Associations:** Cultural centers and municipalities use it to foster a sense of community pride.
-*   **Digital Innovation:** Tech startups based in the region's innovation hubs are using it to brand themselves as part of the European tech scene while retaining local roots.
+The [registry](/en/glossary/registry/) is operated by **Région Grand Est**, the regional authority that took over Alsace's administrative functions when France merged the Alsace, Champagne-Ardenne, and Lorraine regions into Grand Est in 2016. Technical operation runs through **AFNIC**, the same organization that operates France's national `.fr` domain, so `.alsace` shares its back-end infrastructure with the country's main registry. Operator information is published at [mondomaine.alsace](https://mondomaine.alsace).
 
-## **Notable Entities Using .alsace**
+Because `.alsace` is a **geographic** [gTLD](/en/glossary/gtld/), it names something narrower than France's [ccTLD](/en/glossary/cctld/), `.fr`: `.fr` covers the whole country, while `.alsace` names one region within it. Search engines don't automatically geo-lock every gTLD, but because `.alsace` is explicitly geographic, site owners can set regional or national geotargeting in tools like Google Search Console to reinforce the place signal the name already carries.
 
-While .alsace is a niche regional domain, it is used by major players within the region to reinforce their brand identity.
+## History of .alsace
 
-*   **Marque Alsace (marque.alsace):** This is the official territorial brand agency for the region. Their usage of the domain sets the standard for how the TLD represents regional values and economic attractiveness.
-*   **Vins d'Alsace (vins.alsace):** The official site for the Alsace wine industry. This is a prime example of using a GeoTLD to categorize an entire industry's digital presence, acting as a seal of quality.
-*   **Tourisme Alsace (visit.alsace):** A major travel portal that leverages the domain for clarity and search relevance, targeting international travelers planning trips to the region.
+`.alsace` came out of ICANN's 2012-round New gTLD Program, delegated to the root zone on **September 18, 2014**. At delegation, it represented Alsace as an administrative region in its own right.
 
-For domain investors and developers, these examples illustrate the high value placed on "keyword.alsace" domains within the French and European markets.
+That changed in **2016**, when France's territorial reform merged Alsace with Champagne-Ardenne and Lorraine into the larger **Région Grand Est**. The `.alsace` TLD continued under the new regional authority's administration, with **AFNIC**, the operator behind `.fr`, handling the technical back-end throughout. The result is a domain whose name still reflects the historic Alsace identity even though an administrative region of that exact name no longer stands on its own.
 
-## **Why Choose .alsace?**
+## How people use .alsace
 
-Choosing a .alsace domain offers distinct advantages over a crowded .com or a generic .fr, especially if your project has ties to the region.
+Real-world use of `.alsace` concentrates in a handful of sectors tied closely to the region's economy and identity:
 
-*   **Stronger Local SEO:** Search engines like Google often use domain extensions as a signal of relevance. If you are targeting customers in Eastern France, a .alsace domain can help you rank higher in local search results.
-*   **Availability of Premium Names:** Because it is a newer and more specific registry compared to legacy TLDs, there is a much higher chance of securing short, memorable, and keyword-rich domain names (e.g., `bakery.alsace` or `crypto.alsace`) that would be unavailable or prohibitively expensive elsewhere.
-*   **Trust and Authentication:** Using this domain acts as a digital "Made in Alsace" stamp. It builds immediate trust with users who value local sourcing and regional expertise.
-*   **Cultural Branding:** It connects your brand to values associated with the region: quality, tradition, and European centrality.
+- **Local businesses**, using a `.alsace` address to signal an actual presence in the region.
+- **Tourism and hospitality** operators, from hotels to tour organizers, marketing stays and visits in Alsace.
+- **Wine and gastronomy producers**, a sector central to Alsace's regional identity and export reputation.
+- **Local institutions**, including cultural, community, and public bodies tied to the region.
 
-## **Register Your .alsace Domain at Namefi**
+**Who it's not ideal for:** businesses with no real connection to Alsace, since the nexus expectation means the name isn't available on a purely speculative or defensive basis. It's also a weaker fit for brands that need France-wide reach, since `.fr` or `.com` cover that ground far better than a single-region suffix.
 
-Whether you are a winemaker looking to [tokenize](/en/glossary/tokenize/) your vintage assets or a startup establishing a local presence in Strasbourg, the .alsace domain is your gateway to a distinct digital identity.
+## Notable sites using .alsace
 
-At **Namefi**, we make registering your domain simple, secure, and future-proof. As an [ICANN](/en/glossary/icann/)-accredited [registrar](/en/glossary/registrar/), we bridge the gap between traditional Web2 domains and the [Web3](/en/glossary/web3/) ecosystem. When you register with us, you aren't just buying a URL; you are securing an asset that can be easily managed via [blockchain](/en/glossary/blockchain/) technology if you choose, offering unparalleled ownership and transfer fluidity.
+Adoption of `.alsace` concentrates among local businesses, tourism and hospitality operators, wine and gastronomy producers, and local institutions, rather than one dominant flagship site. That pattern fits a regionally-gated suffix: the organizations actually using it are the ones with a genuine Alsace connection, a smaller and more specific pool than an open global gTLD would attract. Rather than name an address that could change hands, it's more accurate to describe the use: regional businesses and institutions using the name to state their Alsace identity directly.
 
-**Ready to claim your piece of Alsace online?**
+## .alsace vs other domains
 
-[**Register your .alsace domain at Namefi today**](https://namefi.io) and start building a brand that resonates locally and performs globally. Don't wait until your perfect name is taken!
+| Feature | .alsace | [.com](/en/tld/com) | .fr | [.xyz](/en/tld/xyz) |
+| --- | --- | --- | --- | --- |
+| Type | Geographic new gTLD | Legacy gTLD | Country-code TLD (France) | New gTLD (generic) |
+| Restrictions | Local nexus expected (Alsace) | Open to all | Set by French/EU policy | Open to all |
+| Geographic scope | One region | None | Whole country | None |
+| Best fit | Alsace-connected businesses and institutions | Any brand, anywhere | France-wide presence | Generic or Web3-native brands |
+
+Choose `.com` when you want the broadest reach with no geographic tie. Choose `.fr` when you need to represent the whole of France rather than one region. Choose a generic new gTLD like [`.xyz`](/en/tld/xyz) when geography shouldn't factor into your name at all. Choose `.alsace` when your business or organization has a genuine link to the region and you want the address to say so directly.
+
+## Why choose .alsace?
+
+- **Direct regional identity.** The name itself signals a genuine Alsace connection, which a generic `.com` or even a national `.fr` address can't communicate as precisely.
+- **Fit for tourism and gastronomy.** Alsace's wine routes and food culture give the suffix an obvious marketing angle for the sectors that rely on them most.
+- **Shared national infrastructure.** Because AFNIC, the operator of `.fr`, runs the technical back-end, `.alsace` benefits from the same infrastructure as France's main registry.
+- **Availability.** As a newer, narrower namespace than `.com` or `.fr`, short and descriptive `.alsace` names are easier to secure.
+
+## Things to consider
+
+- **The nexus expectation is real.** `.alsace` isn't available purely on demand; plan for a link to the region, not an instant, unrestricted purchase.
+- **Lower general recognition than .com or .fr.** Outside Alsace-focused contexts, the suffix is far less familiar to typical visitors.
+- **Narrow by design.** `.alsace` only makes sense for organizations connected to the region; it isn't a substitute for `.fr` if you need France-wide reach.
+
+## Who can register a .alsace domain?
+
+**Registration restrictions: local nexus expected.** `.alsace` expects registrants to show a link to the Alsace region, for example a local business, residence, or institution, under eligibility policy set by the registry operator, **Région Grand Est**. It is not an open, first-come-first-served namespace like `.com`; it is built for entities connected to the region.
+
+Current eligibility rules and application steps are published by the operator at [mondomaine.alsace](https://mondomaine.alsace). The authoritative technical record is the [IANA root-zone entry](https://www.iana.org/domains/root/db/alsace.html); as a live [ICANN](/en/glossary/icann/) new gTLD, the underlying contract also appears in ICANN's [registry agreements database](https://www.icann.org/en/registry-agreements/details/alsace).
+
+## .alsace pricing and value
+
+`.alsace` pricing follows patterns common to nexus-gated geographic new gTLDs:
+
+- **Eligibility comes before price.** You need a qualifying link to Alsace before a name is available to you, which narrows the buyer pool compared with open gTLDs.
+- **First-year and renewal pricing can differ.** Check the standard renewal rate, not just an introductory offer, before committing to a name.
+- **Cost drivers** include the registrar you choose and any classification the registry applies to specific names.
+
+This page intentionally quotes no figures, since prices and offers change across registrars and over time.
+
+## Reputation and email deliverability
+
+Because registration expects a genuine link to Alsace, the suffix is structurally less exposed to the bulk, speculative registration that damages reputation on wide-open, low-cost extensions. Real use by tourism operators, wine producers, and local institutions gives `.alsace` a legitimate, place-based profile rather than a bargain-bin one.
+
+Deliverability still depends mainly on configuration rather than the suffix itself. Set up correct **SPF, DKIM, and DMARC** records, warm up new sending domains gradually, and keep list hygiene tight. A properly authenticated `.alsace` sender should deliver mail as reliably as any other gTLD.
+
+## Branding and naming tips
+
+- **Lead with what you do.** Since the name already states the region, use the second-level name for the business itself, such as `winery.alsace` or `hotel.alsace`, rather than repeating "Alsace" again.
+- **Keep the left side short**, since the suffix already carries meaning and length.
+- **Confirm your nexus early.** Check Région Grand Est's eligibility rules before building a brand around the name.
+- **Pair with .fr where it helps.** Businesses that also want France-wide reach may want to hold both `.alsace` and `.fr`.
+
+## How to register a .alsace domain at Namefi
+
+1. **Search** for your desired name on [Namefi](https://namefi.io) to check availability.
+2. **Confirm eligibility** against Région Grand Est's Alsace nexus requirement.
+3. **Register** and configure DNS. Namefi provides fast, reliable DNS management.
+
+Namefi is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) with transparent pricing, and it supports [Web3](/en/glossary/web3/) tokenization, so you can optionally [tokenize](/en/glossary/tokenize/) an eligible domain for easier transfer and on-chain management. [Search and register your .alsace domain at Namefi](https://namefi.io).
+
+## Frequently asked questions
+
+### Can anyone register a .alsace domain?
+
+Registration expects a link to the Alsace region, such as a local business, residence, or institution. It is not a fully open, anyone-anywhere gTLD like `.com`, but a suffix built specifically for Alsace-connected registrants.
+
+### Does a .alsace domain affect SEO?
+
+As a geographic gTLD, `.alsace` carries a built-in regional signal for Alsace-focused searches. Site owners can reinforce this with explicit geotargeting in tools like Google Search Console. Content, links, and user experience still decide most of the ranking outcome.
+
+### Who operates the .alsace registry?
+
+The `.alsace` registry is operated by Région Grand Est, with AFNIC, the operator of France's `.fr` domain, providing the technical back-end. It was delegated to the DNS root zone on September 18, 2014.
+
+### Who should register a .alsace domain?
+
+Alsace businesses, tourism and hospitality operators, wine and gastronomy producers, and local institutions. It suits anyone who wants a name that signals a genuine connection to the region.
+
+### Is .alsace the same as .fr?
+
+No. `.fr` is France's national country-code domain, open broadly to European registrants. `.alsace` is a narrower geographic gTLD for one French region, sharing AFNIC as its technical back-end but run under its own regional eligibility policy.
+
+## Related resources
+
+- [.com domain](/en/tld/com) — the legacy benchmark with no geographic tie.
+- [.xyz domain](/en/tld/xyz) — a generic new gTLD alternative with no nexus requirement.
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals of top-level domains.
+- [What are tokenized domains?](/en/blog/what-are-tokenized-domains/) — how Web3 domain ownership works.
+- [Glossary: registry](/en/glossary/registry/), [registrar](/en/glossary/registrar/), [ICANN](/en/glossary/icann/), and [Web3](/en/glossary/web3/).

--- a/content/tld/en/alsace.md
+++ b/content/tld/en/alsace.md
@@ -3,7 +3,7 @@ title: 'What Is the .alsace Domain? A Geo-TLD for the Alsace Region'
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .alsace domain is a geographic gTLD for the Alsace region of eastern France. Learn who runs it, who can register, and how it suits local branding.'

--- a/content/tld/en/alstom.md
+++ b/content/tld/en/alstom.md
@@ -1,13 +1,22 @@
 ---
-title: "What is .alstom TLD and why choose it?"
-date: '2025-12-10'
+title: "What Is the .alstom Domain? Alstom's Brand TLD Explained"
+date: '2026-07-24'
 language: 'en'
 tags: ['tld']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
-description: "Explore the .alstom TLD, a specialized domain for the rail transport giant. Understand the power of Brand TLDs and how to secure your own digital identity."
-keywords: [".alstom domains", ".alstom TLD", "top-level domain", "what is .alstom", "why choose .alstom", "what is the .alstom domain", "why choose the .alstom domain", "Alstom brand registry", "corporate TLD strategy", "domain investing", "blockchain domains", "tokenized domain", "dedicated brand domains", "transportation industry domains", "Namefi domain registration"]
+description: 'The .alstom domain is the closed brand TLD of rail transport group Alstom, not open to the public. Learn what it is, who runs it, and what to register instead.'
+keywords: ['.alstom domain', 'what is .alstom', '.alstom TLD', 'Alstom brand domain', 'dot-brand TLD', 'Alstom registry operator', 'closed generic TLD', 'is .alstom available']
+faqs:
+  - question: 'Can anyone register a .alstom domain?'
+    answer: 'No. .alstom is a closed brand TLD delegated to Alstom. Only Alstom and parties it authorizes can hold a .alstom name, so it is not available to the general public through any registrar.'
+  - question: 'Who operates the .alstom registry?'
+    answer: 'Alstom is the registry operator, with CORE Association providing the technical back-end. The TLD was delegated to the DNS root zone on December 4, 2015 under ICANN''s New gTLD Program.'
+  - question: 'What is Alstom?'
+    answer: 'Alstom is a French multinational company in rail transport, making trains, signalling systems, and rail infrastructure. The .alstom domain is its own brand name secured as a top-level domain.'
+  - question: 'What can I register instead of .alstom?'
+    answer: 'Because .alstom is closed, choose an open extension for your own project. A matching .com, or a modern alternative like .io or .xyz, can be registered by anyone through an accredited registrar such as Namefi.'
 relatedArticles:
   - /en/blog/what-are-tokenized-domains/
   - /en/blog/top-tlds-to-secure-for-your-business/
@@ -28,55 +37,113 @@ relatedGlossary:
   - /en/glossary/web3/
 ---
 
-## **What is .alstom?**
+The **.alstom** domain is a **closed brand [top-level domain](/en/glossary/tld/)** operated by **Alstom**, the French multinational rail transport group. It is not a public extension: unlike [.com](/en/tld/com/) or [.io](/en/tld/io/), you cannot register a `.alstom` name for your own project, because the entire namespace belongs to one company.
 
-The **.alstom** extension is a specialized type of [Top-Level Domain (TLD)](/en/glossary/tld/) known as a "dot-brand" or **Brand TLD**. Unlike open domains like [.com](/en/tld/com/) or [.net](/en/tld/net/) that generally allow public registration, .alstom was created specifically for **Alstom**, a global leader in the green and smart mobility sector, primarily known for manufacturing trains and rail infrastructure.
+If you searched for the ".alstom domain" hoping to buy one, the short answer is that you can't — but this page explains exactly what `.alstom` is, who controls it, why a company runs its own TLD, and what you can register instead.
 
-Launched during [ICANN's new gTLD program](https://newgtlds.icann.org/en/about/program), this domain extension allows the corporation to create a trusted, secure, and branded digital ecosystem. It is categorized as a [generic Top-Level Domain](/en/glossary/gtld/) (gTLD) but operates with restricted eligibility, meaning it is managed exclusively by the company to protect its intellectual property and ensure consumer safety.
+## .alstom at a glance
 
-For domain investors and developers, .alstom serves as a prime example of how major corporations are moving away from crowded legacy TLDs to establish their own sovereign digital territory on the internet.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Brand [new gTLD](/en/glossary/new-gtld/) (closed / "dot-brand") |
+| Registry operator | Alstom (technical back-end by CORE Association) |
+| Year delegated | 2015 |
+| IDN support | Not relevant — closed namespace |
+| DNSSEC | Supported |
+| Registration restrictions | **Closed** — restricted to Alstom and parties it authorizes; not available to the public |
+| Best for | Alstom's own corporate, product, and campaign sites |
 
-## **How People Are Using .alstom**
+## What is .alstom?
 
-Because .alstom is a closed [registry](/en/glossary/registry/), general public usage is not the primary function. Instead, usage is strategic and focused on corporate governance. Here is how the namespace is utilized:
+`.alstom` is a **[generic top-level domain](/en/glossary/gtld/)** that ICANN delegated to **Alstom**, a French multinational active in rail transport — trains, signalling systems, and rail infrastructure. The string is simply the company's own brand name.
 
-*   **Corporate Identity & Branding:** Alstom uses the TLD to reinforce its brand name at the root level of the internet, ensuring that any website ending in .alstom is authentically connected to the company.
-*   **Internal Infrastructure:** Large corporations often use brand TLDs for internal portals, employee resources, and project management systems (e.g., `staff.alstom` or `cloud.alstom`).
-*   **Product Showcases:** Dedicated pages for specific train models, signaling systems, or green mobility solutions can be hosted on clean, descriptive URLs.
-*   **Security & Anti-Phishing:** By restricting registration solely to the organization, the company guarantees that no third party can create fraudulent sites using the .alstom extension.
+`.alstom` is a **brand TLD**, often called a "dot-brand," not an open extension anyone can buy into. Alstom applied for the string so that it, and only it, would control every domain ending in `.alstom`. You can confirm the delegation and operator on the authoritative [IANA root-zone record for .alstom](https://www.iana.org/domains/root/db/alstom.html).
 
-## **Notable Entities Using .alstom**
+## History of .alstom
 
-As a restricted Brand TLD, the "notable entities" are exclusively the parent company and its subsidiaries.
+The `.alstom` string was delegated to the DNS [root zone](/en/glossary/root-zone/) on **December 4, 2015**, following an application under [ICANN](/en/glossary/icann/)'s New gTLD Program. **CORE Association** handled the technical registry operation on Alstom's behalf. Its registry agreement includes Specification 13, the contract clause that formally designates a TLD as a brand and lets the operator keep it closed.
 
-1.  **Alstom (Parent Company):** The primary [registrant](/en/glossary/registrant/) and user. Alstom is a French multinational rolling stock manufacturer operating worldwide.
-2.  **Alstom Subsidiaries:** Various regional divisions or specific project entities falling under the Alstom umbrella utilize the infrastructure for secure communications.
-3.  **Digital Mobility Projects:** While specific public-facing URLs often redirect to their main .com or regional sites, the infrastructure supports their extensive digital mobility and signaling portfolio.
+The record has remained active since delegation, unlike several brand TLDs that were later handed back and removed from the root.
 
-For more information on the registry operator, you can visit the [IANA Delegation Record for .alstom](https://www.iana.org/domains/root/db/alstom.html).
+## Is .alstom available to register?
 
-## **Why Choose .alstom?**
+**No.** `.alstom` is a **closed brand TLD**, so there is no open registration and no [registrar](/en/glossary/registrar/) — including Namefi — can sell you a `.alstom` name. Registrations are limited to Alstom and organizations it authorizes, such as subsidiaries or partners. This is by design: a dot-brand exists precisely so the trademark holder controls the whole namespace and no one else can register a confusing or malicious lookalike.
 
-While .alstom is not open for public registration, understanding why a company chooses to operate its own TLD highlights the future of domain naming and digital identity. Here are the advantages of this strategy:
+If you have a genuine business relationship with Alstom and a legitimate need for a `.alstom` address, that request would go through Alstom's own corporate channels, not a commercial registrar.
 
-*   **Unparalleled Trust:** When a user sees a URL ending in .alstom, they know with 100% certainty that they are interacting with the official entity. It eliminates the risk of typo-squatting.
-*   **Total Control:** The registry owner has complete control over policy, pricing, and allocation. They do not have to worry about a domain squatter buying `besttrains.alstom`.
-*   **SEO & Branding:** A custom TLD is the ultimate branding signal. It allows for short, memorable, and keyword-rich domain names that legacy TLDs can no longer offer due to saturation.
-*   **Future-Proofing:** Owning a TLD provides a foundation for future technologies, potentially integrating with **[Web3](/en/glossary/web3/)** and **tokenized assets** for supply chain management within the company's ecosystem.
+## How Alstom uses .alstom
 
-## **Register Your .alstom Domain at Namefi**
+Brand TLDs give a company a private space to organize its web presence. Typical uses for a dot-brand like `.alstom` include:
 
-The .alstom TLD represents the pinnacle of corporate digital strategy. While .alstom itself is restricted to the corporation, you can apply the same strategic thinking to your own portfolio by choosing high-value, descriptive, or Web3-ready domains.
+- **Product and division sites** on clean, memorable addresses tied directly to the brand.
+- **Campaign and event pages** that are obviously official because only the company can create them.
+- **Internal tools and portals** where a branded suffix signals a trusted, first-party destination.
 
-At **Namefi**, we specialize in the next generation of [domain ownership](/en/glossary/domain-ownership/). Whether you are looking for available gTLDs to build your brand or investing in tokenized domains for the decentralized web, we provide a seamless experience.
+**Who it's not for:** anyone outside Alstom. Because the namespace is closed, there is no scenario in which an independent developer, supplier, or business can build on `.alstom`.
 
-**Why Register with Namefi?**
-*   **[ICANN](/en/glossary/icann/)-Accredited:** Secure, compliant, and trustworthy registration services.
-*   **Web3 Integration:** We bridge the gap between Web2 and Web3, allowing you to [tokenize](/en/glossary/tokenize/) your domains for easier transfer and management.
-*   **Smart Search:** Find the perfect alternative to closed TLDs to ensure your project has the professional edge it needs.
+## Notable sites using .alstom
 
-Ready to secure your digital identity?
+There are **no third-party sites** on `.alstom`, and there never will be while it stays a closed brand TLD — every `.alstom` address is controlled by Alstom. The company's main public presence runs from [alstom.com](https://www.alstom.com), and it uses the brand TLD selectively rather than as a wholesale replacement. Rather than point to a specific address that may change, the honest description is simple: `.alstom` is Alstom's private namespace, used only for the company's own properties.
 
-**[Register Your Domain at Namefi](https://namefi.io)**
+## What is a dot-brand TLD?
 
-Don't wait for the perfect name to disappear. Start your search today and claim your piece of the internet with Namefi.
+A **dot-brand** (or brand TLD) is a top-level domain that a single company owns and operates for its exclusive use, secured through ICANN's [New gTLD Program](/en/glossary/new-gtld/). Hundreds were delegated during the same application round, and they share a few defining traits:
+
+- **Closed registration.** Only the brand and its affiliates can hold names.
+- **Specification 13.** A registry-agreement addendum that formally recognizes the TLD as a brand and relaxes some rules that apply to open generics.
+- **Security and control.** The brand eliminates the risk of anyone else registering a `.alstom` lookalike, which strengthens resistance to [phishing](/en/glossary/phishing/) and impersonation.
+
+Some brands invest heavily in their TLD; others register it defensively and barely use it. A number of companies have even terminated their dot-brands after deciding the upkeep was not worth it.
+
+## .alstom vs open domain alternatives
+
+If your goal was a short, brandable name rather than the `.alstom` string specifically, an open extension is the right tool. Here is how a closed brand TLD compares with domains you can actually register:
+
+| Feature | .alstom | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.xyz](/en/tld/xyz/) |
+| --- | --- | --- | --- | --- |
+| Who can register | Alstom only | Anyone | Anyone | Anyone |
+| Type | Brand new gTLD (closed) | Legacy gTLD | ccTLD used generically | New gTLD |
+| Core use | Alstom's own sites | Universal default | Tech & startups | Generic / Web3 |
+| Available to you | No | Yes | Yes | Yes |
+
+For your own venture, a matching `.com` remains the safest default; [.io](/en/tld/io/) suits technical products; and [.xyz](/en/tld/xyz/) is a flexible, low-cost modern option.
+
+## Reputation and trust
+
+Ironically, the closed nature of `.alstom` is exactly what makes it trustworthy: because only Alstom can create these addresses, a `.alstom` link is verifiably official, which is why brand TLDs are considered strong against impersonation and email spoofing. That trust, however, benefits Alstom alone — it does not transfer to any name you might register, since you cannot register one. For your own project, deliverability and reputation will come from a well-configured domain on an open extension, not from a brand TLD you don't control.
+
+## Looking for an "alstom"-style name? Register an alternative at Namefi
+
+You can't buy a `.alstom` domain, but if you want a short, industrial- or transport-flavored name of your own, you can secure it on an open extension in minutes:
+
+1. **Search** your desired name across open TLDs like `.com`, `.io`, or `.xyz`.
+2. **Choose** the extension that fits your brand and budget.
+3. **Register** and configure [DNS](/en/glossary/dns/).
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for provable ownership and easier transfer.
+
+## Frequently asked questions
+
+### Can anyone register a .alstom domain?
+
+No. `.alstom` is a closed brand TLD delegated to Alstom. Only Alstom and parties it authorizes can hold a `.alstom` name, so it is not available to the general public through any registrar.
+
+### Who operates the .alstom registry?
+
+Alstom is the registry operator, with CORE Association providing the technical back-end. The TLD was delegated to the DNS root zone on December 4, 2015 under ICANN's New gTLD Program.
+
+### What is Alstom?
+
+Alstom is a French multinational company in rail transport, making trains, signalling systems, and rail infrastructure. The `.alstom` domain is its own brand name secured as a top-level domain.
+
+### What can I register instead of .alstom?
+
+Because `.alstom` is closed, choose an open extension for your own project. A matching `.com`, or a modern alternative like `.io` or `.xyz`, can be registered by anyone through an accredited registrar such as Namefi.
+
+## Related resources
+
+- [What is a TLD?](/en/blog/what-is-a-tld/) — the fundamentals behind top-level domains.
+- [How a TLD affects domain value](/en/blog/how-tld-affects-domain-value/) — why the extension matters.
+- [.com TLD guide](/en/tld/com/) — the open default to compare against.
+- [.io TLD guide](/en/tld/io/) and [.xyz TLD guide](/en/tld/xyz/) — modern open alternatives.
+- Glossary: [new gTLD](/en/glossary/new-gtld/), [registry](/en/glossary/registry/), [ICANN](/en/glossary/icann/).

--- a/content/tld/en/alstom.md
+++ b/content/tld/en/alstom.md
@@ -3,7 +3,7 @@ title: "What Is the .alstom Domain? Alstom's Brand TLD Explained"
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .alstom domain is the closed brand TLD of rail transport group Alstom, not open to the public. Learn what it is, who runs it, and what to register instead.'

--- a/content/tld/en/am.md
+++ b/content/tld/en/am.md
@@ -1,31 +1,22 @@
 ---
-title: 'What is the .am TLD and why choose it?'
-date: '2025-12-10'
+title: 'What Is the .am Domain? Armenia''s Global Domain-Hack ccTLD'
+date: '2026-07-24'
 language: 'en'
-tags:
-  - 'tld'
-authors:
-  - 'namefiteam'
-editors:
-  - victor-zhou
+tags: ['tld']
+authors: ['namefiteam']
+editors: ['victor-zhou']
 draft: false
-description: 'Explore the .am domain extension: from "AM radio" to creative domain hacks like "I am." Learn why this TLD is perfect for branding and how to register yours.'
-keywords:
-  - '.am domains'
-  - '.am TLD'
-  - '.am top-level domain'
-  - 'what is .am'
-  - 'why choose .am'
-  - 'what is the .am domain'
-  - 'why choose the .am domain'
-  - 'domain investing .am'
-  - 'blockchain domains'
-  - 'tokenized domain'
-  - 'Armenia ccTLD'
-  - 'creative domain hacks'
-  - 'asset management domains'
-  - 'radio station domains'
-  - 'tech startup branding'
+description: 'What is the .am domain? Armenia''s open, worldwide ccTLD known for domain hacks like will.i.am. Manager, eligibility, pricing, and registration explained.'
+keywords: ['.am domain', '.am TLD', 'what is .am', 'Armenia domain', 'domain hack TLDs', 'AM radio domain', 'generic ccTLD', 'register .am domain']
+faqs:
+  - question: 'Can anyone register a .am domain?'
+    answer: 'Yes. .am is Armenia''s ccTLD, but it has been open to registrants worldwide for decades, with no local-presence requirement. Registration is first-come, first-served through any participating registrar.'
+  - question: 'Does a .am domain affect SEO?'
+    answer: 'No, not inherently. Google lists .am among the ccTLDs it treats as generic rather than geo-targeted, so a .am site is not confined to Armenia search results and can rank for a global audience.'
+  - question: 'Why do people use .am for domain hacks?'
+    answer: '"AM" is also the English first-person verb "am," which lets a name ending in "i" or a similar sound complete a full phrase across the dot, as in will.i.am. That wordplay, combined with open worldwide registration, has made .am a recurring domain-hack choice.'
+  - question: 'Who should register a .am domain?'
+    answer: 'Anyone building a domain hack around the word "am," projects with an AM radio or broadcast angle, and registrants anywhere in the world looking for a short, open ccTLD alternative to .com.'
 relatedArticles:
   - /en/blog/domain-hacks-explained/
   - /en/blog/from-instagr-am-to-instagram-com/
@@ -46,46 +37,129 @@ relatedGlossary:
   - /en/glossary/dns/
 ---
 
-## **What is .am?**
+The **.am** domain is the [ccTLD](/en/glossary/cctld/) for **Armenia**, and it has become one of the internet's favorite domain-hack extensions: open to registrants worldwide, and spelling out the English word "am," which lets a name complete a sentence across the final dot. The most famous example is the musician **will.i.am**, whose personal domain is a straightforward, real use of the trick.
 
-The **.am** extension is the **Country Code [Top-Level Domain (ccTLD)](/en/glossary/tld/)** designated for **Armenia**. It was introduced in 1994 and is administered by the [Internet Society of Armenia (ISOC-AM)](https://www.isoc.am/).
+This guide covers what .am really is, who runs it, who can register one, how it is priced, and how it is perceived for SEO and email.
 
-While it was originally intended to serve entities connected to the Republic of Armenia, the .am domain has gained massive popularity on the global stage. Unlike some strictly restricted country codes, .am is open for registration to anyone worldwide. This openness, combined with its phonetic versatility, has transitioned it from a purely geographic indicator to a favorite among tech startups, media companies, and creatives.
+## .am at a glance
 
-Because the letters "AM" are globally recognized as a symbol for radio broadcasting (Amplitude Modulation) and the morning hours (Ante Meridiem), the extension naturally appeals to communication and broadcasting industries.
+| Fact | Detail |
+| --- | --- |
+| TLD type | Country-code TLD (ccTLD) for Armenia |
+| Registry operator | "Internet Society" NGO, operating AMNIC (amnic.net) |
+| Year delegated | 1994 (August 26) |
+| Registration restrictions | Open to all — no local presence required |
+| Google treatment | Listed among the ccTLDs Google treats as generic, not geo-targeted |
+| Best for | Domain-hack branding, AM radio/broadcast-adjacent projects, open global registration |
 
-## **How People Are Using .am**
+## What is .am?
 
-The utility of the .am TLD goes far beyond Armenian borders. Its unique letter combination allows for a variety of strategic uses:
+**.am** is the country-code [Top-Level Domain](/en/glossary/tld/) assigned under the ISO 3166-1 system to **Armenia**, listed by [IANA](https://www.iana.org/domains/root/db/am.html) with the **"Internet Society" NGO** as the manager, operating the registry as [AMNIC](https://amnic.net/).
 
-*   **Broadcasting and Media:** Radio stations, podcasts, and streaming services frequently use .am to signify "on-air" presence or audio content.
-*   **[Domain Hacks](/en/blog/domain-hacks-explained/):** "AM" corresponds to the first-person verb "am." This allows for creative sentences within a URL, such as `who.i.am` or `dream.te.am`.
-*   **Asset Management:** In the financial sector, firms dealing with Asset Management utilize .am as a concise industry abbreviation.
-*   **Tech Startups:** Many technology companies choose .am for its availability of short, memorable names compared to the overcrowded [.com](/en/tld/com/) namespace.
-*   **Local Presence:** Businesses operating within Armenia use it to establish local trust and improve search engine rankings within the country.
+.am has been run as an **open registry** with no local-presence requirement, and that openness combined with a linguistic coincidence explains most of its use outside Armenia: "AM" is the English first-person verb "am," which lets a domain complete a phrase across the dot, and it is also the standard abbreviation for AM radio broadcasting. Google includes .am on its list of ccTLDs it [treats as generic rather than country-specific](https://developers.google.com/search/docs/crawling-indexing/manage-international-sites), so a .am site is not tied to Armenia search results.
 
-## **Notable Entities Using .am**
+## History of .am
 
-Several high-profile brands and celebrities have utilized the .am extension, proving its legitimacy and cool factor in the digital space.
+The .am ccTLD was delegated on **August 26, 1994**. It is managed by the **"Internet Society" NGO**, which operates the registry as AMNIC through [amnic.net](https://amnic.net/), running .am as an open, worldwide namespace rather than restricting registration to local entities.
 
-*   **Instagram (Historically):** Before acquiring their .com, the social media giant famously launched as `instagr.am`, popularizing the concept of domain hacking.
-*   **Will.i.am:** The famous musician and tech entrepreneur uses his own name as a [domain hack](/en/glossary/domain-hack/) (`will.i.am`) for his personal brand and philanthropic foundation.
-*   **Stre.am:** A notable live video platform that utilized the TLD to complete the word "stream."
-*   **Ucom:** As a major Armenian telecommunications company (`ucom.am`), it represents the standard corporate usage of the TLD within its home country.
+## How people use .am
 
-## **Why Choose .am?**
+Because of its open registration policy and the "am" wordplay, .am draws a mix of registrants:
 
-If you are considering a new web address, here is why .am might be the perfect fit for your portfolio:
+- **[Domain hacks](/en/blog/domain-hacks-explained/).** A name ending in a sound that pairs with "am" (as in `i.am`) or a word split across the dot (as in `cr.am`) can form a complete phrase or word using the extension.
+- **AM radio and broadcast-adjacent projects.** The letters read naturally as short for AM radio, making the extension a fit for broadcasting-flavored branding.
+- **Registrants worldwide** looking for a short, open alternative to a saturated [.com](/en/tld/com/) namespace.
 
-*   **Creative Branding:** It offers some of the best opportunities for "domain hacks" (using the extension to finish a word), making your URL memorable and conversational.
-*   **Availability:** While .com is saturated, you have a much higher chance of finding short, premium keywords or 3-letter names with a .am extension.
-*   **[Search Engine Optimization](/en/glossary/seo/) (SEO):** While it is a [ccTLD](/en/glossary/cctld/), Google and other search engines crawl .am sites effectively. For businesses in Armenia, it provides a local SEO boost. For global brands, it is treated similarly to generic domains due to its widespread use.
-*   **Versatility:** Whether you are an **A**sset **M**anager or an **AM** radio station, the acronym fits multiple major industries perfectly.
+**Who it's not ideal for:** brands with no wordplay or broadcast angle at all, where neither of .am's built-in associations adds anything.
 
-## **Register Your .am Domain at Namefi**
+## Notable sites using .am
 
-Ready to secure a domain that defines who you are? Whether you are building a creative portfolio, a financial platform, or the next big tech startup, .am offers the flexibility you need.
+**will.i.am** — the musician and entrepreneur's official site is a real, well-known example of the .am domain hack, using his own name split across the dot. Beyond that specific case, .am's open registration policy and "am" wordplay mean most registrations are smaller domain-hack and broadcast-adjacent projects rather than other widely recognized platforms.
 
-At **Namefi**, we make domain registration effortless. As an [ICANN](/en/glossary/icann/)-accredited [registrar](/en/glossary/registrar/), we combine traditional reliability with cutting-edge [Web3](/en/glossary/web3/) innovation. When you register with us, you can enjoy seamless [NFT](/en/glossary/nft/) integration, allowing you to [tokenize](/en/glossary/tokenize/) your domain for easier transfer and management on the [blockchain](/en/glossary/blockchain/).
+## .am vs other domains
 
-**[Register your .am domain at Namefi today](https://namefi.io)** and start building your digital identity on a foundation that stands out.
+| Feature | .am | [.com](/en/tld/com/) | [.io](/en/tld/io/) | [.co](/en/tld/co/) |
+| --- | --- | --- | --- | --- |
+| Type | ccTLD (used globally) | Legacy gTLD | ccTLD (used globally) | ccTLD (used globally) |
+| Core association | Domain hacks ("am"), AM radio | The default web standard | Tech / "Input-Output" | Generic, short alternative to .com |
+| Registration eligibility | Open worldwide | Open worldwide | Open worldwide | Open worldwide |
+| Availability of short names | Better than .com | Very poor | Moderate | Poor |
+
+Choose **.com** when the exact name is available — it remains the default for most audiences. Reach for **.am** when a domain hack ending in "am" or a broadcast angle fits your brand. **[.io](/en/tld/io/)** suits developer- and infrastructure-focused tech brands, and **[.co](/en/tld/co/)** works as a generic short alternative with no thematic association.
+
+## Why choose .am?
+
+- **Open worldwide.** No local-presence requirement, unlike many other ccTLDs.
+- **Proven domain hack.** will.i.am gives the extension a real, recognizable example of the wordplay working.
+- **Broadcast fit.** A natural short form for AM radio and broadcast-adjacent branding.
+- **Treated as generic by Google.** Search visibility is not confined to Armenia.
+
+## Things to consider
+
+- **A ccTLD by nature.** Because .am technically belongs to Armenia, its long-term rules are set by the "Internet Society" NGO and AMNIC under national policy, not by an [ICANN](/en/glossary/icann/) registry agreement.
+- **The wordplay only works for the right name.** A domain hack ending in "am" needs a name that actually completes a word or phrase — it does not suit every brand.
+- **One flagship example, not a category.** will.i.am is a real, well-known .am domain, but it does not mean the extension carries broad mainstream recognition beyond that.
+
+## Who can register a .am domain?
+
+**Registration restrictions: open to all.** There is **no local-presence or Armenian residency requirement** to register a second-level .am domain. Registration is available to individuals and organizations anywhere in the world through any participating [registrar](/en/glossary/registrar/), on a first-come, first-served basis.
+
+Because .am is a ccTLD, it is governed by Armenia's registry policy rather than an ICANN registry agreement. The authoritative sources for current management details are the [IANA root-zone entry](https://www.iana.org/domains/root/db/am.html) and the registry's own site, [amnic.net](https://amnic.net/).
+
+## .am pricing and value
+
+This page intentionally quotes no numbers, but a few dynamics are worth knowing:
+
+- **Premium classification is common across ccTLDs.** Check whether your specific name carries a premium price before assuming a standard rate applies.
+- **First-year vs. renewal pricing can differ.** As with most TLDs, confirm the standard renewal rate rather than assuming an introductory rate continues.
+- **What drives cost.** Name length, how cleanly it completes the "am" wordplay, and registry [wholesale pricing](/en/glossary/wholesale-pricing/) are the main factors shaping cost.
+
+For exact, current figures, check live pricing at registration time.
+
+## Reputation and email deliverability
+
+We are not aware of .am carrying any negative bulk-mail or spam reputation. As with any TLD, email deliverability depends far more on **sending reputation, SPF/DKIM/DMARC authentication, and list hygiene** than on the suffix itself. A properly authenticated .am sender should reach inboxes normally.
+
+The main practical caveat is fit: a business with no wordplay or broadcast connection may find a .am email address reads as unexpected to some recipients.
+
+## Branding and naming tips
+
+- **Test the wordplay out loud.** A good .am domain hack should read as a natural phrase or word when spoken, the way will.i.am does.
+- **Use the broadcast association if relevant.** AM radio and audio-adjacent brands get a built-in keyword fit.
+- **Check premium status first.** Confirm classification and renewal pricing before settling on a name.
+
+## How to register a .am domain at Namefi
+
+1. **Search** for your desired name and the .am extension.
+2. **Choose** an available name and confirm whether it is classified as premium.
+3. **Register** and configure DNS.
+
+[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing and the option to hold your name as a [tokenized domain](/en/glossary/tokenized-domain/) for easier transfer and provable ownership.
+
+## Frequently asked questions
+
+### Can anyone register a .am domain?
+
+Yes. .am is Armenia's ccTLD, but it has been open to registrants worldwide for decades, with no local-presence requirement. Registration is first-come, first-served through any participating registrar.
+
+### Does a .am domain affect SEO?
+
+No, not inherently. Google lists .am among the ccTLDs it treats as generic rather than geo-targeted, so a .am site is not confined to Armenia search results and can rank for a global audience.
+
+### Why do people use .am for domain hacks?
+
+"AM" is also the English first-person verb "am," which lets a name ending in "i" or a similar sound complete a full phrase across the dot, as in will.i.am. That wordplay, combined with open worldwide registration, has made .am a recurring domain-hack choice.
+
+### Who should register a .am domain?
+
+Anyone building a domain hack around the word "am," projects with an AM radio or broadcast angle, and registrants anywhere in the world looking for a short, open ccTLD alternative to .com.
+
+## Related resources
+
+- [.com TLD guide](/en/tld/com/)
+- [.io TLD guide](/en/tld/io/)
+- [.co TLD guide](/en/tld/co/)
+- [Domain hacks explained](/en/blog/domain-hacks-explained/)
+- [Glossary: registrar](/en/glossary/registrar/)
+- [Glossary: ICANN](/en/glossary/icann/)
+- [Glossary: ccTLD](/en/glossary/cctld/)

--- a/content/tld/en/am.md
+++ b/content/tld/en/am.md
@@ -3,7 +3,7 @@ title: 'What Is the .am Domain? Armenia''s Global Domain-Hack ccTLD'
 date: '2026-07-24'
 language: 'en'
 tags: ['tld']
-authors: ['namefiteam']
+authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'What is the .am domain? Armenia''s open, worldwide ccTLD known for domain hacks like will.i.am. Manager, eligibility, pricing, and registration explained.'


### PR DESCRIPTION
# PR: Regenerate the 39 oldest `.a*` TLD pages onto the current template (EN, Phase 1)

## Summary

The 39 oldest TLD pages in `content/tld/en` (an abandoned first alphabetical batch, all
`.a*` suffixes) were still on a superseded template that **fabricated notability** and was
**dense with AI-slop diction**. This PR regenerates all 39 EN pages onto the repo's current
TLD-page template (`prompts/tld-page.md`), matching the `tv.md` / `legal.md` exemplars.

This is **Phase 1 (English only)** — the canonical ranking surface. Re-translating the
sibling-locale files from the new EN is **Phase 2** (separate PR).

## The defects fixed

1. **Fabricated "Notable Entities"** — the old `## Notable Entities Using .x` section invented
   users: `aco`/`active` literally labeled bullets "Hypothetical/Emerging"; 20 pages used vague
   "various …" claims; `abc.md` attributed the TLD to **Alphabet/Google** — which is **factually
   wrong** (`.abc` belongs to **Disney / the American Broadcasting Company**, verified via IANA).
2. **AI-slop diction** — 36/39 used "utilize", 36/39 "seamless", plus "leverage / the world of /
   realm of / in the expanding universe of the internet". Baseline deslop density 10–20 per file.

## Solution

- **Fact-verified every page against the IANA root-zone database** (`.../root/db/<tld>.html`).
  This surfaced two content-integrity problems the old pages hid:
  - **5 of the 39 TLDs are REVOKED / terminated** and no longer in the DNS root zone:
    `.active` (2019), `.aigo` (2020), `.adac` (2022), `.abarth` + `.alfaromeo` (both 2023).
    Their pages now **honestly state the TLD was terminated and cannot be registered**, instead
    of implying availability.
  - **`.abc` is Disney's ABC**, not Alphabet/Google — corrected.
- **~24 are dot-brand (closed) TLDs.** Their pages now honestly say the namespace is restricted
  to the brand with **no third-party public sites**, rather than inventing users — the single
  correction that removes most of the fabrication.
- **Open / ccTLD / geo / sponsored** pages (aero, adult, airforce, africa, abudhabi, alsace,
  ac/ad/af/ag/al/am) describe **real** typical use and eligibility, citing the authoritative
  source (IANA + operator policy pages; ICANN registry agreements for live gTLDs).
- Rebuilt each page in the template's section order with migrated frontmatter (quoted
  title/description, human-readable keyword chips, a `faqs:` block matching the visible FAQ).
- **Preserved each file's existing `related*` frontmatter verbatim** so the translated sibling
  files stay in sync and `data:validate` stays green (locale resync is Phase 2).

## Test plan (all run from repo root, over `content/tld/en`)

- [x] `node ~/.claude/skills/deslop/scripts/scan-slop.mjs content/tld/en` — all 39 pages score
      0.0–2.3 density (well within the new-template range, target <4); zero "utilize" / "seamless"
      corpus-wide.
- [x] `bun data:validate` — passes; `Checked 3900 file(s): 0 locale-mismatch, 0 relationship-mismatch`.
- [x] `bun lint:mdx` — clean, exit 0.
- [x] `bun .agents/skills/cross-link/link-audit.ts content/tld/en` — `Audited 103 file(s): 0 broken,
      0 missing-locale, 0 locale-mismatch, 0 relationship-mismatch, 0 missing-translation fallback`.
- [x] Manual: grepped all 39 for "various "/"hypothetical"/"emerging)"/"notable entities" — clean.
      Verified `.abc` → Disney/ABC (not Alphabet), `.aco` → ACO Severin Ahlmann drainage-systems
      company (not "Accountable Care Organization"). Verified `related*` frontmatter is
      byte-identical to `origin/main` on all 39 files (translated siblings stay in sync). Confirmed
      only the 39 cohort files changed and `ae.md` was untouched.

## Review notes

- Act only on **Cursor Bugbot**; ignore CodeRabbit (per repo policy).
- Merging bumps `apps/resources/data` on astra **dev** only; production is a separate release.

## Claude session summary

- 2026-07-24T11:00Z — Set up fresh worktree `tld-regen-a-batch` off freshly-fetched `origin/main`;
  confirmed the 39-file cohort via `grep -rl 'Notable Entities Using' content/tld/en`.
- 2026-07-24T11:05Z — Read the target template (`prompts/tld-page.md`) and exemplars (`tv.md`,
  `legal.md`); surveyed author/priority/locale conventions across the existing 103 TLD pages.
- 2026-07-24T11:10Z — Fact-verified all 39 TLDs against the IANA root-zone database
  (`iana.org/domains/root/db/<tld>.html`). Found 5 revoked/terminated TLDs (active, aigo, adac,
  abarth, alfaromeo) and that `.abc` is Disney/ABC, not Alphabet/Google as the old page claimed.
- 2026-07-24T11:15Z — Hand-wrote two golden-reference pages (`abb.md` for live dot-brand,
  `abarth.md` for a revoked TLD) and validated them against all four QA gates, establishing the
  `related*`-frontmatter-preservation rule needed to keep `data:validate` green.
- 2026-07-24T11:20Z — Dispatched 7 parallel Sonnet drafting agents (each given pre-verified,
  IANA-sourced facts and a matching golden reference) to regenerate the remaining 33 files across
  dot-brand, geo, open/sponsored, and ccTLD categories.
- 2026-07-24T11:35Z — Individually validated all 39 files on disk (deslop, link-audit, fabrication
  grep) as each batch landed; fixed 2 broken links (an unlinked `sponsored-tld` glossary reference)
  and trimmed a few intensifiers.
- 2026-07-24T11:40Z — Ran the full corpus-wide QA gate suite (deslop, `data:validate`,
  `lint:mdx`, `link-audit`), confirmed scope (only the 39 files + `ae.md` untouched), committed,
  and opened this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/d3servelabs/codesmith/namefi-resources/pr/275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787485267&installation_model_id=1368&pr_number=275&repository=d3servelabs%2Fnamefi-resources&return_to=https%3A%2F%2Fgithub.com%2Fd3servelabs%2Fnamefi-resources%2Fpull%2F275&signature=7d1edb188f62727631d6f5990b3464c3efd69740232c4955931720c0db7e9294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only MDX under `content/tld/en` with no application or auth changes; main risk is factual accuracy in SEO copy, which the PR explicitly targets via IANA verification.
> 
> **Overview**
> **Regenerates the 39 oldest English `content/tld/en` pages whose slugs start with `a`** onto the current TLD template (`prompts/tld-page.md`), replacing copy that invented users and pushed registration where none exists.
> 
> **Closed dot-brand pages** now state the namespace is restricted to the trademark holder, with no public registrar sales and no third-party “notable sites,” plus structured **FAQs**, fact tables, history, and pointers to open alternatives (`.com`, `.io`, `.xyz`) and Namefi.
> 
> **Terminated TLDs** (e.g. `.abarth`, `.active`) are documented as removed from the DNS root zone and **not registrable**, instead of sounding available.
> 
> **Factual corrections** include **`.abc` → Disney/ABC** (not Alphabet) and **`.aco` → ACO drainage systems** (not Accountable Care Organizations). **Open/geo/ccTLD-style pages** (e.g. `.abudhabi`, `.ac`) add eligibility, SEO/email notes, and comparison tables where the old pages were generic marketing.
> 
> Frontmatter is refreshed (titles, descriptions, keywords, `faqs:`) while **existing `related*` blocks are kept verbatim** for locale/data validation; non-English siblings are out of scope (Phase 2).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d9c6090b9ff3088f541b07cfa28f2c30af6c14e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated a large set of TLD guides with clearer, more structured explanations, fact tables, histories, eligibility details, usage guidance, FAQs, and related resources.
  * Clarified which brand TLDs are closed or restricted, including registration availability and authorized access.
  * Identified terminated TLDs and explained that they are no longer registrable, with guidance toward open alternatives.
  * Expanded practical advice on comparisons, reputation, email deliverability, branding, pricing, and registration.
  * Refreshed metadata, titles, descriptions, keywords, dates, and calls to action across the articles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->