### PR TITLE
content: add shared keyword-templates registry + pilot extras-only migration

### DIFF
--- a/.claude/rules/content.md
+++ b/.claude/rules/content.md
@@ -109,6 +109,35 @@ older plan/GOAL doc, **this file wins** — update the plan, not the rule.
 - Each language serves **its own page** — self-canonical + `hreflang` +
   `x-default`. Never canonicalize a translated page back to English.
 
+## Keyword templates (`keywords:` frontmatter)
+
+- **`content/keyword-templates.json`** is the shared, locale-aware base-pattern
+  registry for TLD and glossary `keywords:` boilerplate (see
+  [issue #276](https://github.com/d3servelabs/namefi-resources/issues/276)).
+  `namefi-astra` expands it at render time and merges it with each page's own
+  `keywords:` array (case-insensitive dedupe), so `astra`'s composed
+  `<meta keywords>` and visible chip list are the union of the template
+  expansion + the page's own list — never a change to this file alone.
+- **Shape:** one file, two top-level keys — `tld` and `glossary` — each a map
+  of `locale → string[]` phrase patterns. `{tld}` (the bare slug, e.g. `io`)
+  and `{term}` (the page's own `title`) are the only placeholders; astra
+  substitutes them verbatim.
+- **`keywords:` semantics did not change name, only scope.** For a slug+locale
+  the registry covers, write **only the 2-5 keywords genuinely unique to that
+  page** — the template supplies the rest. A page with no template match (a
+  locale the registry doesn't cover yet, or before the registry existed)
+  renders its `keywords:` literally, exactly as before — **no re-authoring is
+  required** for the existing ~260-file corpus; only newly-authored or
+  deliberately-migrated pages need trimming. This is why one field name works
+  for both eras: dedupe against a legacy full array just collapses the
+  boilerplate that already matches the template output.
+- Only include a boilerplate phrase in the registry if it is true for **every**
+  page of that content type — e.g. `.{tld} domain` fits both open (`.com`) and
+  closed dot-brand (`.abb`) TLDs, but `register .{tld} domain` does not (closed
+  TLDs aren't registrable) — keep type-specific phrasing as a page's own extra.
+- Translate new locale entries the same way as `termbase.json` (native-LQA
+  sign-off, natural register, not word-for-word) — see Translations above.
+
 ## Validation, PRs, and publishing
 
 1. **Per change:** `bun data:validate` + `bun lint:mdx` + `link-audit` (0 broken).

--- a/content/glossary/de/dns.md
+++ b/content/glossary/de/dns.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Das hierarchische Namensystem, das menschenlesbare Domainnamen in IP-Adressen übersetzt, die Computer zur Weiterleitung von Datenverkehr im Internet verwenden.
-keywords: ['DNS', 'Domain Name System', 'Namensauflösung', 'DNS-Lookup', 'DNS-Einträge', 'Nameserver', 'Rekursiver Resolver', 'DNSSEC', 'Internetinfrastruktur']
+keywords: ['Domain Name System', 'Namensauflösung', 'DNS-Lookup', 'DNS-Einträge', 'Nameserver', 'Rekursiver Resolver', 'DNSSEC', 'Internetinfrastruktur']
 also_known_as: ['Domain Name System']
 level: 2
 sources:

--- a/content/glossary/en/dns.md
+++ b/content/glossary/en/dns.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The hierarchical naming system that translates human-readable domain names into the IP addresses computers use to route traffic across the internet.
-keywords: ['DNS', 'domain name system', 'name resolution', 'DNS lookup', 'DNS records', 'nameserver', 'recursive resolver', 'DNSSEC', 'internet infrastructure']
+keywords: ['domain name system', 'name resolution', 'DNS lookup', 'DNS records', 'nameserver', 'recursive resolver', 'DNSSEC', 'internet infrastructure']
 also_known_as: ['Domain Name System']
 level: 2
 sources:

--- a/content/glossary/en/icann.md
+++ b/content/glossary/en/icann.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The nonprofit that coordinates the global domain name system, IP allocation, and protocol identifiers, and accredits domain registrars worldwide.
-keywords: ['ICANN', 'internet governance', 'domain policy', 'DNS oversight', 'IANA', 'gTLD', 'registrar accreditation', 'multistakeholder', 'UDRP']
+keywords: ['internet governance', 'domain policy', 'DNS oversight', 'IANA', 'gTLD', 'registrar accreditation', 'multistakeholder', 'UDRP']
 also_known_as: ['Internet Corporation for Assigned Names and Numbers']
 level: 2
 sources:

--- a/content/glossary/en/tld.md
+++ b/content/glossary/en/tld.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A top-level domain (TLD) is the rightmost label in a domain name, such as .com, .org, or .de, delegated through the IANA root zone under ICANN oversight.
-keywords: ['TLD', 'top-level domain', 'gTLD', 'ccTLD', 'new gTLD', 'DNS', 'IANA', 'ICANN', 'root zone', 'domain registry']
+keywords: ['top-level domain', 'gTLD', 'ccTLD', 'new gTLD', 'DNS', 'IANA', 'ICANN', 'root zone', 'domain registry']
 also_known_as: ['Top-Level Domain']
 level: 2
 sources:

--- a/content/keyword-templates.json
+++ b/content/keyword-templates.json
@@ -1,0 +1,10 @@
+{
+  "tld": {
+    "en": ["what is .{tld}", ".{tld} domain", ".{tld} TLD"],
+    "de": ["was ist .{tld}", ".{tld} Domain", ".{tld} TLD"]
+  },
+  "glossary": {
+    "en": ["{term}", "what is {term}", "{term} meaning", "{term} definition"],
+    "de": ["{term}", "was ist {term}", "{term} Bedeutung", "{term} Definition"]
+  }
+}

--- a/content/tld/de/aarp.md
+++ b/content/tld/de/aarp.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Erfahren Sie alles über die .aarp Top-Level-Domain: Einblicke in diese exklusive TLD, ihre Bedeutung für Vertrauen im Netz und wie Sie Ihre perfekte Domain bei Namefi finden."
-keywords: [".aarp domains", ".aarp TLD", "top-level domain", "was ist .aarp", "warum .aarp wählen", "was ist die .aarp domain", "warum die .aarp domain wählen", "domain investing", "blockchain domains", "tokenized domain", "Marken-TLD", "AARP Organisation", "sichere domains", "exklusive TLD", "Namefi"]
+keywords: ["top-level domain", "warum .aarp wählen", "was ist die .aarp domain", "warum die .aarp domain wählen", "domain investing", "blockchain domains", "tokenized domain", "Marken-TLD", "AARP Organisation", "sichere domains", "exklusive TLD", "Namefi"]
 relatedArticles:
   - /de/blog/top-tlds-to-secure-for-your-accounting-firm/
   - /de/blog/top-tlds-to-secure-for-your-business/

--- a/content/tld/de/abb.md
+++ b/content/tld/de/abb.md
@@ -13,10 +13,7 @@ translators:
 draft: false
 description: 'Erfahren Sie alles über die .abb Top-Level-Domain (TLD): Ihre Bedeutung, Anwendungsbereiche und warum kurze, prägnante Domains für Marken und Web3 von entscheidender Bedeutung sind.'
 keywords:
-  - .abb domains
-  - .abb TLD
   - top-level domain
-  - was ist .abb
   - warum .abb wählen
   - was ist die .abb domain
   - warum die .abb domain wählen

--- a/content/tld/en/aarp.md
+++ b/content/tld/en/aarp.md
@@ -7,7 +7,7 @@ authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .aarp domain is the closed brand TLD of the nonprofit AARP, not open to the public. Learn what it is, who runs it, why it exists, and what to register instead.'
-keywords: ['.aarp domain', 'what is .aarp', '.aarp TLD', 'AARP brand domain', 'dot-brand TLD', 'AARP registry', 'closed generic TLD', 'is .aarp available']
+keywords: ['AARP brand domain', 'dot-brand TLD', 'AARP registry', 'closed generic TLD', 'is .aarp available']
 faqs:
   - question: 'Can anyone register a .aarp domain?'
     answer: 'No. .aarp is a closed brand TLD delegated to AARP. Only AARP and parties it authorizes can hold a .aarp name, so it is not available to the general public through any registrar.'

--- a/content/tld/en/abarth.md
+++ b/content/tld/en/abarth.md
@@ -7,7 +7,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .abarth domain was a brand TLD for the Abarth car marque that ICANN terminated in 2023. Learn its history, why it was removed, and what to register instead.'
-keywords: ['.abarth domain', 'what is .abarth', '.abarth TLD', 'Abarth brand domain', 'terminated TLD', 'discontinued gTLD', 'dot-brand TLD', 'is .abarth available']
+keywords: ['Abarth brand domain', 'terminated TLD', 'discontinued gTLD', 'dot-brand TLD', 'is .abarth available']
 faqs:
   - question: 'Can I register a .abarth domain?'
     answer: 'No. .abarth was terminated in 2023 and removed from the DNS root zone, so it no longer exists as a working extension and cannot be registered through any registrar. Even before that, it was a closed brand TLD never open to the public.'

--- a/content/tld/en/abb.md
+++ b/content/tld/en/abb.md
@@ -7,7 +7,7 @@ authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .abb domain is the closed brand TLD of engineering group ABB Ltd, not open to the public. Learn what it is, who runs it, why it exists, and what to register instead.'
-keywords: ['.abb domain', 'what is .abb', '.abb TLD', 'ABB brand domain', 'dot-brand TLD', 'ABB Ltd registry', 'closed generic TLD', 'is .abb available']
+keywords: ['ABB brand domain', 'dot-brand TLD', 'ABB Ltd registry', 'closed generic TLD', 'is .abb available']
 faqs:
   - question: 'Can anyone register a .abb domain?'
     answer: 'No. .abb is a closed brand TLD delegated to ABB Ltd. Only ABB and parties it authorizes can hold a .abb name, so it is not available to the general public through any registrar.'

--- a/content/tld/en/abbott.md
+++ b/content/tld/en/abbott.md
@@ -7,7 +7,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .abbott domain is the closed brand TLD of Abbott Laboratories, not open to the public. Learn what it is, who runs it, why it exists, and what to register instead.'
-keywords: ['.abbott domain', 'what is .abbott', '.abbott TLD', 'Abbott brand domain', 'dot-brand TLD', 'Abbott Laboratories registry', 'closed generic TLD', 'is .abbott available']
+keywords: ['Abbott brand domain', 'dot-brand TLD', 'Abbott Laboratories registry', 'closed generic TLD', 'is .abbott available']
 faqs:
   - question: 'Can anyone register a .abbott domain?'
     answer: 'No. .abbott is a closed brand TLD delegated to Abbott Laboratories. Only Abbott and parties it authorizes can hold a .abbott name, so it is not available to the general public through any registrar.'

--- a/content/tld/en/accenture.md
+++ b/content/tld/en/accenture.md
@@ -7,7 +7,7 @@ authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .accenture domain is Accenture''s closed brand TLD, not open to the public. Learn what it is, who runs it, why it exists, and what to register instead.'
-keywords: ['.accenture domain', 'what is .accenture', '.accenture TLD', 'Accenture brand domain', 'dot-brand TLD', 'Accenture registry operator', 'closed generic TLD', 'is .accenture available']
+keywords: ['Accenture brand domain', 'dot-brand TLD', 'Accenture registry operator', 'closed generic TLD', 'is .accenture available']
 faqs:
   - question: 'Can anyone register a .accenture domain?'
     answer: 'No. .accenture is a closed brand TLD delegated to Accenture plc. Only Accenture and parties it authorizes can hold a .accenture name, so it is not available to the general public through any registrar.'


### PR DESCRIPTION
## Summary

Implements the `namefi-resources` half of #276 — a shared, locale-aware keyword-pattern template so TLD/glossary pages stop hand-typing boilerplate `keywords:` per page/locale.

- Adds **`content/keyword-templates.json`**: one registry file, two top-level keys (`tld`, `glossary`), each `locale → string[]` phrase patterns with `{tld}` / `{term}` placeholders. Authored for `en` + `de` (proof of the i18n path; the remaining 8 locales are a follow-up).
- Migrates a pilot set to **extras-only** `keywords:` to prove the round-trip: `.aarp`, `.abarth`, `.abb`, `.abbott`, `.accenture` (en) + `.aarp`, `.abb` (de); glossary `dns`, `tld`, `icann` (en) + `dns` (de).
- Documents the convention in `.claude/rules/content.md` (new "Keyword templates" section).

## Solution — open questions resolved

Per issue #276's "Open Questions":

- **Field naming:** kept `keywords:` (no new field). For a slug+locale the registry covers, it now means "extras only"; everywhere else (locale not yet translated, or page not migrated) it's unchanged. One name works for both eras because the astra-side merge dedupes case-insensitively against whatever's already there — a legacy full array just collapses its boilerplate against the template output.
- **One registry vs two:** one file, two top-level keys. Small artifact, mirrors `termbase.json`'s single-file precedent, one fs read in astra.
- **Migration path:** **no corpus-wide re-authoring in this pass** (by design/scope). Unmigrated pages keep rendering exactly as today — verified below.
- **Translation authoring:** same convention as `termbase.json` — native-LQA sign-off, natural register per locale, not word-for-word (see `.claude/rules/content.md` → Translations).

Boilerplate phrases were chosen conservatively — only patterns true for **every** page of that type. E.g. `.{tld} domain` fits both open (`.com`) and closed dot-brand (`.abb`) TLDs, but `register .{tld} domain` doesn't (closed TLDs aren't registrable) — so that stays a page's own extra, not template boilerplate.

Companion PR (render-time merge): https://github.com/d3servelabs/namefi-astra/pull/5525

Closes part of #276 (this repo's half; the astra PR closes the render side).

## Test plan

- [x] `bun data:validate` — 0 errors, same pre-existing warning count (26) as before this change; no new warnings from pilot files.
- [x] `bun lint:mdx` — passes.
- [x] `bun .agents/skills/cross-link/link-audit.ts` on all 11 pilot files — 0 broken, 0 missing-locale, 0 locale-mismatch.
- [x] Verified in `namefi-astra` (see that PR) that the composed `<meta keywords>` and visible chip list are correct for both migrated and unmigrated pages, and that a locale the registry doesn't cover (e.g. `es`) falls back to the page's literal `keywords:` unchanged.