### PR TITLE
content: migrate en+de TLD/glossary keywords to extras-only form

### DIFF
--- a/content/glossary/de/301-redirect.md
+++ b/content/glossary/de/301-redirect.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein HTTP-Statuscode, der Browsern und Suchmaschinen mitteilt, dass eine Seite dauerhaft auf eine neue URL umgezogen ist.
-keywords: ['301-Weiterleitung', 'Permanente Weiterleitung', 'HTTP-Weiterleitung', 'SEO', 'Domain-Weiterleitung', 'Link-Equity']
+keywords: ['Permanente Weiterleitung', 'HTTP-Weiterleitung', 'SEO', 'Domain-Weiterleitung', 'Link-Equity']
 also_known_as: ['Permanente Weiterleitung']
 level: 1
 sources:

--- a/content/glossary/de/acpa.md
+++ b/content/glossary/de/acpa.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein US-Gesetz, das Markeninhabern erlaubt, Cybersquatter vor einem Bundesgericht zu verklagen – eine Alternative zur UDRP.
-keywords: ['ACPA', 'Anticybersquatting', 'US-Markenrecht', 'Domain-Streit', 'Bundesgericht']
+keywords: ['Anticybersquatting', 'US-Markenrecht', 'Domain-Streit', 'Bundesgericht']
 also_known_as: ['Anticybersquatting Consumer Protection Act']
 level: 1
 sources:

--- a/content/glossary/de/aftermarket.md
+++ b/content/glossary/de/aftermarket.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Der Wiederverkaufsmarkt für bereits registrierte Domains, auf dem Namen zwischen Eigentümern gehandelt werden.
-keywords: ['Aftermarket', 'Sekundärmarkt', 'Domain-Wiederverkauf', 'Domain-Investition', 'Domain-Verkäufe']
+keywords: ['Sekundärmarkt', 'Domain-Wiederverkauf', 'Domain-Investition', 'Domain-Verkäufe']
 also_known_as: ['Sekundärmarkt']
 level: 1
 sources:

--- a/content/glossary/de/ai-agent.md
+++ b/content/glossary/de/ai-agent.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Software, die von einem KI-Modell angetrieben wird und im Auftrag eines Nutzers handelt – Käufe tätigt, APIs aufruft und zunehmend mit anderen Agenten interagiert.
-keywords: ['KI-Agent', 'autonomer Agent', 'Agenten-Identität', 'Agenten-Handel', 'On-Chain-Agent', 'agentische KI']
+keywords: ['autonomer Agent', 'Agenten-Identität', 'Agenten-Handel', 'On-Chain-Agent', 'agentische KI']
 level: 1
 sources:
   - https://modelcontextprotocol.io/

--- a/content/glossary/de/aml.md
+++ b/content/glossary/de/aml.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Anti-Money-Laundering – die laufende Transaktionsüberwachung und Meldepflicht, die regulierte Dienste zur Aufdeckung illegaler Gelder einsetzen.
-keywords: ['AML', 'Anti-Money-Laundering', 'Geldwäschebekämpfung', 'Transaktionsüberwachung', 'Sanctions-Screening', 'Compliance']
+keywords: ['Anti-Money-Laundering', 'Geldwäschebekämpfung', 'Transaktionsüberwachung', 'Sanctions-Screening', 'Compliance']
 also_known_as: ['Anti-Money-Laundering']
 level: 1
 sources:

--- a/content/glossary/de/anchor-text.md
+++ b/content/glossary/de/anchor-text.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Die sichtbaren, anklickbaren Wörter eines Hyperlinks – ein Signal, das Suchmaschinen verwenden, um das Linkziel zu verstehen.
-keywords: ['Ankertext', 'Linktext', 'Backlinks', 'SEO', 'Hyperlink', 'Ranking-Signale']
+keywords: ['Linktext', 'Backlinks', 'SEO', 'Hyperlink', 'Ranking-Signale']
 level: 1
 sources:
   - https://developers.google.com/search/docs/crawling-indexing/links-crawlable

--- a/content/glossary/de/atomic-transfer.md
+++ b/content/glossary/de/atomic-transfer.md
@@ -7,7 +7,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was ist ein atomarer Transfer und wie gewährleistet er sichere Domain-Transaktionen?
-keywords: ["atomarer Transfer","Blockchain-Transaktion","Alles-oder-Nichts","sicherer Austausch","Smart Contract"]
+keywords: ["Blockchain-Transaktion", "Alles-oder-Nichts", "sicherer Austausch", "Smart Contract"]
 relatedArticles:
   - /de/blog/how-tokenization-changes-domain-flipping/
   - /de/blog/selling-domains-as-nfts/

--- a/content/glossary/de/auction.md
+++ b/content/glossary/de/auction.md
@@ -8,7 +8,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Welche verschiedenen Auktionsarten werden für Domainverkäufe verwendet?
-keywords: ["Auktion","holländische Auktion","englische Auktion","dynamische Auktion","Preisfindung","Domainverkäufe"]
+keywords: ["holländische Auktion", "englische Auktion", "dynamische Auktion", "Preisfindung", "Domainverkäufe"]
 relatedArticles:
   - /de/blog/how-to-win-domain-auctions/
   - /de/blog/domain-terminology-guide/

--- a/content/glossary/de/auth-code.md
+++ b/content/glossary/de/auth-code.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein kurzes domainspezifisches Geheimnis, das ein Registrar ausstellt, um die Übertragung einer Domain zu einem anderen Registrar zu autorisieren, auch EPP-Code oder Transfer-Code genannt.
-keywords: ['Auth-Code', 'EPP-Code', 'Transfer-Code', 'Domain-Transfer', 'Autorisierungscode', 'AuthInfo-Code']
+keywords: ['EPP-Code', 'Transfer-Code', 'Domain-Transfer', 'Autorisierungscode', 'AuthInfo-Code']
 level: 1
 sources:
   - https://datatracker.ietf.org/doc/html/rfc5731

--- a/content/glossary/de/automated-delegation.md
+++ b/content/glossary/de/automated-delegation.md
@@ -7,7 +7,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was ist automatisierte Delegierung und wie verwalten Smart Contracts die Domain-Kontrolle?
-keywords: ["automatisierte Delegierung","Smart Contracts","Domain-Management","programmierbare Kontrolle","Automatisierung"]
+keywords: ["Smart Contracts", "Domain-Management", "programmierbare Kontrolle", "Automatisierung"]
 relatedArticles:
   - /de/blog/the-curve-finance-dns-hijack/
   - /de/blog/tokenized-domain-use-cases-2026/

--- a/content/glossary/de/backlink.md
+++ b/content/glossary/de/backlink.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein eingehender Hyperlink von einer anderen Website auf die eigene – der wichtigste Treiber für Suchranking und Domain-Autorität.
-keywords: ['Backlink', 'Eingehender Link', 'Linkaufbau', 'Link-Equity', 'SEO']
+keywords: ['Eingehender Link', 'Linkaufbau', 'Link-Equity', 'SEO']
 also_known_as: ['Eingehender Link']
 level: 1
 sources:

--- a/content/glossary/de/backorder.md
+++ b/content/glossary/de/backorder.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein Dienst, der versucht, eine Domain im Moment ihrer Freigabe zu registrieren, damit man einen ablaufenden Namen beanspruchen kann.
-keywords: ['Backorder', 'Drop-Catching', 'abgelaufene Domain', 'Pending Delete', 'Domain-Erwerb']
+keywords: ['Drop-Catching', 'abgelaufene Domain', 'Pending Delete', 'Domain-Erwerb']
 level: 1
 sources:
   - https://www.namebio.com/

--- a/content/glossary/de/bad-faith.md
+++ b/content/glossary/de/bad-faith.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Das Registrieren oder Verwenden einer Domain zur Ausnutzung einer Marke – ein erforderliches Element für einen UDRP-Erfolg.
-keywords: ['Bösgläubigkeit', 'UDRP', 'Domain-Streit', 'Cybersquatting', 'Markenmissbrauch']
+keywords: ['UDRP', 'Domain-Streit', 'Cybersquatting', 'Markenmissbrauch']
 level: 1
 sources:
   - https://www.wipo.int/amc/en/domains/

--- a/content/glossary/de/bgp-hijack.md
+++ b/content/glossary/de/bgp-hijack.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Umleitung des Internetverkehrs durch falsche Ankündigung von IP-Routen – ein Netzwerkangriff unterhalb der DNS-Ebene.
-keywords: ['BGP-Hijack', 'Route-Hijacking', 'IP-Präfix', 'Netzwerksicherheit', 'Internet-Routing']
+keywords: ['Route-Hijacking', 'IP-Präfix', 'Netzwerksicherheit', 'Internet-Routing']
 level: 1
 sources:
   - https://www.cloudflare.com/learning/security/glossary/bgp-hijacking/

--- a/content/glossary/de/blockchain.md
+++ b/content/glossary/de/blockchain.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein gemeinsames, nur erweitertes Hauptbuch, das auf vielen Computern gespeichert wird – das Fundament tokenisierter Eigentumsrechte.
-keywords: ['Blockchain', 'Verteiltes Hauptbuch', 'Dezentralisiert', 'Unveränderlich', 'Konsens']
+keywords: ['Verteiltes Hauptbuch', 'Dezentralisiert', 'Unveränderlich', 'Konsens']
 level: 1
 sources:
   - https://ethereum.org/en/developers/docs/intro-to-ethereum/

--- a/content/glossary/de/brandable-domain.md
+++ b/content/glossary/de/brandable-domain.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein kurzer, einprägsamer, oft erfundener Name, der als Marke funktioniert – ähnlich einem Kunstwort.
-keywords: ['Brandable Domain', 'Marken-Domain', 'erfundene Domain', 'Kunstwort-Domain', 'einprägsame Domain']
+keywords: ['Marken-Domain', 'erfundene Domain', 'Kunstwort-Domain', 'einprägsame Domain']
 level: 1
 sources:
   - https://moz.com/learn/seo/domain

--- a/content/glossary/de/buy-it-now.md
+++ b/content/glossary/de/buy-it-now.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein fester Sofortkaufpreis auf einem Domain-Angebot – wer ihn zahlt, schließt den Kauf sofort ab, ohne Verhandlung.
-keywords: ['Sofortkauf', 'BIN', 'Sofortkauf', 'Festpreis', 'Domain-Listing']
+keywords: ['BIN', 'Festpreis', 'Domain-Listing']
 also_known_as: ['BIN']
 level: 1
 sources:

--- a/content/glossary/de/cctld.md
+++ b/content/glossary/de/cctld.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Eine zweistellige Top-Level-Domain, die einem Land oder Gebiet zugewiesen ist, wie .uk, .de oder .jp.
-keywords: ['ccTLD', 'länderspezifische TLD', 'Länder-Domain', '.uk', '.de', 'ISO 3166']
+keywords: ['länderspezifische TLD', 'Länder-Domain', '.uk', '.de', 'ISO 3166']
 level: 1
 sources:
   - https://www.iana.org/domains/root/db

--- a/content/glossary/de/censorship-free.md
+++ b/content/glossary/de/censorship-free.md
@@ -7,7 +7,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was bedeutet "zensurfrei" für Domain-Eigentum und -Verwaltung?
-keywords: ["zensurfrei","Zensurresistenz","dezentralisiert","Freiheit","nicht aufzuhalten"]
+keywords: ["Zensurresistenz", "dezentralisiert", "Freiheit", "nicht aufzuhalten"]
 relatedArticles:
   - /de/blog/why-tokenize-domains/
   - /de/blog/onchain-domain-flipping/

--- a/content/glossary/de/collateral.md
+++ b/content/glossary/de/collateral.md
@@ -8,7 +8,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was ist Sicherheit (Collateral) und wie können Domains als Sicherheit in DeFi dienen?
-keywords: ["Sicherheit","Collateral","Kreditvergabe","Kreditaufnahme","Domain-Sicherheit","DeFi"]
+keywords: ["Collateral", "Kreditvergabe", "Kreditaufnahme", "Domain-Sicherheit", "DeFi"]
 relatedArticles:
   - /de/blog/tokenized-domain-use-cases-2026/
   - /de/blog/what-are-xstocks/

--- a/content/glossary/de/comparable-sales.md
+++ b/content/glossary/de/comparable-sales.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Frühere Verkäufe ähnlicher Domains, die als Referenzwerte zur Schätzung des Werts eines Namens herangezogen werden.
-keywords: ['vergleichbare Verkäufe', 'Comps', 'Domain-Verkaufsdaten', 'Domain-Referenzwerte', 'Domain-Preishistorie']
+keywords: ['Comps', 'Domain-Verkaufsdaten', 'Domain-Referenzwerte', 'Domain-Preishistorie']
 also_known_as: ['Comps']
 level: 1
 sources:

--- a/content/glossary/de/composability.md
+++ b/content/glossary/de/composability.md
@@ -8,7 +8,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was ist Komponierbarkeit und wie findet sie Anwendung bei tokenisierten Domains?
-keywords: ["Komponierbarkeit","Interoperabilität","Bausteine","DeFi","Web3-Integration"]
+keywords: ["Interoperabilität", "Bausteine", "DeFi", "Web3-Integration"]
 relatedArticles:
   - /de/blog/what-are-tokenized-domains/
   - /de/blog/why-tokenize-domains/

--- a/content/glossary/de/cross-registrar-transfer.md
+++ b/content/glossary/de/cross-registrar-transfer.md
@@ -7,7 +7,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was sind Cross-Registrar-Transfers und wie vereinfacht die Tokenisierung den Prozess?
-keywords: ["Cross-Registrar-Transfer","Registrar-Transfer","Domain-Migration","Transferprozess","Tokenisierung"]
+keywords: ["Registrar-Transfer", "Domain-Migration", "Transferprozess", "Tokenisierung"]
 relatedArticles:
   - /de/blog/how-to-sell-a-domain-name-you-own/
   - /de/blog/how-tokenization-changes-domain-flipping/

--- a/content/glossary/de/cryptographic-security.md
+++ b/content/glossary/de/cryptographic-security.md
@@ -7,7 +7,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was ist kryptografische Sicherheit und wie schützt sie tokenisierte Domains?
-keywords: ["kryptografische Sicherheit","Verschlüsselung","private Schlüssel","digitale Signaturen","Blockchain-Sicherheit"]
+keywords: ["Verschlüsselung", "private Schlüssel", "digitale Signaturen", "Blockchain-Sicherheit"]
 relatedArticles:
   - /de/blog/the-godaddy-multi-year-breach/
   - /de/blog/the-2020-twitter-bitcoin-account-takeover/

--- a/content/glossary/de/custodial-ownership.md
+++ b/content/glossary/de/custodial-ownership.md
@@ -7,7 +7,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was ist verwahrte Eigentümerschaft und wie unterscheidet sie sich von der Selbstverwahrung?
-keywords: ["verwahrte Eigentümerschaft","Verwahrung","Drittanbieterkontrolle","Registrar-Kontrolle","zentralisierte Speicherung"]
+keywords: ["Verwahrung", "Drittanbieterkontrolle", "Registrar-Kontrolle", "zentralisierte Speicherung"]
 relatedArticles:
   - /de/blog/onchain-domain-custody-and-recovery/
   - /de/blog/how-tokenization-changes-domain-flipping/

--- a/content/glossary/de/cybersquatting.md
+++ b/content/glossary/de/cybersquatting.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Das bösgläubige Registrieren einer Domain, die einer fremden Marke entspricht, in der Absicht, davon zu profitieren.
-keywords: ['Cybersquatting', 'Bösgläubigkeit', 'Domain-Streit', 'Markenverletzung', 'UDRP']
+keywords: ['Bösgläubigkeit', 'Domain-Streit', 'Markenverletzung', 'UDRP']
 level: 1
 sources:
   - https://www.wipo.int/amc/en/domains/

--- a/content/glossary/de/dao.md
+++ b/content/glossary/de/dao.md
@@ -7,7 +7,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was ist ein DAO und wie kann es mit der Domainverwaltung in Verbindung stehen?
-keywords: ["DAO","dezentrale autonome Organisation","Governance","kollektives Eigentum","Smart Contracts"]
+keywords: ["dezentrale autonome Organisation", "Governance", "kollektives Eigentum", "Smart Contracts"]
 relatedArticles:
   - /de/blog/why-a-dao-should-control-the-main-domain/
   - /de/blog/tokenized-domain-use-cases-2026/

--- a/content/glossary/de/defi.md
+++ b/content/glossary/de/defi.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Dezentrale Finanzen bieten Kredite, Darlehen und Handel über Smart Contracts auf öffentlichen Blockchains an, ohne Banken oder Makler als Vermittler.
-keywords: ['DeFi', 'dezentrale Finanzen', 'Kreditvergabe', 'Kreditaufnahme', 'Sicherheit', 'DEX', 'Geldmärkte', 'On-Chain-Finanzen']
+keywords: ['dezentrale Finanzen', 'Kreditvergabe', 'Kreditaufnahme', 'Sicherheit', 'DEX', 'Geldmärkte', 'On-Chain-Finanzen']
 level: 1
 sources:
   - https://ethereum.org/en/defi/

--- a/content/glossary/de/did.md
+++ b/content/glossary/de/did.md
@@ -8,7 +8,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was ist DID und welche Rolle spielen Domains bei der dezentralen Identität?
-keywords: ["DID","dezentrale Identität","selbstsouveräne Identität","Blockchain-Identität","Web3-Identität"]
+keywords: ["dezentrale Identität", "selbstsouveräne Identität", "Blockchain-Identität", "Web3-Identität"]
 relatedArticles:
   - /de/blog/what-are-tokenized-domains/
   - /de/blog/the-2020-twitter-bitcoin-account-takeover/

--- a/content/glossary/de/dns-hijacking.md
+++ b/content/glossary/de/dns-hijacking.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Umleitung des Datenverkehrs einer Domain durch Manipulation der DNS-Auflösung statt der Registrierung selbst.
-keywords: ['DNS-Hijacking', 'Cache-Poisoning', 'DNS-Spoofing', 'DNSSEC', 'Datenverkehrsumleitung']
+keywords: ['Cache-Poisoning', 'DNS-Spoofing', 'DNSSEC', 'Datenverkehrsumleitung']
 level: 1
 sources:
   - https://www.cloudflare.com/learning/dns/dns-cache-poisoning/

--- a/content/glossary/de/dns-propagation.md
+++ b/content/glossary/de/dns-propagation.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Die Verzögerung, bevor eine DNS-Änderung überall sichtbar ist, da alte Einträge in den Resolver-Caches ablaufen.
-keywords: ['DNS-Propagierung', 'DNS-Aktualisierungsverzögerung', 'TTL', 'DNS-Cache', 'Nameserver-Änderung']
+keywords: ['DNS-Aktualisierungsverzögerung', 'TTL', 'DNS-Cache', 'Nameserver-Änderung']
 level: 1
 sources:
   - https://www.cloudflare.com/learning/dns/glossary/time-to-live-ttl/

--- a/content/glossary/de/dns-resolver.md
+++ b/content/glossary/de/dns-resolver.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Der Server, der eine Domain-Anfrage entgegennimmt und die DNS-Hierarchie durchläuft, um die passende Adresse zurückzugeben.
-keywords: ['DNS-Resolver', 'rekursiver Resolver', 'Resolver', '8.8.8.8', '1.1.1.1', 'DNS-Lookup']
+keywords: ['rekursiver Resolver', 'Resolver', '8.8.8.8', '1.1.1.1', 'DNS-Lookup']
 level: 1
 sources:
   - https://datatracker.ietf.org/doc/html/rfc1034

--- a/content/glossary/de/dnssec.md
+++ b/content/glossary/de/dnssec.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Kryptografische Signaturen auf DNS-Einträgen, die es Resolvern ermöglichen zu überprüfen, ob eine Antwort authentisch ist und nicht gefälscht oder während der Übertragung manipuliert wurde.
-keywords: ['DNSSEC', 'DNS-Sicherheit', 'Domain-Sicherheit', 'DS-Eintrag', 'Vertrauenskette', 'kryptografisches DNS']
+keywords: ['DNS-Sicherheit', 'Domain-Sicherheit', 'DS-Eintrag', 'Vertrauenskette', 'kryptografisches DNS']
 level: 1
 sources:
   - https://datatracker.ietf.org/doc/html/rfc4033

--- a/content/glossary/de/domain-appraisal.md
+++ b/content/glossary/de/domain-appraisal.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Die Schätzung des Marktwerts einer Domain anhand vergleichbarer Verkäufe, Keyword-Nachfrage, Länge und Endung.
-keywords: ['Domain-Bewertung', 'Domain-Wertermittlung', 'Domain-Wert', 'Domain-Preisgestaltung', 'vergleichbare Verkäufe']
+keywords: ['Domain-Wertermittlung', 'Domain-Wert', 'Domain-Preisgestaltung', 'vergleichbare Verkäufe']
 also_known_as: ['Domain-Wertermittlung']
 level: 1
 sources:

--- a/content/glossary/de/domain-authority.md
+++ b/content/glossary/de/domain-authority.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein Reputationssignal, das abschätzt, wie gut eine Domain rankt – hauptsächlich bestimmt durch qualitativ hochwertige eingehende Links.
-keywords: ['Domain-Autorität', 'Backlinks', 'Link-Equity', 'SEO', 'Ranking-Signal', 'Eingehende Links']
+keywords: ['Backlinks', 'Link-Equity', 'SEO', 'Ranking-Signal', 'Eingehende Links']
 level: 1
 sources:
   - https://developers.google.com/search/docs/fundamentals/seo-starter-guide

--- a/content/glossary/de/domain-broker.md
+++ b/content/glossary/de/domain-broker.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein Vermittler, der einen Domainverkauf zwischen Käufer und Verkäufer verhandelt, in der Regel gegen eine Provision.
-keywords: ['Domain-Broker', 'Domain-Vermittlung', 'Domain-Verhandlung', 'Domain-Intermediär', 'Domain-Provision']
+keywords: ['Domain-Vermittlung', 'Domain-Verhandlung', 'Domain-Intermediär', 'Domain-Provision']
 level: 1
 sources:
   - https://www.investopedia.com/terms/b/broker.asp

--- a/content/glossary/de/domain-bundle.md
+++ b/content/glossary/de/domain-bundle.md
@@ -8,7 +8,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was ist ein Domain-Paket und wie ermöglicht Tokenisierung die Portfolioverwaltung?
-keywords: ["Domain-Paket","Portfolio","Großhandel","Domain-Sammlung","Asset-Management"]
+keywords: ["Portfolio", "Großhandel", "Domain-Sammlung", "Asset-Management"]
 relatedArticles:
   - /de/blog/why-tokenize-domains/
   - /de/blog/domain-terminology-guide/

--- a/content/glossary/de/domain-expiration.md
+++ b/content/glossary/de/domain-expiration.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Das Datum, an dem die Registrierungslaufzeit einer Domain endet; wird sie nicht verlängert, beginnt ein Verfallsprozess bis zur Löschung.
-keywords: ['Domain-Ablauf', 'abgelaufene Domain', 'Verlängerung', 'Grace Period', 'Redemption']
+keywords: ['abgelaufene Domain', 'Verlängerung', 'Grace Period', 'Redemption']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/name-holder-faqs-2017-10-10-en

--- a/content/glossary/de/domain-financing.md
+++ b/content/glossary/de/domain-financing.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Der Kauf einer Domain in Raten über die Zeit statt als einmalige Vorauszahlung.
-keywords: ['Domain-Finanzierung', 'Ratenzahlung', 'Zahlungsplan', 'Domain-Erwerb', 'Domain-Investment']
+keywords: ['Ratenzahlung', 'Zahlungsplan', 'Domain-Erwerb', 'Domain-Investment']
 level: 1
 sources:
   - https://www.namebio.com/

--- a/content/glossary/de/domain-forwarding.md
+++ b/content/glossary/de/domain-forwarding.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Das automatische Senden von Besuchern von einer Domain zu einer anderen Adresse, häufig über eine 301-Weiterleitung.
-keywords: ['Domain-Weiterleitung', '301-Weiterleitung', 'URL-Weiterleitung', 'DNS', 'Domain-Verwaltung']
+keywords: ['301-Weiterleitung', 'URL-Weiterleitung', 'DNS', 'Domain-Verwaltung']
 level: 1
 sources:
   - https://developers.google.com/search/docs/crawling-indexing/301-redirects

--- a/content/glossary/de/domain-hack.md
+++ b/content/glossary/de/domain-hack.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein Name, der über den Punkt hinweg ein Wort unter Einbeziehung der TLD buchstabiert, wie del.icio.us oder examp.le.
-keywords: ['Domain-Hack', 'Kreative Domain', 'TLD-Wortspiel', 'Markenfähige Domain', 'ccTLD']
+keywords: ['Kreative Domain', 'TLD-Wortspiel', 'Markenfähige Domain', 'ccTLD']
 level: 1
 sources:
   - https://www.namebio.com/

--- a/content/glossary/de/domain-hijacking.md
+++ b/content/glossary/de/domain-hijacking.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Der Diebstahl einer Domain durch unbefugte Übernahme des Registrar-Kontos oder der Registrierung.
-keywords: ['Domain-Hijacking', 'Kontoübernahme', 'Domain-Diebstahl', 'Registrar-Sicherheit', 'Unbefugter Transfer']
+keywords: ['Kontoübernahme', 'Domain-Diebstahl', 'Registrar-Sicherheit', 'Unbefugter Transfer']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/name-holder-faqs-2017-10-10-en

--- a/content/glossary/de/domain-liquidity.md
+++ b/content/glossary/de/domain-liquidity.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Wie schnell eine Domain nahe ihrem geschätzten Wert verkauft werden kann – hoch bei großartigen Namen, niedrig bei Nischen-Domains.
-keywords: ['Domain-Liquidität', 'Liquidität', 'Domain-Marktgängigkeit', 'Domain-Verkaufsgeschwindigkeit', 'Domain-Markttiefe']
+keywords: ['Domain-Liquidität', 'Domain-Marktgängigkeit', 'Domain-Verkaufsgeschwindigkeit', 'Domain-Markttiefe']
 level: 1
 sources:
   - https://www.investopedia.com/terms/l/liquidity.asp

--- a/content/glossary/de/domain-ownership.md
+++ b/content/glossary/de/domain-ownership.md
@@ -8,7 +8,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was bedeutet Domain-Eigentum, wenn es tokenisiert ist?
-keywords: ["Domain-Eigentum","NFT-Domain","Registrar","Custodial","Wallet-Eigentum"]
+keywords: ["NFT-Domain", "Registrar", "Custodial", "Wallet-Eigentum"]
 relatedArticles:
   - /de/blog/why-tokenize-domains/
   - /de/blog/what-are-tokenized-domains/

--- a/content/glossary/de/domain-parking.md
+++ b/content/glossary/de/domain-parking.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Das Platzieren von Anzeigen oder einem Verkaufshinweis auf einer unentwickelten Domain, um Einnahmen zu erzielen oder die Verfügbarkeit zu signalisieren.
-keywords: ['Domain-Parking', 'Geparkte Domain', 'Monetarisierung', 'Domain-Investment', 'Passives Einkommen']
+keywords: ['Geparkte Domain', 'Monetarisierung', 'Domain-Investment', 'Passives Einkommen']
 also_known_as: ['Geparkte Domain']
 level: 1
 sources:

--- a/content/glossary/de/domain-portfolio.md
+++ b/content/glossary/de/domain-portfolio.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Eine Sammlung von Domains, die ein Eigentümer als Investition hält und mit Verlängerungen, Verkäufen und Bewertungen verwaltet.
-keywords: ['Domain-Portfolio', 'Domain-Investition', 'Domain-Verwaltung', 'Domain-Bewertung', 'Domain-Assets']
+keywords: ['Domain-Investition', 'Domain-Verwaltung', 'Domain-Bewertung', 'Domain-Assets']
 level: 1
 sources:
   - https://www.investopedia.com/terms/p/portfolio.asp

--- a/content/glossary/de/domain-renewal.md
+++ b/content/glossary/de/domain-renewal.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Die Zahlung zur Verlängerung einer Domain-Registrierung vor deren Ablauf, häufig automatisch für jede Laufzeit.
-keywords: ['Domain-Verlängerung', 'Auto-Renew', 'Registrierungslaufzeit', 'Ablauf', 'Verlängerungsgebühr']
+keywords: ['Auto-Renew', 'Registrierungslaufzeit', 'Ablauf', 'Verlängerungsgebühr']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/name-holder-faqs-2017-10-10-en

--- a/content/glossary/de/domain-tasting.md
+++ b/content/glossary/de/domain-tasting.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Eine weitgehend veraltete Praxis, Domains zu registrieren und innerhalb der kostenlosen Add Grace Period wieder zu stornieren.
-keywords: ['Domain Tasting', 'AGP', 'Add Grace Period', 'Domain Kiting', 'ICANN-Richtlinie']
+keywords: ['AGP', 'Add Grace Period', 'Domain Kiting', 'ICANN-Richtlinie']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/agp-policy-2008-06-25-en

--- a/content/glossary/de/domain-theft.md
+++ b/content/glossary/de/domain-theft.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Der unbefugte Transfer einer Domain aus der Kontrolle ihres rechtmäßigen Eigentümers, oft durch Kontoübernahme.
-keywords: ['Domain-Diebstahl', 'Unbefugter Transfer', 'Kontoübernahme', 'Domain-Sicherheit', 'Wiederherstellung']
+keywords: ['Unbefugter Transfer', 'Kontoübernahme', 'Domain-Sicherheit', 'Wiederherstellung']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/name-holder-faqs-2017-10-10-en

--- a/content/glossary/de/domain-trading.md
+++ b/content/glossary/de/domain-trading.md
@@ -8,7 +8,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was ist Domain-Handel und wie verbessert die Tokenisierung das Handelserlebnis?
-keywords: ["Domain-Handel","Domain-Investition","digitales Immobilien","Sekundärmarkt","Liquidität"]
+keywords: ["Domain-Investition", "digitales Immobilien", "Sekundärmarkt", "Liquidität"]
 relatedArticles:
   - /de/blog/onchain-domain-flipping/
   - /de/blog/end-user-vs-reseller-domain-pricing/

--- a/content/glossary/de/domaining.md
+++ b/content/glossary/de/domaining.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Die Praxis, in Domainnamen zu investieren – sie zu registrieren, zu kaufen und mit Gewinn zu verkaufen.
-keywords: ['Domaining', 'Domainer', 'Domain-Investition', 'Domain-Flipping', 'Domain-Spekulation']
+keywords: ['Domainer', 'Domain-Investition', 'Domain-Flipping', 'Domain-Spekulation']
 level: 1
 sources:
   - https://www.namebio.com/

--- a/content/glossary/de/end-user.md
+++ b/content/glossary/de/end-user.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein Käufer, der eine Domain tatsächlich für ein Unternehmen oder Projekt nutzen möchte, nicht um sie weiterzuverkaufen.
-keywords: ['Endnutzer', 'Domain-Käufer', 'Domain-Einsatz', 'Unternehmens-Domain', 'Domain-Deployment']
+keywords: ['Domain-Käufer', 'Domain-Einsatz', 'Unternehmens-Domain', 'Domain-Deployment']
 level: 1
 sources:
   - https://en.wikipedia.org/wiki/End_user

--- a/content/glossary/de/ens.md
+++ b/content/glossary/de/ens.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Der Ethereum Name Service ordnet menschenlesbare Namen wie alice.eth Wallet-Adressen und Einträgen zu und wird vollständig durch On-Chain-Smart-Contracts verwaltet.
-keywords: ['ENS', 'Ethereum Name Service', '.eth', 'Web3-Name', 'On-Chain-Naming', 'Wallet-Alias', 'Krypto-Identität']
+keywords: ['Ethereum Name Service', '.eth', 'Web3-Name', 'On-Chain-Naming', 'Wallet-Alias', 'Krypto-Identität']
 level: 1
 sources:
   - https://docs.ens.domains/

--- a/content/glossary/de/epp-status-codes.md
+++ b/content/glossary/de/epp-status-codes.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Die standardisierten Flags einer Domain, die ihren Zustand anzeigen – gesperrt, zurückgehalten, ausstehender Transfer und mehr.
-keywords: ['EPP-Statuscodes', 'clientHold', 'serverTransferProhibited', 'Domain-Status', 'Pending Delete']
+keywords: ['clientHold', 'serverTransferProhibited', 'Domain-Status', 'Pending Delete']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/epp-status-codes-2014-06-16-en

--- a/content/glossary/de/epp.md
+++ b/content/glossary/de/epp.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Das Standardprotokoll, das Registrare nutzen, um Domains mit einer Registry zu registrieren und zu verwalten.
-keywords: ['EPP', 'Extensible Provisioning Protocol', 'Domain-Verwaltung', 'Registry-Protokoll', 'RFC 5730']
+keywords: ['Extensible Provisioning Protocol', 'Domain-Verwaltung', 'Registry-Protokoll', 'RFC 5730']
 also_known_as: ['Extensible Provisioning Protocol']
 level: 1
 sources:

--- a/content/glossary/de/erc-20.md
+++ b/content/glossary/de/erc-20.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Der Ethereum-Standard für fungible Token wie Stablecoins – das Pendant zum ERC-721-NFT-Standard.
-keywords: ['ERC-20', 'Fungibler Token', 'Token-Standard', 'Stablecoin', 'Ethereum-Token']
+keywords: ['Fungibler Token', 'Token-Standard', 'Stablecoin', 'Ethereum-Token']
 level: 1
 sources:
   - https://eips.ethereum.org/EIPS/eip-20

--- a/content/glossary/de/erc-721.md
+++ b/content/glossary/de/erc-721.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Der Ethereum-Standard-Interface für nicht-fungible Token ermöglicht es Wallets und Marktplätzen, jeden einzigartigen Token einheitlich zu verwalten, einschließlich tokenisierter Domains.
-keywords: ['ERC-721', 'NFT-Standard', 'Ethereum-Token-Standard', 'nicht-fungibler Token', 'tokenisierter Domain-Standard']
+keywords: ['NFT-Standard', 'Ethereum-Token-Standard', 'nicht-fungibler Token', 'tokenisierter Domain-Standard']
 level: 1
 sources:
   - https://eips.ethereum.org/EIPS/eip-721

--- a/content/glossary/de/escrow.md
+++ b/content/glossary/de/escrow.md
@@ -8,7 +8,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was ist Treuhand und wie bieten Smart Contracts eine vertrauenslose Treuhand für Domains?
-keywords: ["Treuhand","vertrauenswürdige dritte Partei","Smart Contract Treuhand","Trustless","sichere Transaktionen"]
+keywords: ["vertrauenswürdige dritte Partei", "Smart Contract Treuhand", "Trustless", "sichere Transaktionen"]
 relatedArticles:
   - /de/blog/domain-escrow-explained/
   - /de/blog/how-tokenized-marketplaces-replace-escrow/

--- a/content/glossary/de/ethereum.md
+++ b/content/glossary/de/ethereum.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Die führende Smart-Contract-Blockchain und das Netzwerk, auf dem die meisten tokenisierten Domains ausgegeben werden.
-keywords: ['Ethereum', 'ETH', 'Smart Contract', 'EVM', 'Dezentralisierte Anwendungen']
+keywords: ['ETH', 'Smart Contract', 'EVM', 'Dezentralisierte Anwendungen']
 also_known_as: ['ETH']
 level: 1
 sources:

--- a/content/glossary/de/exact-match-domain.md
+++ b/content/glossary/de/exact-match-domain.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Eine Domain, die exakt einem Suchbegriff entspricht, wie besthotels.com – früher hoch geschätzt für SEO.
-keywords: ['Exact-Match Domain', 'EMD', 'Keyword-Match-Domain', 'SEO-Domain', 'Suchrankig-Domain']
+keywords: ['EMD', 'Keyword-Match-Domain', 'SEO-Domain', 'Suchrankig-Domain']
 also_known_as: ['EMD']
 level: 1
 sources:

--- a/content/glossary/de/farcaster.md
+++ b/content/glossary/de/farcaster.md
@@ -7,7 +7,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was ist Farcaster und wie stehen Domains im Zusammenhang mit dezentralen sozialen Netzwerken?
-keywords: ["Farcaster","dezentrales soziales Netzwerk","Web3-Sozial","Blockchain-Identität","soziales Protokoll"]
+keywords: ["dezentrales soziales Netzwerk", "Web3-Sozial", "Blockchain-Identität", "soziales Protokoll"]
 relatedArticles:
   - /de/blog/what-are-tokenized-domains/
   - /de/blog/why-tokenize-domains/

--- a/content/glossary/de/fractional-ownership.md
+++ b/content/glossary/de/fractional-ownership.md
@@ -7,7 +7,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was ist Teileigentum und wie trifft es auf wertvolle Domains zu?
-keywords: ["Teileigentum","gemeinsames Eigentum","Domain-Fragmentierung","Zugänglichkeit","Tokenisierung"]
+keywords: ["gemeinsames Eigentum", "Domain-Fragmentierung", "Zugänglichkeit", "Tokenisierung"]
 relatedArticles:
   - /de/blog/tokenized-domain-use-cases-2026/
   - /de/blog/why-tokenize-domains/

--- a/content/glossary/de/gas.md
+++ b/content/glossary/de/gas.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Die Gebühr, die für die Verarbeitung einer Transaktion auf einer Blockchain gezahlt wird, in der nativen Währung des Netzwerks berechnet und steigt mit der Auslastung; Layer-2-Netzwerke verlangen deutlich weniger.
-keywords: ['Gas', 'Gasgebühr', 'Transaktionsgebühr', 'Gwei', 'Ethereum-Gas', 'Base-Gas', 'L2-Gebühren', 'Mint-Kosten']
+keywords: ['Gasgebühr', 'Transaktionsgebühr', 'Gwei', 'Ethereum-Gas', 'Base-Gas', 'L2-Gebühren', 'Mint-Kosten']
 level: 1
 sources:
   - https://ethereum.org/en/developers/docs/gas/

--- a/content/glossary/de/grace-period.md
+++ b/content/glossary/de/grace-period.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein kurzes Zeitfenster direkt nach dem Ablauf einer Domain, in dem man sie noch zum normalen Preis verlängern kann.
-keywords: ['Grace Period', 'Auto-Renew Grace Period', 'Domain-Ablauf', 'Verlängerung', 'RGP']
+keywords: ['Auto-Renew Grace Period', 'Domain-Ablauf', 'Verlängerung', 'RGP']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/errp-2013-02-28-en

--- a/content/glossary/de/gtld.md
+++ b/content/glossary/de/gtld.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Eine nicht länderspezifische Top-Level-Domain wie .com, .org oder .xyz, die unter ICANN-Vertrag betrieben wird.
-keywords: ['gTLD', 'generische TLD', '.com', '.org', '.xyz', 'ICANN']
+keywords: ['generische TLD', '.com', '.org', '.xyz', 'ICANN']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/tlds-2012-02-25-en

--- a/content/glossary/de/hardware-wallet.md
+++ b/content/glossary/de/hardware-wallet.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein dediziertes Offline-Gerät, das die privaten Schlüssel einer Wallet speichert und Transaktionen auf dem Gerät signiert, sodass die Schlüssel niemals einen internetverbundenen Computer berühren.
-keywords: ['Hardware-Wallet', 'Cold Wallet', 'Ledger', 'Trezor', 'GridPlus', 'Keystone', 'Secure Element', 'Self-Custody']
+keywords: ['Cold Wallet', 'Ledger', 'Trezor', 'GridPlus', 'Keystone', 'Secure Element', 'Self-Custody']
 level: 1
 sources:
   - https://ethereum.org/en/wallets/

--- a/content/glossary/de/holding-cost.md
+++ b/content/glossary/de/holding-cost.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Die laufenden Verlängerungsgebühren, die ein Investor zahlt, um eine Domain bis zum Verkauf zu behalten.
-keywords: ['Haltekosten', 'Tragekosten', 'Domain-Verlängerungskosten', 'Domain-Investitionskosten', 'jährliche Verlängerungsgebühr']
+keywords: ['Tragekosten', 'Domain-Verlängerungskosten', 'Domain-Investitionskosten', 'jährliche Verlängerungsgebühr']
 also_known_as: ['Tragekosten']
 level: 1
 sources:

--- a/content/glossary/de/iana.md
+++ b/content/glossary/de/iana.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Die Instanz, die die DNS-Root-Zone pflegt und IP-Adressblöcke sowie Protokollnummern vergibt.
-keywords: ['IANA', 'Root-Zone', 'IP-Vergabe', 'Protokollnummern', 'ICANN']
+keywords: ['Root-Zone', 'IP-Vergabe', 'Protokollnummern', 'ICANN']
 level: 1
 sources:
   - https://www.iana.org/

--- a/content/glossary/de/icann.md
+++ b/content/glossary/de/icann.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Die gemeinnützige Organisation, die das globale Domain-Name-System, die IP-Zuteilung und Protokollkennungen koordiniert und Registrare weltweit akkreditiert.
-keywords: ['ICANN', 'Internet-Governance', 'Domain-Politik', 'DNS-Aufsicht', 'IANA', 'gTLD', 'Registrar-Akkreditierung', 'Multistakeholder', 'UDRP']
+keywords: ['Internet-Governance', 'Domain-Politik', 'DNS-Aufsicht', 'IANA', 'gTLD', 'Registrar-Akkreditierung', 'Multistakeholder', 'UDRP']
 also_known_as: ['Internet Corporation for Assigned Names and Numbers']
 level: 2
 sources:

--- a/content/glossary/de/internet-native-asset.md
+++ b/content/glossary/de/internet-native-asset.md
@@ -7,7 +7,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was sind Internet-native Assets und wie passen Domains in diese Kategorie?
-keywords: ["Internet-natives Asset","digitales Asset","Blockchain","natives Internet","tokenisierte Domains"]
+keywords: ["digitales Asset", "Blockchain", "natives Internet", "tokenisierte Domains"]
 relatedArticles:
   - /de/blog/why-tokenize-domains/
   - /de/blog/from-snapchat-com-to-snap-com/

--- a/content/glossary/de/ip-address.md
+++ b/content/glossary/de/ip-address.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Die numerische Adresse, die ein Gerät im Netzwerk identifiziert und auf die DNS einen Domainnamen abbildet.
-keywords: ['IP-Adresse', 'IPv4', 'IPv6', 'A-Record', 'AAAA-Record', 'Netzwerk']
+keywords: ['IPv4', 'IPv6', 'A-Record', 'AAAA-Record', 'Netzwerk']
 level: 1
 sources:
   - https://datatracker.ietf.org/doc/html/rfc791

--- a/content/glossary/de/ipfs.md
+++ b/content/glossary/de/ipfs.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein Peer-to-Peer-Protokoll, das Dateien anhand ihres Inhalts adressiert und dezentrale Web-Daten hostet.
-keywords: ['IPFS', 'Inhaltsadressierung', 'Peer-to-Peer', 'dezentraler Speicher', 'CID']
+keywords: ['Inhaltsadressierung', 'Peer-to-Peer', 'dezentraler Speicher', 'CID']
 also_known_as: ['InterPlanetary File System']
 level: 1
 sources:

--- a/content/glossary/de/keyword-domain.md
+++ b/content/glossary/de/keyword-domain.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Eine Domain, die auf einem wertvollen Suchbegriff oder einer Phrase aufgebaut ist und für ihre beschreibende Klarheit geschätzt wird.
-keywords: ['Keyword-Domain', 'keyword-reiche Domain', 'beschreibende Domain', 'Such-Keyword-Domain', 'SEO-Domainname']
+keywords: ['keyword-reiche Domain', 'beschreibende Domain', 'Such-Keyword-Domain', 'SEO-Domainname']
 level: 1
 sources:
   - https://developers.google.com/search/docs/fundamentals/seo-starter-guide

--- a/content/glossary/de/kyc.md
+++ b/content/glossary/de/kyc.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Know Your Customer — die Identitätsprüfungen, die ein regulierter Finanz- oder Kryptodienst vor der Nutzeraufnahme durchführt.
-keywords: ['KYC', 'Know Your Customer', 'Identitätsverifizierung', 'Onboarding', 'Compliance']
+keywords: ['Know Your Customer', 'Identitätsverifizierung', 'Onboarding', 'Compliance']
 also_known_as: ['Know Your Customer']
 level: 1
 sources:

--- a/content/glossary/de/layer-2.md
+++ b/content/glossary/de/layer-2.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein Netzwerk auf einer Blockchain, das Transaktionen schneller und günstiger macht, wie Base auf Ethereum.
-keywords: ['layer 2', 'rollup', 'skalierung', 'optimistic rollup', 'ZK rollup']
+keywords: ['rollup', 'skalierung', 'optimistic rollup', 'ZK rollup']
 level: 1
 sources:
   - https://ethereum.org/en/layer-2/

--- a/content/glossary/de/lease-to-own.md
+++ b/content/glossary/de/lease-to-own.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Der Erwerb einer Domain durch wiederkehrende Zahlungen, die auf den vollen Kaufpreis angerechnet werden – ein Geschwister des Miet-zum-Kauf-Modells.
-keywords: ['mietkauf', 'domain-erwerb', 'ratenzahlung', 'domain-finanzierung', 'miete-zu-eigentum']
+keywords: ['domain-erwerb', 'ratenzahlung', 'domain-finanzierung', 'miete-zu-eigentum']
 level: 1
 sources:
   - https://www.investopedia.com/terms/l/lease-option.asp

--- a/content/glossary/de/leasing.md
+++ b/content/glossary/de/leasing.md
@@ -7,7 +7,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was ist Domain-Leasing und wie ermöglicht Tokenisierung neue Leasing-Modelle?
-keywords: ["Leasing","Domainmiete","passives Einkommen","Smart-Contract-Leasing","automatisierte Zahlungen"]
+keywords: ["Domainmiete", "passives Einkommen", "Smart-Contract-Leasing", "automatisierte Zahlungen"]
 relatedArticles:
   - /de/blog/tokenized-domain-use-cases-2026/
   - /de/blog/why-tokenize-domains/

--- a/content/glossary/de/lending-protocol.md
+++ b/content/glossary/de/lending-protocol.md
@@ -7,7 +7,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was sind Lending-Protokolle und wie können Domains im DeFi-Lending verwendet werden?
-keywords: ["Lending-Protokoll","DeFi","Sicherheit","Ausleihe","Domain-Finanzierung","Rendite"]
+keywords: ["DeFi", "Sicherheit", "Ausleihe", "Domain-Finanzierung", "Rendite"]
 relatedArticles:
   - /de/blog/tokenized-domain-use-cases-2026/
   - /de/blog/what-are-tokenized-domains/

--- a/content/glossary/de/lens.md
+++ b/content/glossary/de/lens.md
@@ -7,7 +7,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was ist das Lens Protocol und wie nutzt es Domains für die soziale Identität?
-keywords: ["Lens","Lens Protocol","dezentrales Soziales","NFT-Profile","sozialer Graph","Web3-Identität"]
+keywords: ["Lens Protocol", "dezentrales Soziales", "NFT-Profile", "sozialer Graph", "Web3-Identität"]
 relatedArticles:
   - /de/blog/what-are-tokenized-domains/
   - /de/blog/why-tokenize-domains/

--- a/content/glossary/de/make-offer.md
+++ b/content/glossary/de/make-offer.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein Domain-Angebot, das Käufer einlädt, ein Gebot einzureichen, das der Verkäufer annehmen, gegenbieten oder ablehnen kann.
-keywords: ['Preisverhandlung', 'Bestgebot', 'Domain-Verhandlung', 'Angebot', 'Gegenangebot']
+keywords: ['Bestgebot', 'Domain-Verhandlung', 'Angebot', 'Gegenangebot']
 level: 1
 sources:
   - https://www.sedo.com/

--- a/content/glossary/de/marketplace.md
+++ b/content/glossary/de/marketplace.md
@@ -8,7 +8,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was sind NFT-Marktplätze und wie erleichtern sie den Domain-Handel?
-keywords: ["Marktplatz","OpenSea","Blur","NFT-Handel","Domain-Marktplatz","Sekundärmarkt"]
+keywords: ["OpenSea", "Blur", "NFT-Handel", "Domain-Marktplatz", "Sekundärmarkt"]
 relatedArticles:
   - /de/blog/onchain-domain-marketplaces-compared/
   - /de/blog/how-tokenized-marketplaces-replace-escrow/

--- a/content/glossary/de/minting.md
+++ b/content/glossary/de/minting.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Das Erstellen eines neuen Tokens auf einer Blockchain – bei einer Domain bedeutet es die Ausgabe des NFT, das deren Eigentümerschaft repräsentiert.
-keywords: ['prägen', 'minting', 'NFT-erstellung', 'token-ausgabe', 'on-chain']
+keywords: ['minting', 'NFT-erstellung', 'token-ausgabe', 'on-chain']
 also_known_as: ['Mint']
 level: 1
 sources:

--- a/content/glossary/de/multi-sig.md
+++ b/content/glossary/de/multi-sig.md
@@ -7,7 +7,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was ist Multi-Sig und wie verbessert es die Domain-Sicherheit?
-keywords: ["Multi-Sig","Multisig","mehrere Signaturen","verbesserte Sicherheit","geteilte Verwahrung"]
+keywords: ["Multisig", "mehrere Signaturen", "verbesserte Sicherheit", "geteilte Verwahrung"]
 relatedArticles:
   - /de/blog/do-multisig-wallets-actually-improve-security/
   - /de/blog/onchain-domain-custody-and-recovery/

--- a/content/glossary/de/nameserver.md
+++ b/content/glossary/de/nameserver.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein Server, der DNS-Anfragen für eine Domain beantwortet; seine NS Records benennen die autoritativen Server.
-keywords: ['Nameserver', 'NS Record', 'autoritativer Server', 'DNS-Delegierung', 'DNS-Hosting']
+keywords: ['NS Record', 'autoritativer Server', 'DNS-Delegierung', 'DNS-Hosting']
 level: 1
 sources:
   - https://datatracker.ietf.org/doc/html/rfc1034

--- a/content/glossary/de/new-gtld.md
+++ b/content/glossary/de/new-gtld.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Eine generische Top-Level-Domain, die durch das Erweiterungsprogramm von ICANN eingeführt wurde, wie .app, .xyz oder .shop.
-keywords: ['New gTLD', 'ICANN-Erweiterung', '.app', '.xyz', '.shop', 'Domain-Endung']
+keywords: ['ICANN-Erweiterung', '.app', '.xyz', '.shop', 'Domain-Endung']
 level: 1
 sources:
   - https://newgtlds.icann.org/en/

--- a/content/glossary/de/nft.md
+++ b/content/glossary/de/nft.md
@@ -8,7 +8,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was ist ein NFT und wie hängt es mit der Domain-Tokenisierung zusammen?
-keywords: ["NFT","non-fungible token","blockchain","einzigartiger Vermögenswert","Domain-NFT"]
+keywords: ["non-fungible token", "blockchain", "einzigartiger Vermögenswert", "Domain-NFT"]
 relatedArticles:
   - /de/blog/selling-domains-as-nfts/
   - /de/blog/what-are-tokenized-domains/

--- a/content/glossary/de/on-chain.md
+++ b/content/glossary/de/on-chain.md
@@ -8,7 +8,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was bedeutet "On-Chain" im Kontext von Domains?
-keywords: ["On-Chain","Blockchain","Smart Contracts","Domain-NFT","Dezentralisierung"]
+keywords: ["Blockchain", "Smart Contracts", "Domain-NFT", "Dezentralisierung"]
 relatedArticles:
   - /de/blog/how-tokenization-changes-domain-flipping/
   - /de/blog/what-are-tokenized-domains/

--- a/content/glossary/de/pending-delete.md
+++ b/content/glossary/de/pending-delete.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Der letzte Status, bevor eine nicht verlängerte Domain wieder für die öffentliche Registrierung freigegeben wird.
-keywords: ['Pending Delete', 'Domain Drop', 'Drop Catching', 'abgelaufene Domain', 'Freigabe']
+keywords: ['Domain Drop', 'Drop Catching', 'abgelaufene Domain', 'Freigabe']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/epp-status-codes-2014-06-16-en

--- a/content/glossary/de/permissionless.md
+++ b/content/glossary/de/permissionless.md
@@ -7,7 +7,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was bedeutet "permissionless" in Blockchain und Domainverwaltung?
-keywords: ["permissionless","dezentralisiert","zensurresistent","offener Zugang","blockchain"]
+keywords: ["dezentralisiert", "zensurresistent", "offener Zugang", "blockchain"]
 relatedArticles:
   - /de/blog/why-tokenize-domains/
   - /de/blog/what-are-tokenized-domains/

--- a/content/glossary/de/phishing.md
+++ b/content/glossary/de/phishing.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Das Täuschen von Personen zur Preisgabe von Zugangsdaten oder Geldern über gefälschte Seiten und Nachrichten, die vertrauenswürdige Marken imitieren.
-keywords: ['phishing', 'social engineering', 'zugangsdaten-diebstahl', 'identitätsbetrug', 'domain-missbrauch']
+keywords: ['social engineering', 'zugangsdaten-diebstahl', 'identitätsbetrug', 'domain-missbrauch']
 level: 1
 sources:
   - https://consumer.ftc.gov/articles/how-recognize-and-avoid-phishing-scams

--- a/content/glossary/de/ppc.md
+++ b/content/glossary/de/ppc.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein Werbemodell, bei dem der Eigentümer bei jedem Klick eines Besuchers auf eine Anzeige verdient – genutzt zur Monetarisierung geparkter Domains.
-keywords: ['PPC', 'pay-per-click', 'domain-monetarisierung', 'werbeeinnahmen', 'parking-einnahmen']
+keywords: ['pay-per-click', 'domain-monetarisierung', 'werbeeinnahmen', 'parking-einnahmen']
 also_known_as: ['Pay-Per-Click']
 level: 1
 sources:

--- a/content/glossary/de/premium-domain.md
+++ b/content/glossary/de/premium-domain.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Eine hochwertige Domain, die aufgrund ihrer Einprägsamkeit, Kürze oder Keyword-Stärke über dem Standardpreis bewertet wird.
-keywords: ['Premium-Domain', 'Premium-Name', 'Registry-Premium', 'Aftermarket', 'Domain-Wert']
+keywords: ['Premium-Name', 'Registry-Premium', 'Aftermarket', 'Domain-Wert']
 level: 1
 sources:
   - https://www.namebio.com/

--- a/content/glossary/de/private-key.md
+++ b/content/glossary/de/private-key.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Die geheime Zahl, die ein Blockchain-Konto kontrolliert und dessen Transaktionen signiert; sie darf niemals weitergegeben werden.
-keywords: ['privater schlüssel', 'signing key', 'wallet-schlüssel', 'geheimer schlüssel', 'blockchain-konto']
+keywords: ['signing key', 'wallet-schlüssel', 'geheimer schlüssel', 'blockchain-konto']
 level: 1
 sources:
   - https://ethereum.org/en/developers/docs/accounts/

--- a/content/glossary/de/protocol-asset.md
+++ b/content/glossary/de/protocol-asset.md
@@ -7,7 +7,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was sind Protokoll-Assets und wie fungieren tokenisierte Domains als Protokoll-Assets?
-keywords: ["Protokoll-Asset","Blockchain-Protokoll","Infrastruktur-Asset","Netzwerk-Asset","Utility Token"]
+keywords: ["Blockchain-Protokoll", "Infrastruktur-Asset", "Netzwerk-Asset", "Utility Token"]
 relatedArticles:
   - /de/blog/what-are-tokenized-domains/
   - /de/blog/why-tokenize-domains/

--- a/content/glossary/de/public-key.md
+++ b/content/glossary/de/public-key.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Die teilbare Hälfte eines Blockchain-Schlüsselpaares, aus dem privaten Schlüssel abgeleitet; dient zum Empfangen von Geldern und zur Signaturverifizierung.
-keywords: ['öffentlicher schlüssel', 'adresse', 'verifikationsschlüssel', 'asymmetrische kryptographie', 'blockchain-konto']
+keywords: ['adresse', 'verifikationsschlüssel', 'asymmetrische kryptographie', 'blockchain-konto']
 level: 1
 sources:
   - https://ethereum.org/en/developers/docs/accounts/

--- a/content/glossary/de/redemption-period.md
+++ b/content/glossary/de/redemption-period.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein Zeitfenster nach dem Ablauf, in dem eine verfallene Domain gegen eine hohe Wiederherstellungsgebühr noch zurückgeholt werden kann.
-keywords: ['Redemption Period', 'RGP', 'Redemption Grace Period', 'Wiederherstellung abgelaufener Domain', 'Wiederherstellungsgebühr']
+keywords: ['RGP', 'Redemption Grace Period', 'Wiederherstellung abgelaufener Domain', 'Wiederherstellungsgebühr']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/errp-2013-02-28-en

--- a/content/glossary/de/registrant.md
+++ b/content/glossary/de/registrant.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Die Person oder Organisation, die die Rechte an einem registrierten Domainnamen hält — der eingetragene Inhaber.
-keywords: ['Registrant', 'Domain-Inhaber', 'Registered Name Holder', 'RNH', 'Domain-Eigentum']
+keywords: ['Domain-Inhaber', 'Registered Name Holder', 'RNH', 'Domain-Eigentum']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/name-holder-faqs-2017-10-10-en

--- a/content/glossary/de/registrar.md
+++ b/content/glossary/de/registrar.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein von ICANN akkreditiertes Unternehmen, das berechtigt ist, Domainnamen im Auftrag der Öffentlichkeit zu registrieren und als Schnittstelle zwischen Registranten und Registries fungiert.
-keywords: ['Registrar', 'Domain-Registrar', 'ICANN-Akkreditierung', 'Domainregistrierung', 'RAA', 'EPP', 'Auth-Code', 'Transfer-Sperre', 'Domain-Transfer']
+keywords: ['Domain-Registrar', 'ICANN-Akkreditierung', 'Domainregistrierung', 'RAA', 'EPP', 'Auth-Code', 'Transfer-Sperre', 'Domain-Transfer']
 level: 2
 sources:
   - https://www.icann.org/en/accredited-registrars

--- a/content/glossary/de/registry-lock.md
+++ b/content/glossary/de/registry-lock.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein Hochsicherheitsdienst, bei dem die Registry eine Domain einfriert, sodass Änderungen eine manuelle Out-of-Band-Genehmigung erfordern.
-keywords: ['registry-sperre', 'domain-sperre', 'hochsicherheitssperre', 'domain-hijacking-prävention', 'out-of-band-verifizierung']
+keywords: ['domain-sperre', 'hochsicherheitssperre', 'domain-hijacking-prävention', 'out-of-band-verifizierung']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/epp-status-codes-2014-06-16-en

--- a/content/glossary/de/registry.md
+++ b/content/glossary/de/registry.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Die Organisation, die die maßgebliche Datenbank und Nameserver für eine Top-Level-Domain betreibt und den Einzelhandelsverkauf an Registrare delegiert.
-keywords: ['Registry', 'Registry-Betreiber', 'TLD-Registry', 'Domain-Registry', 'ICANN', 'Registrar', 'EPP', 'gTLD-Registry', 'ccTLD-Registry', 'Shared-Registry-System']
+keywords: ['Registry-Betreiber', 'TLD-Registry', 'Domain-Registry', 'ICANN', 'Registrar', 'EPP', 'gTLD-Registry', 'ccTLD-Registry', 'Shared-Registry-System']
 also_known_as: ['Registry-Betreiber']
 level: 2
 sources:

--- a/content/glossary/de/rent-to-own.md
+++ b/content/glossary/de/rent-to-own.md
@@ -7,7 +7,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was ist Mietkauf und wie kann er auf den Domain-Erwerb angewendet werden?
-keywords: ["Mietkauf","schrittweiser Eigentumserwerb","Zahlungspläne","Domain-Erwerb","Smart Contracts"]
+keywords: ["schrittweiser Eigentumserwerb", "Zahlungspläne", "Domain-Erwerb", "Smart Contracts"]
 relatedArticles:
   - /de/blog/taxes-and-accounting-for-domain-investors/
   - /de/blog/why-tokenize-domains/

--- a/content/glossary/de/reseller.md
+++ b/content/glossary/de/reseller.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein Unternehmen, das Domains unter der Akkreditierung eines größeren Registrars verkauft, ohne eine eigene zu besitzen.
-keywords: ['reseller', 'domain-reseller', 'white-label-registrar', 'ICANN-akkreditierung', 'registrar']
+keywords: ['domain-reseller', 'white-label-registrar', 'ICANN-akkreditierung', 'registrar']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/what-2012-02-25-en

--- a/content/glossary/de/reserve-price.md
+++ b/content/glossary/de/reserve-price.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Der niedrigste Preis, den ein Verkäufer akzeptiert, oft verborgen – darunter wird ein Gebot oder Auktionsgebot abgelehnt.
-keywords: ['Mindestpreis', 'Mindestgebot', 'Reservepreis', 'Bodenpreis', 'Domain-Auktionsreserve']
+keywords: ['Mindestgebot', 'Reservepreis', 'Bodenpreis', 'Domain-Auktionsreserve']
 level: 1
 sources:
   - https://www.investopedia.com/terms/r/reserveprice.asp

--- a/content/glossary/de/reserved-names.md
+++ b/content/glossary/de/reserved-names.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Domains, die eine Registry von der offenen Registrierung zurückhält, wie Premium-, Richtlinien- oder geschützte Labels.
-keywords: ['Reservierte Namen', 'Gesperrte Namen', 'Registry-reserviert', 'Premium reserviert', 'Kollisionsliste']
+keywords: ['Gesperrte Namen', 'Registry-reserviert', 'Premium reserviert', 'Kollisionsliste']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/tlds-2012-02-25-en

--- a/content/glossary/de/retail-pricing.md
+++ b/content/glossary/de/retail-pricing.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Der Preis, den ein Endnutzer für eine Domain zahlt, die er nutzen möchte – typischerweise weit über dem Großhandels-Investorbodenpreis.
-keywords: ['Einzelhandelspreis', 'Endnutzerpreis', 'Domain-Einzelhandel', 'Endnutzer-Preis', 'Vollpreis']
+keywords: ['Endnutzerpreis', 'Domain-Einzelhandel', 'Endnutzer-Preis', 'Vollpreis']
 also_known_as: ['Endnutzerpreis']
 level: 1
 sources:

--- a/content/glossary/de/revenue-sharing.md
+++ b/content/glossary/de/revenue-sharing.md
@@ -7,7 +7,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was ist Umsatzbeteiligung und wie kann sie auf die Domain-Monetarisierung angewendet werden?
-keywords: ["umsatzbeteiligung","passives Einkommen","Domain-Monetarisierung","Gewinnverteilung","Smart Contracts"]
+keywords: ["passives Einkommen", "Domain-Monetarisierung", "Gewinnverteilung", "Smart Contracts"]
 relatedArticles:
   - /de/blog/domain-parking-and-monetization/
   - /de/blog/why-tokenize-domains/

--- a/content/glossary/de/reverse-domain-hijacking.md
+++ b/content/glossary/de/reverse-domain-hijacking.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Der missbräuchliche Einsatz des UDRP in böser Absicht, um eine Domain von ihrem rechtmäßigen Eigentümer zu entreißen.
-keywords: ['reverse domain hijacking', 'RDNH', 'UDRP-missbrauch', 'domain-streit', 'bösgläubiger beschwerdeführer']
+keywords: ['RDNH', 'UDRP-missbrauch', 'domain-streit', 'bösgläubiger beschwerdeführer']
 also_known_as: ['RDNH']
 level: 1
 sources:

--- a/content/glossary/de/root-zone.md
+++ b/content/glossary/de/root-zone.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Die Spitze der DNS-Hierarchie, die jede TLD und die dafür autoritativen Server auflistet.
-keywords: ['Root-Zone', 'Root-Server', 'DNS-Hierarchie', 'TLD-Delegierung', 'IANA']
+keywords: ['Root-Server', 'DNS-Hierarchie', 'TLD-Delegierung', 'IANA']
 level: 1
 sources:
   - https://www.iana.org/domains/root

--- a/content/glossary/de/second-level-domain.md
+++ b/content/glossary/de/second-level-domain.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Das Label direkt links von der TLD — das „example" in example.com — der Teil, den man tatsächlich registriert.
-keywords: ['Second-Level-Domain', 'SLD', 'Root-Domain', 'Apex-Domain', 'registrierbarer Name']
+keywords: ['SLD', 'Root-Domain', 'Apex-Domain', 'registrierbarer Name']
 level: 1
 sources:
   - https://datatracker.ietf.org/doc/html/rfc1034

--- a/content/glossary/de/seed-phrase.md
+++ b/content/glossary/de/seed-phrase.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Eine Liste von 12 oder 24 Wörtern, die den Master-Schlüssel einer Wallet kodiert; wer sie besitzt, kontrolliert die Wallet, weshalb sie das Einzige ist, das unbedingt gesichert werden muss.
-keywords: ['Seed-Phrase', 'Wiederherstellungsphrase', 'Mnemonic-Phrase', 'Wallet-Backup', 'BIP39', '12 Wörter', '24 Wörter', 'Krypto-Wiederherstellung']
+keywords: ['Wiederherstellungsphrase', 'Mnemonic-Phrase', 'Wallet-Backup', 'BIP39', '12 Wörter', '24 Wörter', 'Krypto-Wiederherstellung']
 level: 1
 sources:
   - https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki

--- a/content/glossary/de/sell-through-rate.md
+++ b/content/glossary/de/sell-through-rate.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Der Anteil eines Domain-Portfolios, der in einem bestimmten Zeitraum verkauft wird – eine wichtige Liquiditätskennzahl für Investoren.
-keywords: ['Verkaufsquote', 'STR', 'Domain-Liquidität', 'Portfolio-Performance', 'Domain-Verkaufsgeschwindigkeit']
+keywords: ['STR', 'Domain-Liquidität', 'Portfolio-Performance', 'Domain-Verkaufsgeschwindigkeit']
 also_known_as: ['STR']
 level: 1
 sources:

--- a/content/glossary/de/seo.md
+++ b/content/glossary/de/seo.md
@@ -8,7 +8,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was ist SEO und wie beeinflusst die Domain-Tokenisierung die Suchmaschinenoptimierung?
-keywords: ["SEO","Suchmaschinenoptimierung","Domainwert","Suchrankings","digitales Marketing"]
+keywords: ["Suchmaschinenoptimierung", "Domainwert", "Suchrankings", "digitales Marketing"]
 relatedArticles:
   - /de/blog/marketplace-seo-for-domain-listings/
   - /de/blog/ai-vs-io-domain/

--- a/content/glossary/de/serp.md
+++ b/content/glossary/de/serp.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Die Ergebnisseite, die eine Suchmaschine für eine Anfrage zurückgibt und auf der Domains um Sichtbarkeit konkurrieren.
-keywords: ['serp', 'suchergebnisse', 'seo', 'suchmaschine', 'organisches ranking', 'suchsichtbarkeit']
+keywords: ['suchergebnisse', 'seo', 'suchmaschine', 'organisches ranking', 'suchsichtbarkeit']
 also_known_as: ['Search Engine Results Page']
 level: 1
 sources:

--- a/content/glossary/de/short-domain.md
+++ b/content/glossary/de/short-domain.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Sehr kurze Domains – drei bis vier Buchstaben oder rein numerisch – für ihre Kürze geschätzt, besonders in bestimmten Märkten.
-keywords: ['kurze Domain', 'numerische Domain', 'LLLL-Domain', 'NNNN-Domain', 'Drei-Buchstaben-Domain', 'Vier-Buchstaben-Domain']
+keywords: ['numerische Domain', 'LLLL-Domain', 'NNNN-Domain', 'Drei-Buchstaben-Domain', 'Vier-Buchstaben-Domain']
 level: 1
 sources:
   - https://www.namebio.com/

--- a/content/glossary/de/smart-contract.md
+++ b/content/glossary/de/smart-contract.md
@@ -8,7 +8,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was sind Smart Contracts und wie ermöglichen sie die Domain-Tokenisierung?
-keywords: ["Smart Contract","Blockchain","automatisierte Ausführung","programmierbare Logik","dezentralisiert"]
+keywords: ["Blockchain", "automatisierte Ausführung", "programmierbare Logik", "dezentralisiert"]
 relatedArticles:
   - /de/blog/domain-escrow-explained/
   - /de/blog/the-badgerdao-frontend-attack/

--- a/content/glossary/de/stablecoin.md
+++ b/content/glossary/de/stablecoin.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Eine Kryptowährung, die darauf ausgelegt ist, einen stabilen Wert gegenüber einer Referenz wie dem US-Dollar zu halten, und die für Zahlungen und Abrechnungen ohne Krypto-Preisvolatilität verwendet wird.
-keywords: ['Stablecoin', 'USDC', 'USDT', 'DAI', 'Fiat-gekoppelt', 'Krypto-Zahlung', 'On-Chain-Dollar']
+keywords: ['USDC', 'USDT', 'DAI', 'Fiat-gekoppelt', 'Krypto-Zahlung', 'On-Chain-Dollar']
 level: 1
 sources:
   - https://ethereum.org/en/stablecoins/

--- a/content/glossary/de/subdomain.md
+++ b/content/glossary/de/subdomain.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein Präfix, das einer Domain hinzugefügt wird, um eine separate Adresse zu erstellen, wie blog.example.com oder app.example.com.
-keywords: ['Subdomain', 'Host', 'blog.example.com', 'DNS', 'Second-Level-Domain']
+keywords: ['Host', 'blog.example.com', 'DNS', 'Second-Level-Domain']
 level: 1
 sources:
   - https://datatracker.ietf.org/doc/html/rfc1034

--- a/content/glossary/de/tld.md
+++ b/content/glossary/de/tld.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Eine Top-Level-Domain (TLD) ist das rechteste Label eines Domainnamens, z. B. .com, .org oder .de, delegiert über die IANA-Root-Zone unter ICANN-Aufsicht.
-keywords: ['TLD', 'Top-Level-Domain', 'gTLD', 'ccTLD', 'neue gTLD', 'DNS', 'IANA', 'ICANN', 'Root-Zone', 'Domain-Registry']
+keywords: ['Top-Level-Domain', 'gTLD', 'ccTLD', 'neue gTLD', 'DNS', 'IANA', 'ICANN', 'Root-Zone', 'Domain-Registry']
 also_known_as: ['Top-Level-Domain']
 level: 2
 sources:

--- a/content/glossary/de/tmch.md
+++ b/content/glossary/de/tmch.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: ICANNs zentrale Markendatenbank, die Sunrise-Vorregistrierungen und Markenbenachrichtigungen in neuen gTLDs ermöglicht.
-keywords: ['TMCH', 'Trademark Clearinghouse', 'Sunrise-Periode', 'Markenschutz', 'neues gTLD']
+keywords: ['TMCH', 'Sunrise-Periode', 'Markenschutz', 'neues gTLD']
 also_known_as: ['TMCH']
 level: 1
 sources:

--- a/content/glossary/de/tokenize.md
+++ b/content/glossary/de/tokenize.md
@@ -8,7 +8,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was bedeutet es, eine Domain oder ein Asset zu tokenisieren?
-keywords: ["tokenisieren","tokenisierung","NFT","digitales Asset","On-Chain-Asset"]
+keywords: ["tokenisieren", "NFT", "digitales Asset", "On-Chain-Asset"]
 relatedArticles:
   - /de/blog/what-are-tokenized-domains/
   - /de/blog/why-tokenize-domains/

--- a/content/glossary/de/tokenized-domain.md
+++ b/content/glossary/de/tokenized-domain.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Eine echte DNS-Domain, deren Eigentümerschaft als Blockchain-Token repräsentiert wird, den man in einer Wallet hält.
-keywords: ['tokenisierte domain', 'domain NFT', 'on-chain domain', 'domain-eigentümerschaft', 'web3 domain']
+keywords: ['domain NFT', 'on-chain domain', 'domain-eigentümerschaft', 'web3 domain']
 level: 1
 sources:
   - https://ethereum.org/en/nft/

--- a/content/glossary/de/trademark.md
+++ b/content/glossary/de/trademark.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein rechtlich geschütztes Kennzeichen zur Identifikation von Waren oder Dienstleistungen einer Marke, zentral für viele Domain-Streitigkeiten.
-keywords: ['marke', 'markenschutz', 'geistiges eigentum', 'domain-streit', 'UDRP', 'WIPO']
+keywords: ['markenschutz', 'geistiges eigentum', 'domain-streit', 'UDRP', 'WIPO']
 level: 1
 sources:
   - https://www.wipo.int/trademarks/en/

--- a/content/glossary/de/transfer-lock.md
+++ b/content/glossary/de/transfer-lock.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein Status, der den Transfer einer Domain zu einem anderen Registrar blockiert, bis er explizit aufgehoben wird.
-keywords: ['transfer-sperre', 'registrar-sperre', 'domain-sicherheit', 'EPP-status', 'domain-transfer']
+keywords: ['registrar-sperre', 'domain-sicherheit', 'EPP-status', 'domain-transfer']
 also_known_as: ['Registrar-Sperre']
 level: 1
 sources:

--- a/content/glossary/de/ttl.md
+++ b/content/glossary/de/ttl.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Wie lange, in Sekunden, ein DNS-Eintrag von Resolvern zwischengespeichert werden darf, bevor er erneut abgefragt werden muss.
-keywords: ['TTL', 'Time to Live', 'DNS-Cache', 'DNS-Propagierung', 'Eintrag-Caching']
+keywords: ['Time to Live', 'DNS-Cache', 'DNS-Propagierung', 'Eintrag-Caching']
 level: 1
 sources:
   - https://datatracker.ietf.org/doc/html/rfc1035

--- a/content/glossary/de/type-in-traffic.md
+++ b/content/glossary/de/type-in-traffic.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Besucher, die eine Website durch direktes Eintippen einer vermuteten Domain erreichen – die Grundlage der Domain-Parking-Einnahmen.
-keywords: ['type-in-traffic', 'direktnavigation', 'domain parking', 'exact-match-domain', 'domain-wert']
+keywords: ['direktnavigation', 'domain parking', 'exact-match-domain', 'domain-wert']
 level: 1
 sources:
   - https://www.namebio.com/

--- a/content/glossary/de/typosquatting.md
+++ b/content/glossary/de/typosquatting.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Das Registrieren von Schreibfehlervarianten populärer Domains, um falsch getippten Traffic abzufangen – oft für Anzeigen oder Phishing.
-keywords: ['typosquatting', 'tipp-domain', 'phishing', 'markenmissbrauch', 'cybersquatting']
+keywords: ['tipp-domain', 'phishing', 'markenmissbrauch', 'cybersquatting']
 level: 1
 sources:
   - https://www.cloudflare.com/learning/ssl/what-is-typosquatting/

--- a/content/glossary/de/udrp.md
+++ b/content/glossary/de/udrp.md
@@ -8,7 +8,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was ist die UDRP und wie beeinflusst sie das tokenisierte Domain-Eigentum?
-keywords: ["UDRP","Domain-Streitigkeiten","Markenschutz","Cybersquatting","Rechtsrahmen"]
+keywords: ["Domain-Streitigkeiten", "Markenschutz", "Cybersquatting", "Rechtsrahmen"]
 relatedArticles:
   - /de/blog/what-is-udrp/
   - /de/blog/cybersquatting-vs-domaining-udrp-acpa/

--- a/content/glossary/de/urs.md
+++ b/content/glossary/de/urs.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein schnelles, kostengünstiges Mittel, das eine klar verletzende Domain suspendiert und das UDRP ergänzt.
-keywords: ['URS', 'Uniform Rapid Suspension', 'domain-suspendierung', 'markenverletzung', 'neues gTLD']
+keywords: ['Uniform Rapid Suspension', 'domain-suspendierung', 'markenverletzung', 'neues gTLD']
 also_known_as: ['Uniform Rapid Suspension']
 level: 1
 sources:

--- a/content/glossary/de/wallet.md
+++ b/content/glossary/de/wallet.md
@@ -8,7 +8,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Was ist eine Krypto-Wallet und wie speichert sie tokenisierte Domains?
-keywords: ["Wallet","Krypto-Wallet","privater Schlüssel","Speicherung digitaler Assets","Domain-Speicherung"]
+keywords: ["Krypto-Wallet", "privater Schlüssel", "Speicherung digitaler Assets", "Domain-Speicherung"]
 relatedArticles:
   - /de/blog/recovering-a-tokenized-domain-after-wallet-loss/
   - /de/blog/do-multisig-wallets-actually-improve-security/

--- a/content/glossary/de/web3.md
+++ b/content/glossary/de/web3.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Eine Vision des Internets auf öffentlichen Blockchains, bei der Nutzer ihre Daten, Assets und Identität durch eigene Schlüssel kontrollieren – nicht über Plattform-Konten.
-keywords: ['Web3', 'dezentrales Web', 'Blockchain-Internet', 'Nutzereigentum', 'Peer-to-Peer', 'Dezentralisierung', 'Kryptowährung', 'Smart Contracts', 'DeFi', 'NFT']
+keywords: ['dezentrales Web', 'Blockchain-Internet', 'Nutzereigentum', 'Peer-to-Peer', 'Dezentralisierung', 'Kryptowährung', 'Smart Contracts', 'DeFi', 'NFT']
 level: 2
 sources:
   - https://ethereum.org/en/web3/

--- a/content/glossary/de/whois-privacy.md
+++ b/content/glossary/de/whois-privacy.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein Dienst, der die persönlichen Kontaktdaten eines Registranten in öffentlichen WHOIS- oder RDAP-Einträgen maskiert.
-keywords: ['WHOIS-datenschutz', 'datenschutz', 'RDAP', 'registrant-datenschutz', 'kontaktmaskierung']
+keywords: ['datenschutz', 'RDAP', 'registrant-datenschutz', 'kontaktmaskierung']
 also_known_as: ['Datenschutz']
 level: 1
 sources:

--- a/content/glossary/de/whois.md
+++ b/content/glossary/de/whois.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: WHOIS und sein Nachfolger RDAP sind die öffentlichen Suchdienste für die Registrierungsdetails einer Domain, wie den Registrar und das Ablaufdatum.
-keywords: ['WHOIS', 'RDAP', 'Domain-Registrierungs-Lookup', 'Registrantinformationen', 'Domain-Eigentümer-Lookup']
+keywords: ['RDAP', 'Domain-Registrierungs-Lookup', 'Registrantinformationen', 'Domain-Eigentümer-Lookup']
 level: 1
 sources:
   - https://www.icann.org/rdap

--- a/content/glossary/de/wholesale-pricing.md
+++ b/content/glossary/de/wholesale-pricing.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Der Investor-zu-Investor-Bodenpreis einer Domain – was ein Domainer akzeptiert, um schnell zu liquidieren, unter dem Einzelhandelspreis.
-keywords: ['Großhandelspreis', 'Investorenpreis', 'Domain-Großhandel', 'Liquidationspreis', 'Domainer-Preisgestaltung']
+keywords: ['Investorenpreis', 'Domain-Großhandel', 'Liquidationspreis', 'Domainer-Preisgestaltung']
 also_known_as: ['Investorenpreis']
 level: 1
 sources:

--- a/content/glossary/de/wipo.md
+++ b/content/glossary/de/wipo.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Die UN-Behörde, deren Schiedsgerichtszentrum viele UDRP-Domain-Streitigkeiten entscheidet.
-keywords: ['WIPO', 'World Intellectual Property Organization', 'UDRP', 'domain-streit', 'schiedsverfahren']
+keywords: ['World Intellectual Property Organization', 'UDRP', 'domain-streit', 'schiedsverfahren']
 also_known_as: ['World Intellectual Property Organization']
 level: 1
 sources:

--- a/content/glossary/de/x402.md
+++ b/content/glossary/de/x402.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Ein offenes Protokoll, das den HTTP-Status 402 Payment Required nutzt, um Servern und KI-Agenten zu ermöglichen, On-Chain-Zahlungen inline mit Anfragen anzufordern und zu empfangen.
-keywords: ['x402', 'HTTP 402', 'Payment Required', 'On-Chain-Zahlungen', 'Agenten-Zahlungen', 'Krypto-Zahlungen', 'Mikrozahlung']
+keywords: ['HTTP 402', 'Payment Required', 'On-Chain-Zahlungen', 'Agenten-Zahlungen', 'Krypto-Zahlungen', 'Mikrozahlung']
 level: 1
 sources:
   - https://www.x402.org/

--- a/content/glossary/de/zone-file.md
+++ b/content/glossary/de/zone-file.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: Die Textdatei, die alle DNS-Einträge einer Domain enthält, einschließlich Glue Records für ihre Nameserver.
-keywords: ['Zone-File', 'Glue Record', 'DNS-Zone', 'autoritative Einträge', 'Nameserver']
+keywords: ['Glue Record', 'DNS-Zone', 'autoritative Einträge', 'Nameserver']
 level: 1
 sources:
   - https://datatracker.ietf.org/doc/html/rfc1035

--- a/content/glossary/en/301-redirect.md
+++ b/content/glossary/en/301-redirect.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: An HTTP status telling browsers and search engines that a page has permanently moved to a new URL.
-keywords: ['301 redirect', 'permanent redirect', 'http redirect', 'seo', 'domain forwarding', 'link equity']
+keywords: ['permanent redirect', 'http redirect', 'seo', 'domain forwarding', 'link equity']
 also_known_as: ['Permanent Redirect']
 level: 1
 sources:

--- a/content/glossary/en/acpa.md
+++ b/content/glossary/en/acpa.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A US law letting trademark owners sue cybersquatters in federal court, an alternative to the UDRP.
-keywords: ['ACPA', 'anticybersquatting', 'US trademark law', 'domain dispute', 'federal court']
+keywords: ['anticybersquatting', 'US trademark law', 'domain dispute', 'federal court']
 also_known_as: ['Anticybersquatting Consumer Protection Act']
 level: 1
 sources:

--- a/content/glossary/en/aftermarket.md
+++ b/content/glossary/en/aftermarket.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The resale market for already-registered domains, where names are bought and sold between owners.
-keywords: ['aftermarket', 'secondary market', 'domain resale', 'domain investing', 'domain sales']
+keywords: ['secondary market', 'domain resale', 'domain investing', 'domain sales']
 also_known_as: ['Secondary Market']
 level: 1
 sources:

--- a/content/glossary/en/ai-agent.md
+++ b/content/glossary/en/ai-agent.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Software powered by an AI model that acts on a user's behalf — making purchases, calling APIs, and increasingly transacting with other agents.
-keywords: ['AI agent', 'autonomous agent', 'agent identity', 'agent commerce', 'on-chain agent', 'agentic AI']
+keywords: ['autonomous agent', 'agent identity', 'agent commerce', 'on-chain agent', 'agentic AI']
 level: 1
 sources:
   - https://modelcontextprotocol.io/

--- a/content/glossary/en/aml.md
+++ b/content/glossary/en/aml.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Anti-Money-Laundering — the ongoing transaction monitoring and reporting regulated services use to detect illicit funds.
-keywords: ['AML', 'Anti-Money-Laundering', 'transaction monitoring', 'sanctions screening', 'compliance']
+keywords: ['Anti-Money-Laundering', 'transaction monitoring', 'sanctions screening', 'compliance']
 also_known_as: ['Anti-Money-Laundering']
 level: 1
 sources:

--- a/content/glossary/en/anchor-text.md
+++ b/content/glossary/en/anchor-text.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The visible, clickable words of a hyperlink, a signal search engines use to understand the target.
-keywords: ['anchor text', 'link text', 'backlinks', 'seo', 'hyperlink', 'ranking signals']
+keywords: ['link text', 'backlinks', 'seo', 'hyperlink', 'ranking signals']
 level: 1
 sources:
   - https://developers.google.com/search/docs/crawling-indexing/links-crawlable

--- a/content/glossary/en/atomic-transfer.md
+++ b/content/glossary/en/atomic-transfer.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A transaction that completes fully or not at all, never in a partial state, so an asset and its payment swap in one indivisible on-chain step.
-keywords: ['atomic transfer', 'blockchain transaction', 'all-or-nothing', 'secure exchange', 'smart contract']
+keywords: ['blockchain transaction', 'all-or-nothing', 'secure exchange', 'smart contract']
 level: 1
 sources:
   - https://ethereum.org/en/developers/docs/transactions/

--- a/content/glossary/en/auction.md
+++ b/content/glossary/en/auction.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A competitive sale format where buyers bid to set the price, run as English (ascending), Dutch (descending), or dynamic timed auctions.
-keywords: ['auction', 'Dutch auction', 'English auction', 'dynamic auction', 'price discovery', 'domain sales']
+keywords: ['Dutch auction', 'English auction', 'dynamic auction', 'price discovery', 'domain sales']
 level: 1
 sources:
   - https://www.investopedia.com/terms/a/auction.asp

--- a/content/glossary/en/auth-code.md
+++ b/content/glossary/en/auth-code.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A short per-domain secret a registrar issues to authorize moving a domain to another registrar, also called an EPP code or transfer code.
-keywords: ['auth code', 'EPP code', 'transfer code', 'domain transfer', 'authorization code', 'AuthInfo code']
+keywords: ['EPP code', 'transfer code', 'domain transfer', 'authorization code', 'AuthInfo code']
 level: 1
 sources:
   - https://datatracker.ietf.org/doc/html/rfc5731

--- a/content/glossary/en/automated-delegation.md
+++ b/content/glossary/en/automated-delegation.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Handing control of a domain or its records to a smart contract that enforces rules automatically, with no human approving each change.
-keywords: ['automated delegation', 'smart contracts', 'domain management', 'programmable control', 'automation']
+keywords: ['smart contracts', 'domain management', 'programmable control', 'automation']
 level: 1
 sources:
   - https://ethereum.org/en/developers/docs/smart-contracts/

--- a/content/glossary/en/backlink.md
+++ b/content/glossary/en/backlink.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: An inbound hyperlink from another website to yours; the primary driver of search ranking and domain authority.
-keywords: ['backlink', 'inbound link', 'link building', 'link equity', 'seo']
+keywords: ['inbound link', 'link building', 'link equity', 'seo']
 also_known_as: ['Inbound Link']
 level: 1
 sources:

--- a/content/glossary/en/backorder.md
+++ b/content/glossary/en/backorder.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A service that tries to register a domain the instant it drops, so you can claim an expiring name.
-keywords: ['backorder', 'drop-catching', 'expired domain', 'pending delete', 'domain acquisition']
+keywords: ['drop-catching', 'expired domain', 'pending delete', 'domain acquisition']
 level: 1
 sources:
   - https://www.namebio.com/

--- a/content/glossary/en/bad-faith.md
+++ b/content/glossary/en/bad-faith.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Registering or using a domain to exploit a trademark, a required element to win a UDRP case.
-keywords: ['bad faith', 'UDRP', 'domain dispute', 'cybersquatting', 'trademark abuse']
+keywords: ['UDRP', 'domain dispute', 'cybersquatting', 'trademark abuse']
 level: 1
 sources:
   - https://www.wipo.int/amc/en/domains/

--- a/content/glossary/en/bgp-hijack.md
+++ b/content/glossary/en/bgp-hijack.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Rerouting internet traffic by falsely announcing IP routes, a network-layer attack that sits below DNS.
-keywords: ['BGP hijack', 'route hijacking', 'IP prefix', 'network security', 'internet routing']
+keywords: ['route hijacking', 'IP prefix', 'network security', 'internet routing']
 level: 1
 sources:
   - https://www.cloudflare.com/learning/security/glossary/bgp-hijacking/

--- a/content/glossary/en/blockchain.md
+++ b/content/glossary/en/blockchain.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A shared, append-only ledger maintained across many computers, the foundation of tokenized ownership.
-keywords: ['blockchain', 'distributed ledger', 'decentralized', 'immutable', 'consensus']
+keywords: ['distributed ledger', 'decentralized', 'immutable', 'consensus']
 level: 1
 sources:
   - https://ethereum.org/en/developers/docs/intro-to-ethereum/

--- a/content/glossary/en/brandable-domain.md
+++ b/content/glossary/en/brandable-domain.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A short, catchy, often invented name that works as a memorable brand, like a made-up word.
-keywords: ['brandable domain', 'brand domain', 'invented domain', 'made-up word domain', 'memorable domain']
+keywords: ['brand domain', 'invented domain', 'made-up word domain', 'memorable domain']
 level: 1
 sources:
   - https://moz.com/learn/seo/domain

--- a/content/glossary/en/buy-it-now.md
+++ b/content/glossary/en/buy-it-now.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A fixed instant-purchase price on a domain listing — meet it and the sale completes immediately, no negotiation.
-keywords: ['buy it now', 'BIN', 'instant purchase', 'fixed price', 'domain listing']
+keywords: ['BIN', 'instant purchase', 'fixed price', 'domain listing']
 also_known_as: ['BIN']
 level: 1
 sources:

--- a/content/glossary/en/cctld.md
+++ b/content/glossary/en/cctld.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A two-letter top-level domain assigned to a country or territory, such as .uk, .de, or .jp.
-keywords: ['ccTLD', 'country-code TLD', 'country domain', '.uk', '.de', 'ISO 3166']
+keywords: ['country-code TLD', 'country domain', '.uk', '.de', 'ISO 3166']
 level: 1
 sources:
   - https://www.iana.org/domains/root/db

--- a/content/glossary/en/censorship-free.md
+++ b/content/glossary/en/censorship-free.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A property where no single authority can unilaterally seize, block, or alter ownership, because control rests with the holder's keys on a public ledger.
-keywords: ['censorship-free', 'censorship resistance', 'decentralized', 'freedom', 'unstoppable']
+keywords: ['censorship resistance', 'decentralized', 'freedom', 'unstoppable']
 level: 1
 sources:
   - https://ethereum.org/en/web3/

--- a/content/glossary/en/collateral.md
+++ b/content/glossary/en/collateral.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: An asset pledged to secure a loan that the lender can claim on default; a tokenized domain can serve as collateral in NFT-aware lending.
-keywords: ['collateral', 'security', 'lending', 'borrowing', 'domain collateral', 'DeFi']
+keywords: ['security', 'lending', 'borrowing', 'domain collateral', 'DeFi']
 level: 1
 sources:
   - https://www.investopedia.com/terms/c/collateral.asp

--- a/content/glossary/en/comparable-sales.md
+++ b/content/glossary/en/comparable-sales.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Past sales of similar domains used as benchmarks to estimate what a name is worth.
-keywords: ['comparable sales', 'comps', 'domain sales data', 'domain benchmarks', 'domain pricing history']
+keywords: ['comps', 'domain sales data', 'domain benchmarks', 'domain pricing history']
 also_known_as: ['Comps']
 level: 1
 sources:

--- a/content/glossary/en/composability.md
+++ b/content/glossary/en/composability.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The ability to combine independent on-chain components like building blocks, so a tokenized domain can plug into lending, trading, and other protocols.
-keywords: ['composability', 'interoperability', 'building blocks', 'DeFi', 'Web3 integration']
+keywords: ['interoperability', 'building blocks', 'DeFi', 'Web3 integration']
 level: 1
 sources:
   - https://ethereum.org/en/developers/docs/smart-contracts/

--- a/content/glossary/en/consensus-mechanism.md
+++ b/content/glossary/en/consensus-mechanism.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The rules a blockchain's participants follow to agree on a single, shared transaction history without a central authority.
-keywords: ['consensus mechanism', 'blockchain consensus', 'sybil resistance', 'proof of work', 'proof of stake', 'finality']
+keywords: ['blockchain consensus', 'sybil resistance', 'proof of work', 'proof of stake', 'finality']
 level: 1
 sources:
   - https://bitcoin.org/bitcoin.pdf

--- a/content/glossary/en/cross-registrar-transfer.md
+++ b/content/glossary/en/cross-registrar-transfer.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Moving a domain's registration from one ICANN registrar to another using an auth code, while keeping the same owner and the same name.
-keywords: ['cross-registrar transfer', 'registrar transfer', 'domain migration', 'transfer process', 'tokenization']
+keywords: ['registrar transfer', 'domain migration', 'transfer process', 'tokenization']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/name-holder-faqs-2017-10-10-en

--- a/content/glossary/en/cryptographic-security.md
+++ b/content/glossary/en/cryptographic-security.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Protection based on public-key cryptography, where only the holder of a private key can authorize actions, rather than a password a server could leak.
-keywords: ['cryptographic security', 'encryption', 'private keys', 'digital signatures', 'blockchain security']
+keywords: ['encryption', 'private keys', 'digital signatures', 'blockchain security']
 level: 1
 sources:
   - https://ethereum.org/en/developers/docs/accounts/

--- a/content/glossary/en/custodial-ownership.md
+++ b/content/glossary/en/custodial-ownership.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: An arrangement where a third party holds the private keys to your assets for you, so you depend on their security and their permission to transact.
-keywords: ['custodial ownership', 'custody', 'third-party control', 'registrar control', 'centralized storage']
+keywords: ['custody', 'third-party control', 'registrar control', 'centralized storage']
 level: 1
 sources:
   - https://ethereum.org/en/wallets/

--- a/content/glossary/en/cybersquatting.md
+++ b/content/glossary/en/cybersquatting.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Registering a domain matching someone else's trademark in bad faith, hoping to profit from it.
-keywords: ['cybersquatting', 'bad faith', 'domain dispute', 'trademark infringement', 'UDRP']
+keywords: ['bad faith', 'domain dispute', 'trademark infringement', 'UDRP']
 level: 1
 sources:
   - https://www.wipo.int/amc/en/domains/

--- a/content/glossary/en/dao.md
+++ b/content/glossary/en/dao.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A Decentralized Autonomous Organization run by smart-contract rules and member voting rather than a central executive, often managing a shared treasury.
-keywords: ['DAO', 'decentralized autonomous organization', 'governance', 'collective ownership', 'smart contracts']
+keywords: ['decentralized autonomous organization', 'governance', 'collective ownership', 'smart contracts']
 level: 1
 sources:
   - https://ethereum.org/en/dao/

--- a/content/glossary/en/data-availability.md
+++ b/content/glossary/en/data-availability.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The confidence that the data needed to verify a block was actually published and is available to network participants.
-keywords: ['data availability', 'da', 'data availability sampling', 'das', 'celestia', 'eigenda', 'rollup data']
+keywords: ['da', 'data availability sampling', 'das', 'celestia', 'eigenda', 'rollup data']
 also_known_as: ['DA']
 level: 1
 sources:

--- a/content/glossary/en/defi.md
+++ b/content/glossary/en/defi.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Decentralized Finance offers lending, borrowing, and trading through smart contracts on public blockchains, without banks or brokers as intermediaries.
-keywords: ['DeFi', 'decentralized finance', 'lending', 'borrowing', 'collateral', 'DEX', 'money markets', 'on-chain finance']
+keywords: ['decentralized finance', 'lending', 'borrowing', 'collateral', 'DEX', 'money markets', 'on-chain finance']
 level: 1
 sources:
   - https://ethereum.org/en/defi/

--- a/content/glossary/en/did.md
+++ b/content/glossary/en/did.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A Decentralized Identifier is a globally unique ID controlled by its owner's keys rather than a central registry, used to prove identity across services.
-keywords: ['DID', 'decentralized identity', 'self-sovereign identity', 'blockchain identity', 'Web3 identity']
+keywords: ['decentralized identity', 'self-sovereign identity', 'blockchain identity', 'Web3 identity']
 level: 1
 sources:
   - https://www.w3.org/TR/did-core/

--- a/content/glossary/en/digital-signature.md
+++ b/content/glossary/en/digital-signature.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Cryptographic proof, generated with a private key, that a transaction was authorized by the account owner and hasn't been altered.
-keywords: ['digital signature', 'ECDSA', 'EdDSA', 'BLS signature', 'transaction signing', 'signature verification']
+keywords: ['ECDSA', 'EdDSA', 'BLS signature', 'transaction signing', 'signature verification']
 level: 1
 sources:
   - https://ethereum.org/en/developers/docs/accounts/

--- a/content/glossary/en/dns-hijacking.md
+++ b/content/glossary/en/dns-hijacking.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Redirecting a domain's traffic by tampering with DNS resolution rather than its registration.
-keywords: ['DNS hijacking', 'cache poisoning', 'DNS spoofing', 'DNSSEC', 'traffic redirection']
+keywords: ['cache poisoning', 'DNS spoofing', 'DNSSEC', 'traffic redirection']
 level: 1
 sources:
   - https://www.cloudflare.com/learning/dns/dns-cache-poisoning/

--- a/content/glossary/en/dns-propagation.md
+++ b/content/glossary/en/dns-propagation.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The delay before a DNS change is seen everywhere, as cached old records expire across resolvers.
-keywords: ['DNS propagation', 'DNS update delay', 'TTL', 'DNS cache', 'nameserver change']
+keywords: ['DNS update delay', 'TTL', 'DNS cache', 'nameserver change']
 level: 1
 sources:
   - https://www.cloudflare.com/learning/dns/glossary/time-to-live-ttl/

--- a/content/glossary/en/dns-resolver.md
+++ b/content/glossary/en/dns-resolver.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The server that takes a domain lookup and walks the DNS hierarchy to return the matching address.
-keywords: ['DNS resolver', 'recursive resolver', 'resolver', '8.8.8.8', '1.1.1.1', 'DNS lookup']
+keywords: ['recursive resolver', 'resolver', '8.8.8.8', '1.1.1.1', 'DNS lookup']
 level: 1
 sources:
   - https://datatracker.ietf.org/doc/html/rfc1034

--- a/content/glossary/en/dnssec.md
+++ b/content/glossary/en/dnssec.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Cryptographic signatures on DNS records that let resolvers verify a response is authentic and was not forged or tampered with in transit.
-keywords: ['DNSSEC', 'DNS security', 'domain security', 'DS record', 'chain of trust', 'cryptographic DNS']
+keywords: ['DNS security', 'domain security', 'DS record', 'chain of trust', 'cryptographic DNS']
 level: 1
 sources:
   - https://datatracker.ietf.org/doc/html/rfc4033

--- a/content/glossary/en/domain-appraisal.md
+++ b/content/glossary/en/domain-appraisal.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Estimating a domain's market value from comparable sales, keyword demand, length, and extension.
-keywords: ['domain appraisal', 'domain valuation', 'domain worth', 'domain pricing', 'comparable sales']
+keywords: ['domain valuation', 'domain worth', 'domain pricing', 'comparable sales']
 also_known_as: ['Domain Valuation']
 level: 1
 sources:

--- a/content/glossary/en/domain-authority.md
+++ b/content/glossary/en/domain-authority.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A reputation signal estimating how well a domain ranks, driven largely by quality inbound links.
-keywords: ['domain authority', 'backlinks', 'link equity', 'seo', 'ranking signal', 'inbound links']
+keywords: ['backlinks', 'link equity', 'seo', 'ranking signal', 'inbound links']
 level: 1
 sources:
   - https://developers.google.com/search/docs/fundamentals/seo-starter-guide

--- a/content/glossary/en/domain-broker.md
+++ b/content/glossary/en/domain-broker.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: An intermediary who negotiates a domain sale between buyer and seller, usually for a commission.
-keywords: ['domain broker', 'domain brokerage', 'domain negotiation', 'domain intermediary', 'domain commission']
+keywords: ['domain brokerage', 'domain negotiation', 'domain intermediary', 'domain commission']
 level: 1
 sources:
   - https://www.investopedia.com/terms/b/broker.asp

--- a/content/glossary/en/domain-bundle.md
+++ b/content/glossary/en/domain-bundle.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A group of related domain names sold or managed together as one package, often covering multiple TLDs or spelling variants of a single brand.
-keywords: ['domain bundle', 'portfolio', 'bulk trading', 'domain collection', 'asset management']
+keywords: ['portfolio', 'bulk trading', 'domain collection', 'asset management']
 level: 1
 sources:
   - https://www.namebio.com/

--- a/content/glossary/en/domain-expiration.md
+++ b/content/glossary/en/domain-expiration.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The date a domain's registration ends; if not renewed, it begins a lapse process toward deletion.
-keywords: ['domain expiration', 'expired domain', 'renewal', 'grace period', 'redemption']
+keywords: ['expired domain', 'renewal', 'grace period', 'redemption']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/name-holder-faqs-2017-10-10-en

--- a/content/glossary/en/domain-financing.md
+++ b/content/glossary/en/domain-financing.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Paying for a domain over time in installments instead of a single upfront sum.
-keywords: ['domain financing', 'installment', 'payment plan', 'domain acquisition', 'domain investing']
+keywords: ['installment', 'payment plan', 'domain acquisition', 'domain investing']
 level: 1
 sources:
   - https://www.namebio.com/

--- a/content/glossary/en/domain-forwarding.md
+++ b/content/glossary/en/domain-forwarding.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Sending visitors from one domain automatically to another address, often via a 301 redirect.
-keywords: ['domain forwarding', '301 redirect', 'URL redirect', 'DNS', 'domain management']
+keywords: ['301 redirect', 'URL redirect', 'DNS', 'domain management']
 level: 1
 sources:
   - https://developers.google.com/search/docs/crawling-indexing/301-redirects

--- a/content/glossary/en/domain-hack.md
+++ b/content/glossary/en/domain-hack.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A name that spans the dot to spell a word using the TLD, like del.icio.us or examp.le.
-keywords: ['domain hack', 'creative domain', 'TLD wordplay', 'brandable domain', 'ccTLD']
+keywords: ['creative domain', 'TLD wordplay', 'brandable domain', 'ccTLD']
 level: 1
 sources:
   - https://www.namebio.com/

--- a/content/glossary/en/domain-hijacking.md
+++ b/content/glossary/en/domain-hijacking.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The theft of a domain by gaining unauthorized control of its registrar account or registration.
-keywords: ['domain hijacking', 'account compromise', 'domain theft', 'registrar security', 'unauthorized transfer']
+keywords: ['account compromise', 'domain theft', 'registrar security', 'unauthorized transfer']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/name-holder-faqs-2017-10-10-en

--- a/content/glossary/en/domain-liquidity.md
+++ b/content/glossary/en/domain-liquidity.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: How quickly a domain can be sold near its estimated value — high for great names, low for niche ones.
-keywords: ['domain liquidity', 'liquidity', 'domain marketability', 'domain sell speed', 'domain market depth']
+keywords: ['domain liquidity', 'domain marketability', 'domain sell speed', 'domain market depth']
 level: 1
 sources:
   - https://www.investopedia.com/terms/l/liquidity.asp

--- a/content/glossary/en/domain-ownership.md
+++ b/content/glossary/en/domain-ownership.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The rights to control, use, and transfer a domain; tokenization records those rights on-chain in a wallet instead of only in a registrar account.
-keywords: ['domain ownership', 'NFT domain', 'registrar', 'custodial', 'wallet ownership']
+keywords: ['NFT domain', 'registrar', 'custodial', 'wallet ownership']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/name-holder-faqs-2017-10-10-en

--- a/content/glossary/en/domain-parking.md
+++ b/content/glossary/en/domain-parking.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Placing ads or a for-sale notice on an undeveloped domain to earn revenue or signal availability.
-keywords: ['domain parking', 'parked domain', 'monetization', 'domain investing', 'passive income']
+keywords: ['parked domain', 'monetization', 'domain investing', 'passive income']
 also_known_as: ['Parked Domain']
 level: 1
 sources:

--- a/content/glossary/en/domain-portfolio.md
+++ b/content/glossary/en/domain-portfolio.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A collection of domains held by one owner, managed as an investment with renewals, sales, and valuation.
-keywords: ['domain portfolio', 'domain investing', 'domain management', 'domain valuation', 'domain assets']
+keywords: ['domain investing', 'domain management', 'domain valuation', 'domain assets']
 level: 1
 sources:
   - https://www.investopedia.com/terms/p/portfolio.asp

--- a/content/glossary/en/domain-renewal.md
+++ b/content/glossary/en/domain-renewal.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Paying to extend a domain's registration before it expires, often automatically each term.
-keywords: ['domain renewal', 'auto-renew', 'registration term', 'expiration', 'renewal fee']
+keywords: ['auto-renew', 'registration term', 'expiration', 'renewal fee']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/name-holder-faqs-2017-10-10-en

--- a/content/glossary/en/domain-tasting.md
+++ b/content/glossary/en/domain-tasting.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A largely defunct tactic of registering domains then cancelling within the free add-grace period.
-keywords: ['domain tasting', 'AGP', 'add grace period', 'domain kiting', 'ICANN policy']
+keywords: ['AGP', 'add grace period', 'domain kiting', 'ICANN policy']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/agp-policy-2008-06-25-en

--- a/content/glossary/en/domain-theft.md
+++ b/content/glossary/en/domain-theft.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The unauthorized transfer of a domain out of its rightful owner's control, often via account compromise.
-keywords: ['domain theft', 'unauthorized transfer', 'account compromise', 'domain security', 'recovery']
+keywords: ['unauthorized transfer', 'account compromise', 'domain security', 'recovery']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/name-holder-faqs-2017-10-10-en

--- a/content/glossary/en/domain-trading.md
+++ b/content/glossary/en/domain-trading.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Buying and selling domain names to profit from price differences, ranging from quick flips to long-term holds in a managed portfolio.
-keywords: ['domain trading', 'domain investing', 'digital real estate', 'secondary market', 'liquidity']
+keywords: ['domain investing', 'digital real estate', 'secondary market', 'liquidity']
 level: 1
 sources:
   - https://www.namebio.com/

--- a/content/glossary/en/domaining.md
+++ b/content/glossary/en/domaining.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The practice of investing in domain names — registering, buying, and selling them for profit.
-keywords: ['domaining', 'domainer', 'domain investing', 'domain flipping', 'domain speculation']
+keywords: ['domainer', 'domain investing', 'domain flipping', 'domain speculation']
 level: 1
 sources:
   - https://www.namebio.com/

--- a/content/glossary/en/end-user.md
+++ b/content/glossary/en/end-user.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A buyer who wants a domain to actually use for a business or project, not to resell it.
-keywords: ['end user', 'domain buyer', 'domain end use', 'business domain', 'domain deployment']
+keywords: ['domain buyer', 'domain end use', 'business domain', 'domain deployment']
 level: 1
 sources:
   - https://en.wikipedia.org/wiki/End_user

--- a/content/glossary/en/ens.md
+++ b/content/glossary/en/ens.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The Ethereum Name Service maps human-readable names like alice.eth to wallet addresses and records, managed entirely by on-chain smart contracts.
-keywords: ['ENS', 'Ethereum Name Service', '.eth', 'web3 name', 'on-chain naming', 'wallet alias', 'crypto identity']
+keywords: ['Ethereum Name Service', '.eth', 'web3 name', 'on-chain naming', 'wallet alias', 'crypto identity']
 level: 1
 sources:
   - https://docs.ens.domains/

--- a/content/glossary/en/epp-status-codes.md
+++ b/content/glossary/en/epp-status-codes.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The standardized flags on a domain that show its state — locked, on hold, pending transfer, and more.
-keywords: ['EPP status codes', 'clientHold', 'serverTransferProhibited', 'domain status', 'pending delete']
+keywords: ['clientHold', 'serverTransferProhibited', 'domain status', 'pending delete']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/epp-status-codes-2014-06-16-en

--- a/content/glossary/en/epp.md
+++ b/content/glossary/en/epp.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The standard protocol registrars use to register and manage domains with a registry.
-keywords: ['EPP', 'Extensible Provisioning Protocol', 'domain management', 'registry protocol', 'RFC 5730']
+keywords: ['Extensible Provisioning Protocol', 'domain management', 'registry protocol', 'RFC 5730']
 also_known_as: ['Extensible Provisioning Protocol']
 level: 1
 sources:

--- a/content/glossary/en/erc-20.md
+++ b/content/glossary/en/erc-20.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The Ethereum standard for fungible tokens like stablecoins, complementing the ERC-721 NFT standard.
-keywords: ['ERC-20', 'fungible token', 'token standard', 'stablecoin', 'ethereum token']
+keywords: ['fungible token', 'token standard', 'stablecoin', 'ethereum token']
 level: 1
 sources:
   - https://eips.ethereum.org/EIPS/eip-20

--- a/content/glossary/en/erc-721.md
+++ b/content/glossary/en/erc-721.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The Ethereum standard interface for non-fungible tokens that lets wallets and marketplaces handle any unique token, including tokenized domains, alike.
-keywords: ['ERC-721', 'NFT standard', 'Ethereum token standard', 'non-fungible token', 'tokenized domain standard']
+keywords: ['NFT standard', 'Ethereum token standard', 'non-fungible token', 'tokenized domain standard']
 level: 1
 sources:
   - https://eips.ethereum.org/EIPS/eip-721

--- a/content/glossary/en/escrow.md
+++ b/content/glossary/en/escrow.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A neutral third party or smart contract that holds funds or assets until both sides meet the agreed terms, then releases them, cutting counterparty risk.
-keywords: ['escrow', 'trusted third party', 'smart contract escrow', 'trustless', 'secure transactions']
+keywords: ['trusted third party', 'smart contract escrow', 'trustless', 'secure transactions']
 level: 1
 sources:
   - https://www.investopedia.com/terms/e/escrow.asp

--- a/content/glossary/en/ethereum-virtual-machine.md
+++ b/content/glossary/en/ethereum-virtual-machine.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The stack-based, deterministic runtime that executes smart contract code identically across every Ethereum node.
-keywords: ['ethereum virtual machine', 'evm', 'evm compatible', 'smart contract execution', 'solidity']
+keywords: ['evm', 'evm compatible', 'smart contract execution', 'solidity']
 also_known_as: ['EVM']
 level: 1
 sources:

--- a/content/glossary/en/ethereum.md
+++ b/content/glossary/en/ethereum.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The leading smart-contract blockchain, and the network most tokenized domains are issued on.
-keywords: ['ethereum', 'ETH', 'smart contract', 'EVM', 'decentralized applications']
+keywords: ['ETH', 'smart contract', 'EVM', 'decentralized applications']
 also_known_as: ['ETH']
 level: 1
 sources:

--- a/content/glossary/en/exact-match-domain.md
+++ b/content/glossary/en/exact-match-domain.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A domain that exactly matches a search keyword, like besthotels.com, once highly prized for SEO.
-keywords: ['exact-match domain', 'EMD', 'keyword match domain', 'SEO domain', 'search ranking domain']
+keywords: ['EMD', 'keyword match domain', 'SEO domain', 'search ranking domain']
 also_known_as: ['EMD']
 level: 1
 sources:

--- a/content/glossary/en/farcaster.md
+++ b/content/glossary/en/farcaster.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A decentralized social network built on Ethereum where accounts, identities, and social graphs live on-chain rather than on one company's servers.
-keywords: ['Farcaster', 'decentralized social', 'Web3 social', 'blockchain identity', 'social protocol']
+keywords: ['decentralized social', 'Web3 social', 'blockchain identity', 'social protocol']
 level: 1
 sources:
   - https://docs.farcaster.xyz/

--- a/content/glossary/en/fractional-ownership.md
+++ b/content/glossary/en/fractional-ownership.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Splitting a single high-value asset into smaller tradable shares so several people can own portions of it, enabled on-chain by token standards.
-keywords: ['fractional ownership', 'shared ownership', 'domain fractionalization', 'accessibility', 'tokenization']
+keywords: ['shared ownership', 'domain fractionalization', 'accessibility', 'tokenization']
 level: 1
 sources:
   - https://www.investopedia.com/terms/f/fractionalownership.asp

--- a/content/glossary/en/fully-homomorphic-encryption.md
+++ b/content/glossary/en/fully-homomorphic-encryption.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: An encryption scheme that allows computation directly on encrypted data, producing an encrypted result without ever decrypting the inputs.
-keywords: ['fully homomorphic encryption', 'fhe', 'confidential computing', 'encrypted computation', 'lattice cryptography']
+keywords: ['fhe', 'confidential computing', 'encrypted computation', 'lattice cryptography']
 also_known_as: ['FHE']
 level: 1
 sources:

--- a/content/glossary/en/gas.md
+++ b/content/glossary/en/gas.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The fee paid to process a transaction on a blockchain, priced in the network's native asset and rising with congestion; Layer 2s charge far less.
-keywords: ['gas', 'gas fee', 'transaction fee', 'gwei', 'Ethereum gas', 'Base gas', 'L2 fees', 'mint cost']
+keywords: ['gas fee', 'transaction fee', 'gwei', 'Ethereum gas', 'Base gas', 'L2 fees', 'mint cost']
 level: 1
 sources:
   - https://ethereum.org/en/developers/docs/gas/

--- a/content/glossary/en/grace-period.md
+++ b/content/glossary/en/grace-period.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A short window right after a domain expires when you can still renew it at the normal price.
-keywords: ['grace period', 'auto-renew grace period', 'domain expiration', 'renewal', 'RGP']
+keywords: ['auto-renew grace period', 'domain expiration', 'renewal', 'RGP']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/errp-2013-02-28-en

--- a/content/glossary/en/gtld.md
+++ b/content/glossary/en/gtld.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A top-level domain not tied to a country, such as .com, .org, or .xyz, run under ICANN contract.
-keywords: ['gTLD', 'generic TLD', '.com', '.org', '.xyz', 'ICANN']
+keywords: ['generic TLD', '.com', '.org', '.xyz', 'ICANN']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/tlds-2012-02-25-en

--- a/content/glossary/en/hardware-wallet.md
+++ b/content/glossary/en/hardware-wallet.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A dedicated offline device that stores a wallet's private keys and signs transactions on-device, so the keys never touch an internet-connected computer.
-keywords: ['hardware wallet', 'cold wallet', 'Ledger', 'Trezor', 'GridPlus', 'Keystone', 'secure element', 'self-custody']
+keywords: ['cold wallet', 'Ledger', 'Trezor', 'GridPlus', 'Keystone', 'secure element', 'self-custody']
 level: 1
 sources:
   - https://ethereum.org/en/wallets/

--- a/content/glossary/en/hash-function.md
+++ b/content/glossary/en/hash-function.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A one-way function that turns any input into a fixed-size fingerprint, used to chain blocks and detect tampering.
-keywords: ['hash function', 'cryptographic hash function', 'SHA-256', 'Keccak-256', 'hashing', 'collision resistance']
+keywords: ['cryptographic hash function', 'SHA-256', 'Keccak-256', 'hashing', 'collision resistance']
 also_known_as: ['Cryptographic Hash Function']
 level: 1
 sources:

--- a/content/glossary/en/holding-cost.md
+++ b/content/glossary/en/holding-cost.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The ongoing renewal fees an investor pays to keep a domain until it sells.
-keywords: ['holding cost', 'carrying cost', 'domain renewal cost', 'domain investment cost', 'annual renewal fee']
+keywords: ['carrying cost', 'domain renewal cost', 'domain investment cost', 'annual renewal fee']
 also_known_as: ['Carrying Cost']
 level: 1
 sources:

--- a/content/glossary/en/iana.md
+++ b/content/glossary/en/iana.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The function that maintains the DNS root zone and allocates IP address blocks and protocol numbers.
-keywords: ['IANA', 'root zone', 'IP allocation', 'protocol numbers', 'ICANN']
+keywords: ['root zone', 'IP allocation', 'protocol numbers', 'ICANN']
 level: 1
 sources:
   - https://www.iana.org/

--- a/content/glossary/en/internet-native-asset.md
+++ b/content/glossary/en/internet-native-asset.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: An asset that originates and lives on the internet itself, like a domain or token, rather than being a digital record of a physical or legal object.
-keywords: ['internet-native asset', 'digital asset', 'blockchain', 'native internet', 'tokenized domains']
+keywords: ['digital asset', 'blockchain', 'native internet', 'tokenized domains']
 level: 1
 sources:
   - https://ethereum.org/en/nft/

--- a/content/glossary/en/ip-address.md
+++ b/content/glossary/en/ip-address.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The numeric address that identifies a device on a network, which DNS maps a domain name to.
-keywords: ['IP address', 'IPv4', 'IPv6', 'A record', 'AAAA record', 'networking']
+keywords: ['IPv4', 'IPv6', 'A record', 'AAAA record', 'networking']
 level: 1
 sources:
   - https://datatracker.ietf.org/doc/html/rfc791

--- a/content/glossary/en/ipfs.md
+++ b/content/glossary/en/ipfs.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A peer-to-peer protocol that addresses files by their content, used to host decentralized web data.
-keywords: ['IPFS', 'content addressing', 'peer-to-peer', 'decentralized storage', 'CID']
+keywords: ['content addressing', 'peer-to-peer', 'decentralized storage', 'CID']
 also_known_as: ['InterPlanetary File System']
 level: 1
 sources:

--- a/content/glossary/en/keyword-domain.md
+++ b/content/glossary/en/keyword-domain.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A domain built around a valuable search keyword or phrase, valued for descriptive clarity.
-keywords: ['keyword domain', 'keyword-rich domain', 'descriptive domain', 'search keyword domain', 'SEO domain name']
+keywords: ['keyword-rich domain', 'descriptive domain', 'search keyword domain', 'SEO domain name']
 level: 1
 sources:
   - https://developers.google.com/search/docs/fundamentals/seo-starter-guide

--- a/content/glossary/en/kyc.md
+++ b/content/glossary/en/kyc.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Know Your Customer — the identity-verification checks a regulated financial or crypto service runs before onboarding a user.
-keywords: ['KYC', 'Know Your Customer', 'identity verification', 'onboarding', 'compliance']
+keywords: ['Know Your Customer', 'identity verification', 'onboarding', 'compliance']
 also_known_as: ['Know Your Customer']
 level: 1
 sources:

--- a/content/glossary/en/layer-2.md
+++ b/content/glossary/en/layer-2.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A network built on top of a blockchain to make transactions faster and cheaper, like Base on Ethereum.
-keywords: ['layer 2', 'rollup', 'scaling', 'optimistic rollup', 'ZK rollup']
+keywords: ['rollup', 'scaling', 'optimistic rollup', 'ZK rollup']
 level: 1
 sources:
   - https://ethereum.org/en/layer-2/

--- a/content/glossary/en/lease-to-own.md
+++ b/content/glossary/en/lease-to-own.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Acquiring a domain through recurring payments that build toward full ownership, a sibling of rent-to-own.
-keywords: ['lease-to-own', 'domain acquisition', 'installment', 'domain financing', 'rent-to-own']
+keywords: ['domain acquisition', 'installment', 'domain financing', 'rent-to-own']
 level: 1
 sources:
   - https://www.investopedia.com/terms/l/lease-option.asp

--- a/content/glossary/en/leasing.md
+++ b/content/glossary/en/leasing.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Renting the use of a domain for a recurring fee while keeping ownership, with smart contracts able to enforce terms and automate the payments.
-keywords: ['leasing', 'domain rental', 'passive income', 'smart contract leasing', 'automated payments']
+keywords: ['domain rental', 'passive income', 'smart contract leasing', 'automated payments']
 level: 1
 sources:
   - https://www.investopedia.com/terms/l/lease.asp

--- a/content/glossary/en/lending-protocol.md
+++ b/content/glossary/en/lending-protocol.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A smart-contract platform where users supply assets to earn interest and borrowers take loans against collateral, with no bank as intermediary.
-keywords: ['lending protocol', 'DeFi', 'collateral', 'borrowing', 'domain finance', 'yield']
+keywords: ['DeFi', 'collateral', 'borrowing', 'domain finance', 'yield']
 level: 1
 sources:
   - https://ethereum.org/en/defi/

--- a/content/glossary/en/lens.md
+++ b/content/glossary/en/lens.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Lens Protocol is a decentralized social graph where profiles, follows, and posts are owned by users as on-chain assets they can carry between apps.
-keywords: ['Lens', 'Lens Protocol', 'decentralized social', 'NFT profiles', 'social graph', 'Web3 identity']
+keywords: ['Lens Protocol', 'decentralized social', 'NFT profiles', 'social graph', 'Web3 identity']
 level: 1
 sources:
   - https://www.lens.xyz/

--- a/content/glossary/en/make-offer.md
+++ b/content/glossary/en/make-offer.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A domain listing that invites buyers to submit a bid the seller can accept, counter, or decline.
-keywords: ['make offer', 'best offer', 'domain negotiation', 'offer', 'counteroffer']
+keywords: ['best offer', 'domain negotiation', 'offer', 'counteroffer']
 level: 1
 sources:
   - https://www.sedo.com/

--- a/content/glossary/en/marketplace.md
+++ b/content/glossary/en/marketplace.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: An online venue where buyers and sellers trade assets; for NFTs and tokenized domains, examples include OpenSea and Blur.
-keywords: ['marketplace', 'OpenSea', 'Blur', 'NFT trading', 'domain marketplace', 'secondary market']
+keywords: ['OpenSea', 'Blur', 'NFT trading', 'domain marketplace', 'secondary market']
 level: 1
 sources:
   - https://ethereum.org/en/nft/

--- a/content/glossary/en/merkle-tree.md
+++ b/content/glossary/en/merkle-tree.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A tree of hashes that commits to a large dataset in one root hash, letting anyone verify a single item with a short proof.
-keywords: ['merkle tree', 'hash tree', 'merkle root', 'merkle proof', 'merkle branch', 'SPV']
+keywords: ['hash tree', 'merkle root', 'merkle proof', 'merkle branch', 'SPV']
 also_known_as: ['Hash Tree']
 level: 1
 sources:

--- a/content/glossary/en/minting.md
+++ b/content/glossary/en/minting.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Creating a new token on a blockchain — for a domain, issuing the NFT that represents its ownership.
-keywords: ['minting', 'mint', 'NFT creation', 'token issuance', 'on-chain']
+keywords: ['mint', 'NFT creation', 'token issuance', 'on-chain']
 also_known_as: ['Mint']
 level: 1
 sources:

--- a/content/glossary/en/multi-sig.md
+++ b/content/glossary/en/multi-sig.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A wallet that needs several private keys to approve a transaction, such as two of three signers, so one compromised key cannot move funds alone.
-keywords: ['multi-sig', 'multisig', 'multiple signatures', 'enhanced security', 'shared custody']
+keywords: ['multisig', 'multiple signatures', 'enhanced security', 'shared custody']
 level: 1
 sources:
   - https://docs.safe.global/

--- a/content/glossary/en/nameserver.md
+++ b/content/glossary/en/nameserver.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A server that answers DNS queries for a domain; its NS records name the authoritative servers.
-keywords: ['nameserver', 'NS record', 'authoritative server', 'DNS delegation', 'DNS hosting']
+keywords: ['NS record', 'authoritative server', 'DNS delegation', 'DNS hosting']
 level: 1
 sources:
   - https://datatracker.ietf.org/doc/html/rfc1034

--- a/content/glossary/en/new-gtld.md
+++ b/content/glossary/en/new-gtld.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A generic top-level domain introduced by ICANN's expansion program, such as .app, .xyz, or .shop.
-keywords: ['new gTLD', 'ICANN expansion', '.app', '.xyz', '.shop', 'domain extension']
+keywords: ['ICANN expansion', '.app', '.xyz', '.shop', 'domain extension']
 level: 1
 sources:
   - https://newgtlds.icann.org/en/

--- a/content/glossary/en/nft.md
+++ b/content/glossary/en/nft.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A Non-Fungible Token is a unique, indivisible blockchain token used to represent ownership of a specific item such as a tokenized domain.
-keywords: ['NFT', 'non-fungible token', 'blockchain', 'unique asset', 'domain NFT']
+keywords: ['non-fungible token', 'blockchain', 'unique asset', 'domain NFT']
 level: 1
 sources:
   - https://eips.ethereum.org/EIPS/eip-721

--- a/content/glossary/en/on-chain.md
+++ b/content/glossary/en/on-chain.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Describes data or actions recorded directly on a blockchain, where they are public, verifiable, and secured by the network rather than a private server.
-keywords: ['on-chain', 'blockchain', 'smart contracts', 'domain NFT', 'decentralization']
+keywords: ['blockchain', 'smart contracts', 'domain NFT', 'decentralization']
 level: 1
 sources:
   - https://ethereum.org/en/developers/docs/transactions/

--- a/content/glossary/en/optimistic-rollup.md
+++ b/content/glossary/en/optimistic-rollup.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A rollup that assumes off-chain transactions are valid by default and relies on a fraud-proof challenge window instead of cryptographic proofs.
-keywords: ['optimistic rollup', 'fraud proof', 'challenge window', 'rollup', 'layer 2', 'arbitrum', 'optimism', 'base']
+keywords: ['fraud proof', 'challenge window', 'rollup', 'layer 2', 'arbitrum', 'optimism', 'base']
 level: 1
 sources:
   - https://ethereum.org/en/developers/docs/scaling/optimistic-rollups/

--- a/content/glossary/en/pending-delete.md
+++ b/content/glossary/en/pending-delete.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The final status before an unrenewed domain is released back to the public for registration.
-keywords: ['pending delete', 'domain drop', 'drop catching', 'expired domain', 'release']
+keywords: ['domain drop', 'drop catching', 'expired domain', 'release']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/epp-status-codes-2014-06-16-en

--- a/content/glossary/en/permissionless.md
+++ b/content/glossary/en/permissionless.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A system anyone can use or build on without a gatekeeper's approval, because the rules are enforced by open protocols rather than a central authority.
-keywords: ['permissionless', 'decentralized', 'censorship-resistant', 'open access', 'blockchain']
+keywords: ['decentralized', 'censorship-resistant', 'open access', 'blockchain']
 level: 1
 sources:
   - https://ethereum.org/en/web3/

--- a/content/glossary/en/phishing.md
+++ b/content/glossary/en/phishing.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Tricking people into revealing credentials or funds via fake sites and messages that impersonate trusted brands.
-keywords: ['phishing', 'social engineering', 'credential theft', 'impersonation', 'domain abuse']
+keywords: ['social engineering', 'credential theft', 'impersonation', 'domain abuse']
 level: 1
 sources:
   - https://consumer.ftc.gov/articles/how-recognize-and-avoid-phishing-scams

--- a/content/glossary/en/ppc.md
+++ b/content/glossary/en/ppc.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: An ad model where the owner earns each time a visitor clicks an ad, used to monetize parked domains.
-keywords: ['PPC', 'pay-per-click', 'domain monetization', 'ad revenue', 'parking revenue']
+keywords: ['pay-per-click', 'domain monetization', 'ad revenue', 'parking revenue']
 also_known_as: ['Pay-Per-Click']
 level: 1
 sources:

--- a/content/glossary/en/premium-domain.md
+++ b/content/glossary/en/premium-domain.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A high-value domain priced above standard rates for its memorability, brevity, or keyword strength.
-keywords: ['premium domain', 'premium name', 'registry premium', 'aftermarket', 'domain value']
+keywords: ['premium name', 'registry premium', 'aftermarket', 'domain value']
 level: 1
 sources:
   - https://www.namebio.com/

--- a/content/glossary/en/private-key.md
+++ b/content/glossary/en/private-key.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The secret number that controls a blockchain account and signs its transactions; it must never be shared.
-keywords: ['private key', 'signing key', 'wallet key', 'secret key', 'blockchain account']
+keywords: ['signing key', 'wallet key', 'secret key', 'blockchain account']
 level: 1
 sources:
   - https://ethereum.org/en/developers/docs/accounts/

--- a/content/glossary/en/proof-of-stake.md
+++ b/content/glossary/en/proof-of-stake.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A consensus mechanism where validators lock up the network's asset as a bond and are chosen to propose blocks in proportion to their stake.
-keywords: ['proof of stake', 'pos', 'staking', 'validator', 'slashing', 'ethereum merge']
+keywords: ['pos', 'staking', 'validator', 'slashing', 'ethereum merge']
 also_known_as: ['PoS']
 level: 1
 sources:

--- a/content/glossary/en/proof-of-work.md
+++ b/content/glossary/en/proof-of-work.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A consensus mechanism where miners compete to solve a computational puzzle to earn the right to add the next block.
-keywords: ['proof of work', 'pow', 'bitcoin mining', 'hash puzzle', 'mining difficulty']
+keywords: ['pow', 'bitcoin mining', 'hash puzzle', 'mining difficulty']
 also_known_as: ['PoW']
 level: 1
 sources:

--- a/content/glossary/en/protocol-asset.md
+++ b/content/glossary/en/protocol-asset.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: An asset whose existence and rules are defined by an open protocol's smart contracts, so it works the same for everyone without a controlling company.
-keywords: ['protocol asset', 'blockchain protocol', 'infrastructure asset', 'network asset', 'utility token']
+keywords: ['blockchain protocol', 'infrastructure asset', 'network asset', 'utility token']
 level: 1
 sources:
   - https://ethereum.org/en/developers/docs/smart-contracts/

--- a/content/glossary/en/public-key.md
+++ b/content/glossary/en/public-key.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The shareable half of a blockchain key pair, derived from the private key; used to receive funds and verify signatures.
-keywords: ['public key', 'address', 'verification key', 'asymmetric cryptography', 'blockchain account']
+keywords: ['address', 'verification key', 'asymmetric cryptography', 'blockchain account']
 level: 1
 sources:
   - https://ethereum.org/en/developers/docs/accounts/

--- a/content/glossary/en/redemption-period.md
+++ b/content/glossary/en/redemption-period.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A post-expiration window where a lapsed domain can be recovered, usually for a steep redemption fee.
-keywords: ['redemption period', 'RGP', 'redemption grace period', 'expired domain recovery', 'redemption fee']
+keywords: ['RGP', 'redemption grace period', 'expired domain recovery', 'redemption fee']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/errp-2013-02-28-en

--- a/content/glossary/en/registrant.md
+++ b/content/glossary/en/registrant.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The person or organization that holds the rights to a registered domain name — the owner of record.
-keywords: ['registrant', 'domain owner', 'registered name holder', 'RNH', 'domain ownership']
+keywords: ['domain owner', 'registered name holder', 'RNH', 'domain ownership']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/name-holder-faqs-2017-10-10-en

--- a/content/glossary/en/registrar.md
+++ b/content/glossary/en/registrar.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: An ICANN-accredited company authorized to register domain names on behalf of the public, acting as the interface between registrants and registries.
-keywords: ['registrar', 'domain registrar', 'ICANN accreditation', 'domain registration', 'RAA', 'EPP', 'auth code', 'transfer lock', 'domain transfer']
+keywords: ['domain registrar', 'ICANN accreditation', 'domain registration', 'RAA', 'EPP', 'auth code', 'transfer lock', 'domain transfer']
 level: 2
 sources:
   - https://www.icann.org/en/accredited-registrars

--- a/content/glossary/en/registry-lock.md
+++ b/content/glossary/en/registry-lock.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A high-security service where the registry freezes a domain so changes need manual out-of-band approval.
-keywords: ['registry lock', 'domain lock', 'high-security lock', 'domain hijacking prevention', 'out-of-band verification']
+keywords: ['domain lock', 'high-security lock', 'domain hijacking prevention', 'out-of-band verification']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/epp-status-codes-2014-06-16-en

--- a/content/glossary/en/registry.md
+++ b/content/glossary/en/registry.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The organization that operates the authoritative database and nameservers for a top-level domain, delegating retail sales to registrars.
-keywords: ['registry', 'registry operator', 'TLD registry', 'domain registry', 'ICANN', 'registrar', 'EPP', 'gTLD registry', 'ccTLD registry', 'shared registry system']
+keywords: ['registry operator', 'TLD registry', 'domain registry', 'ICANN', 'registrar', 'EPP', 'gTLD registry', 'ccTLD registry', 'shared registry system']
 also_known_as: ['Registry Operator']
 level: 2
 sources:

--- a/content/glossary/en/rent-to-own.md
+++ b/content/glossary/en/rent-to-own.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A purchase arrangement where the buyer pays in installments while using the domain and gains full ownership once the agreed total is paid.
-keywords: ['rent-to-own', 'gradual ownership', 'payment plans', 'domain acquisition', 'smart contracts']
+keywords: ['gradual ownership', 'payment plans', 'domain acquisition', 'smart contracts']
 level: 1
 sources:
   - https://www.investopedia.com/terms/l/lease-option.asp

--- a/content/glossary/en/reseller.md
+++ b/content/glossary/en/reseller.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A company that sells domains under a larger registrar's accreditation rather than holding its own.
-keywords: ['reseller', 'domain reseller', 'white-label registrar', 'ICANN accreditation', 'registrar']
+keywords: ['domain reseller', 'white-label registrar', 'ICANN accreditation', 'registrar']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/what-2012-02-25-en

--- a/content/glossary/en/reserve-price.md
+++ b/content/glossary/en/reserve-price.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The lowest price a seller will accept, often hidden, below which an offer or auction bid is rejected.
-keywords: ['reserve price', 'minimum offer', 'reserve bid', 'floor price', 'domain auction reserve']
+keywords: ['minimum offer', 'reserve bid', 'floor price', 'domain auction reserve']
 level: 1
 sources:
   - https://www.investopedia.com/terms/r/reserveprice.asp

--- a/content/glossary/en/reserved-names.md
+++ b/content/glossary/en/reserved-names.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Domains a registry withholds from open registration, such as premium, policy, or protected labels.
-keywords: ['reserved names', 'blocked names', 'registry reserved', 'premium reserved', 'collision list']
+keywords: ['blocked names', 'registry reserved', 'premium reserved', 'collision list']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/tlds-2012-02-25-en

--- a/content/glossary/en/retail-pricing.md
+++ b/content/glossary/en/retail-pricing.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The price an end user pays for a domain they intend to use — typically far above the wholesale investor floor.
-keywords: ['retail pricing', 'end user pricing', 'domain retail', 'end-user price', 'full price']
+keywords: ['end user pricing', 'domain retail', 'end-user price', 'full price']
 also_known_as: ['End-User Pricing']
 level: 1
 sources:

--- a/content/glossary/en/revenue-sharing.md
+++ b/content/glossary/en/revenue-sharing.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: An arrangement that automatically splits income from an asset among parties by preset percentages, enforceable on-chain by smart contracts.
-keywords: ['revenue-sharing', 'passive income', 'domain monetization', 'profit distribution', 'smart contracts']
+keywords: ['passive income', 'domain monetization', 'profit distribution', 'smart contracts']
 level: 1
 sources:
   - https://www.investopedia.com/terms/r/revenue-sharing.asp

--- a/content/glossary/en/reverse-domain-hijacking.md
+++ b/content/glossary/en/reverse-domain-hijacking.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Abusing the UDRP in bad faith to try to seize a domain from its legitimate owner.
-keywords: ['reverse domain hijacking', 'RDNH', 'UDRP abuse', 'domain dispute', 'bad faith complainant']
+keywords: ['RDNH', 'UDRP abuse', 'domain dispute', 'bad faith complainant']
 also_known_as: ['RDNH']
 level: 1
 sources:

--- a/content/glossary/en/rollup.md
+++ b/content/glossary/en/rollup.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A layer 2 scaling technique that executes transactions off the main chain and posts the compressed data and result back to it.
-keywords: ['rollup', 'layer 2', 'optimistic rollup', 'zk rollup', 'scaling', 'l2']
+keywords: ['layer 2', 'optimistic rollup', 'zk rollup', 'scaling', 'l2']
 level: 1
 sources:
   - https://l2beat.com/scaling/summary

--- a/content/glossary/en/root-zone.md
+++ b/content/glossary/en/root-zone.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The top of the DNS hierarchy, listing every TLD and the servers authoritative for it.
-keywords: ['root zone', 'root servers', 'DNS hierarchy', 'TLD delegation', 'IANA']
+keywords: ['root servers', 'DNS hierarchy', 'TLD delegation', 'IANA']
 level: 1
 sources:
   - https://www.iana.org/domains/root

--- a/content/glossary/en/second-level-domain.md
+++ b/content/glossary/en/second-level-domain.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The label directly left of the TLD — the "example" in example.com — the part you actually register.
-keywords: ['second-level domain', 'SLD', 'root domain', 'apex domain', 'registrable name']
+keywords: ['SLD', 'root domain', 'apex domain', 'registrable name']
 level: 1
 sources:
   - https://datatracker.ietf.org/doc/html/rfc1034

--- a/content/glossary/en/secure-multiparty-computation.md
+++ b/content/glossary/en/secure-multiparty-computation.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A cryptographic technique letting several parties jointly compute a result from their private inputs without revealing those inputs to each other.
-keywords: ['secure multi-party computation', 'mpc', 'smpc', 'threshold signature', 'threshold custody']
+keywords: ['mpc', 'smpc', 'threshold signature', 'threshold custody']
 also_known_as: ['MPC', 'SMPC']
 level: 1
 sources:

--- a/content/glossary/en/seed-phrase.md
+++ b/content/glossary/en/seed-phrase.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A list of 12 or 24 words that encodes a wallet's master key; anyone holding it controls the wallet, so it is the one thing you must back up.
-keywords: ['seed phrase', 'recovery phrase', 'mnemonic phrase', 'wallet backup', 'BIP39', '12 words', '24 words', 'crypto recovery']
+keywords: ['recovery phrase', 'mnemonic phrase', 'wallet backup', 'BIP39', '12 words', '24 words', 'crypto recovery']
 level: 1
 sources:
   - https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki

--- a/content/glossary/en/sell-through-rate.md
+++ b/content/glossary/en/sell-through-rate.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The share of a domain portfolio that sells in a given period — a key liquidity metric for investors.
-keywords: ['sell-through rate', 'STR', 'domain liquidity', 'portfolio performance', 'domain sales velocity']
+keywords: ['STR', 'domain liquidity', 'portfolio performance', 'domain sales velocity']
 also_known_as: ['STR']
 level: 1
 sources:

--- a/content/glossary/en/seo.md
+++ b/content/glossary/en/seo.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Search Engine Optimization is the practice of improving a site's content and structure so it ranks higher in search results and draws more visitors.
-keywords: ['SEO', 'search engine optimization', 'domain value', 'search rankings', 'digital marketing']
+keywords: ['search engine optimization', 'domain value', 'search rankings', 'digital marketing']
 level: 1
 sources:
   - https://developers.google.com/search/docs/fundamentals/seo-starter-guide

--- a/content/glossary/en/serp.md
+++ b/content/glossary/en/serp.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The page of results a search engine returns for a query, where domains compete for visibility.
-keywords: ['serp', 'search results', 'seo', 'search engine', 'organic ranking', 'search visibility']
+keywords: ['search results', 'seo', 'search engine', 'organic ranking', 'search visibility']
 also_known_as: ['Search Engine Results Page']
 level: 1
 sources:

--- a/content/glossary/en/sharding.md
+++ b/content/glossary/en/sharding.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A scaling technique that splits a blockchain's validation work across multiple parallel subsets of nodes instead of one.
-keywords: ['sharding', 'shard', 'scalability trilemma', 'data availability sampling', 'ethereum sharding']
+keywords: ['shard', 'scalability trilemma', 'data availability sampling', 'ethereum sharding']
 level: 1
 sources:
   - https://vitalik.eth.limo/general/2021/04/07/sharding.html

--- a/content/glossary/en/short-domain.md
+++ b/content/glossary/en/short-domain.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Very short domains — three to four letters or all-digits — prized for brevity, especially in some markets.
-keywords: ['short domain', 'numeric domain', 'LLLL domain', 'NNNN domain', 'three-letter domain', 'four-letter domain']
+keywords: ['numeric domain', 'LLLL domain', 'NNNN domain', 'three-letter domain', 'four-letter domain']
 level: 1
 sources:
   - https://www.namebio.com/

--- a/content/glossary/en/smart-contract.md
+++ b/content/glossary/en/smart-contract.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A program stored on a blockchain that runs exactly as written when its conditions are met, enabling agreements that execute without an intermediary.
-keywords: ['smart contract', 'blockchain', 'automated execution', 'programmable logic', 'decentralized']
+keywords: ['blockchain', 'automated execution', 'programmable logic', 'decentralized']
 level: 1
 sources:
   - https://ethereum.org/en/developers/docs/smart-contracts/

--- a/content/glossary/en/stablecoin.md
+++ b/content/glossary/en/stablecoin.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A cryptocurrency designed to hold a steady value against a reference like the US dollar, used to pay and settle without crypto price volatility.
-keywords: ['stablecoin', 'USDC', 'USDT', 'DAI', 'fiat-pegged', 'crypto payment', 'on-chain dollars']
+keywords: ['USDC', 'USDT', 'DAI', 'fiat-pegged', 'crypto payment', 'on-chain dollars']
 level: 1
 sources:
   - https://ethereum.org/en/stablecoins/

--- a/content/glossary/en/subdomain.md
+++ b/content/glossary/en/subdomain.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A prefix added to a domain to create a separate address, such as blog.example.com or app.example.com.
-keywords: ['subdomain', 'host', 'blog.example.com', 'DNS', 'second-level domain']
+keywords: ['host', 'blog.example.com', 'DNS', 'second-level domain']
 level: 1
 sources:
   - https://datatracker.ietf.org/doc/html/rfc1034

--- a/content/glossary/en/tmch.md
+++ b/content/glossary/en/tmch.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: ICANN's central trademark database powering Sunrise pre-registration and brand claims in new gTLDs.
-keywords: ['TMCH', 'Trademark Clearinghouse', 'Sunrise period', 'brand protection', 'new gTLD']
+keywords: ['TMCH', 'Sunrise period', 'brand protection', 'new gTLD']
 also_known_as: ['TMCH']
 level: 1
 sources:

--- a/content/glossary/en/tokenize.md
+++ b/content/glossary/en/tokenize.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: To represent ownership of an asset like a domain as a transferable token on a blockchain so it can be held in a wallet and traded on-chain.
-keywords: ['tokenize', 'tokenization', 'NFT', 'digital asset', 'on-chain asset']
+keywords: ['tokenization', 'NFT', 'digital asset', 'on-chain asset']
 level: 1
 sources:
   - https://ethereum.org/en/nft/

--- a/content/glossary/en/tokenized-domain.md
+++ b/content/glossary/en/tokenized-domain.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A real DNS domain whose ownership is represented as a blockchain token you hold in a wallet.
-keywords: ['tokenized domain', 'domain NFT', 'on-chain domain', 'domain ownership', 'web3 domain']
+keywords: ['domain NFT', 'on-chain domain', 'domain ownership', 'web3 domain']
 level: 1
 sources:
   - https://ethereum.org/en/nft/

--- a/content/glossary/en/trademark.md
+++ b/content/glossary/en/trademark.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A legally protected mark identifying a brand's goods or services, central to many domain disputes.
-keywords: ['trademark', 'brand protection', 'intellectual property', 'domain dispute', 'UDRP', 'WIPO']
+keywords: ['brand protection', 'intellectual property', 'domain dispute', 'UDRP', 'WIPO']
 level: 1
 sources:
   - https://www.wipo.int/trademarks/en/

--- a/content/glossary/en/transfer-lock.md
+++ b/content/glossary/en/transfer-lock.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A status that blocks a domain from transferring to another registrar until it is explicitly unlocked.
-keywords: ['transfer lock', 'registrar lock', 'domain security', 'EPP status', 'domain transfer']
+keywords: ['registrar lock', 'domain security', 'EPP status', 'domain transfer']
 also_known_as: ['Registrar Lock']
 level: 1
 sources:

--- a/content/glossary/en/trusted-execution-environment.md
+++ b/content/glossary/en/trusted-execution-environment.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A hardware-isolated region of a processor that runs code and holds data securely, shielded from the rest of the system including the operating system.
-keywords: ['trusted execution environment', 'tee', 'secure enclave', 'intel sgx', 'confidential computing']
+keywords: ['tee', 'secure enclave', 'intel sgx', 'confidential computing']
 also_known_as: ['TEE', 'Secure Enclave']
 level: 1
 sources:

--- a/content/glossary/en/ttl.md
+++ b/content/glossary/en/ttl.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: How long, in seconds, a DNS record may be cached by resolvers before it must be looked up again.
-keywords: ['TTL', 'time to live', 'DNS cache', 'DNS propagation', 'record caching']
+keywords: ['time to live', 'DNS cache', 'DNS propagation', 'record caching']
 level: 1
 sources:
   - https://datatracker.ietf.org/doc/html/rfc1035

--- a/content/glossary/en/type-in-traffic.md
+++ b/content/glossary/en/type-in-traffic.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Visitors who reach a site by typing a guessed domain directly, the basis of domain parking revenue.
-keywords: ['type-in traffic', 'direct navigation', 'domain parking', 'exact match domain', 'domain value']
+keywords: ['direct navigation', 'domain parking', 'exact match domain', 'domain value']
 level: 1
 sources:
   - https://www.namebio.com/

--- a/content/glossary/en/typosquatting.md
+++ b/content/glossary/en/typosquatting.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Registering misspellings of popular domains to catch mistyped traffic, often for ads or phishing.
-keywords: ['typosquatting', 'typo domain', 'phishing', 'brand abuse', 'cybersquatting']
+keywords: ['typo domain', 'phishing', 'brand abuse', 'cybersquatting']
 level: 1
 sources:
   - https://www.cloudflare.com/learning/ssl/what-is-typosquatting/

--- a/content/glossary/en/udrp.md
+++ b/content/glossary/en/udrp.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: ICANN's mandatory policy for resolving domain disputes, mainly trademark and cybersquatting claims, as a faster, cheaper alternative to court.
-keywords: ['UDRP', 'domain disputes', 'trademark protection', 'cybersquatting', 'legal framework']
+keywords: ['domain disputes', 'trademark protection', 'cybersquatting', 'legal framework']
 level: 1
 sources:
   - https://www.icann.org/resources/pages/udrp-2012-02-25-en

--- a/content/glossary/en/urs.md
+++ b/content/glossary/en/urs.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A fast, low-cost remedy that suspends a clearly infringing domain, complementing the UDRP.
-keywords: ['URS', 'Uniform Rapid Suspension', 'domain suspension', 'trademark infringement', 'new gTLD']
+keywords: ['Uniform Rapid Suspension', 'domain suspension', 'trademark infringement', 'new gTLD']
 also_known_as: ['Uniform Rapid Suspension']
 level: 1
 sources:

--- a/content/glossary/en/wallet.md
+++ b/content/glossary/en/wallet.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: Software or a device that stores the private keys controlling your on-chain assets and signs transactions, such as MetaMask or a hardware wallet.
-keywords: ['wallet', 'crypto wallet', 'private key', 'digital asset storage', 'domain storage']
+keywords: ['crypto wallet', 'private key', 'digital asset storage', 'domain storage']
 level: 1
 sources:
   - https://ethereum.org/en/wallets/

--- a/content/glossary/en/web3.md
+++ b/content/glossary/en/web3.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A vision of the internet on public blockchains where users own their data, assets, and identity through their own keys, not platform accounts.
-keywords: ['Web3', 'decentralized web', 'blockchain internet', 'user ownership', 'peer-to-peer', 'decentralization', 'cryptocurrency', 'smart contracts', 'DeFi', 'NFT']
+keywords: ['decentralized web', 'blockchain internet', 'user ownership', 'peer-to-peer', 'decentralization', 'cryptocurrency', 'smart contracts', 'DeFi', 'NFT']
 level: 2
 sources:
   - https://ethereum.org/en/web3/

--- a/content/glossary/en/webassembly.md
+++ b/content/glossary/en/webassembly.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A portable, near-native-speed binary instruction format that several blockchains use as their smart contract execution engine.
-keywords: ['webassembly', 'wasm', 'cosmwasm', 'wasm smart contracts', 'stack-based virtual machine']
+keywords: ['wasm', 'cosmwasm', 'wasm smart contracts', 'stack-based virtual machine']
 also_known_as: ['Wasm']
 level: 1
 sources:

--- a/content/glossary/en/whois-privacy.md
+++ b/content/glossary/en/whois-privacy.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A service that masks a registrant's personal contact details in public WHOIS or RDAP records.
-keywords: ['WHOIS privacy', 'privacy protection', 'RDAP', 'registrant privacy', 'contact masking']
+keywords: ['privacy protection', 'RDAP', 'registrant privacy', 'contact masking']
 also_known_as: ['Privacy Protection']
 level: 1
 sources:

--- a/content/glossary/en/whois.md
+++ b/content/glossary/en/whois.md
@@ -7,7 +7,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: WHOIS and its successor RDAP are the public lookup services for a domain's registration details, such as its registrar and expiration date.
-keywords: ['WHOIS', 'RDAP', 'domain registration lookup', 'registrant information', 'domain ownership lookup']
+keywords: ['RDAP', 'domain registration lookup', 'registrant information', 'domain ownership lookup']
 level: 1
 sources:
   - https://www.icann.org/rdap

--- a/content/glossary/en/wholesale-pricing.md
+++ b/content/glossary/en/wholesale-pricing.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The investor-to-investor floor price for a domain — what a domainer accepts to liquidate quickly, below retail.
-keywords: ['wholesale pricing', 'investor pricing', 'domain wholesale', 'liquidation price', 'domainer pricing']
+keywords: ['investor pricing', 'domain wholesale', 'liquidation price', 'domainer pricing']
 also_known_as: ['Investor Pricing']
 level: 1
 sources:

--- a/content/glossary/en/wipo.md
+++ b/content/glossary/en/wipo.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The UN agency whose arbitration center decides many UDRP domain-name disputes.
-keywords: ['WIPO', 'World Intellectual Property Organization', 'UDRP', 'domain dispute', 'arbitration']
+keywords: ['World Intellectual Property Organization', 'UDRP', 'domain dispute', 'arbitration']
 also_known_as: ['World Intellectual Property Organization']
 level: 1
 sources:

--- a/content/glossary/en/x402.md
+++ b/content/glossary/en/x402.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: An open protocol that uses the HTTP 402 Payment Required status to let servers and AI agents request and receive on-chain payments inline with requests.
-keywords: ['x402', 'HTTP 402', 'payment required', 'on-chain payments', 'agent payments', 'crypto payments', 'micropayment']
+keywords: ['HTTP 402', 'payment required', 'on-chain payments', 'agent payments', 'crypto payments', 'micropayment']
 level: 1
 sources:
   - https://www.x402.org/

--- a/content/glossary/en/zero-knowledge-proof.md
+++ b/content/glossary/en/zero-knowledge-proof.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A cryptographic method that lets one party prove a statement is true without revealing any information beyond its validity.
-keywords: ['zero-knowledge proof', 'zkp', 'zk proof', 'zk-snark', 'zk rollup', 'validity proof']
+keywords: ['zkp', 'zk proof', 'zk-snark', 'zk rollup', 'validity proof']
 also_known_as: ['ZK Proof', 'ZKP']
 level: 1
 sources:

--- a/content/glossary/en/zk-rollup.md
+++ b/content/glossary/en/zk-rollup.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: A rollup that submits a cryptographic validity proof with every batch of transactions instead of relying on a fraud-proof challenge window.
-keywords: ['zk rollup', 'zero-knowledge rollup', 'validity proof', 'zk-snark', 'zk-stark', 'zksync', 'starknet']
+keywords: ['zero-knowledge rollup', 'validity proof', 'zk-snark', 'zk-stark', 'zksync', 'starknet']
 also_known_as: ['Zero-Knowledge Rollup', 'Validity Rollup']
 level: 1
 sources:

--- a/content/glossary/en/zone-file.md
+++ b/content/glossary/en/zone-file.md
@@ -6,7 +6,7 @@ tags: ['glossary']
 authors: ['namefiteam']
 editors: ['victor-zhou']
 description: The text file holding all the DNS records for a domain, including glue records for its nameservers.
-keywords: ['zone file', 'glue record', 'DNS zone', 'authoritative records', 'nameserver']
+keywords: ['glue record', 'DNS zone', 'authoritative records', 'nameserver']
 level: 1
 sources:
   - https://datatracker.ietf.org/doc/html/rfc1035

--- a/content/tld/de/aaa.md
+++ b/content/tld/de/aaa.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Erfahren Sie alles über die .aaa Domain: Ein Symbol für Qualität und Exzellenz. Entdecken Sie Vorteile, Anwendungsfälle und wie Sie Ihre Domain bei Namefi registrieren.'
-keywords: ['.aaa domains', '.aaa TLD', 'top-level domain', 'was ist .aaa', 'warum .aaa wählen', 'was ist die .aaa domain', 'warum die .aaa domain wählen', 'domain investing', 'blockchain domains', 'tokenized domains', 'web3 domains', 'namefi', 'aaa domain bedeutung', 'neue gTLDs', 'domain registrieren']
+keywords: ['.aaa domains', 'top-level domain', 'warum .aaa wählen', 'was ist die .aaa domain', 'warum die .aaa domain wählen', 'domain investing', 'blockchain domains', 'tokenized domains', 'web3 domains', 'namefi', 'aaa domain bedeutung', 'neue gTLDs', 'domain registrieren']
 relatedArticles:
   - /de/blog/what-are-tokenized-domains/
   - /de/blog/what-is-a-tld/

--- a/content/tld/de/abarth.md
+++ b/content/tld/de/abarth.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Alles über die exklusive .abarth Domain. Erfahren Sie, was diese Top-Level-Domain für die Automobilwelt bedeutet, ihre Vorteile und wie Namefi die Domain-Registrierung revolutioniert."
-keywords: [".abarth domains", ".abarth TLD", "top-level domain", "was ist .abarth", "warum .abarth wählen", "was ist die .abarth domain", "warum die .abarth domain wählen", "Abarth Automarke", "Marken-TLD", "Domain-Investition", "Blockchain Domains", "Tokenisierte Domains", "Web3 Integration", "digitale Markenführung", "exklusive Domains"]
+keywords: [".abarth domains", "top-level domain", "warum .abarth wählen", "was ist die .abarth domain", "warum die .abarth domain wählen", "Abarth Automarke", "Marken-TLD", "Domain-Investition", "Blockchain Domains", "Tokenisierte Domains", "Web3 Integration", "digitale Markenführung", "exklusive Domains"]
 relatedArticles:
   - /de/blog/top-tlds-to-secure-for-your-business/
   - /de/blog/what-are-tokenized-domains/

--- a/content/tld/de/abbott.md
+++ b/content/tld/de/abbott.md
@@ -14,9 +14,7 @@ draft: false
 description: "Erfahren Sie alles über die .abbott Top-Level-Domain: Einblicke in Marken-TLDs, Vorteile für die digitale Identität und wie Namefi die Domain-Welt revolutioniert."
 keywords:
   - .abbott domains
-  - .abbott TLD
   - top-level domain
-  - was ist .abbott
   - warum .abbott wählen
   - was ist die .abbott domain
   - warum die .abbott domain wählen

--- a/content/tld/de/abbvie.md
+++ b/content/tld/de/abbvie.md
@@ -14,9 +14,7 @@ draft: false
 description: "Erfahren Sie alles über die .abbvie TLD: Was sie ist, wie sie genutzt wird und warum Marken-Domains in der Web3-Ära wichtig sind."
 keywords:
   - .abbvie domains
-  - .abbvie TLD
   - top-level domain
-  - was ist .abbvie
   - warum .abbvie wählen
   - was ist die .abbvie domain
   - warum die .abbvie domain wählen

--- a/content/tld/de/abc.md
+++ b/content/tld/de/abc.md
@@ -14,9 +14,7 @@ draft: false
 description: 'Entdecken Sie das Potenzial der .abc Domain. Erfahren Sie, warum diese TLD für Einfachheit und Innovation steht und wie Sie sie bei Namefi registrieren.'
 keywords:
   - .abc domains
-  - .abc TLD
   - .abc top-level domain
-  - was ist .abc
   - warum .abc wählen
   - was ist die .abc domain
   - warum die .abc domain wählen

--- a/content/tld/de/able.md
+++ b/content/tld/de/able.md
@@ -14,9 +14,7 @@ draft: false
 description: 'Entdecken Sie die .able Domain: Eine vielseitige Endung für kreative Marken und Web3-Innovationen. Erfahren Sie alles über Vorteile, Nutzung und Registrierung.'
 keywords:
   - '.able domains'
-  - '.able TLD'
   - 'top-level domain'
-  - 'was ist .able'
   - 'warum .able wählen'
   - 'was ist die .able domain'
   - 'domain investing'

--- a/content/tld/de/abogado.md
+++ b/content/tld/de/abogado.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Erfahren Sie alles über die .abogado-Domain: Die ideale TLD für Rechtsanwälte und den juristischen Markt. Entdecken Sie Vorteile, Nutzung und Registrierung bei Namefi."
-keywords: [".abogado domains", "TLD", "top-level domain", "was ist .abogado", "warum .abogado wählen", "was ist die .abogado domain", "warum die .abogado domain wählen", "Rechtsanwalt Domain", "juristische Domains", "Anwalt Marketing", "Namefi", "Domain Investment", "Blockchain Domains", "tokenisierte Domains", "Domainregistrierung für Anwälte"]
+keywords: [".abogado domains", "TLD", "top-level domain", "warum .abogado wählen", "was ist die .abogado domain", "warum die .abogado domain wählen", "Rechtsanwalt Domain", "juristische Domains", "Anwalt Marketing", "Namefi", "Domain Investment", "Blockchain Domains", "tokenisierte Domains", "Domainregistrierung für Anwälte"]
 relatedArticles:
   - /de/blog/top-tlds-to-secure-for-your-law-firm/
   - /de/blog/top-tlds-to-secure-for-your-accounting-firm/

--- a/content/tld/de/abudhabi.md
+++ b/content/tld/de/abudhabi.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Erfahren Sie alles über die .abudhabi Domain. Entdecken Sie die Vorteile dieser geografischen TLD für Unternehmen in den VAE und registrieren Sie Ihre Domain bei Namefi."
-keywords: [".abudhabi domains", ".abudhabi TLD", "top-level domain", "was ist .abudhabi", "warum .abudhabi wählen", "was ist die .abudhabi domain", "warum die .abudhabi domain wählen", "domain investing", "blockchain domains", "tokenized domains", "UAE business domains", "Abu Dhabi digital identity", "geoTLD", "Namefi", "Middle East domains"]
+keywords: [".abudhabi domains", "top-level domain", "warum .abudhabi wählen", "was ist die .abudhabi domain", "warum die .abudhabi domain wählen", "domain investing", "blockchain domains", "tokenized domains", "UAE business domains", "Abu Dhabi digital identity", "geoTLD", "Namefi", "Middle East domains"]
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/top-tlds-to-secure-for-your-accounting-firm/

--- a/content/tld/de/ac.md
+++ b/content/tld/de/ac.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Erfahren Sie alles über die .ac Top-Level-Domain: Ideal für akademische Zwecke, Tech-Startups und Unternehmen in Aachen. Jetzt bei Namefi registrieren."
-keywords: [".ac domains", ".ac TLD", ".ac top-level domain", "was ist .ac", "warum .ac wählen", "was ist die .ac domain", "warum die .ac domain wählen", "domain investieren", "blockchain domains", "tokenisierte domains", "ascension island domain", "akademische domains", "aachen domains", "namefi registrar", "web3 domains"]
+keywords: [".ac domains", ".ac top-level domain", "warum .ac wählen", "was ist die .ac domain", "warum die .ac domain wählen", "domain investieren", "blockchain domains", "tokenisierte domains", "ascension island domain", "akademische domains", "aachen domains", "namefi registrar", "web3 domains"]
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/top-tlds-to-secure-for-your-accounting-firm/

--- a/content/tld/de/academy.md
+++ b/content/tld/de/academy.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Erfahren Sie alles über die .academy Domain: Ideal für Bildung, Kurse und Coaching. Sichern Sie sich Ihre digitale Identität jetzt bei Namefi."
-keywords: [".academy domains", ".academy TLD", ".academy top-level domain", "was ist .academy", "warum .academy wählen", "was ist die .academy domain", "warum die .academy domain wählen", "Bildungs-Domain", "Online-Kurs Domain", "domain investing", "blockchain domains", "tokenized domains", "Web3 domains", "Namefi", "Domain Registrierung"]
+keywords: [".academy domains", ".academy top-level domain", "warum .academy wählen", "was ist die .academy domain", "warum die .academy domain wählen", "Bildungs-Domain", "Online-Kurs Domain", "domain investing", "blockchain domains", "tokenized domains", "Web3 domains", "Namefi", "Domain Registrierung"]
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/what-are-tokenized-domains/

--- a/content/tld/de/accenture.md
+++ b/content/tld/de/accenture.md
@@ -16,7 +16,6 @@ keywords:
   - '.accenture domains'
   - 'TLD'
   - 'top-level domain'
-  - 'was ist .accenture'
   - 'warum .accenture wählen'
   - 'was ist die .accenture domain'
   - 'warum die .accenture domain wählen'

--- a/content/tld/de/accountant.md
+++ b/content/tld/de/accountant.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Erfahren Sie alles über die .accountant TLD: Vorteile für Finanzprofis, Verfügbarkeit und wie Sie diese vertrauenswürdige Domain bei Namefi registrieren."
-keywords: [".accountant domains", ".accountant TLD", ".accountant top-level domain", "was ist .accountant", "warum .accountant wählen", "was ist die .accountant domain", "warum die .accountant domain wählen", "Buchhalter Domain", "Finanzdienstleister Domains", "Domain Investing", "Blockchain Domains", "Tokenisierte Domains", "Steuerberater Marketing", "Web3 Domains"]
+keywords: [".accountant domains", ".accountant top-level domain", "warum .accountant wählen", "was ist die .accountant domain", "warum die .accountant domain wählen", "Buchhalter Domain", "Finanzdienstleister Domains", "Domain Investing", "Blockchain Domains", "Tokenisierte Domains", "Steuerberater Marketing", "Web3 Domains"]
 relatedArticles:
   - /de/blog/top-tlds-to-secure-for-your-accounting-firm/
   - /de/blog/what-is-a-tld/

--- a/content/tld/de/accountants.md
+++ b/content/tld/de/accountants.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Entdecken Sie die .accountants Domain: Die ideale digitale Identität für Steuerberater, Buchhalter und Finanzexperten. Sichern Sie sich jetzt Ihren Namen.'
-keywords: ['.accountants domains', '.accountants TLD', '.accountants top-level domain', 'was ist .accountants', 'warum .accountants wählen', 'was ist die .accountants domain', 'warum die .accountants domain wählen', 'Domain Investition', 'Blockchain Domains', 'tokenisierte Domains', 'Steuerberater Domain', 'Buchhaltung Website', 'Finanzdienstleister Webadresse', 'Web3 Domains', 'Firmennamen Registrierung']
+keywords: ['.accountants domains', '.accountants top-level domain', 'warum .accountants wählen', 'was ist die .accountants domain', 'warum die .accountants domain wählen', 'Domain Investition', 'Blockchain Domains', 'tokenisierte Domains', 'Steuerberater Domain', 'Buchhaltung Website', 'Finanzdienstleister Webadresse', 'Web3 Domains', 'Firmennamen Registrierung']
 relatedArticles:
   - /de/blog/top-tlds-to-secure-for-your-accounting-firm/
   - /de/blog/what-is-a-tld/

--- a/content/tld/de/aco.md
+++ b/content/tld/de/aco.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: Entdecken Sie das Potenzial der .aco Domain. Erfahren Sie alles über die Bedeutung, SEO-Vorteile und wie Sie diese TLD bei Namefi registrieren können.
-keywords: ['.aco domains', 'TLD', 'top-level domain', 'was ist .aco', 'warum .aco wählen', 'was ist die .aco domain', 'warum die .aco domain wählen', 'domain investing', 'blockchain', 'tokenized domain', 'web3 domains', 'domain namen kaufen', 'nischen domains', 'markenschutz']
+keywords: ['.aco domains', 'TLD', 'top-level domain', 'warum .aco wählen', 'was ist die .aco domain', 'warum die .aco domain wählen', 'domain investing', 'blockchain', 'tokenized domain', 'web3 domains', 'domain namen kaufen', 'nischen domains', 'markenschutz']
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/ai-vs-io-domain/

--- a/content/tld/de/active.md
+++ b/content/tld/de/active.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Erfahren Sie alles über die .active Top-Level-Domain. Entdecken Sie, warum diese Endung perfekt für Fitness, Tech und dynamische Marken ist und wie Sie sie bei Namefi registrieren.'
-keywords: ['.active domains', '.active TLD', 'top-level domain', 'was ist .active', 'warum .active wählen', 'was ist die .active domain', 'warum die .active domain wählen', 'domain investieren', 'blockchain domains', 'tokenisierte domains', 'fitness domains', 'lifestyle domains', 'tech domains', 'web3 domains', 'domain registrierung']
+keywords: ['.active domains', 'top-level domain', 'warum .active wählen', 'was ist die .active domain', 'warum die .active domain wählen', 'domain investieren', 'blockchain domains', 'tokenisierte domains', 'fitness domains', 'lifestyle domains', 'tech domains', 'web3 domains', 'domain registrierung']
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/what-are-tokenized-domains/

--- a/content/tld/de/actor.md
+++ b/content/tld/de/actor.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Entdecken Sie die .actor Domain: Die perfekte digitale Bühne für Schauspieler und Künstler. Erfahren Sie alles über Vorteile, Verfügbarkeit und Registrierung.'
-keywords: ['.actor domains', '.actor TLD', '.actor top-level domain', 'what is .actor', 'why choose .actor', 'what is the .actor domain', 'why choose the .actor domain', 'domain investing', 'tokenized domains', 'blockchain domains', 'schauspieler webseite', 'online portfolio', 'digital identity', 'namefi', 'domain registrierung']
+keywords: ['.actor domains', '.actor top-level domain', 'what is .actor', 'why choose .actor', 'what is the .actor domain', 'why choose the .actor domain', 'domain investing', 'tokenized domains', 'blockchain domains', 'schauspieler webseite', 'online portfolio', 'digital identity', 'namefi', 'domain registrierung']
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/what-are-tokenized-domains/

--- a/content/tld/de/ad.md
+++ b/content/tld/de/ad.md
@@ -15,9 +15,7 @@ draft: false
 description: 'Erfahren Sie alles über die .ad-Domain: Von der Herkunft in Andorra bis hin zum Potenzial für Werbung und Marketing. Jetzt informieren und bei Namefi registrieren.'
 keywords:
   - .ad domains
-  - .ad TLD
   - top-level domain
-  - was ist .ad
   - warum .ad wählen
   - was ist die .ad domain
   - warum die .ad domain wählen

--- a/content/tld/de/adac.md
+++ b/content/tld/de/adac.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Erfahren Sie alles über die .adac Top-Level-Domain: Bedeutung, Vorteile für die Markenidentität und ihre Rolle in der digitalen Welt der Mobilität.'
-keywords: ['.adac domains', '.adac TLD', 'top-level domain', 'was ist .adac', 'warum .adac wählen', 'was ist die .adac domain', 'warum die .adac domain wählen', 'Domain Investitionen', 'Blockchain Domains', 'tokenisierte Domains', 'ADAC', 'Marken TLD', 'Auto Domains', 'Web3 Domains', 'Domain Registrierung']
+keywords: ['.adac domains', 'top-level domain', 'warum .adac wählen', 'was ist die .adac domain', 'warum die .adac domain wählen', 'Domain Investitionen', 'Blockchain Domains', 'tokenisierte Domains', 'ADAC', 'Marken TLD', 'Auto Domains', 'Web3 Domains', 'Domain Registrierung']
 relatedArticles:
   - /de/blog/top-tlds-to-secure-for-your-accounting-firm/
   - /de/blog/what-is-a-tld/

--- a/content/tld/de/ads.md
+++ b/content/tld/de/ads.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Entdecken Sie die Vorteile der .ads-Domain für Ihr Marketing-Business. Erfahren Sie, warum diese TLD perfekt für Werbeagenturen und Ad-Tech ist.'
-keywords: ['.ads', '.ads domains', '.ads TLD', 'was ist .ads', 'warum .ads wählen', 'was ist die .ads domain', 'warum die .ads domain wählen', 'werbeagentur domain', 'online werbung', 'domain handel', 'blockchain domains', 'tokenisierte domains', 'ad tech', 'marketing tld', 'neue gTLD']
+keywords: ['.ads', '.ads domains', 'warum .ads wählen', 'was ist die .ads domain', 'warum die .ads domain wählen', 'werbeagentur domain', 'online werbung', 'domain handel', 'blockchain domains', 'tokenisierte domains', 'ad tech', 'marketing tld', 'neue gTLD']
 relatedArticles:
   - /de/blog/top-tlds-to-secure-for-your-startup/
   - /de/blog/what-is-a-tld/

--- a/content/tld/de/adult.md
+++ b/content/tld/de/adult.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Erfahren Sie alles über die .adult-TLD: Bedeutung, Vorteile für die Erwachsenenbranche & SEO. Jetzt sicher & diskret bei Namefi registrieren!"
-keywords: [".adult domains", ".adult TLD", "top-level domain", "what is .adult", "why choose .adult", "was ist die .adult domain", "warum .adult wählen", "domain investing", "blockchain domains", "tokenized domain", "adult entertainment branding", "digital identity", "web3 domains", "domain registration germany", "niche tld"]
+keywords: [".adult domains", "top-level domain", "what is .adult", "why choose .adult", "was ist die .adult domain", "warum .adult wählen", "domain investing", "blockchain domains", "tokenized domain", "adult entertainment branding", "digital identity", "web3 domains", "domain registration germany", "niche tld"]
 relatedArticles:
   - /de/blog/top-tlds-to-secure-for-your-accounting-firm/
   - /de/blog/top-tlds-to-secure-for-your-business/

--- a/content/tld/de/ae.md
+++ b/content/tld/de/ae.md
@@ -15,9 +15,7 @@ draft: false
 description: 'Erfahren Sie alles über die .ae Domain. Perfekt für Unternehmen in den VAE, SEO und globale Marken. Sichern Sie sich Ihre digitale Identität jetzt mit Namefi.'
 keywords:
   - .ae domains
-  - .ae TLD
   - .ae top-level domain
-  - was ist .ae
   - warum .ae wählen
   - was ist die .ae domain
   - warum die .ae domain wählen

--- a/content/tld/de/aero.md
+++ b/content/tld/de/aero.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Entdecken Sie die .aero-Domain: Die exklusive Top-Level-Domain für die Luftfahrtindustrie. Erfahren Sie alles über Vorteile, Zugangsvoraussetzungen und die Registrierung bei Namefi."
-keywords: [".aero domains", ".aero TLD", "top-level domain", "was ist .aero", "warum .aero wählen", "was ist die .aero domain", "warum die .aero domain wählen", "luftfahrt domains", "aviation industry domains", "domain investing", "blockchain domains", "tokenized domain", "SITA domain", "flughafen domain", "fluggesellschaft domain"]
+keywords: [".aero domains", "top-level domain", "warum .aero wählen", "was ist die .aero domain", "warum die .aero domain wählen", "luftfahrt domains", "aviation industry domains", "domain investing", "blockchain domains", "tokenized domain", "SITA domain", "flughafen domain", "fluggesellschaft domain"]
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/top-tlds-to-secure-for-your-accounting-firm/

--- a/content/tld/de/af.md
+++ b/content/tld/de/af.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Erfahren Sie alles über die .af-Domain: Von ihrer Herkunft als ccTLD für Afghanistan bis hin zu ihrer Beliebtheit für kreative Domain-Hacks und modernes Branding. Sichern Sie sich jetzt Ihre .af-Adresse."
-keywords: [".af domains", ".af TLD", "top-level domain", "was ist .af", "warum .af wählen", "was ist die .af domain", "warum die .af domain wählen", "domain investing", "blockchain domains", "tokenized domain", "domain hacks", "afghanistan domain", "kreative domains", "web3 domains", "namefi"]
+keywords: [".af domains", "top-level domain", "warum .af wählen", "was ist die .af domain", "warum die .af domain wählen", "domain investing", "blockchain domains", "tokenized domain", "domain hacks", "afghanistan domain", "kreative domains", "web3 domains", "namefi"]
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/ai-vs-io-domain/

--- a/content/tld/de/afamilycompany.md
+++ b/content/tld/de/afamilycompany.md
@@ -14,9 +14,7 @@ draft: false
 description: 'Erfahren Sie alles über die .afamilycompany TLD: Ein Symbol für Vertrauen und familiäre Unternehmenswerte. Entdecken Sie Vorteile und Hintergründe bei Namefi.'
 keywords:
   - .afamilycompany domains
-  - .afamilycompany TLD
   - top-level domain
-  - was ist .afamilycompany
   - warum .afamilycompany wählen
   - was ist die .afamilycompany domain
   - warum die .afamilycompany domain wählen

--- a/content/tld/de/afl.md
+++ b/content/tld/de/afl.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Alles über die .afl Domain: Eine exklusive TLD für den Australian Football. Erfahren Sie mehr über Vorteile, Nutzung und die Registrierung bei Namefi."
-keywords: [".afl domains", ".afl TLD", "top-level domain", "was ist .afl", "warum .afl wählen", "was ist die .afl domain", "warum die .afl domain wählen", "domain investing", "blockchain domains", "tokenized domain", "Australian Football League domain", "sport domains", "marken TLD", "Web3 domains", "digitale identität"]
+keywords: [".afl domains", "top-level domain", "warum .afl wählen", "was ist die .afl domain", "warum die .afl domain wählen", "domain investing", "blockchain domains", "tokenized domain", "Australian Football League domain", "sport domains", "marken TLD", "Web3 domains", "digitale identität"]
 relatedArticles:
   - /de/blog/what-are-tokenized-domains/
   - /de/blog/what-is-a-tld/

--- a/content/tld/de/africa.md
+++ b/content/tld/de/africa.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Entdecken Sie die .africa Domain: Eine digitale Identität für den gesamten Kontinent. Perfekt für panafrikanische Marken. Jetzt bei Namefi registrieren.'
-keywords: ['.africa domains', '.africa TLD', '.africa top-level domain', 'was ist .africa', 'warum .africa wählen', 'was ist die .africa domain', 'warum die .africa domain wählen', 'Afrika Domain registrieren', 'Domain Investing Afrika', 'Blockchain Domains', 'tokenisierte Domains', 'Web3 Domains', 'Namefi', 'digitale Identität Afrika', 'Markenschutz Afrika']
+keywords: ['.africa domains', '.africa top-level domain', 'warum .africa wählen', 'was ist die .africa domain', 'warum die .africa domain wählen', 'Afrika Domain registrieren', 'Domain Investing Afrika', 'Blockchain Domains', 'tokenisierte Domains', 'Web3 Domains', 'Namefi', 'digitale Identität Afrika', 'Markenschutz Afrika']
 relatedArticles:
   - /de/blog/ai-vs-io-domain/
   - /de/blog/what-is-a-tld/

--- a/content/tld/de/ag.md
+++ b/content/tld/de/ag.md
@@ -14,9 +14,7 @@ draft: false
 description: 'Entdecken Sie die Bedeutung der .ag Domain: Ideal für Aktiengesellschaften im deutschsprachigen Raum und Unternehmen in Antigua. Sichern Sie sich Ihre .ag TLD bei Namefi.'
 keywords:
   - '.ag domains'
-  - '.ag TLD'
   - '.ag top-level domain'
-  - 'was ist .ag'
   - 'warum .ag wählen'
   - 'was ist die .ag domain'
   - 'warum die .ag domain wählen'

--- a/content/tld/de/agakhan.md
+++ b/content/tld/de/agakhan.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Erfahren Sie alles über die .agakhan Top-Level-Domain: Bedeutung, Nutzung und Vorteile. Entdecken Sie, wie diese exklusive TLD Vertrauen schafft und wie Namefi Ihre Domain-Reise unterstützt.'
-keywords: ['.agakhan domains', 'TLD', 'top-level domain', 'was ist .agakhan', 'warum .agakhan wählen', 'was ist die .agakhan domain', 'warum die .agakhan domain wählen', 'domain investieren', 'blockchain domains', 'tokenisierte domains', 'Aga Khan Development Network', 'exklusive domains', 'web3 domains', 'marken TLD', 'domain registrierung']
+keywords: ['.agakhan domains', 'TLD', 'top-level domain', 'warum .agakhan wählen', 'was ist die .agakhan domain', 'warum die .agakhan domain wählen', 'domain investieren', 'blockchain domains', 'tokenisierte domains', 'Aga Khan Development Network', 'exklusive domains', 'web3 domains', 'marken TLD', 'domain registrierung']
 relatedArticles:
   - /de/blog/top-tlds-to-secure-for-your-accounting-firm/
   - /de/blog/what-is-a-tld/

--- a/content/tld/de/agency.md
+++ b/content/tld/de/agency.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Erfahren Sie alles über die .agency Domain: Perfekt für Dienstleister und Kreative. Entdecken Sie Vorteile, Verfügbarkeit und wie Sie Ihre Domain bei Namefi sichern."
-keywords: ['.agency domains', '.agency TLD', '.agency top-level domain', 'what is .agency', 'why choose .agency', 'what is the .agency domain', 'why choose the .agency domain', 'was ist .agency', 'warum .agency wählen', 'domain investing', 'blockchain domains', 'tokenized domains', 'Werbeagentur Domain', 'Marketing Agentur', 'Dienstleister Domains']
+keywords: ['.agency domains', '.agency top-level domain', 'what is .agency', 'why choose .agency', 'what is the .agency domain', 'why choose the .agency domain', 'warum .agency wählen', 'domain investing', 'blockchain domains', 'tokenized domains', 'Werbeagentur Domain', 'Marketing Agentur', 'Dienstleister Domains']
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/top-tlds-to-secure-for-your-business/

--- a/content/tld/de/ai.md
+++ b/content/tld/de/ai.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: '.ai ist Anguilas Ländercode-Domain, die zur globalen KI-Branding-Erweiterung geworden ist. Erfahren Sie, wer sie betreibt, welche Registrierungsregeln gelten, wie sie sich auf SEO auswirkt und wie Sie .ai bei Namefi registrieren.'
-keywords: ['.ai Domain', 'Was ist .ai', '.ai TLD', 'Anguilla ccTLD', '.ai Domain registrieren', 'KI-Startup-Domain', '.ai vs .io', 'wer besitzt .ai']
+keywords: ['Anguilla ccTLD', '.ai Domain registrieren', 'KI-Startup-Domain', '.ai vs .io', 'wer besitzt .ai']
 faqs:
   - question: 'Kann jeder eine .ai-Domain registrieren?'
     answer: 'Ja. Das .ai-Register ist weltweit für alle offen, ohne Anforderungen an lokale Präsenz oder Nachweise. Der wesentliche Unterschied zu den meisten TLDs besteht darin, dass .ai in einer Mindestlaufzeit von zwei Jahren statt in Einjahresabschnitten verkauft wird.'

--- a/content/tld/de/aig.md
+++ b/content/tld/de/aig.md
@@ -14,9 +14,7 @@ draft: false
 description: 'Entdecken Sie die .aig Domain: Die perfekte Wahl für KI-Innovationen und Web3. Erfahren Sie alles über Vorteile, Nutzung und Registrierung bei Namefi.'
 keywords:
   - .aig domains
-  - .aig TLD
   - top-level domain
-  - was ist .aig
   - warum .aig wählen
   - was ist die .aig domain
   - warum die .aig domain wählen

--- a/content/tld/de/aigo.md
+++ b/content/tld/de/aigo.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Erfahren Sie alles über die .aigo Top-Level-Domain: Ideal für KI, Tech und Web3. Entdecken Sie die Vorteile und sichern Sie sich Ihre Domain bei Namefi."
-keywords: [".aigo domains", ".aigo TLD", "top-level domain", "was ist .aigo", "warum .aigo wählen", "was ist die .aigo domain", "warum die .aigo domain wählen", "blockchain domains", "tokenisierte domains", "web3 domains", "domain investieren", "künstliche intelligenz domains", "tech startups domains", "namefi", "digitale identität"]
+keywords: [".aigo domains", "top-level domain", "warum .aigo wählen", "was ist die .aigo domain", "warum die .aigo domain wählen", "blockchain domains", "tokenisierte domains", "web3 domains", "domain investieren", "künstliche intelligenz domains", "tech startups domains", "namefi", "digitale identität"]
 relatedArticles:
   - /de/blog/ai-vs-io-domain/
   - /de/blog/what-is-a-tld/

--- a/content/tld/de/airbus.md
+++ b/content/tld/de/airbus.md
@@ -14,9 +14,7 @@ draft: false
 description: "Erfahren Sie alles über die .airbus Top-Level-Domain: Eine exklusive Marken-TLD, ihre Bedeutung für die digitale Identität und was Domain-Investoren wissen müssen."
 keywords:
   - .airbus domains
-  - .airbus TLD
   - top-level domain
-  - was ist .airbus
   - warum .airbus wählen
   - was ist die .airbus domain
   - warum die .airbus domain wählen

--- a/content/tld/de/airforce.md
+++ b/content/tld/de/airforce.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Entdecken Sie die .airforce TLD: Die perfekte Domain für Luftfahrt, Militär und Veteranen. Erfahren Sie alles über Vorteile und Registrierung bei Namefi.'
-keywords: ['.airforce domains', '.airforce TLD', '.airforce top-level domain', 'was ist .airforce', 'warum .airforce wählen', 'was ist die .airforce domain', 'warum die .airforce domain wählen', 'Luftwaffen Domain', 'Militär Webadresse', 'Luftfahrt Blog', 'Veteranen Webseite', 'Domain Investieren', 'Tokenisierte Domains', 'Web3 Domains', 'Luftfahrt Community']
+keywords: ['.airforce domains', '.airforce top-level domain', 'warum .airforce wählen', 'was ist die .airforce domain', 'warum die .airforce domain wählen', 'Luftwaffen Domain', 'Militär Webadresse', 'Luftfahrt Blog', 'Veteranen Webseite', 'Domain Investieren', 'Tokenisierte Domains', 'Web3 Domains', 'Luftfahrt Community']
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/what-are-tokenized-domains/

--- a/content/tld/de/airtel.md
+++ b/content/tld/de/airtel.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Erfahren Sie alles über die .airtel Top-Level-Domain. Entdecken Sie die Vorteile, Anwendungsfälle und wie Sie Premium-Domains und Blockchain-Assets bei Namefi sichern."
-keywords: [".airtel domains", ".airtel TLD", "top-level domain", "was ist .airtel", "warum .airtel wählen", "was ist die .airtel domain", "warum die .airtel domain wählen", "domain investing", "blockchain domains", "tokenized domain", "marken domains", "airtel registrierung", "telekommunikation domains"]
+keywords: [".airtel domains", "top-level domain", "warum .airtel wählen", "was ist die .airtel domain", "warum die .airtel domain wählen", "domain investing", "blockchain domains", "tokenized domain", "marken domains", "airtel registrierung", "telekommunikation domains"]
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/top-tlds-to-secure-for-your-business/

--- a/content/tld/de/akdn.md
+++ b/content/tld/de/akdn.md
@@ -14,9 +14,7 @@ draft: false
 description: 'Entdecken Sie alles über die .akdn Domain: Eine exklusive TLD für das Aga Khan Development Network. Erfahren Sie mehr über Vorteile, Nutzung und Bedeutung.'
 keywords:
   - .akdn domains
-  - .akdn TLD
   - top-level domain
-  - was ist .akdn
   - warum .akdn wählen
   - was ist die .akdn domain
   - warum die .akdn domain wählen

--- a/content/tld/de/al.md
+++ b/content/tld/de/al.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Entdecken Sie die Vorteile der .al Top-Level-Domain für Ihr Unternehmen und Web3-Projekte. Erfahren Sie mehr über Verfügbarkeit, SEO und Registrierung bei Namefi."
-keywords: [".al domains", ".al TLD", "top-level domain", "was ist .al", "warum .al wählen", "was ist die .al domain", "warum die .al domain wählen", "domain investing", "blockchain domains", "tokenized domain", "albanien domain", "kurze domains kaufen", "domain hacks", "web3 domains", "namefi"]
+keywords: [".al domains", "top-level domain", "warum .al wählen", "was ist die .al domain", "warum die .al domain wählen", "domain investing", "blockchain domains", "tokenized domain", "albanien domain", "kurze domains kaufen", "domain hacks", "web3 domains", "namefi"]
 relatedArticles:
   - /de/blog/ai-vs-io-domain/
   - /de/blog/what-is-a-tld/

--- a/content/tld/de/alfaromeo.md
+++ b/content/tld/de/alfaromeo.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Erfahren Sie alles über die .alfaromeo Top-Level-Domain. Entdecken Sie die Vorteile dieser exklusiven Marken-TLD, ihre Bedeutung für SEO und digitale Identität."
-keywords: [".alfaromeo domains", ".alfaromeo TLD", "top-level domain", "was ist .alfaromeo", "warum .alfaromeo wählen", "was ist die .alfaromeo domain", "warum die .alfaromeo domain wählen", "domain investing", "blockchain domains", "tokenisierte domains", "marken tld", "automobil domains", "namefi", "web3 domains", "neue gtlds"]
+keywords: [".alfaromeo domains", "top-level domain", "warum .alfaromeo wählen", "was ist die .alfaromeo domain", "warum die .alfaromeo domain wählen", "domain investing", "blockchain domains", "tokenisierte domains", "marken tld", "automobil domains", "namefi", "web3 domains", "neue gtlds"]
 relatedArticles:
   - /de/blog/top-tlds-to-secure-for-your-business/
   - /de/blog/what-are-tokenized-domains/

--- a/content/tld/de/alibaba.md
+++ b/content/tld/de/alibaba.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Entdecken Sie die .alibaba TLD: Alles über Bedeutung, Vorteile und Sicherheit dieser exklusiven Domain-Endung für E-Commerce und Tech-Investoren."
-keywords: [".alibaba domains", ".alibaba TLD", "top-level domain", "was ist .alibaba", "warum .alibaba wählen", "was ist die .alibaba domain", "warum die .alibaba domain wählen", "domain investing", "blockchain domains", "tokenized domain", "marken tld", "e-commerce domains", "namefi", "domain registrierung", "alibaba cloud"]
+keywords: [".alibaba domains", "top-level domain", "warum .alibaba wählen", "was ist die .alibaba domain", "warum die .alibaba domain wählen", "domain investing", "blockchain domains", "tokenized domain", "marken tld", "e-commerce domains", "namefi", "domain registrierung", "alibaba cloud"]
 relatedArticles:
   - /de/blog/top-tlds-to-secure-for-your-business/
   - /de/blog/top-tlds-to-secure-for-your-fashion-brand/

--- a/content/tld/de/alipay.md
+++ b/content/tld/de/alipay.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Erfahren Sie alles über die .alipay Top-Level-Domain. Entdecken Sie, warum diese TLD für Vertrauen im E-Commerce und Fintech steht und wie Sie sie für Ihre digitale Identität nutzen können.'
-keywords: ['.alipay domains', '.alipay TLD', 'top-level domain', 'was ist .alipay', 'warum .alipay wählen', 'was ist die .alipay domain', 'warum die .alipay domain wählen', 'domain investing', 'blockchain domains', 'tokenized domain', 'fintech domains', 'e-commerce domains', 'domain registrierung', 'digitale identität', 'web3 domains']
+keywords: ['.alipay domains', 'top-level domain', 'warum .alipay wählen', 'was ist die .alipay domain', 'warum die .alipay domain wählen', 'domain investing', 'blockchain domains', 'tokenized domain', 'fintech domains', 'e-commerce domains', 'domain registrierung', 'digitale identität', 'web3 domains']
 relatedArticles:
   - /de/blog/top-tlds-to-secure-for-your-accounting-firm/
   - /de/blog/what-are-tokenized-domains/

--- a/content/tld/de/allfinanz.md
+++ b/content/tld/de/allfinanz.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Erfahren Sie alles über die .allfinanz TLD: Eine spezialisierte Domainendung für umfassende Finanzdienstleistungen. Entdecken Sie Vorteile, SEO-Potenzial und Registrierungsmöglichkeiten."
-keywords: [".allfinanz domains", ".allfinanz TLD", "top-level domain", "was ist .allfinanz", "warum .allfinanz wählen", "was ist die .allfinanz domain", "warum die .allfinanz domain wählen", "allfinanzkonzept online", "finanzdienstleister domains", "domain investieren", "blockchain domains", "tokenisierte domains", "deutsche vermögensberatung domain", "fintech domains", "web3 domain registrierung"]
+keywords: [".allfinanz domains", "top-level domain", "warum .allfinanz wählen", "was ist die .allfinanz domain", "warum die .allfinanz domain wählen", "allfinanzkonzept online", "finanzdienstleister domains", "domain investieren", "blockchain domains", "tokenisierte domains", "deutsche vermögensberatung domain", "fintech domains", "web3 domain registrierung"]
 relatedArticles:
   - /de/blog/top-tlds-to-secure-for-your-accounting-firm/
   - /de/blog/what-is-a-tld/

--- a/content/tld/de/allstate.md
+++ b/content/tld/de/allstate.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Erfahren Sie alles über die .allstate Top-Level-Domain: Einblicke in Brand-TLDs, Sicherheitsvorteile und warum exklusive Domain-Endungen die Zukunft der digitalen Identität prägen."
-keywords: ['.allstate domains', '.allstate TLD', 'top-level domain', 'was ist .allstate', 'warum .allstate wählen', 'was ist die .allstate domain', 'warum die .allstate domain wählen', 'domain investieren', 'blockchain domains', 'tokenisierte domains', 'Web3 domains', 'Allstate Marken-TLD', 'sichere domains', 'ICANN neue gTLDs', 'Namefi domain registrierung']
+keywords: ['.allstate domains', 'top-level domain', 'warum .allstate wählen', 'was ist die .allstate domain', 'warum die .allstate domain wählen', 'domain investieren', 'blockchain domains', 'tokenisierte domains', 'Web3 domains', 'Allstate Marken-TLD', 'sichere domains', 'ICANN neue gTLDs', 'Namefi domain registrierung']
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/what-are-tokenized-domains/

--- a/content/tld/de/ally.md
+++ b/content/tld/de/ally.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Entdecken Sie die .ally Domain: Die perfekte TLD für Partnerschaften, Inklusion und Communitys. Erfahren Sie, warum Sie Ihre .ally Domain noch heute bei Namefi registrieren sollten.'
-keywords: ['.ally domains', '.ally TLD', 'top-level domain', 'was ist .ally', 'warum .ally wählen', 'was ist die .ally domain', 'warum die .ally domain wählen', 'domain investieren', 'blockchain domains', 'tokenisierte domains', 'web3 domains', 'neue gTLD', 'domainregistrierung', 'digitale identität', 'partnerschaft domains']
+keywords: ['.ally domains', 'top-level domain', 'warum .ally wählen', 'was ist die .ally domain', 'warum die .ally domain wählen', 'domain investieren', 'blockchain domains', 'tokenisierte domains', 'web3 domains', 'neue gTLD', 'domainregistrierung', 'digitale identität', 'partnerschaft domains']
 relatedArticles:
   - /de/blog/what-are-tokenized-domains/
   - /de/blog/what-is-a-tld/

--- a/content/tld/de/alsace.md
+++ b/content/tld/de/alsace.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Erfahren Sie alles über die .alsace TLD: Die perfekte Domain für Unternehmen und Kultur im Elsass. Entdecken Sie Vorteile, SEO-Chancen und Registrierung bei Namefi."
-keywords: ['.alsace domains', '.alsace TLD', 'top-level domain', 'was ist .alsace', 'warum .alsace wählen', 'was ist die .alsace domain', 'warum die .alsace domain wählen', 'Elsass Domain registrieren', 'GeoTLD Elsass', 'lokale SEO Domains', 'Domain Investment', 'Blockchain Domains', 'Namefi', 'Web3 Domains', 'digitale Identität Elsass']
+keywords: ['.alsace domains', 'top-level domain', 'warum .alsace wählen', 'was ist die .alsace domain', 'warum die .alsace domain wählen', 'Elsass Domain registrieren', 'GeoTLD Elsass', 'lokale SEO Domains', 'Domain Investment', 'Blockchain Domains', 'Namefi', 'Web3 Domains', 'digitale Identität Elsass']
 relatedArticles:
   - /de/blog/ai-vs-io-domain/
   - /de/blog/what-is-a-tld/

--- a/content/tld/de/alstom.md
+++ b/content/tld/de/alstom.md
@@ -14,7 +14,6 @@ draft: false
 description: 'Erfahren Sie alles über die .alstom Top-Level-Domain. Einblicke in diese exklusive Marken-TLD, ihre Bedeutung für den Schienenverkehr und Domain-Trends.'
 keywords:
   - .alstom domains
-  - .alstom TLD
   - top-level domain
   - what is .alstom
   - why choose .alstom

--- a/content/tld/de/am.md
+++ b/content/tld/de/am.md
@@ -14,9 +14,7 @@ draft: false
 description: 'Erfahren Sie alles über die .am-Domain: Von der Bedeutung für Armenien bis hin zu Radio-Hacks und SEO-Vorteilen. Sichern Sie sich Ihre Adresse bei Namefi.'
 keywords:
   - '.am domains'
-  - '.am TLD'
   - '.am top-level domain'
-  - 'was ist .am'
   - 'warum .am wählen'
   - 'was ist die .am domain'
   - 'warum die .am domain wählen'

--- a/content/tld/de/app.md
+++ b/content/tld/de/app.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Erfahren Sie alles über die .app Domain: Die sichere Wahl für Apps und Entwickler. Entdecken Sie Vorteile, SEO-Potenzial und wie Sie sie bei Namefi registrieren.'
-keywords: ['.app domains', '.app TLD', '.app top-level domain', 'was ist .app', 'warum .app wählen', 'was ist die .app domain', 'warum die .app domain wählen', 'domain investing', 'tokenisierte domains', 'blockchain domains', 'app entwickler', 'sichere domains', 'google registry', 'web3 domains', 'namefi']
+keywords: ['.app domains', '.app top-level domain', 'warum .app wählen', 'was ist die .app domain', 'warum die .app domain wählen', 'domain investing', 'tokenisierte domains', 'blockchain domains', 'app entwickler', 'sichere domains', 'google registry', 'web3 domains', 'namefi']
 relatedArticles:
   - /de/blog/top-tlds-to-secure-for-your-startup/
   - /de/blog/top-tlds-to-secure-for-your-saas/

--- a/content/tld/de/biz.md
+++ b/content/tld/de/biz.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Die .biz-Domain ist eine offene, geschäftsorientierte gTLD, die von GoDaddy Registry betrieben wird. Erfahren Sie, für wen sie geeignet ist, wie sie im Vergleich zu .com abschneidet und was Sie vor dem Kauf wissen sollten.'
-keywords: ['.biz', '.biz-Domains', '.biz TLD', 'was ist .biz', 'Business-Domain-Endung', 'biz vs com', 'GoDaddy Registry', 'echte geschäftliche Nutzung']
+keywords: ['.biz', '.biz-Domains', 'Business-Domain-Endung', 'biz vs com', 'GoDaddy Registry', 'echte geschäftliche Nutzung']
 faqs:
   - question: 'Kann jeder eine .biz-Domain registrieren?'
     answer: 'Fast. Der .biz-Namensraum ist weltweit offen, ohne Hürden bei Qualifikation, Marke oder lokaler Präsenz, aber Registrierungen sind für echte geschäftliche oder kommerzielle Nutzung gedacht. Nicht-kommerzielle oder rein spekulative Registrierungen können im Prinzip angefochten werden, auch wenn die Durchsetzung in der Praxis gering ist.'

--- a/content/tld/de/blog.md
+++ b/content/tld/de/blog.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Erfahren Sie alles über die .blog Domain: Vorteile für SEO, Branding und warum diese Endung perfekt für Content-Creator und Unternehmen ist. Jetzt bei Namefi registrieren."
-keywords: [".blog domains", ".blog TLD", "top-level domain", "was ist .blog", "warum .blog wählen", "was ist die .blog domain", "warum die .blog domain wählen", "Domain investieren", "Blockchain Domains", "tokenisierte Domains", "Web3 Domains", "Blog starten", "Content Marketing", "Domain registrieren", "Namefi"]
+keywords: [".blog domains", "top-level domain", "warum .blog wählen", "was ist die .blog domain", "warum die .blog domain wählen", "Domain investieren", "Blockchain Domains", "tokenisierte Domains", "Web3 Domains", "Blog starten", "Content Marketing", "Domain registrieren", "Namefi"]
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/ai-vs-io-domain/

--- a/content/tld/de/cc.md
+++ b/content/tld/de/cc.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Was ist die .cc-Domain? Die länderspezifische TLD der Kokosinseln (Keelinginseln), betrieben von Verisign und weltweit als kurze, markenfähige Alternative zu .com vermarktet. Erfahren Sie, wer sie betreibt, wer registrieren kann, wie die Preisgestaltung funktioniert und wie es um die SEO steht.'
-keywords: ['.cc-Domains', '.cc TLD', 'cc Domain', 'was ist .cc', 'was ist die .cc-Domain', '.cc vs .com', 'cc Domain Bedeutung', 'Kokosinseln Keelinginseln Domain', '.cc-Domain registrieren', 'kurze markenfähige Domain', 'Domain-Hack cc']
+keywords: ['.cc-Domains', 'cc Domain', 'was ist die .cc-Domain', '.cc vs .com', 'cc Domain Bedeutung', 'Kokosinseln Keelinginseln Domain', '.cc-Domain registrieren', 'kurze markenfähige Domain', 'Domain-Hack cc']
 faqs:
   - question: 'Kann jeder eine .cc-Domain registrieren?'
     answer: 'Ja. Obwohl .cc technisch gesehen die länderspezifische TLD der Kokosinseln (Keelinginseln) ist, steht sie jedem weltweit offen, ohne Anforderung an lokale Präsenz oder Wohnsitz. Die Registrierung erfolgt nach dem Prinzip „first-come, first-served" auf der zweiten Ebene.'

--- a/content/tld/de/city.md
+++ b/content/tld/de/city.md
@@ -8,7 +8,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: .city ist die Domain für lokale Unternehmen, kommunale Dienste und städtische Websites. Perfekt zur Etablierung einer lokalen Präsenz.
-keywords: ["tld", ".city Domain", "lokales Geschäft", "kommunale Dienste", "städtische Websites", "lokale Präsenz"]
+keywords: ["tld", "lokales Geschäft", "kommunale Dienste", "städtische Websites", "lokale Präsenz"]
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/what-are-tokenized-domains/

--- a/content/tld/de/click.md
+++ b/content/tld/de/click.md
@@ -14,9 +14,7 @@ draft: false
 description: 'Entdecken Sie die Vorteile der .click Domain. Erfahren Sie, warum Startups und Marketer diese TLD für starke Handlungsaufforderungen nutzen und wie Sie sie bei Namefi registrieren.'
 keywords:
   - '.click domains'
-  - '.click TLD'
   - '.click top-level domain'
-  - 'was ist .click'
   - 'warum .click wählen'
   - 'was ist die .click domain'
   - 'warum die .click domain wählen'

--- a/content/tld/de/cloud.md
+++ b/content/tld/de/cloud.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Entdecken Sie die Vorteile der .cloud-Domain für Ihr Business. Erfahren Sie mehr über Nutzungsmöglichkeiten und registrieren Sie Ihre .cloud-Domain bei Namefi."
-keywords: [".cloud domains", ".cloud TLD", "top-level domain .cloud", "was ist .cloud", "warum .cloud wählen", "was ist die .cloud domain", "warum die .cloud domain wählen", "cloud domain kaufen", "domain investing", "blockchain domains", "tokenisierte domains", "web3 domains", "SaaS domains", "cloud computing trends", "neue gTLDs"]
+keywords: [".cloud domains", "top-level domain .cloud", "warum .cloud wählen", "was ist die .cloud domain", "warum die .cloud domain wählen", "cloud domain kaufen", "domain investing", "blockchain domains", "tokenisierte domains", "web3 domains", "SaaS domains", "cloud computing trends", "neue gTLDs"]
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/ai-vs-io-domain/

--- a/content/tld/de/club.md
+++ b/content/tld/de/club.md
@@ -15,9 +15,7 @@ draft: false
 description: 'Erfahren Sie alles über die .club Domain: Ideal für Communitys, Unternehmen und Web3-Projekte. Jetzt informieren und Ihre .club Domain bei Namefi sichern.'
 keywords:
   - .club domains
-  - .club TLD
   - top-level domain club
-  - was ist .club
   - warum .club wählen
   - was ist die .club domain
   - warum die .club domain wählen

--- a/content/tld/de/co.md
+++ b/content/tld/de/co.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Was ist die .co-Domain? Die länderspezifische TLD Kolumbiens, weltweit als kurze „.com"- oder „Company"-Alternative vermarktet. Erfahren Sie, wer sie betreibt, wer registrieren kann, wie die Preisgestaltung funktioniert und wie es um die SEO steht.'
-keywords: ['.co-Domains', '.co TLD', 'co Domain', 'was ist .co', 'was ist die .co-Domain', '.co vs .com', 'co Domain für Startups', 'Kolumbien Domain', '.co-Domain registrieren', 'kurze Company-Domain']
+keywords: ['.co-Domains', 'co Domain', 'was ist die .co-Domain', '.co vs .com', 'co Domain für Startups', 'Kolumbien Domain', '.co-Domain registrieren', 'kurze Company-Domain']
 faqs:
   - question: 'Kann jeder eine .co-Domain registrieren?'
     answer: 'Ja. Obwohl .co technisch gesehen die länderspezifische TLD Kolumbiens ist, steht sie seit ihrem Neustart im Jahr 2010 jedem weltweit offen, ohne Anforderung an lokale Präsenz oder kolumbianischen Wohnsitz. Die Registrierung erfolgt nach dem Prinzip „first-come, first-served" auf der zweiten Ebene.'

--- a/content/tld/de/com.md
+++ b/content/tld/de/com.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Die .com-Domain ist die Standard-Adresse des kommerziellen Internets. Erfahren Sie mehr über ihre Geschichte, wer eine registrieren kann, wie die Preisgestaltung funktioniert und warum sie nach wie vor führend ist.'
-keywords: ['.com-Domains', 'was ist .com', '.com TLD', '.com Domain-Endung', '.com-Domain registrieren', 'com Domain Bedeutung', '.com vs .net', 'Geschäftsdomains']
+keywords: ['.com-Domains', '.com Domain-Endung', '.com-Domain registrieren', 'com Domain Bedeutung', '.com vs .net', 'Geschäftsdomains']
 faqs:
   - question: 'Kann jeder eine .com-Domain registrieren?'
     answer: 'Ja. Der .com-Namensraum steht jedem weltweit offen, ohne Anforderungen an lokale Präsenz, Geschäftstätigkeit, Qualifikationen oder Zugehörigkeit zu einer Gemeinschaft. Die ursprüngliche kommerzielle Absicht wird nicht mehr durchgesetzt, sodass Privatpersonen, gemeinnützige Organisationen und Unternehmen gleichermaßen eine registrieren können.'

--- a/content/tld/de/de.md
+++ b/content/tld/de/de.md
@@ -9,7 +9,7 @@ translators: ['kai-kunstmann']
 draft: false
 selfCanonical: true
 description: 'Die .de-Domain ist die offizielle Länderendung für Deutschland, betrieben von DENIC. Erfahren Sie, wer sie registrieren darf, welche DENIC-Regeln gelten und worauf Sie achten sollten.'
-keywords: ['.de Domain', 'was ist .de', 'DENIC', 'ccTLD Deutschland', '.de registrieren', 'deutsche Domain', 'Länder-Top-Level-Domain', 'Domain Deutschland', 'Zustellungsbevollmächtigter .de', '.de vs .com']
+keywords: ['DENIC', 'ccTLD Deutschland', '.de registrieren', 'deutsche Domain', 'Länder-Top-Level-Domain', 'Domain Deutschland', 'Zustellungsbevollmächtigter .de', '.de vs .com']
 faqs:
   - question: 'Kann jeder eine .de-Domain registrieren?'
     answer: 'Ja. Die .de-Endung ist für alle offen, ob Privatperson, Verein oder Unternehmen, mit Sitz in Deutschland oder im Ausland. Es gibt keine Wohnsitzpflicht. Wer keinen deutschen Wohnsitz hat, muss auf Verlangen von DENIC innerhalb von zwei Wochen einen in Deutschland ansässigen Zustellungsbevollmächtigten benennen.'

--- a/content/tld/de/dev.md
+++ b/content/tld/de/dev.md
@@ -8,7 +8,7 @@ authors: ["namefiteam"]
 editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 description: .dev ist Googles sichere Domain für Entwickler und Entwicklungsprojekte. Erfahren Sie, warum sie die erste Wahl für Programmierer, Technologieunternehmen und Entwicklungsteams ist.
-keywords: ["tld", ".dev Domain", "Entwickler", "Entwicklungsprojekte", "Tech-Unternehmen", "Programmierung", "HTTPS", "Google"]
+keywords: ["tld", "Entwickler", "Entwicklungsprojekte", "Tech-Unternehmen", "Programmierung", "HTTPS", "Google"]
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/top-tlds-to-secure-for-your-startup/

--- a/content/tld/de/fun.md
+++ b/content/tld/de/fun.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Entdecken Sie die Vorteile der .fun Domain. Ideal für Unterhaltung, Spiele und kreative Marken. Jetzt bei Namefi registrieren und Online-Präsenz stärken!'
-keywords: ['.fun domains', '.fun TLD', '.fun top-level domain', 'what is .fun', 'why choose .fun', 'what is the .fun domain', 'why choose the .fun domain', 'domain investing', 'blockchain domains', 'tokenized domain', 'gaming domains', 'entertainment TLD', 'kreative webseiten', 'web3 domains', 'Namefi registrar']
+keywords: ['.fun domains', '.fun top-level domain', 'what is .fun', 'why choose .fun', 'what is the .fun domain', 'why choose the .fun domain', 'domain investing', 'blockchain domains', 'tokenized domain', 'gaming domains', 'entertainment TLD', 'kreative webseiten', 'web3 domains', 'Namefi registrar']
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/ai-vs-io-domain/

--- a/content/tld/de/info.md
+++ b/content/tld/de/info.md
@@ -15,9 +15,7 @@ draft: false
 description: 'Erfahren Sie alles über die .info Domain: Bedeutung, Geschichte und Vorteile. Entdecken Sie, warum .info ideal für Informationsseiten und Branding ist.'
 keywords:
   - .info domains
-  - .info TLD
   - top-level domain
-  - was ist .info
   - warum .info wählen
   - was ist die .info domain
   - warum die .info domain wählen

--- a/content/tld/de/io.md
+++ b/content/tld/de/io.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Die .io-Domain ist der De-facto-Standard für Startups, Entwickler und Web3-Projekte. Erfahren Sie mehr über ihren Ursprung, die Registrierungsmöglichkeiten, Preisdynamik und Reputation.'
-keywords: ['.io-Domains', 'was ist .io', '.io TLD', '.io-Domain-Endung', '.io-Domain registrieren', 'io-Domain-Bedeutung', '.io vs .ai', 'Tech-Startup-Domains']
+keywords: ['.io-Domains', '.io-Domain-Endung', '.io-Domain registrieren', 'io-Domain-Bedeutung', '.io vs .ai', 'Tech-Startup-Domains']
 faqs:
   - question: 'Kann jeder eine .io-Domain registrieren?'
     answer: 'Ja. Der .io-Namensraum steht jedem weltweit offen, ohne Anforderungen an lokale Präsenz, Geschäftstätigkeit oder Nachweise. Sie benötigen keine Verbindung zum Britischen Territorium im Indischen Ozean, um eine Domain zu registrieren.'

--- a/content/tld/de/live.md
+++ b/content/tld/de/live.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Alles über die .live TLD: Vorteile, Nutzungstrends und SEO-Tipps. Erfahren Sie, warum .live ideal für Streaming und Events ist, und registrieren Sie sie bei Namefi."
-keywords: [".live domains", ".live TLD", ".live top-level domain", "was ist .live", "warum .live wählen", "was ist die .live domain", "warum die .live domain wählen", "Live-Streaming Domains", "Echtzeit-Content", "Domain Investing", "Web3 Domains", "Tokenisierte Domains", "Blockchain Assets", "Identity Digital", "Content Creator Domains"]
+keywords: [".live domains", ".live top-level domain", "warum .live wählen", "was ist die .live domain", "warum die .live domain wählen", "Live-Streaming Domains", "Echtzeit-Content", "Domain Investing", "Web3 Domains", "Tokenisierte Domains", "Blockchain Assets", "Identity Digital", "Content Creator Domains"]
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/what-are-tokenized-domains/

--- a/content/tld/de/me.md
+++ b/content/tld/de/me.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Was ist die .me-Domain? Montenegros länderspezifische TLD, weltweit als Endung für persönliches Branding und Domain-Hacks vermarktet, bei der der Name mit „me" vervollständigt wird. Erfahren Sie, wer sie betreibt, wer registrieren kann, wie die Preisgestaltung funktioniert und wie es um die SEO steht.'
-keywords: ['.me-Domains', '.me TLD', 'me Domain', 'was ist .me', 'was ist die .me-Domain', '.me vs .com', 'me Domain für persönliches Branding', 'Montenegro Domain', '.me-Domain registrieren', 'Domain-Hack .me', 'about.me']
+keywords: ['.me-Domains', 'me Domain', 'was ist die .me-Domain', '.me vs .com', 'me Domain für persönliches Branding', 'Montenegro Domain', '.me-Domain registrieren', 'Domain-Hack .me', 'about.me']
 faqs:
   - question: 'Kann jeder eine .me-Domain registrieren?'
     answer: 'Ja. Obwohl .me technisch gesehen die länderspezifische TLD Montenegros ist, steht sie seit ihrem öffentlichen Start im Jahr 2008 jedem weltweit offen, ohne Anforderung an lokale Präsenz oder montenegrinischen Wohnsitz. Die Registrierung erfolgt nach dem Prinzip „first-come, first-served" auf der zweiten Ebene.'

--- a/content/tld/de/net.md
+++ b/content/tld/de/net.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Alles über die .net TLD: Erfahren Sie, warum diese Endung für Netzwerke und Tech-Firmen steht und wie Sie Ihre .net-Domain sicher bei Namefi registrieren."
-keywords: [".net domains", ".net TLD", "top-level domain", "was ist .net", "warum .net wählen", "was ist die .net domain", "warum die .net domain wählen", "domain investieren", "blockchain domains", "tokenisierte domains", "gTLD", "netzwerk domains", "domain registrierung", "internet infrastruktur", "web3 domains"]
+keywords: [".net domains", "top-level domain", "warum .net wählen", "was ist die .net domain", "warum die .net domain wählen", "domain investieren", "blockchain domains", "tokenisierte domains", "gTLD", "netzwerk domains", "domain registrierung", "internet infrastruktur", "web3 domains"]
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/ai-vs-io-domain/

--- a/content/tld/de/now.md
+++ b/content/tld/de/now.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Entdecken Sie die .now Domain: Die perfekte Endung für Echtzeit-Dienste, Events und moderne Marken. Erfahren Sie Vorteile und Anwendungsfälle bei Namefi.'
-keywords: ['.now domains', '.now TLD', 'top-level domain', 'was ist .now', 'warum .now wählen', 'was ist die .now domain', 'warum die .now domain wählen', 'domain investing', 'blockchain domains', 'tokenized domains', 'Web3 domains', 'echtzeit business', 'neue gTLD', 'domain registrierung', 'digitale identität', 'web3 integration', 'namefi']
+keywords: ['.now domains', 'top-level domain', 'warum .now wählen', 'was ist die .now domain', 'warum die .now domain wählen', 'domain investing', 'blockchain domains', 'tokenized domains', 'Web3 domains', 'echtzeit business', 'neue gTLD', 'domain registrierung', 'digitale identität', 'web3 integration', 'namefi']
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/how-to-sell-a-domain-name-you-own/

--- a/content/tld/de/online.md
+++ b/content/tld/de/online.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Erfahren Sie alles über die .online-TLD: Ihre Bedeutung, Vorteile für SEO und Branding sowie Verfügbarkeit. Registrieren Sie Ihre .online-Domain noch heute bei Namefi."
-keywords: [".online domains", ".online TLD", "top-level domain", "was ist .online", "warum .online wählen", "was ist die .online domain", "warum die .online domain wählen", "domain investing", "blockchain domains", "tokenized domain", "neue gTLD", "domain registrierung", "web3 domains", "günstige domains", "markenschutz domain"]
+keywords: [".online domains", "top-level domain", "warum .online wählen", "was ist die .online domain", "warum die .online domain wählen", "domain investing", "blockchain domains", "tokenized domain", "neue gTLD", "domain registrierung", "web3 domains", "günstige domains", "markenschutz domain"]
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/top-tlds-to-secure-for-your-business/

--- a/content/tld/de/shop.md
+++ b/content/tld/de/shop.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Die .shop-Domain ist eine offene neue gTLD, die vom GMO Registry betrieben wird und signalisiert: „Hier kann man kaufen." Erfahre, wer sie nutzt, welche Regeln gelten, wie sich die Preise entwickeln und was sie für SEO bedeutet.'
-keywords: ['.shop-Domains', 'was ist .shop', '.shop TLD', '.shop-Domain-Registrierung', 'E-Commerce-Domain', 'GMO Registry', 'neue gTLD für den Handel', '.shop-Domain kaufen']
+keywords: ['.shop-Domains', '.shop-Domain-Registrierung', 'E-Commerce-Domain', 'GMO Registry', 'neue gTLD für den Handel', '.shop-Domain kaufen']
 faqs:
   - question: 'Kann jeder eine .shop-Domain registrieren?'
     answer: 'Ja. .shop ist eine offene generische Top-Level-Domain ohne Berechtigungsvoraussetzungen. Jede Einzelperson oder jedes Unternehmen weltweit kann einen verfügbaren Namen nach dem Prinzip „Wer zuerst kommt, mahlt zuerst" registrieren. Es gibt keine Anforderungen an Qualifikationen, lokale Präsenz oder Mitgliedschaft in einer Gemeinschaft.'

--- a/content/tld/de/site.md
+++ b/content/tld/de/site.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Erfahren Sie alles über die .site Top-Level-Domain: Ihre Bedeutung, Vorteile für SEO und Branding sowie Gründe, warum sie ideal für Ihr nächstes Projekt ist."
-keywords: ['.site domains', 'TLD', 'Top-Level-Domain', 'was ist .site', 'warum .site wählen', 'was ist die .site domain', 'warum die .site domain wählen', 'domain investieren', 'blockchain domains', 'tokenisierte domains', 'namefi', 'günstige domains kaufen', 'neue gTLD trends', 'webseite erstellen', 'markenschutz domains']
+keywords: ['.site domains', 'TLD', 'Top-Level-Domain', 'warum .site wählen', 'was ist die .site domain', 'warum die .site domain wählen', 'domain investieren', 'blockchain domains', 'tokenisierte domains', 'namefi', 'günstige domains kaufen', 'neue gTLD trends', 'webseite erstellen', 'markenschutz domains']
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/top-tlds-to-secure-for-your-fashion-brand/

--- a/content/tld/de/space.md
+++ b/content/tld/de/space.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Entdecken Sie die .space Domain: Eine kreative TLD für Visionäre und Startups. Erfahren Sie alles über Vorteile, SEO und tokenisierte Domains bei Namefi."
-keywords: [".space", ".space domains", ".space TLD", "top-level domain", "was ist .space", "warum .space wählen", "was ist die .space domain", "warum die .space domain wählen", "domain investing", "blockchain domains", "tokenized domains", "web3 domains", "günstige domains kaufen", "creative domains", "Namefi"]
+keywords: [".space", ".space domains", "top-level domain", "warum .space wählen", "was ist die .space domain", "warum die .space domain wählen", "domain investing", "blockchain domains", "tokenized domains", "web3 domains", "günstige domains kaufen", "creative domains", "Namefi"]
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/ai-vs-io-domain/

--- a/content/tld/de/store.md
+++ b/content/tld/de/store.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Entdecken Sie die Vorteile der .store TLD für Ihren Online-Shop. Erfahren Sie, warum sie perfekt für E-Commerce ist und registrieren Sie sie bei Namefi.'
-keywords: ['.store domains', '.store TLD', '.store top-level domain', 'was ist .store', 'warum .store wählen', 'was ist die .store domain', 'warum die .store domain wählen', 'domain investing', 'blockchain domains', 'tokenized domains', 'e-commerce domains', 'online shop domain name', 'Namefi registrar', 'digital asset domains', 'neue gTLD']
+keywords: ['.store domains', '.store top-level domain', 'warum .store wählen', 'was ist die .store domain', 'warum die .store domain wählen', 'domain investing', 'blockchain domains', 'tokenized domains', 'e-commerce domains', 'online shop domain name', 'Namefi registrar', 'digital asset domains', 'neue gTLD']
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/top-tlds-to-secure-for-your-ecommerce-store/

--- a/content/tld/de/tech.md
+++ b/content/tld/de/tech.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Entdecken Sie die Vorteile der .tech-Domain für Startups, Entwickler und Web3. Erfahren Sie, warum .tech die perfekte Wahl für Ihre digitale Identität bei Namefi ist.'
-keywords: ['.tech domains', '.tech TLD', 'top-level domain', 'was ist .tech', 'warum .tech wählen', 'was ist die .tech domain', 'warum die .tech domain wählen', 'domain investing', 'blockchain domains', 'tokenisierte domains', 'technologie domain', 'tech startup namen', 'namefi', 'neue gTLD', 'radix registry']
+keywords: ['.tech domains', 'top-level domain', 'warum .tech wählen', 'was ist die .tech domain', 'warum die .tech domain wählen', 'domain investing', 'blockchain domains', 'tokenisierte domains', 'technologie domain', 'tech startup namen', 'namefi', 'neue gTLD', 'radix registry']
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/top-tlds-to-secure-for-your-startup/

--- a/content/tld/de/today.md
+++ b/content/tld/de/today.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Entdecken Sie das Potenzial der .today-Domain für News, Blogs und zeitkritische Inhalte. Erfahren Sie mehr über Vorteile, SEO und die Registrierung bei Namefi."
-keywords: [".today domains", ".today TLD", ".today top-level domain", "was ist .today", "warum .today wählen", "was ist die .today domain", "warum die .today domain wählen", "domain investieren", "blockchain domains", "tokenisierte domains", "nachrichten domains", "zeitungs domains", "neue gTLDs", "domain kaufen", "Namefi"]
+keywords: [".today domains", ".today top-level domain", "warum .today wählen", "was ist die .today domain", "warum die .today domain wählen", "domain investieren", "blockchain domains", "tokenisierte domains", "nachrichten domains", "zeitungs domains", "neue gTLDs", "domain kaufen", "Namefi"]
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/top-tlds-to-secure-for-your-ecommerce-store/

--- a/content/tld/de/top.md
+++ b/content/tld/de/top.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Entdecken Sie die Bedeutung und Vorteile der .top-TLD. Erfahren Sie, warum sie für Marken und Investoren attraktiv ist. Jetzt .top bei Namefi registrieren!"
-keywords: [".top domains", ".top TLD", "top-level domain", "was ist .top", "warum .top wählen", "was ist die .top domain", "warum die .top domain wählen", "domain investing", "blockchain domains", "tokenized domain", ".top registrieren", "günstige domains", "domain endung top", "namefi domains", "web3 domains"]
+keywords: [".top domains", "top-level domain", "warum .top wählen", "was ist die .top domain", "warum die .top domain wählen", "domain investing", "blockchain domains", "tokenized domain", ".top registrieren", "günstige domains", "domain endung top", "namefi domains", "web3 domains"]
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/top-tlds-to-secure-for-your-ecommerce-store/

--- a/content/tld/de/tv.md
+++ b/content/tld/de/tv.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Was ist die .tv-Domain? Tuvalus länderspezifische TLD, weltweit als Heimat von Fernsehen, Video und Live-Streaming vermarktet. Erfahren Sie, wer sie betreibt, wer registrieren kann, wie die Preisgestaltung funktioniert und wie es um die SEO steht.'
-keywords: ['.tv-Domains', '.tv TLD', 'tv Domain', 'was ist .tv', 'was ist die .tv-Domain', '.tv für Streaming', 'tv Domain für Video', 'Tuvalu Domain', '.tv-Domain registrieren', 'twitch.tv', 'Video-Streaming-Domain']
+keywords: ['.tv-Domains', 'tv Domain', 'was ist die .tv-Domain', '.tv für Streaming', 'tv Domain für Video', 'Tuvalu Domain', '.tv-Domain registrieren', 'twitch.tv', 'Video-Streaming-Domain']
 faqs:
   - question: 'Kann jeder eine .tv-Domain registrieren?'
     answer: 'Ja. Obwohl .tv technisch gesehen die länderspezifische TLD Tuvalus ist, steht sie seit Jahrzehnten jedem weltweit offen, ohne Anforderung an lokale Präsenz oder tuvaluischen Wohnsitz. Die Registrierung erfolgt nach dem Prinzip „first-come, first-served" auf der zweiten Ebene, auch wenn viele kurze oder Wörterbuch-Namen als Premium klassifiziert sind.'

--- a/content/tld/de/us.md
+++ b/content/tld/de/us.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Was ist die .us-Domain? Die offizielle länderspezifische TLD der Vereinigten Staaten, beschränkt auf Registranten mit einer echten US-Präsenz. Erfahren Sie, wer sie betreibt, was das Nexus-Erfordernis ist, wie die Preisgestaltung funktioniert und wie es um SEO und E-Mail-Zustellbarkeit steht.'
-keywords: ['.us-Domains', '.us TLD', 'us Domain', 'was ist .us', 'was ist die .us-Domain', '.us vs .com', 'US-Nexus-Erfordernis', 'Vereinigte-Staaten-Domain', '.us-Domain registrieren', 'amerikanische Domain-Endung', 'del.icio.us']
+keywords: ['.us-Domains', 'us Domain', 'was ist die .us-Domain', '.us vs .com', 'US-Nexus-Erfordernis', 'Vereinigte-Staaten-Domain', '.us-Domain registrieren', 'amerikanische Domain-Endung', 'del.icio.us']
 faqs:
   - question: 'Kann jeder eine .us-Domain registrieren?'
     answer: 'Nein. Anders als die meisten vermarkteten ccTLDs erzwingt .us ein US-Nexus-Erfordernis: Registranten müssen US-Bürger oder -Einwohner, in den USA gegründete Einrichtungen oder ausländische Organisationen mit einer echten Präsenz in den Vereinigten Staaten sein. Es gibt keine offene Registrierung für jeden überall.'

--- a/content/tld/de/vip.md
+++ b/content/tld/de/vip.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Erfahren Sie alles über die .vip Domain: Bedeutung, Vorteile für Ihr Branding und SEO. Registrieren Sie jetzt Ihre exklusive Webadresse bei Namefi."
-keywords: [".vip domains", ".vip TLD", ".vip top-level domain", "was ist .vip", "warum .vip wählen", "was ist die .vip domain", "warum die .vip domain wählen", "exklusive domains", "luxus domain endungen", "domain registrieren", "Web3 domains", "Blockchain Domains", "Namefi", "Domain Investing", "tokenisierte domains"]
+keywords: [".vip domains", ".vip top-level domain", "warum .vip wählen", "was ist die .vip domain", "warum die .vip domain wählen", "exklusive domains", "luxus domain endungen", "domain registrieren", "Web3 domains", "Blockchain Domains", "Namefi", "Domain Investing", "tokenisierte domains"]
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/top-tlds-to-secure-for-your-fashion-brand/

--- a/content/tld/de/website.md
+++ b/content/tld/de/website.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Erfahren Sie alles über die .website Domain: Vorteile, Verfügbarkeit und warum sie die ideale Wahl für Ihr Online-Projekt bei Namefi ist.'
-keywords: ['.website domains', '.website TLD', '.website top-level domain', 'was ist .website', 'warum .website wählen', 'was ist die .website domain', 'warum die .website domain wählen', 'Domain investieren', 'Blockchain Domains', 'tokenisierte Domains', 'günstige Domains kaufen', 'neue gTLDs', 'Web3 Domains', 'Domain Registrierung', 'Namefi']
+keywords: ['.website domains', '.website top-level domain', 'warum .website wählen', 'was ist die .website domain', 'warum die .website domain wählen', 'Domain investieren', 'Blockchain Domains', 'tokenisierte Domains', 'günstige Domains kaufen', 'neue gTLDs', 'Web3 Domains', 'Domain Registrierung', 'Namefi']
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/how-to-sell-a-domain-name-you-own/

--- a/content/tld/de/world.md
+++ b/content/tld/de/world.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: "Entdecken Sie die globale Reichweite der .world Domain. Erfahren Sie, warum Communities, Marken und Web3-Projekte diese TLD wählen. Jetzt bei Namefi registrieren!"
-keywords: [".world domains", ".world TLD", ".world top-level domain", "what is .world", "why choose .world", "what is the .world domain", "why choose the .world domain", ".world Domain kaufen", "Domain Investieren", "Blockchain Domains", "tokenisierte Domains", "Web3 Domains", "gTLD", "Markenschutz", "internationale Domains"]
+keywords: [".world domains", ".world top-level domain", "what is .world", "why choose .world", "what is the .world domain", "why choose the .world domain", ".world Domain kaufen", "Domain Investieren", "Blockchain Domains", "tokenisierte Domains", "Web3 Domains", "gTLD", "Markenschutz", "internationale Domains"]
 relatedArticles:
   - /de/blog/what-is-a-tld/
   - /de/blog/top-tlds-to-secure-for-your-business/

--- a/content/tld/de/xyz.md
+++ b/content/tld/de/xyz.md
@@ -9,7 +9,7 @@ editors: ['victor-zhou']
 translators: ['kai-kunstmann']
 draft: false
 description: 'Die .xyz-Domain ist eine offene generische TLD, die 2014 eingeführt wurde und durch Alphabets abc.xyz weltbekannt wurde. Erfahren Sie, für wen sie geeignet ist, wie sie bepreist wird und wie man sie registriert.'
-keywords: ['.xyz-Domains', 'was ist .xyz', '.xyz TLD', '.xyz-Domain-Bedeutung', 'abc.xyz Alphabet', '.xyz vs .com', '.xyz-Domain registrieren', 'ist .xyz gut für SEO']
+keywords: ['.xyz-Domains', '.xyz-Domain-Bedeutung', 'abc.xyz Alphabet', '.xyz vs .com', '.xyz-Domain registrieren', 'ist .xyz gut für SEO']
 faqs:
   - question: 'Kann jeder eine .xyz-Domain registrieren?'
     answer: 'Ja. Die .xyz-Domain ist eine uneingeschränkte generische Top-Level-Domain, sodass jeder weltweit eine auf First-Come-First-Served-Basis registrieren kann – ohne Nachweis-, Unternehmens- oder lokale Präsenzanforderung. Registrierungen werden über ICANN-akkreditierte Registrare abgewickelt, nicht direkt über die Registry.'

--- a/content/tld/en/aaa.md
+++ b/content/tld/en/aaa.md
@@ -7,7 +7,7 @@ authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .aaa domain is the closed brand TLD of the American Automobile Association, not open to the public. Learn what it is, who runs it, and what to register instead.'
-keywords: ['.aaa domain', 'what is .aaa', '.aaa TLD', 'AAA brand domain', 'dot-brand TLD', 'American Automobile Association registry', 'closed generic TLD', 'is .aaa available']
+keywords: ['AAA brand domain', 'dot-brand TLD', 'American Automobile Association registry', 'closed generic TLD', 'is .aaa available']
 faqs:
   - question: 'Can anyone register a .aaa domain?'
     answer: 'No. .aaa is a closed brand TLD delegated to the American Automobile Association, Inc. Only AAA and its authorized motor clubs and affiliates can hold a .aaa name, so it is not available to the general public through any registrar.'

--- a/content/tld/en/abbvie.md
+++ b/content/tld/en/abbvie.md
@@ -7,7 +7,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .abbvie domain is the closed brand TLD of biopharmaceutical company AbbVie, not open to the public. Learn what it is, who runs it, and what to register instead.'
-keywords: ['.abbvie domain', 'what is .abbvie', '.abbvie TLD', 'AbbVie brand domain', 'dot-brand TLD', 'AbbVie Inc registry', 'closed generic TLD', 'is .abbvie available']
+keywords: ['AbbVie brand domain', 'dot-brand TLD', 'AbbVie Inc registry', 'closed generic TLD', 'is .abbvie available']
 faqs:
   - question: 'Can anyone register a .abbvie domain?'
     answer: 'No. .abbvie is a closed brand TLD delegated to AbbVie Inc. Only AbbVie and parties it authorizes can hold a .abbvie name, so it is not available to the general public through any registrar.'

--- a/content/tld/en/abc.md
+++ b/content/tld/en/abc.md
@@ -7,7 +7,7 @@ authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .abc domain is the closed brand TLD of Disney Enterprises for the ABC television network, not open to the public. Learn what it is and what to register instead.'
-keywords: ['.abc domain', 'what is .abc', '.abc TLD', 'ABC brand domain', 'dot-brand TLD', 'Disney Enterprises registry', 'closed generic TLD', 'is .abc available']
+keywords: ['ABC brand domain', 'dot-brand TLD', 'Disney Enterprises registry', 'closed generic TLD', 'is .abc available']
 faqs:
   - question: 'Can anyone register a .abc domain?'
     answer: 'No. .abc is a closed brand TLD delegated to Disney Enterprises, Inc. Only Disney and parties it authorizes can hold a .abc name, so it is not available to the general public through any registrar.'

--- a/content/tld/en/able.md
+++ b/content/tld/en/able.md
@@ -7,7 +7,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .able domain is the closed brand TLD of Japanese real-estate company Able Inc., not open to the public. Learn what it is, and what to register instead.'
-keywords: ['.able domain', 'what is .able', '.able TLD', 'Able Inc brand domain', 'dot-brand TLD', 'Able Inc registry', 'closed generic TLD', 'is .able available']
+keywords: ['Able Inc brand domain', 'dot-brand TLD', 'Able Inc registry', 'closed generic TLD', 'is .able available']
 faqs:
   - question: 'Can anyone register a .able domain?'
     answer: 'No. .able is a closed brand TLD delegated to Able Inc. Only Able Inc. and parties it authorizes can hold a .able name, so it is not available to the general public through any registrar.'

--- a/content/tld/en/abogado.md
+++ b/content/tld/en/abogado.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .abogado domain is a credential-gated TLD for verified lawyers, meaning "abogado" (lawyer) in Spanish — ideal for Hispanic-market legal branding.'
-keywords: ['.abogado domains', 'what is .abogado', '.abogado TLD', 'lawyer domain extension', 'legal domain names', 'Spanish lawyer domain', 'abogado domain registration', 'verified legal TLD']
+keywords: ['.abogado domains', 'lawyer domain extension', 'legal domain names', 'Spanish lawyer domain', 'abogado domain registration', 'verified legal TLD']
 faqs:
   - question: 'Can anyone register a .abogado domain?'
     answer: 'No. The .abogado TLD is credential-gated. You must be a licensed lawyer or an authorized legal institution (law firm, law school, court, or bar association), and an independent third party verifies your status against public legal records before registration is approved.'

--- a/content/tld/en/abudhabi.md
+++ b/content/tld/en/abudhabi.md
@@ -7,7 +7,7 @@ authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .abudhabi domain is a geographic gTLD for the Emirate of Abu Dhabi in the UAE. Learn who operates it, who can register, and whether it suits your brand.'
-keywords: ['.abudhabi domains', '.abudhabi TLD', 'what is .abudhabi', 'Abu Dhabi domain name', 'geographic gTLD', 'UAE domain extension', 'Abu Dhabi government domain', 'geo-targeted domain']
+keywords: ['.abudhabi domains', 'Abu Dhabi domain name', 'geographic gTLD', 'UAE domain extension', 'Abu Dhabi government domain', 'geo-targeted domain']
 faqs:
   - question: 'Can anyone register a .abudhabi domain?'
     answer: 'Not without a connection to the emirate. Registration expects a genuine nexus to Abu Dhabi, such as a local business, institution, or government affiliation, under rules set by the registry operator. It is not an open, anyone-anywhere gTLD like .com.'

--- a/content/tld/en/ac.md
+++ b/content/tld/en/ac.md
@@ -7,7 +7,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'What is the .ac domain? Ascension Island''s open, worldwide ccTLD used for academic branding and domain hacks. Manager, eligibility, and pricing explained.'
-keywords: ['.ac domain', '.ac TLD', 'what is .ac', 'Ascension Island domain', 'academic domain extension', 'domain hack TLDs', 'generic ccTLD', 'register .ac domain']
+keywords: ['Ascension Island domain', 'academic domain extension', 'domain hack TLDs', 'generic ccTLD', 'register .ac domain']
 faqs:
   - question: 'Can anyone register a .ac domain?'
     answer: 'Yes. Although .ac is the country-code TLD for Ascension Island, registration carries no local-presence or residency requirement. Names are available first-come, first-served through any participating registrar, with no need for a genuine Ascension Island connection.'

--- a/content/tld/en/academy.md
+++ b/content/tld/en/academy.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .academy domain is an open gTLD for schools, courses, training centers and coaching brands. Learn who uses it, the rules, pricing dynamics and how to register.'
-keywords: ['.academy domain', 'what is .academy', '.academy TLD', 'academy domain registration', 'education domain extension', 'online course domain', 'training website domain', 'new gTLD']
+keywords: ['academy domain registration', 'education domain extension', 'online course domain', 'training website domain', 'new gTLD']
 faqs:
   - question: 'Can anyone register a .academy domain?'
     answer: 'Yes. The .academy domain is an open generic TLD with no eligibility requirements. There is no residency, business-type, accreditation, or credential check, so individuals and organizations alike can register names on a first-come, first-served basis.'

--- a/content/tld/en/accountant.md
+++ b/content/tld/en/accountant.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .accountant domain is an open new gTLD for accountants, bookkeepers, and finance professionals. Learn who runs it, who can register, and whether it suits your brand.'
-keywords: ['.accountant domain', 'what is .accountant', '.accountant TLD', 'accountant domain name', 'finance domain extension', 'new gTLD for accountants', 'register .accountant', 'bookkeeping website domain']
+keywords: ['accountant domain name', 'finance domain extension', 'new gTLD for accountants', 'register .accountant', 'bookkeeping website domain']
 faqs:
   - question: 'Can anyone register a .accountant domain?'
     answer: 'Yes. .accountant is an open, unrestricted new gTLD. You do not need to be a chartered accountant, CPA, or hold any professional credential to register one, and there is no local-presence requirement.'

--- a/content/tld/en/accountants.md
+++ b/content/tld/en/accountants.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .accountants domain is an open gTLD for CPAs, bookkeepers, and accounting firms. Learn who can register it, how it is priced, and how it affects trust.'
-keywords: ['.accountants domain', 'what is .accountants', '.accountants TLD', 'accounting firm domain', 'CPA domain name', 'Identity Digital gTLD', 'bookkeeping website domain', 'niche TLD for accountants']
+keywords: ['accounting firm domain', 'CPA domain name', 'Identity Digital gTLD', 'bookkeeping website domain', 'niche TLD for accountants']
 faqs:
   - question: 'Can anyone register a .accountants domain?'
     answer: 'Yes. The .accountants extension is an open generic top-level domain with no credential check. You do not need to be a licensed CPA, a registered firm, or a member of any professional body to register one, so accountants and non-accountants alike are eligible.'

--- a/content/tld/en/aco.md
+++ b/content/tld/en/aco.md
@@ -7,7 +7,7 @@ authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .aco domain is the closed brand TLD of German drainage maker ACO, not a healthcare extension. Learn what it is, who runs it, and what to register instead.'
-keywords: ['.aco domain', 'what is .aco', '.aco TLD', 'ACO brand domain', 'dot-brand TLD', 'ACO Severin Ahlmann registry', 'closed generic TLD', 'is .aco available', 'ACO drainage systems']
+keywords: ['ACO brand domain', 'dot-brand TLD', 'ACO Severin Ahlmann registry', 'closed generic TLD', 'is .aco available', 'ACO drainage systems']
 faqs:
   - question: 'Can anyone register a .aco domain?'
     answer: 'No. .aco is a closed brand TLD delegated to ACO Severin Ahlmann GmbH & Co. KG. Only ACO and parties it authorizes can hold a .aco name, so it is not available to the general public through any registrar.'

--- a/content/tld/en/active.md
+++ b/content/tld/en/active.md
@@ -7,7 +7,7 @@ authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .active domain was a brand TLD for The Active Network that ICANN terminated in 2019. Learn its history, why it was removed, and what to register instead.'
-keywords: ['.active domain', 'what is .active', '.active TLD', 'The Active Network domain', 'terminated TLD', 'discontinued gTLD', 'dot-brand TLD', 'is .active available']
+keywords: ['The Active Network domain', 'terminated TLD', 'discontinued gTLD', 'dot-brand TLD', 'is .active available']
 faqs:
   - question: 'Can I register a .active domain?'
     answer: 'No. .active was terminated in 2019 and removed from the DNS root zone, so it no longer exists as a working extension and cannot be registered through any registrar. Even before that, it was a closed brand TLD never open to the public.'

--- a/content/tld/en/ad.md
+++ b/content/tld/en/ad.md
@@ -8,7 +8,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'What is the .ad domain? Andorra''s country-code TLD, generally restricted to local trademark or presence holders. Manager, eligibility, and pricing explained.'
-keywords: ['.ad domain', '.ad TLD', 'what is .ad', 'Andorra domain', 'restricted ccTLD', 'local presence requirement', 'Andorra Telecom registry', 'register .ad domain']
+keywords: ['Andorra domain', 'restricted ccTLD', 'local presence requirement', 'Andorra Telecom registry', 'register .ad domain']
 faqs:
   - question: 'Can anyone register a .ad domain?'
     answer: 'Generally, no. .ad registration typically requires an Andorran trademark or a genuine local commercial presence in Andorra. It is not an open, global namespace the way some other ccTLDs are, so check current eligibility with the registry before planning a brand around it.'

--- a/content/tld/en/adac.md
+++ b/content/tld/en/adac.md
@@ -7,7 +7,7 @@ authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: "The .adac domain was a brand TLD for Germany's ADAC motoring club that ICANN terminated in 2022. Learn its history, why it ended, and what to register instead."
-keywords: ['.adac domain', 'what is .adac', '.adac TLD', 'ADAC brand domain', 'terminated TLD', 'discontinued gTLD', 'dot-brand TLD', 'is .adac available']
+keywords: ['ADAC brand domain', 'terminated TLD', 'discontinued gTLD', 'dot-brand TLD', 'is .adac available']
 faqs:
   - question: 'Can I register a .adac domain?'
     answer: 'No. .adac was terminated in 2022 and removed from the DNS root zone, so it no longer exists as a working extension and cannot be registered through any registrar. Even before that, it was a closed brand TLD never open to the public.'

--- a/content/tld/en/ads.md
+++ b/content/tld/en/ads.md
@@ -7,7 +7,7 @@ authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .ads domain is a closed brand TLD run by Google, not open to advertisers or the public. Learn what it is, who controls it, and what to register instead.'
-keywords: ['.ads domain', 'what is .ads', '.ads TLD', 'Google brand TLD', 'Charleston Road Registry', 'dot-brand TLD', 'closed generic TLD', 'is .ads available']
+keywords: ['Google brand TLD', 'Charleston Road Registry', 'dot-brand TLD', 'closed generic TLD', 'is .ads available']
 faqs:
   - question: 'Can anyone register a .ads domain?'
     answer: 'No. .ads is a closed brand TLD delegated to Charleston Road Registry Inc., a Google entity. Only Google and parties it authorizes can hold a .ads name, so it is not available to advertisers, agencies, or the general public.'

--- a/content/tld/en/adult.md
+++ b/content/tld/en/adult.md
@@ -7,7 +7,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .adult domain is an open gTLD for the adult-content industry, run by ICM Registry AD LLC. Learn who registers it and its email deliverability trade-offs.'
-keywords: ['.adult domain', 'what is .adult', '.adult TLD', 'adult industry domain names', 'ICM Registry AD LLC', 'GoDaddy Registry', 'adult content TLD', 'defensive domain registration']
+keywords: ['adult industry domain names', 'ICM Registry AD LLC', 'GoDaddy Registry', 'adult content TLD', 'defensive domain registration']
 faqs:
   - question: 'Can anyone register a .adult domain?'
     answer: 'Yes. The .adult domain is an open generic TLD with no age-verification or industry-membership requirement to register, so anyone can hold one. Most registrants are either adult-content businesses or mainstream brands registering their own name defensively.'

--- a/content/tld/en/ae.md
+++ b/content/tld/en/ae.md
@@ -9,7 +9,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .ae domain is the country code TLD for the United Arab Emirates. Learn what country .ae is, who can register a .ae domain, eligibility rules, and why it wins UAE and Dubai business trust.'
-keywords: ['ae domain', '.ae domain', 'ae tld', 'ae top level domain', 'uae domain', 'uae tld', 'uae domain extension', 'what is .ae domain', 'what is the .ae domain', 'ae domain country', 'who can register a .ae domain', '.ae domain eligibility', 'dubai domain', 'abu dhabi domain', 'internet tld vereinigte arabische emirate', 'ae land', 'aeDA', 'TDRA domain', 'uae country code', 'buy .ae domain', 'register .ae domain', 'why choose .ae', 'tokenized domains', 'Namefi registrar', 'middle east domain']
+keywords: ['ae domain', 'ae tld', 'ae top level domain', 'uae domain', 'uae tld', 'uae domain extension', 'what is .ae domain', 'what is the .ae domain', 'ae domain country', 'who can register a .ae domain', '.ae domain eligibility', 'dubai domain', 'abu dhabi domain', 'internet tld vereinigte arabische emirate', 'ae land', 'aeDA', 'TDRA domain', 'uae country code', 'buy .ae domain', 'register .ae domain', 'why choose .ae', 'tokenized domains', 'Namefi registrar', 'middle east domain']
 relatedArticles:
   - /en/blog/what-is-a-tld/
   - /en/blog/what-are-tokenized-domains/

--- a/content/tld/en/aero.md
+++ b/content/tld/en/aero.md
@@ -7,7 +7,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .aero domain is a restricted sponsored TLD for the aviation industry, run by SITA. Learn who qualifies for an aero ID and how it compares with .com.'
-keywords: ['.aero domain', 'what is .aero', '.aero TLD', 'SITA registry', 'aviation domain names', 'aero ID eligibility', 'sponsored TLD aviation', 'restricted gTLD']
+keywords: ['SITA registry', 'aviation domain names', 'aero ID eligibility', 'sponsored TLD aviation', 'restricted gTLD']
 faqs:
   - question: 'Who can register a .aero domain?'
     answer: 'Only members of the aviation and air-transport community, such as airlines, airports, and aviation businesses and professionals. Registrants must obtain an aero ID from the registry verifying that eligibility before a name can be registered.'

--- a/content/tld/en/aetna.md
+++ b/content/tld/en/aetna.md
@@ -7,7 +7,7 @@ authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .aetna domain is health insurer Aetna''s closed brand TLD, not open to the public. Learn what it is, who runs it, why it exists, and what to register instead.'
-keywords: ['.aetna domain', 'what is .aetna', '.aetna TLD', 'Aetna brand domain', 'dot-brand TLD', 'Aetna registry operator', 'closed generic TLD', 'is .aetna available']
+keywords: ['Aetna brand domain', 'dot-brand TLD', 'Aetna registry operator', 'closed generic TLD', 'is .aetna available']
 faqs:
   - question: 'Can anyone register a .aetna domain?'
     answer: 'No. .aetna is a closed brand TLD delegated to Aetna Life Insurance Company. Only Aetna and parties it authorizes can hold a .aetna name, so it is not available to the general public through any registrar.'

--- a/content/tld/en/af.md
+++ b/content/tld/en/af.md
@@ -7,7 +7,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'What is the .af domain? Afghanistan''s country-code TLD, managed by AFGNIC. Learn its history, eligibility, and how pricing works before you register.'
-keywords: ['.af domain', '.af TLD', 'what is .af', 'Afghanistan domain', 'AFGNIC registry', 'country code top level domain', 'ccTLD registration', 'register .af domain']
+keywords: ['Afghanistan domain', 'AFGNIC registry', 'country code top level domain', 'ccTLD registration', 'register .af domain']
 faqs:
   - question: 'Can anyone register a .af domain?'
     answer: 'The registry, AFGNIC, sets current eligibility rules for .af, and they can differ from an open global gTLD. Before planning a brand around .af, confirm current registration requirements directly with AFGNIC rather than assuming worldwide open registration.'

--- a/content/tld/en/afl.md
+++ b/content/tld/en/afl.md
@@ -7,7 +7,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .afl domain is the closed brand TLD of the Australian Football League, not open to the public. Learn what it is, who runs it, and what to register instead.'
-keywords: ['.afl domain', 'what is .afl', '.afl TLD', 'Australian Football League domain', 'AFL brand TLD', 'dot-brand TLD', 'closed generic TLD', 'is .afl available']
+keywords: ['Australian Football League domain', 'AFL brand TLD', 'dot-brand TLD', 'closed generic TLD', 'is .afl available']
 faqs:
   - question: 'Can anyone register a .afl domain?'
     answer: 'No. .afl is a closed brand TLD delegated to the Australian Football League. Only the AFL and parties it authorizes can hold a .afl name, so it is not available to the general public through any registrar.'

--- a/content/tld/en/africa.md
+++ b/content/tld/en/africa.md
@@ -7,7 +7,7 @@ authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .africa domain is a geographic gTLD representing the whole African continent. Learn who operates it, who can register, and how it fits pan-African branding.'
-keywords: ['.africa domains', '.africa TLD', 'what is .africa', 'pan-African domain name', 'geographic gTLD', 'African continent domain', 'Registry Africa', 'African business domain']
+keywords: ['.africa domains', 'pan-African domain name', 'geographic gTLD', 'African continent domain', 'Registry Africa', 'African business domain']
 faqs:
   - question: 'Can anyone register a .africa domain?'
     answer: 'Registration is broadly open but expects a connection to Africa. The registry has kept eligibility broad rather than narrowly gatekept, and the namespace has been adopted continent-wide by businesses, governments, media, and pan-African organizations.'

--- a/content/tld/en/ag.md
+++ b/content/tld/en/ag.md
@@ -7,7 +7,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'What is the .ag domain? Antigua and Barbuda''s open ccTLD, known for German AG corporate branding and domain hacks. Manager, eligibility, and pricing.'
-keywords: ['.ag domain', '.ag TLD', 'what is .ag', 'Antigua and Barbuda domain', 'Aktiengesellschaft domain', 'agriculture domain extension', 'domain hack TLDs', 'register .ag domain']
+keywords: ['Antigua and Barbuda domain', 'Aktiengesellschaft domain', 'agriculture domain extension', 'domain hack TLDs', 'register .ag domain']
 faqs:
   - question: 'Can anyone register a .ag domain?'
     answer: 'Yes. .ag is Antigua and Barbuda''s ccTLD, but it has been open to registrants worldwide for years, with no local-presence requirement. Registration is first-come, first-served through any participating registrar.'

--- a/content/tld/en/agakhan.md
+++ b/content/tld/en/agakhan.md
@@ -7,7 +7,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .agakhan domain is the closed brand TLD of the Aga Khan Foundation, not open to the public. Learn what it is, who runs it, and what to register instead.'
-keywords: ['.agakhan domain', 'what is .agakhan', '.agakhan TLD', 'Aga Khan Foundation domain', 'Fondation Aga Khan', 'dot-brand TLD', 'closed generic TLD', 'is .agakhan available']
+keywords: ['Aga Khan Foundation domain', 'Fondation Aga Khan', 'dot-brand TLD', 'closed generic TLD', 'is .agakhan available']
 faqs:
   - question: 'Can anyone register a .agakhan domain?'
     answer: 'No. .agakhan is a closed brand TLD delegated to Fondation Aga Khan, the Aga Khan Foundation. Only the Foundation and parties it authorizes can hold a .agakhan name, so it is not available to the general public through any registrar.'

--- a/content/tld/en/agency.md
+++ b/content/tld/en/agency.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .agency domain is an open new gTLD from Identity Digital, ideal for marketing, creative, real-estate, and consulting firms wanting a descriptive, brandable web address.'
-keywords: ['.agency domain', 'what is .agency', '.agency TLD', '.agency domains', 'agency domain name', 'new gTLD for agencies', 'marketing agency domain', 'creative agency website', 'Identity Digital TLD', 'register .agency']
+keywords: ['.agency domains', 'agency domain name', 'new gTLD for agencies', 'marketing agency domain', 'creative agency website', 'Identity Digital TLD', 'register .agency']
 faqs:
   - question: 'Can anyone register a .agency domain?'
     answer: 'Yes. The .agency domain is an open, unrestricted new gTLD with no credential, membership, or local-presence requirement. Anyone in the world can register an available .agency name through an accredited registrar on a first-come, first-served basis.'

--- a/content/tld/en/ai.md
+++ b/content/tld/en/ai.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'A cypherpunk, a tiny Caribbean island, and the most valuable two letters in tech. The full story of the .ai domain — who runs it, how Anguilla now funds nearly half its government from it, what it costs, and whether you should build on it.'
-keywords: ['.ai domain', 'what is .ai', '.ai TLD', 'Anguilla ccTLD', 'register .ai domain', 'AI startup domain', '.ai vs .io', 'who owns .ai', '.ai domain price', '.ai two year minimum', 'Vince Cate', 'Anguilla AI domain']
+keywords: ['Anguilla ccTLD', 'register .ai domain', 'AI startup domain', '.ai vs .io', 'who owns .ai', '.ai domain price', '.ai two year minimum', 'Vince Cate', 'Anguilla AI domain']
 faqs:
   - question: 'Can anyone register a .ai domain?'
     answer: 'Yes. The .ai registry is open to anyone worldwide with no local-presence or credential requirement. The main difference from most TLDs is that .ai is sold in a minimum two-year term rather than one-year increments.'

--- a/content/tld/en/aig.md
+++ b/content/tld/en/aig.md
@@ -7,7 +7,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .aig domain is the closed brand TLD of American International Group (AIG), a global insurer, not open to the public. Learn who runs it and what to register instead.'
-keywords: ['.aig domain', 'what is .aig', '.aig TLD', 'AIG brand domain', 'dot-brand TLD', 'AIG registry operator', 'closed generic TLD', 'is .aig available']
+keywords: ['AIG brand domain', 'dot-brand TLD', 'AIG registry operator', 'closed generic TLD', 'is .aig available']
 faqs:
   - question: 'Can anyone register a .aig domain?'
     answer: 'No. .aig is a closed brand TLD delegated to American International Group, Inc. Only AIG and parties it authorizes can hold a .aig name, so it is not available to the general public through any registrar.'

--- a/content/tld/en/aigo.md
+++ b/content/tld/en/aigo.md
@@ -7,7 +7,7 @@ authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .aigo domain was a brand TLD for the Chinese electronics brand aigo that ICANN terminated in 2020. Learn its history and what to register instead.'
-keywords: ['.aigo domain', 'what is .aigo', '.aigo TLD', 'aigo brand domain', 'terminated TLD', 'discontinued gTLD', 'dot-brand TLD', 'is .aigo available']
+keywords: ['aigo brand domain', 'terminated TLD', 'discontinued gTLD', 'dot-brand TLD', 'is .aigo available']
 faqs:
   - question: 'Can I register a .aigo domain?'
     answer: 'No. .aigo was terminated in 2020 and removed from the DNS root zone, so it no longer exists as a working extension and cannot be registered through any registrar. Even before that, it was a closed brand TLD never open to the public.'

--- a/content/tld/en/airbus.md
+++ b/content/tld/en/airbus.md
@@ -7,7 +7,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .airbus domain is the closed brand TLD of Airbus S.A.S., the European aerospace manufacturer, not open to the public. Learn who runs it and what to register instead.'
-keywords: ['.airbus domain', 'what is .airbus', '.airbus TLD', 'Airbus brand domain', 'dot-brand TLD', 'Airbus registry operator', 'closed generic TLD', 'is .airbus available']
+keywords: ['Airbus brand domain', 'dot-brand TLD', 'Airbus registry operator', 'closed generic TLD', 'is .airbus available']
 faqs:
   - question: 'Can anyone register a .airbus domain?'
     answer: 'No. .airbus is a closed brand TLD delegated to Airbus S.A.S. Only Airbus and parties it authorizes can hold a .airbus name, so it is not available to the general public through any registrar.'

--- a/content/tld/en/airforce.md
+++ b/content/tld/en/airforce.md
@@ -7,7 +7,7 @@ authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .airforce domain is an open gTLD run by Dog Beach, LLC (Identity Digital), not tied to any air force. Learn who actually uses it and who can register.'
-keywords: ['.airforce domain', 'what is .airforce', '.airforce TLD', 'Dog Beach registry', 'Identity Digital TLD', 'military-themed domain names', 'veteran community domain', 'aviation enthusiast domain']
+keywords: ['Dog Beach registry', 'Identity Digital TLD', 'military-themed domain names', 'veteran community domain', 'aviation enthusiast domain']
 faqs:
   - question: 'Can anyone register a .airforce domain?'
     answer: 'Yes. The .airforce domain is an open generic TLD with no military, veteran, or government affiliation required to register. Any individual or organization can register one through an accredited registrar.'

--- a/content/tld/en/airtel.md
+++ b/content/tld/en/airtel.md
@@ -7,7 +7,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .airtel domain is the closed brand TLD of Bharti Airtel, a major Indian telecom company, not open to the public. Learn who runs it and what to register instead.'
-keywords: ['.airtel domain', 'what is .airtel', '.airtel TLD', 'Airtel brand domain', 'dot-brand TLD', 'Bharti Airtel registry', 'closed generic TLD', 'is .airtel available']
+keywords: ['Airtel brand domain', 'dot-brand TLD', 'Bharti Airtel registry', 'closed generic TLD', 'is .airtel available']
 faqs:
   - question: 'Can anyone register a .airtel domain?'
     answer: 'No. .airtel is a closed brand TLD delegated to Bharti Airtel Limited. Only Airtel and parties it authorizes can hold a .airtel name, so it is not available to the general public through any registrar.'

--- a/content/tld/en/akdn.md
+++ b/content/tld/en/akdn.md
@@ -7,7 +7,7 @@ authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .akdn domain is the closed brand TLD of the Aga Khan Development Network, not open to the public. Learn who runs it and what to register instead.'
-keywords: ['.akdn domain', 'what is .akdn', '.akdn TLD', 'AKDN brand domain', 'dot-brand TLD', 'Aga Khan Development Network domain', 'closed generic TLD', 'is .akdn available']
+keywords: ['AKDN brand domain', 'dot-brand TLD', 'Aga Khan Development Network domain', 'closed generic TLD', 'is .akdn available']
 faqs:
   - question: 'Can anyone register a .akdn domain?'
     answer: 'No. .akdn is a closed brand TLD delegated to the Fondation Aga Khan for the Aga Khan Development Network. Only AKDN entities and parties they authorize can hold a .akdn name, so it is not available to the general public through any registrar.'

--- a/content/tld/en/al.md
+++ b/content/tld/en/al.md
@@ -7,7 +7,7 @@ authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'What is the .al domain? Albania''s country-code TLD, open at the third level but restricted at second-level. Manager, eligibility, and pricing explained.'
-keywords: ['.al domain', '.al TLD', 'what is .al', 'Albania domain', 'domain hack TLDs', 'local presence requirement', 'com.al third level domain', 'register .al domain']
+keywords: ['Albania domain', 'domain hack TLDs', 'local presence requirement', 'com.al third level domain', 'register .al domain']
 faqs:
   - question: 'Can anyone register a .al domain?'
     answer: 'Second-level .al domains (yourname.al) generally require a local presence or a registered entity in Albania. Third-level domains such as yourname.com.al are more open. Check current requirements with AKEP, the registry, before choosing which tier fits your situation.'

--- a/content/tld/en/alfaromeo.md
+++ b/content/tld/en/alfaromeo.md
@@ -7,7 +7,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .alfaromeo domain was a brand TLD for the Italian car marque Alfa Romeo that ICANN terminated in 2023. Learn its history and what to register instead.'
-keywords: ['.alfaromeo domain', 'what is .alfaromeo', '.alfaromeo TLD', 'Alfa Romeo brand domain', 'terminated TLD', 'discontinued gTLD', 'dot-brand TLD', 'is .alfaromeo available']
+keywords: ['Alfa Romeo brand domain', 'terminated TLD', 'discontinued gTLD', 'dot-brand TLD', 'is .alfaromeo available']
 faqs:
   - question: 'Can I register a .alfaromeo domain?'
     answer: 'No. .alfaromeo was terminated in 2023 and removed from the DNS root zone, so it no longer exists as a working extension and cannot be registered through any registrar. Even before that, it was a closed brand TLD never open to the public.'

--- a/content/tld/en/alibaba.md
+++ b/content/tld/en/alibaba.md
@@ -7,7 +7,7 @@ authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .alibaba domain is the closed brand TLD of Alibaba Group, a Chinese e-commerce and technology group, not open to the public. Learn what to register instead.'
-keywords: ['.alibaba domain', 'what is .alibaba', '.alibaba TLD', 'Alibaba brand domain', 'dot-brand TLD', 'Alibaba Group registry', 'closed generic TLD', 'is .alibaba available']
+keywords: ['Alibaba brand domain', 'dot-brand TLD', 'Alibaba Group registry', 'closed generic TLD', 'is .alibaba available']
 faqs:
   - question: 'Can anyone register a .alibaba domain?'
     answer: 'No. .alibaba is a closed brand TLD delegated to Alibaba Group Holding Limited. Only Alibaba Group and parties it authorizes can hold a .alibaba name, so it is not available to the general public through any registrar.'

--- a/content/tld/en/alipay.md
+++ b/content/tld/en/alipay.md
@@ -7,7 +7,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .alipay domain is the closed brand TLD tied to Alibaba Group and its Alipay payments platform, not open to the public. Learn who runs it and what to register instead.'
-keywords: ['.alipay domain', 'what is .alipay', '.alipay TLD', 'Alipay brand domain', 'dot-brand TLD', 'Alibaba Group registry', 'closed generic TLD', 'is .alipay available']
+keywords: ['Alipay brand domain', 'dot-brand TLD', 'Alibaba Group registry', 'closed generic TLD', 'is .alipay available']
 faqs:
   - question: 'Can anyone register a .alipay domain?'
     answer: 'No. .alipay is a closed brand TLD delegated to Alibaba Group Holding Limited for the Alipay payments platform. Only Alibaba Group and parties it authorizes can hold a .alipay name, so it is not available to the public through any registrar.'

--- a/content/tld/en/allstate.md
+++ b/content/tld/en/allstate.md
@@ -7,7 +7,7 @@ authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .allstate domain is the closed brand TLD of insurer Allstate, not open to the public. Learn what it is, who runs it, why it exists, and what to register instead.'
-keywords: ['.allstate domain', 'what is .allstate', '.allstate TLD', 'Allstate brand domain', 'dot-brand TLD', 'Allstate registry operator', 'closed generic TLD', 'is .allstate available']
+keywords: ['Allstate brand domain', 'dot-brand TLD', 'Allstate registry operator', 'closed generic TLD', 'is .allstate available']
 faqs:
   - question: 'Can anyone register a .allstate domain?'
     answer: 'No. .allstate is a closed brand TLD delegated to Allstate. Only Allstate and parties it authorizes can hold a .allstate name, so it is not available to the general public through any registrar.'

--- a/content/tld/en/ally.md
+++ b/content/tld/en/ally.md
@@ -7,7 +7,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .ally domain is the closed brand TLD of Ally Financial, not open to the public despite the common word. Learn who runs it and what to register instead.'
-keywords: ['.ally domain', 'what is .ally', '.ally TLD', 'Ally Financial domain', 'dot-brand TLD', 'Ally Financial registry', 'closed generic TLD', 'is .ally available']
+keywords: ['Ally Financial domain', 'dot-brand TLD', 'Ally Financial registry', 'closed generic TLD', 'is .ally available']
 faqs:
   - question: 'Can anyone register a .ally domain?'
     answer: 'No. .ally is a closed brand TLD delegated to Ally Financial Inc. Only Ally Financial and parties it authorizes can hold a .ally name, so it is not available to the general public through any registrar.'

--- a/content/tld/en/alsace.md
+++ b/content/tld/en/alsace.md
@@ -7,7 +7,7 @@ authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .alsace domain is a geographic gTLD for the Alsace region of eastern France. Learn who runs it, who can register, and how it suits local branding.'
-keywords: ['.alsace domains', '.alsace TLD', 'what is .alsace', 'Alsace region domain', 'geographic gTLD', 'French regional domain', 'Alsace wine domain', 'Region Grand Est']
+keywords: ['.alsace domains', 'Alsace region domain', 'geographic gTLD', 'French regional domain', 'Alsace wine domain', 'Region Grand Est']
 faqs:
   - question: 'Can anyone register a .alsace domain?'
     answer: 'Registration expects a link to the Alsace region, such as a local business, residence, or institution. It is not a fully open, anyone-anywhere gTLD like .com, but a suffix built specifically for Alsace-connected registrants.'

--- a/content/tld/en/alstom.md
+++ b/content/tld/en/alstom.md
@@ -7,7 +7,7 @@ authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'The .alstom domain is the closed brand TLD of rail transport group Alstom, not open to the public. Learn what it is, who runs it, and what to register instead.'
-keywords: ['.alstom domain', 'what is .alstom', '.alstom TLD', 'Alstom brand domain', 'dot-brand TLD', 'Alstom registry operator', 'closed generic TLD', 'is .alstom available']
+keywords: ['Alstom brand domain', 'dot-brand TLD', 'Alstom registry operator', 'closed generic TLD', 'is .alstom available']
 faqs:
   - question: 'Can anyone register a .alstom domain?'
     answer: 'No. .alstom is a closed brand TLD delegated to Alstom. Only Alstom and parties it authorizes can hold a .alstom name, so it is not available to the general public through any registrar.'

--- a/content/tld/en/am.md
+++ b/content/tld/en/am.md
@@ -7,7 +7,7 @@ authors: ['fenwei-bian']
 editors: ['victor-zhou']
 draft: false
 description: 'What is the .am domain? Armenia''s open, worldwide ccTLD known for domain hacks like will.i.am. Manager, eligibility, pricing, and registration explained.'
-keywords: ['.am domain', '.am TLD', 'what is .am', 'Armenia domain', 'domain hack TLDs', 'AM radio domain', 'generic ccTLD', 'register .am domain']
+keywords: ['Armenia domain', 'domain hack TLDs', 'AM radio domain', 'generic ccTLD', 'register .am domain']
 faqs:
   - question: 'Can anyone register a .am domain?'
     answer: 'Yes. .am is Armenia''s ccTLD, but it has been open to registrants worldwide for decades, with no local-presence requirement. Registration is first-come, first-served through any participating registrar.'

--- a/content/tld/en/app.md
+++ b/content/tld/en/app.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .app domain is Google Registry''s gTLD for software and apps, with HTTPS required on every site. Learn who it suits, how it ranks, and how to register one.'
-keywords: ['.app domain', 'what is .app', '.app TLD', '.app domains', 'app domain extension', 'Google Registry .app', '.app HTTPS required', 'register .app domain', 'developer domains']
+keywords: ['.app domains', 'app domain extension', 'Google Registry .app', '.app HTTPS required', 'register .app domain', 'developer domains']
 faqs:
   - question: 'Can anyone register a .app domain?'
     answer: 'Yes. The .app TLD is an open generic top-level domain with no eligibility restrictions, so anyone can register an available name. The one practical condition is technical, not legal: a .app site needs a valid HTTPS certificate to load in browsers.'

--- a/content/tld/en/attorney.md
+++ b/content/tld/en/attorney.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .attorney domain is an open new gTLD built for the legal profession. Learn who runs it, who can register, how it ranks, and whether it suits your firm.'
-keywords: ['.attorney domains', 'what is .attorney', '.attorney TLD', 'attorney domain extension', 'legal domain names', 'law firm domains', 'lawyer website domain', 'Identity Digital TLD']
+keywords: ['.attorney domains', 'attorney domain extension', 'legal domain names', 'law firm domains', 'lawyer website domain', 'Identity Digital TLD']
 faqs:
   - question: 'Can anyone register a .attorney domain?'
     answer: 'Yes. The .attorney domain is an open generic TLD with no credential or bar-membership requirement. Anyone can register one, though it is naturally aimed at attorneys, law firms, and legal-service providers. This makes it different from gated legal TLDs that verify licensure.'

--- a/content/tld/en/biz.md
+++ b/content/tld/en/biz.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .biz domain is an open, business-oriented gTLD run by GoDaddy Registry. Learn who it suits, how it compares to .com, and what to know before buying.'
-keywords: ['.biz', '.biz domains', '.biz TLD', 'what is .biz', 'business domain extension', 'biz vs com', 'GoDaddy Registry', 'bona fide business use']
+keywords: ['.biz', '.biz domains', 'business domain extension', 'biz vs com', 'GoDaddy Registry', 'bona fide business use']
 faqs:
   - question: 'Can anyone register a .biz domain?'
     answer: 'Almost. The .biz namespace is open worldwide with no credential, trademark, or local-presence gate, but registrations are meant for bona fide business or commercial use. Non-commercial or purely speculative registrations can in principle be challenged, though enforcement in practice is light.'

--- a/content/tld/en/blog.md
+++ b/content/tld/en/blog.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .blog domain is an open gTLD run by Automattic that instantly signals a content site. Learn who it suits, how it is priced, and its email reputation.'
-keywords: ['.blog domain', 'what is .blog', '.blog TLD', 'blog domain name', 'Automattic .blog', 'gTLD for blogs', 'register .blog domain', 'content website domain']
+keywords: ['blog domain name', 'Automattic .blog', 'gTLD for blogs', 'register .blog domain', 'content website domain']
 faqs:
   - question: 'Can anyone register a .blog domain?'
     answer: 'Yes. The .blog TLD is open to everyone with no eligibility, credential, or local-presence requirement. You do not need to run a blog or use WordPress to register one. The only exception is premium-tier names, which carry higher registry pricing but no extra qualification.'

--- a/content/tld/en/boutique.md
+++ b/content/tld/en/boutique.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .boutique domain is an open generic extension built for curated shops and small specialty brands. Learn who uses it, how it is priced, and whether it suits you.'
-keywords: ['.boutique domain', 'what is .boutique', 'boutique TLD', 'boutique domain registration', 'domains for small shops', 'curated brand domain', 'new gTLD', 'Binky Moon']
+keywords: ['boutique TLD', 'boutique domain registration', 'domains for small shops', 'curated brand domain', 'new gTLD', 'Binky Moon']
 faqs:
   - question: 'Can anyone register a .boutique domain?'
     answer: 'Yes. .boutique is an open generic top-level domain with no eligibility restrictions. There is no requirement to own a retail store, sell physical goods, or prove any credential, so individuals, brands, and agencies worldwide can register an available name.'

--- a/content/tld/en/cc.md
+++ b/content/tld/en/cc.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'What is the .cc domain? The Cocos (Keeling) Islands country-code TLD, run by Verisign and marketed worldwide as a short, brandable alternative to .com. Learn who runs it, who can register, pricing, and SEO.'
-keywords: ['.cc domains', '.cc TLD', 'cc domain', 'what is .cc', 'what is the .cc domain', '.cc vs .com', 'cc domain meaning', 'Cocos Keeling Islands domain', 'register .cc domain', 'short brandable domain', 'domain hack cc']
+keywords: ['.cc domains', 'cc domain', 'what is the .cc domain', '.cc vs .com', 'cc domain meaning', 'Cocos Keeling Islands domain', 'register .cc domain', 'short brandable domain', 'domain hack cc']
 faqs:
   - question: 'Can anyone register a .cc domain?'
     answer: 'Yes. Although .cc is technically the country-code TLD for the Cocos (Keeling) Islands, it is open to anyone in the world with no local-presence or residency requirement. Registration is first-come, first-served at the second level.'

--- a/content/tld/en/city.md
+++ b/content/tld/en/city.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: '.city is an open generic top-level domain run by Identity Digital, built for local businesses, city guides, and community sites. Here is who it suits and why.'
-keywords: ['.city domain', 'what is .city', '.city TLD', 'local business domain', 'city domain name', 'Identity Digital', 'new gTLD', 'community website domain']
+keywords: ['local business domain', 'city domain name', 'Identity Digital', 'new gTLD', 'community website domain']
 faqs:
   - question: 'Can anyone register a .city domain?'
     answer: 'Yes. .city is an open generic top-level domain with no eligibility restrictions. Anyone in the world can register an available .city name without proving local presence, government ties, or any credential. Standard registry acceptable-use rules still apply.'

--- a/content/tld/en/click.md
+++ b/content/tld/en/click.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .click domain is an open new gTLD built around the web''s core action. Learn who runs it, who it suits, its pricing dynamics, and how it compares.'
-keywords: ['.click domain', 'what is .click', '.click TLD', 'click domain extension', 'call to action domain', 'URL shortener domain', 'new gTLD', 'register .click domain']
+keywords: ['click domain extension', 'call to action domain', 'URL shortener domain', 'new gTLD', 'register .click domain']
 faqs:
   - question: 'Can anyone register a .click domain?'
     answer: 'Yes. .click is an open generic top-level domain with no eligibility restrictions. Anyone, anywhere can register an available .click name on a first-come, first-served basis, with no credential, trademark, or local-presence requirement.'

--- a/content/tld/en/cloud.md
+++ b/content/tld/en/cloud.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .cloud domain is an open gTLD operated by Aruba PEC S.p.A., built for cloud, SaaS, and tech brands. Learn who it suits, its pricing dynamics, and reputation.'
-keywords: ['.cloud domain', 'what is .cloud', '.cloud TLD', 'cloud computing domain', 'SaaS domain name', 'Aruba .cloud registry', 'new gTLD', 'tech domain extension']
+keywords: ['cloud computing domain', 'SaaS domain name', 'Aruba .cloud registry', 'new gTLD', 'tech domain extension']
 faqs:
   - question: 'Can anyone register a .cloud domain?'
     answer: 'Yes. The .cloud TLD is an open generic top-level domain with no eligibility restrictions. Any individual, business, or organization worldwide can register an available .cloud name on a first-come, first-served basis, with no credential, industry, or local-presence requirement.'

--- a/content/tld/en/club.md
+++ b/content/tld/en/club.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .club domain is an open gTLD for communities, memberships, and Web3 groups. Learn who uses it, its SEO standing, pricing dynamics, and how to register.'
-keywords: ['.club domain', '.club TLD', 'what is .club', 'register .club domain', 'community domain', 'membership domain', 'web3 club domain', 'new gTLD', 'club domain SEO']
+keywords: ['register .club domain', 'community domain', 'membership domain', 'web3 club domain', 'new gTLD', 'club domain SEO']
 faqs:
   - question: 'Can anyone register a .club domain?'
     answer: 'Yes. The .club domain is an open generic top-level domain with no membership, credential, or local-presence requirement. Any individual or organization worldwide can register an available name on a first-come, first-served basis.'

--- a/content/tld/en/co.md
+++ b/content/tld/en/co.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'What is the .co domain? Colombia''s country-code TLD, marketed worldwide as a short ".com" or "company" alternative. Learn who runs it, who can register, pricing, and SEO.'
-keywords: ['.co domains', '.co TLD', 'co domain', 'what is .co', 'what is the .co domain', '.co vs .com', 'co domain for startups', 'Colombia domain', 'register .co domain', 'short company domain']
+keywords: ['.co domains', 'co domain', 'what is the .co domain', '.co vs .com', 'co domain for startups', 'Colombia domain', 'register .co domain', 'short company domain']
 faqs:
   - question: 'Can anyone register a .co domain?'
     answer: 'Yes. Although .co is technically Colombia''s country-code TLD, it has been open to anyone in the world since its 2010 relaunch, with no local-presence or Colombian-residency requirement. Registration is first-come, first-served at the second level.'

--- a/content/tld/en/com.md
+++ b/content/tld/en/com.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'How a 1985 afterthought became the internet''s default address — and the most valuable two-and-a-half letters in business. The full story of .com: its birth, its monopoly, its million-dollar heists, and what it means for anyone buying one today.'
-keywords: ['.com domains', 'what is .com', '.com TLD', '.com domain extension', 'register .com domain', 'com domain meaning', '.com vs .net', 'business domains', '.com price', '.com aftermarket', 'history of .com']
+keywords: ['.com domains', '.com domain extension', 'register .com domain', 'com domain meaning', '.com vs .net', 'business domains', '.com price', '.com aftermarket', 'history of .com']
 faqs:
   - question: 'Can anyone register a .com domain?'
     answer: 'Yes. The .com namespace is open to everyone worldwide with no local-presence, business, credential, or community requirement. The original commercial intent has never been enforced, so individuals, nonprofits, and companies alike can register one.'

--- a/content/tld/en/company.md
+++ b/content/tld/en/company.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .company domain is an open generic gTLD anyone can register. Learn who runs it, how it compares to .com, its SEO impact, and whether it suits your business.'
-keywords: ['.company domain', 'what is .company', '.company TLD', '.company vs .com', 'register .company domain', 'business domain extension', 'new gTLD for business', 'Identity Digital TLD']
+keywords: ['.company vs .com', 'register .company domain', 'business domain extension', 'new gTLD for business', 'Identity Digital TLD']
 faqs:
   - question: 'Can anyone register a .company domain?'
     answer: 'Yes. The .company TLD is an open generic gTLD with no eligibility restrictions. There is no requirement to be an incorporated business, hold a trademark, or have a local presence, so individuals, startups, and established firms can all register names on a first-come, first-served basis.'

--- a/content/tld/en/cpa.md
+++ b/content/tld/en/cpa.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .cpa domain is a restricted, credential-gated extension for licensed CPAs and CPA firms in the US, Canada, and Ireland, verified at registration and renewal.'
-keywords: ['.cpa domain', 'what is .cpa', 'cpa domain registration', 'restricted TLD', 'AICPA domain', 'CPA.com', 'licensed CPA domain', 'accounting firm domain']
+keywords: ['cpa domain registration', 'restricted TLD', 'AICPA domain', 'CPA.com', 'licensed CPA domain', 'accounting firm domain']
 faqs:
   - question: 'Can anyone register a .cpa domain?'
     answer: 'No. .cpa is a restricted, credential-gated TLD. Only licensed CPA firms and individually licensed CPAs based in the United States, Canada, or Ireland may register, and the registry verifies your CPA license and identity both at the time of purchase and at every renewal.'

--- a/content/tld/en/deals.md
+++ b/content/tld/en/deals.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .deals domain is an open new gTLD run by Binky Moon (Identity Digital), built for coupon sites, bargain hunters, and e-commerce promotions. Here is who it suits and why.'
-keywords: ['.deals domain', 'what is .deals', '.deals TLD', '.deals domain registration', 'coupon domain', 'deals website domain', 'Binky Moon', 'Identity Digital gTLD']
+keywords: ['.deals domain registration', 'coupon domain', 'deals website domain', 'Binky Moon', 'Identity Digital gTLD']
 faqs:
   - question: 'Can anyone register a .deals domain?'
     answer: 'Yes. The .deals domain is an open generic top-level domain with no eligibility restrictions. Any individual or business can register an available .deals name through an ICANN-accredited registrar, with no credential, membership, or local-presence requirement.'

--- a/content/tld/en/dev.md
+++ b/content/tld/en/dev.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: '.dev is Google''s HTTPS-only top-level domain for developers, projects, and tech teams. Learn who can register it, how it affects SEO, and how to buy one.'
-keywords: ['.dev domain', 'what is .dev', 'dev TLD', 'Google Registry dev', 'HSTS preload', 'developer domain', 'register dev domain', 'dev domain SEO']
+keywords: ['dev TLD', 'Google Registry dev', 'HSTS preload', 'developer domain', 'register dev domain', 'dev domain SEO']
 faqs:
   - question: 'Can anyone register a .dev domain?'
     answer: 'Yes. The .dev TLD is open to everyone with no credential, profession, or local-presence requirement. You do not need to be a software developer or a registered company to buy one, though the suffix reads best for technical projects.'

--- a/content/tld/en/eg.md
+++ b/content/tld/en/eg.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'What is the .eg domain? Egypt''s official country-code TLD, run by the Egyptian Universities Network since 1990. Learn eligibility rules, structure, SEO impact, and who should register.'
-keywords: ['.eg domain', '.eg TLD', 'Egypt domain', 'what is .eg', 'com.eg registration', 'Egypt ccTLD', 'register .eg domain', 'Egyptian Universities Network', '.eg eligibility', 'Egypt domain requirements']
+keywords: ['Egypt domain', 'com.eg registration', 'Egypt ccTLD', 'register .eg domain', 'Egyptian Universities Network', '.eg eligibility', 'Egypt domain requirements']
 faqs:
   - question: 'Can anyone register a .eg domain?'
     answer: 'No. The .eg registry requires that registrants either have a local representative inside Egypt or host their domain on Egyptian DNS servers. Companies outside Egypt must also hold a trademark registered in Egypt or internationally via the Madrid Convention with WIPO, and must appoint a local agent.'

--- a/content/tld/en/esq.md
+++ b/content/tld/en/esq.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .esq domain is a Google Registry extension built for lawyers and law firms. Learn who can register, how it is perceived, and whether it fits your practice.'
-keywords: ['.esq domain', 'what is .esq', '.esq domains', 'esq TLD for lawyers', 'esquire domain', 'Charleston Road Registry', 'Google Registry TLD', 'law firm domain']
+keywords: ['.esq domains', 'esq TLD for lawyers', 'esquire domain', 'Charleston Road Registry', 'Google Registry TLD', 'law firm domain']
 faqs:
   - question: 'Can anyone register a .esq domain?'
     answer: 'Yes. Despite being marketed for the legal profession, .esq is open to everyone on a first-come, first-served basis. The registry does not verify bar membership or legal credentials, so registration is not gated the way .law and .cpa are.'

--- a/content/tld/en/estate.md
+++ b/content/tld/en/estate.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .estate domain is an open generic extension built for real estate agents, brokerages, and property businesses. Learn who uses it, how it is priced, and whether it fits.'
-keywords: ['.estate domain', 'what is .estate', 'estate TLD', 'real estate domain', 'estate domain registration', 'property domain', 'new gTLD', 'Binky Moon']
+keywords: ['estate TLD', 'real estate domain', 'estate domain registration', 'property domain', 'new gTLD', 'Binky Moon']
 faqs:
   - question: 'Can anyone register a .estate domain?'
     answer: 'Yes. .estate is an open generic top-level domain with no eligibility restrictions. You do not need a real estate license, a brokerage, or any credential, so individuals, agents, and companies worldwide can register an available name on a first-come, first-served basis.'

--- a/content/tld/en/eth.md
+++ b/content/tld/en/eth.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: '.eth is not an ICANN domain but an Ethereum Name Service (ENS) name held as an NFT on-chain. Learn how it works, who can register one, and its real limits.'
-keywords: ['.eth domains', 'what is .eth', 'ENS domain', 'Ethereum Name Service', '.eth name NFT', 'register .eth', 'is .eth a real domain', '.eth vs DNS domain']
+keywords: ['.eth domains', 'ENS domain', 'Ethereum Name Service', '.eth name NFT', 'register .eth', 'is .eth a real domain', '.eth vs DNS domain']
 faqs:
   - question: 'Can anyone register a .eth name?'
     answer: 'Yes. Registering a .eth name is permissionless and open to anyone with an Ethereum wallet and enough ETH to cover the annual rent plus gas. There is no credential check, no identity verification, and no ICANN-accredited registrar involved; the rules are enforced entirely by the ENS smart contracts on Ethereum.'

--- a/content/tld/en/fashion.md
+++ b/content/tld/en/fashion.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .fashion domain is an open gTLD for designers, apparel labels, and style brands who want a name that says exactly what they do — here is who it suits and why.'
-keywords: ['.fashion domain', 'what is .fashion', 'fashion TLD', 'fashion brand domain', 'apparel domain name', 'style domain extension', 'register .fashion', 'GoDaddy Registry']
+keywords: ['fashion TLD', 'fashion brand domain', 'apparel domain name', 'style domain extension', 'register .fashion', 'GoDaddy Registry']
 faqs:
   - question: 'Can anyone register a .fashion domain?'
     answer: 'Yes. The .fashion domain is an open generic TLD with no credential, industry, or local-presence requirements, so individuals and businesses anywhere can register one on a first-come, first-served basis. Some labels, such as most two-character names, are reserved by the registry.'

--- a/content/tld/en/finance.md
+++ b/content/tld/en/finance.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .finance domain is an open generic gTLD run by Binky Moon (Identity Digital), built for banks, fintech, advisors and finance media. Here is who it suits and why.'
-keywords: ['.finance domain', 'what is .finance', '.finance domains', 'finance TLD', 'fintech domain', 'finance domain name', 'Identity Digital', 'Binky Moon', 'register .finance']
+keywords: ['.finance domains', 'finance TLD', 'fintech domain', 'finance domain name', 'Identity Digital', 'Binky Moon', 'register .finance']
 faqs:
   - question: 'Can anyone register a .finance domain?'
     answer: 'Yes. The .finance TLD is an open generic gTLD with no eligibility restrictions. You do not need a financial licence, professional credential, or local presence to register one. Standard registrar terms and acceptable-use rules still apply.'

--- a/content/tld/en/fun.md
+++ b/content/tld/en/fun.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .fun domain is an open new gTLD run by Radix, popular with games, events, and Web3 projects like pump.fun. Here is who uses it, the rules, and its value.'
-keywords: ['.fun domain', '.fun TLD', 'what is .fun', '.fun domains', 'Radix registry', 'new gTLD', 'gaming domains', 'pump.fun']
+keywords: ['.fun domains', 'Radix registry', 'new gTLD', 'gaming domains', 'pump.fun']
 faqs:
   - question: 'Can anyone register a .fun domain?'
     answer: 'Yes. The .fun domain is an open new gTLD with no eligibility restrictions, so individuals, businesses, and projects worldwide can register one on a first-come, first-served basis. The only exceptions are ICANN-mandated and registry-reserved names, such as two-character labels and certain premium names.'

--- a/content/tld/en/homes.md
+++ b/content/tld/en/homes.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .homes domain is an open new gTLD run by XYZ Registry, ideal for real estate, property, and housing brands that want a clear, descriptive web address.'
-keywords: ['.homes domain', 'what is .homes', '.homes TLD', 'real estate domain', 'property domain name', 'XYZ Registry', 'new gTLD', 'homes domain registration']
+keywords: ['real estate domain', 'property domain name', 'XYZ Registry', 'new gTLD', 'homes domain registration']
 faqs:
   - question: 'Can anyone register a .homes domain?'
     answer: 'Yes. The .homes TLD is open to everyone with no eligibility checks. The original 2014 launch limited it to verified housing-industry professionals, but the registry removed those restrictions when it relaunched the extension, so any individual or business can register a .homes name today.'

--- a/content/tld/en/house.md
+++ b/content/tld/en/house.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .house domain is an open generic TLD run by Binky Moon (Identity Digital). See who it suits, how it ranks, registration rules, and pricing dynamics.'
-keywords: ['.house domain', 'what is .house', '.house TLD', 'real estate domain', 'home domain extension', 'Binky Moon', 'Identity Digital', 'generic TLD', 'domain registration']
+keywords: ['real estate domain', 'home domain extension', 'Binky Moon', 'Identity Digital', 'generic TLD', 'domain registration']
 faqs:
   - question: 'Can anyone register a .house domain?'
     answer: 'Yes. The .house TLD is an open, unrestricted generic top-level domain. There are no credential, industry, or local-presence requirements, so any individual or organization worldwide can register an available .house name on a first-come, first-served basis.'

--- a/content/tld/en/info.md
+++ b/content/tld/en/info.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .info domain is an open, unrestricted gTLD launched in 2001 for information-led sites. Learn who uses it, its SEO and reputation, and whether to register one.'
-keywords: ['.info', '.info domain', '.info TLD', 'what is .info', 'register .info domain', 'info domain meaning', 'Identity Digital', 'unrestricted gTLD']
+keywords: ['.info', 'register .info domain', 'info domain meaning', 'Identity Digital', 'unrestricted gTLD']
 faqs:
   - question: 'Can anyone register a .info domain?'
     answer: 'Yes. The .info domain is an open, unrestricted gTLD with no eligibility requirements. Anyone, anywhere can register an available .info name without proving a credential, business type, or local presence.'

--- a/content/tld/en/io.md
+++ b/content/tld/en/io.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .io domain is the de facto standard for startups, developers, and Web3 projects. Learn its origin, who can register one, pricing dynamics, and reputation.'
-keywords: ['.io domains', 'what is .io', '.io TLD', '.io domain extension', 'register .io domain', 'io domain meaning', '.io vs .ai', 'tech startup domains']
+keywords: ['.io domains', '.io domain extension', 'register .io domain', 'io domain meaning', '.io vs .ai', 'tech startup domains']
 faqs:
   - question: 'Can anyone register a .io domain?'
     answer: 'Yes. The .io namespace is open to everyone worldwide with no local-presence, business, or credential requirements. You do not need any connection to the British Indian Ocean Territory to register one.'

--- a/content/tld/en/law.md
+++ b/content/tld/en/law.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .law domain is a restricted, credential-gated extension reserved for licensed lawyers, law firms, law schools, and legal regulators, verified at registration and renewal.'
-keywords: ['.law domain', 'what is .law', 'law domain registration', 'restricted TLD', 'lawyer domain', 'law firm domain', 'legal domain name', 'credential-gated TLD']
+keywords: ['law domain registration', 'restricted TLD', 'lawyer domain', 'law firm domain', 'legal domain name', 'credential-gated TLD']
 faqs:
   - question: 'Can anyone register a .law domain?'
     answer: 'No. .law is a restricted, credential-gated TLD. Only qualified lawyers licensed to practice, law firms, law schools, and legal regulators may register, and an independent validation provider verifies your legal credentials both at registration and on an ongoing basis throughout the domain lifecycle.'

--- a/content/tld/en/lawyer.md
+++ b/content/tld/en/lawyer.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .lawyer domain is an open generic gTLD for legal professionals and firms. Learn who can register it, how it compares to .law and .attorney, and whether it fits.'
-keywords: ['lawyer domain', 'what is .lawyer', '.lawyer domains', '.lawyer vs .law', 'legal domain extensions', 'domains for law firms', 'lawyer TLD', 'register .lawyer']
+keywords: ['lawyer domain', '.lawyer domains', '.lawyer vs .law', 'legal domain extensions', 'domains for law firms', 'lawyer TLD', 'register .lawyer']
 faqs:
   - question: 'Can anyone register a .lawyer domain?'
     answer: 'Yes. .lawyer is an open generic top-level domain sold first-come, first-served, with no bar membership, law license, or credential check required to register. This is the main practical difference from .law, which verifies that the registrant is a licensed legal professional.'

--- a/content/tld/en/legal.md
+++ b/content/tld/en/legal.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .legal domain is an open generic TLD for the legal field. Learn who runs it, who can register, how it compares to .law, and whether it suits your firm.'
-keywords: ['.legal domains', 'what is .legal', '.legal TLD', 'legal domain extension', 'law firm domain names', 'lawyer website domain', 'Identity Digital TLD', 'Binky Moon registry']
+keywords: ['.legal domains', 'legal domain extension', 'law firm domain names', 'lawyer website domain', 'Identity Digital TLD', 'Binky Moon registry']
 faqs:
   - question: 'Can anyone register a .legal domain?'
     answer: 'Yes. The .legal domain is an open generic TLD with no credential, license, or bar-membership requirement, so anyone can register one. This is the key difference from .law, which verifies that the registrant is part of the legal profession before it activates the name.'

--- a/content/tld/en/live.md
+++ b/content/tld/en/live.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .live domain is an open new gTLD run by Identity Digital, built for streaming, events, and real-time content. Learn who uses it, the rules, and whether it fits you.'
-keywords: ['.live domains', '.live TLD', 'what is .live', 'why choose .live', 'streaming domain', 'live streaming domain name', 'Identity Digital', 'new gTLD']
+keywords: ['.live domains', 'why choose .live', 'streaming domain', 'live streaming domain name', 'Identity Digital', 'new gTLD']
 faqs:
   - question: 'Can anyone register a .live domain?'
     answer: 'Yes. The .live extension is an open generic top-level domain with no eligibility restrictions. Any individual, business, or organization worldwide can register an available .live name on a first-come, first-served basis, with no credential, license, or local-presence requirement.'

--- a/content/tld/en/loan.md
+++ b/content/tld/en/loan.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'A .loan domain is an open new gTLD for lending and finance sites. Learn who can register it, how it is priced, its spam reputation, and whether it is worth buying.'
-keywords: ['.loan domain', 'what is .loan domain', '.loan tld', 'register .loan domain', 'is .loan domain safe', '.loan domain meaning', 'loan domain extension', 'new gTLD', 'cheap domain extensions', 'finance domain names']
+keywords: ['what is .loan domain', 'register .loan domain', 'is .loan domain safe', '.loan domain meaning', 'loan domain extension', 'new gTLD', 'cheap domain extensions', 'finance domain names']
 faqs:
   - question: 'Can anyone register a .loan domain?'
     answer: 'Yes. The .loan extension is an open generic top-level domain with no eligibility checks. You do not need a financial license, lending credential, or local presence to register one, so anyone worldwide can buy an available .loan name on a first-come, first-served basis.'

--- a/content/tld/en/me.md
+++ b/content/tld/en/me.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'What is the .me domain? Montenegro''s country-code TLD, marketed worldwide as a personal-branding and domain-hack extension where the name completes with "me." Learn who runs it, who can register, pricing, and SEO.'
-keywords: ['.me domains', '.me TLD', 'me domain', 'what is .me', 'what is the .me domain', '.me vs .com', 'me domain for personal branding', 'Montenegro domain', 'register .me domain', 'domain hack .me', 'about.me']
+keywords: ['.me domains', 'me domain', 'what is the .me domain', '.me vs .com', 'me domain for personal branding', 'Montenegro domain', 'register .me domain', 'domain hack .me', 'about.me']
 faqs:
   - question: 'Can anyone register a .me domain?'
     answer: 'Yes. Although .me is technically Montenegro''s country-code TLD, it has been open to anyone in the world since its 2008 public launch, with no local-presence or Montenegrin-residency requirement. Registration is first-come, first-served at the second level.'

--- a/content/tld/en/net.md
+++ b/content/tld/en/net.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .net domain is one of the internet''s original gTLDs, run by Verisign and open to anyone. Learn who uses it, how it compares to .com, and when to register it.'
-keywords: ['.net domain', 'what is .net', '.net TLD', '.net vs .com', 'register .net domain', 'Verisign .net registry', 'is .net good for SEO', 'tech startup domains']
+keywords: ['.net vs .com', 'register .net domain', 'Verisign .net registry', 'is .net good for SEO', 'tech startup domains']
 faqs:
   - question: 'Can anyone register a .net domain?'
     answer: '.net is an open generic top-level domain with no registration restrictions. Anyone, anywhere can register an available .net name without proving membership, credentials, or a local presence. Standard ICANN rules on syntax, trademark sunrise history, and renewal apply.'

--- a/content/tld/en/now.md
+++ b/content/tld/en/now.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .now domain is a closed Amazon brand TLD (dotBrand), not open for public registration. Here is what .now really is and what to buy instead.'
-keywords: ['.now domain', 'what is .now', '.now TLD', '.now top-level domain', 'Amazon Registry Services', 'brand TLD', 'dotBrand', 'Specification 13']
+keywords: ['.now top-level domain', 'Amazon Registry Services', 'brand TLD', 'dotBrand', 'Specification 13']
 faqs:
   - question: 'Can anyone register a .now domain?'
     answer: 'No. .now is a closed Specification 13 brand TLD operated by Amazon Registry Services. Only Amazon, its affiliates, and authorized partners can register .now names, so the suffix is not available to the general public through any registrar.'

--- a/content/tld/en/online.md
+++ b/content/tld/en/online.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .online domain is an open, unrestricted new gTLD by Radix that any person or business can register. Learn who it suits, how it ranks, and what to consider.'
-keywords: ['.online domain', 'what is .online', '.online TLD', 'register .online domain', 'Radix registry', 'new gTLD', 'online domain extension', 'is .online good for SEO']
+keywords: ['register .online domain', 'Radix registry', 'new gTLD', 'online domain extension', 'is .online good for SEO']
 faqs:
   - question: 'Can anyone register a .online domain?'
     answer: 'Yes. .online is an open, unrestricted generic top-level domain. There is no credential, trademark, business, or local-presence requirement, so any individual or organization worldwide can register an available name on a first-come, first-served basis.'

--- a/content/tld/en/org.md
+++ b/content/tld/en/org.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .org domain is an open legacy gTLD run by the nonprofit Public Interest Registry, trusted by charities, open-source projects, and communities worldwide.'
-keywords: ['.org domains', 'what is .org', '.org domain meaning', 'org TLD', 'Public Interest Registry', 'nonprofit domain', 'register .org domain', 'is .org good for SEO']
+keywords: ['.org domains', '.org domain meaning', 'org TLD', 'Public Interest Registry', 'nonprofit domain', 'register .org domain', 'is .org good for SEO']
 faqs:
   - question: 'Can anyone register a .org domain?'
     answer: 'Yes. The .org extension is open and unrestricted, so any individual, business, nonprofit, or project can register an available name. There is no proof-of-nonprofit-status requirement and no local-presence rule.'

--- a/content/tld/en/properties.md
+++ b/content/tld/en/properties.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .properties domain is an open generic gTLD run by Binky Moon (Identity Digital), built for real estate listings, brokers, and property portfolios worldwide.'
-keywords: ['.properties domain', 'what is .properties', '.properties TLD', 'real estate domain', 'property domain name', 'Binky Moon properties', 'Identity Digital real estate gTLD', 'register .properties']
+keywords: ['real estate domain', 'property domain name', 'Binky Moon properties', 'Identity Digital real estate gTLD', 'register .properties']
 faqs:
   - question: 'Can anyone register a .properties domain?'
     answer: 'Yes. The .properties TLD is an open generic gTLD with no eligibility restrictions. Anyone worldwide — agents, developers, property managers, or businesses outside real estate — can register an available name, subject to standard trademark and acceptable-use rules.'

--- a/content/tld/en/realtor.md
+++ b/content/tld/en/realtor.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .realtor domain is a restricted real-estate TLD limited to NAR and CREA members. Learn who can register, who runs it, and how it works for agents.'
-keywords: ['.realtor domains', 'what is .realtor', '.realtor TLD', 'realtor domain extension', 'real estate domain names', 'NAR domain', 'realtor website domain', 'Real Estate Domains LLC']
+keywords: ['.realtor domains', 'realtor domain extension', 'real estate domain names', 'NAR domain', 'realtor website domain', 'Real Estate Domains LLC']
 faqs:
   - question: 'Can anyone register a .realtor domain?'
     answer: 'No. The .realtor domain is restricted to members of the National Association of REALTORS (NAR), members of the Canadian Real Estate Association (CREA), their member boards and associations, and NAR affiliates and licensees in good standing. The general public cannot register one, and NAR determines eligibility at its sole discretion.'

--- a/content/tld/en/realty.md
+++ b/content/tld/en/realty.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .realty domain is an open generic TLD for property professionals. No NAR membership needed, unlike .realtor. See who can register, pricing, and SEO.'
-keywords: ['.realty domains', 'what is .realty', '.realty TLD', '.realty vs .realtor', 'real estate domain names', 'property website domain', 'Internet Naming Co', 'new gTLD for realtors']
+keywords: ['.realty domains', '.realty vs .realtor', 'real estate domain names', 'property website domain', 'Internet Naming Co', 'new gTLD for realtors']
 faqs:
   - question: 'Can anyone register a .realty domain?'
     answer: 'Yes. .realty is an open generic TLD with no eligibility restrictions. Any individual, business, or organization can register one without proving membership, a license, or local presence. This is the key difference from .realtor, which requires National Association of Realtors or Canadian Real Estate Association membership.'

--- a/content/tld/en/sbs.md
+++ b/content/tld/en/sbs.md
@@ -8,7 +8,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .sbs domain is a low-cost open generic gTLD run by ShortDot, often read as "side by side." Learn its origin, real uses, reputation, and whether to buy.'
-keywords: ['.sbs domain', 'what is .sbs', '.sbs domain meaning', 'sbs tld', 'is .sbs safe', 'ShortDot .sbs', 'side by side domain', 'new gTLD']
+keywords: ['.sbs domain meaning', 'sbs tld', 'is .sbs safe', 'ShortDot .sbs', 'side by side domain', 'new gTLD']
 faqs:
   - question: 'Can anyone register a .sbs domain?'
     answer: 'Yes. .sbs is an open, unrestricted generic top-level domain operated by ShortDot SA. There are no credential, membership, or local-presence requirements, so individuals and businesses anywhere in the world can register a .sbs name through any accredited registrar.'

--- a/content/tld/en/shop.md
+++ b/content/tld/en/shop.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .shop domain is an open new gTLD run by GMO Registry that signals "this is a place to buy." Learn who uses it, the rules, pricing dynamics, and SEO.'
-keywords: ['.shop domains', 'what is .shop', '.shop TLD', '.shop domain registration', 'e-commerce domain', 'GMO Registry', 'new gTLD for retail', 'buy .shop domain']
+keywords: ['.shop domains', '.shop domain registration', 'e-commerce domain', 'GMO Registry', 'new gTLD for retail', 'buy .shop domain']
 faqs:
   - question: 'Can anyone register a .shop domain?'
     answer: 'Yes. .shop is an open generic top-level domain with no eligibility restrictions, so any individual or business worldwide can register an available name on a first-come, first-served basis. There is no credential, local-presence, or community requirement.'

--- a/content/tld/en/shopping.md
+++ b/content/tld/en/shopping.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .shopping domain is an open e-commerce gTLD from Binky Moon (Identity Digital). Learn who it suits, how it compares to .shop and .store, and how to register it.'
-keywords: ['.shopping domains', 'what is .shopping', '.shopping TLD', '.shopping domain', 'e-commerce domain', 'retail domain name', 'Binky Moon', 'Identity Digital', 'shopping domain extension', 'buy .shopping domain']
+keywords: ['.shopping domains', 'e-commerce domain', 'retail domain name', 'Binky Moon', 'Identity Digital', 'shopping domain extension', 'buy .shopping domain']
 faqs:
   - question: 'Can anyone register a .shopping domain?'
     answer: 'Yes. The .shopping TLD is an open generic domain with no eligibility restrictions. Any individual or business in any country can register an available name on a first-come, first-served basis, with no credential, trademark, or local-presence requirement.'

--- a/content/tld/en/site.md
+++ b/content/tld/en/site.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .site domain is an open, globally understood new gTLD by Radix. Learn who uses it, its SEO and deliverability profile, and how to register one at Namefi.'
-keywords: ['.site domains', 'what is .site', '.site TLD', '.site domain registration', 'Radix registry', 'new gTLD', 'buy .site domain', 'is .site good for SEO']
+keywords: ['.site domains', '.site domain registration', 'Radix registry', 'new gTLD', 'buy .site domain', 'is .site good for SEO']
 faqs:
   - question: 'Can anyone register a .site domain?'
     answer: 'Yes. The .site extension is an open generic top-level domain with no eligibility restrictions. There is no credential, trademark, business, or local-presence requirement, so individuals and organizations anywhere in the world can register an available .site name on a first-come, first-served basis.'

--- a/content/tld/en/space.md
+++ b/content/tld/en/space.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .space domain is an open new gTLD from Radix, popular with startups, creatives, and space-tech projects. Learn who it suits, how it ranks, and what it costs.'
-keywords: ['.space domain', 'what is .space', 'space TLD', 'register .space domain', 'Radix registry', 'new gTLD', 'creative domain extension', 'startup domain']
+keywords: ['space TLD', 'register .space domain', 'Radix registry', 'new gTLD', 'creative domain extension', 'startup domain']
 faqs:
   - question: 'Can anyone register a .space domain?'
     answer: 'Yes. .space is an open generic TLD with no eligibility restrictions, so individuals, companies, and organizations anywhere in the world can register an available name on a first-come, first-served basis. There is no credential, trademark, or local-presence requirement.'

--- a/content/tld/en/store.md
+++ b/content/tld/en/store.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .store domain is an open new gTLD built for retail and online shopping. Learn who runs it, who should use it, how it affects SEO, and where to register.'
-keywords: ['.store domains', 'what is .store', '.store TLD', 'e-commerce domain', 'online store domain name', 'retail domain extension', 'buy a .store domain', 'register .store']
+keywords: ['.store domains', 'e-commerce domain', 'online store domain name', 'retail domain extension', 'buy a .store domain', 'register .store']
 faqs:
   - question: 'Can anyone register a .store domain?'
     answer: 'Yes. The .store domain is an open generic top-level domain with no eligibility restrictions, so individuals, brands, and businesses anywhere in the world can register one on a first-come, first-served basis. There is no proof of a retail license, local presence, or membership required.'

--- a/content/tld/en/style.md
+++ b/content/tld/en/style.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .style domain is an open generic TLD for fashion, design, and lifestyle brands. Learn who runs it, who can register, pricing dynamics, and how to buy one.'
-keywords: ['.style domains', 'what is .style', '.style TLD', '.style domain', 'fashion domain extension', 'design domain name', 'lifestyle TLD', 'register .style domain', 'Identity Digital', 'new gTLD']
+keywords: ['.style domains', 'fashion domain extension', 'design domain name', 'lifestyle TLD', 'register .style domain', 'Identity Digital', 'new gTLD']
 faqs:
   - question: 'Can anyone register a .style domain?'
     answer: 'Yes. .style is an open generic top-level domain with no eligibility restrictions, so individuals, businesses, and organizations anywhere in the world can register one on a first-come, first-served basis. No credential, trademark, or local presence is required.'

--- a/content/tld/en/tax.md
+++ b/content/tld/en/tax.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .tax domain is an open generic gTLD run by Binky Moon. Learn who uses it, the registration rules, pricing dynamics, reputation, and whether it fits your firm.'
-keywords: ['.tax domain', 'what is .tax', '.tax TLD', 'tax domain extension', '.tax registration', 'accounting domain', 'tax preparer website', 'new gTLD']
+keywords: ['tax domain extension', '.tax registration', 'accounting domain', 'tax preparer website', 'new gTLD']
 faqs:
   - question: 'Can anyone register a .tax domain?'
     answer: 'Yes. The .tax registry is open to everyone with no credential, license, or local-presence requirement. You do not need to be an accountant, tax preparer, or registered firm. Names are sold first-come, first-served, subject only to standard syntax rules and any reserved or premium names the registry holds back.'

--- a/content/tld/en/tech.md
+++ b/content/tld/en/tech.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .tech domain is an open new gTLD run by Radix for technology brands, startups, and developers. Learn who it suits, its trade-offs, and how to register.'
-keywords: ['.tech domain', 'what is .tech', '.tech TLD', 'tech domain extension', 'Radix registry', 'new gTLD for startups', 'developer portfolio domain', 'register .tech domain']
+keywords: ['tech domain extension', 'Radix registry', 'new gTLD for startups', 'developer portfolio domain', 'register .tech domain']
 faqs:
   - question: 'Can anyone register a .tech domain?'
     answer: 'Yes. The .tech domain is an open generic top-level domain with no eligibility restrictions. There is no credential, industry membership, or local-presence requirement, so individuals, startups, and established companies anywhere can register one on a first-come, first-served basis.'

--- a/content/tld/en/today.md
+++ b/content/tld/en/today.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: '.today is an open new gTLD run by Identity Digital, built for news, daily deals, events, and updates. Learn who uses it, the rules, and whether to buy.'
-keywords: ['.today domain', 'what is .today', '.today TLD', 'today domain extension', 'new gTLD', 'Identity Digital', 'domain registration', 'news domain']
+keywords: ['today domain extension', 'new gTLD', 'Identity Digital', 'domain registration', 'news domain']
 faqs:
   - question: 'Can anyone register a .today domain?'
     answer: 'Yes. .today is an open generic top-level domain with no eligibility restrictions. Anyone worldwide can register an available name on a first-come, first-served basis, with no credential, trademark, or local-presence requirement.'

--- a/content/tld/en/top.md
+++ b/content/tld/en/top.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .top domain is an open, low-cost new gTLD popular for short, keyword-rich names. Learn who runs it, who can register, its SEO and reputation trade-offs.'
-keywords: ['.top domains', 'what is .top', '.top TLD', '.top domain meaning', 'is .top good for SEO', '.top vs .com', 'buy .top domain', 'new gTLD']
+keywords: ['.top domains', '.top domain meaning', 'is .top good for SEO', '.top vs .com', 'buy .top domain', 'new gTLD']
 faqs:
   - question: 'Can anyone register a .top domain?'
     answer: 'Yes. The .top domain is an open generic top-level domain with no eligibility requirements. There is no local presence, credential, trademark, or community membership needed, so individuals and businesses anywhere can register an available name on a first-come, first-served basis.'

--- a/content/tld/en/tv.md
+++ b/content/tld/en/tv.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'What is the .tv domain? Tuvalu''s country-code TLD, marketed worldwide as the home of television, video, and live streaming. Learn who runs it, who can register, pricing, and SEO.'
-keywords: ['.tv domains', '.tv TLD', 'tv domain', 'what is .tv', 'what is the .tv domain', '.tv for streaming', 'tv domain for video', 'Tuvalu domain', 'register .tv domain', 'twitch.tv', 'video streaming domain']
+keywords: ['.tv domains', 'tv domain', 'what is the .tv domain', '.tv for streaming', 'tv domain for video', 'Tuvalu domain', 'register .tv domain', 'twitch.tv', 'video streaming domain']
 faqs:
   - question: 'Can anyone register a .tv domain?'
     answer: 'Yes. Although .tv is technically Tuvalu''s country-code TLD, it has been open to anyone in the world for decades, with no local-presence or Tuvaluan-residency requirement. Registration is first-come, first-served at the second level, though many short or dictionary names are classified as premium.'

--- a/content/tld/en/us.md
+++ b/content/tld/en/us.md
@@ -7,7 +7,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'What is the .us domain? The official country-code TLD for the United States, restricted to registrants with a genuine US presence. Learn who runs it, the Nexus Requirement, pricing, SEO, and email deliverability.'
-keywords: ['.us domains', '.us TLD', 'us domain', 'what is .us', 'what is the .us domain', '.us vs .com', 'US nexus requirement', 'United States domain', 'register .us domain', 'American domain extension', 'del.icio.us']
+keywords: ['.us domains', 'us domain', 'what is the .us domain', '.us vs .com', 'US nexus requirement', 'United States domain', 'register .us domain', 'American domain extension', 'del.icio.us']
 faqs:
   - question: 'Can anyone register a .us domain?'
     answer: 'No. Unlike most marketed ccTLDs, .us enforces a US Nexus Requirement: registrants must be US citizens or residents, US-organized entities, or foreign organizations with a bona fide presence in the United States. There is no open, anyone-anywhere registration.'

--- a/content/tld/en/vip.md
+++ b/content/tld/en/vip.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .vip domain is an open new gTLD meaning Very Important Person, built for membership, loyalty, and premium brands. Learn its rules, value, and how to register at Namefi.'
-keywords: ['.vip domain', 'vip domain', '.vip domain meaning', 'what is .vip', '.vip TLD', 'is .vip domain safe', 'register .vip domain', 'membership domains', 'premium domain names', 'new gTLD']
+keywords: ['vip domain', '.vip domain meaning', 'is .vip domain safe', 'register .vip domain', 'membership domains', 'premium domain names', 'new gTLD']
 faqs:
   - question: 'Can anyone register a .vip domain?'
     answer: 'Yes. .vip is an open, unrestricted new gTLD with no eligibility requirements. Individuals, brands, creators, and communities can all register one, subject only to standard availability and the registry policies that apply to every domain.'

--- a/content/tld/en/website.md
+++ b/content/tld/en/website.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: '.website is an open generic top-level domain run by Radix that literally spells out what a site is. Here is who it suits, how it is perceived, and what to weigh.'
-keywords: ['.website domain', 'what is .website', '.website TLD', 'Radix registry', 'generic TLD', 'register .website domain', '.website vs .site', 'new gTLD']
+keywords: ['Radix registry', 'generic TLD', 'register .website domain', '.website vs .site', 'new gTLD']
 faqs:
   - question: 'Can anyone register a .website domain?'
     answer: 'Yes. .website is an unrestricted generic top-level domain operated by Radix. There are no eligibility requirements, credentials, or local-presence rules, and any individual or organization can register an available name on a first-come, first-served basis.'

--- a/content/tld/en/world.md
+++ b/content/tld/en/world.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .world domain is an open generic gTLD run by Identity Digital, ideal for global brands, international projects, and community sites. Here is how it works.'
-keywords: ['.world domain', 'what is .world', 'world TLD', 'world domain registration', 'global domain extension', 'Identity Digital', 'generic top-level domain', 'register .world']
+keywords: ['world TLD', 'world domain registration', 'global domain extension', 'Identity Digital', 'generic top-level domain', 'register .world']
 faqs:
   - question: 'Can anyone register a .world domain?'
     answer: 'Yes. The .world domain is an open generic gTLD with no eligibility restrictions. Any individual, business, or organization anywhere can register an available .world name on a first-come, first-served basis without proving location, profession, or community membership.'

--- a/content/tld/en/xyz.md
+++ b/content/tld/en/xyz.md
@@ -8,7 +8,7 @@ authors: ['namefiteam']
 editors: ['victor-zhou']
 draft: false
 description: 'The .xyz domain is an open generic TLD launched in 2014 and famously used by Alphabet at abc.xyz. Learn who it suits, how it is priced, and how to register.'
-keywords: ['.xyz domains', 'what is .xyz', '.xyz TLD', '.xyz domain meaning', 'abc.xyz Alphabet', '.xyz vs .com', 'register .xyz domain', 'is .xyz good for SEO']
+keywords: ['.xyz domains', '.xyz domain meaning', 'abc.xyz Alphabet', '.xyz vs .com', 'register .xyz domain', 'is .xyz good for SEO']
 faqs:
   - question: 'Can anyone register a .xyz domain?'
     answer: 'Yes. The .xyz domain is an unrestricted generic top-level domain, so anyone worldwide can register one on a first-come, first-served basis with no credential, business, or local-presence requirement. Registrations are handled through ICANN-accredited registrars rather than directly with the registry.'


### PR DESCRIPTION
## Summary

Completes the corpus migration that #278 piloted: strips boilerplate `keywords:` entries from the remaining **en + de** TLD and glossary pages now that `content/keyword-templates.json` auto-expands them at render time (namefi-astra composes template output + page extras, deduped case-insensitively — see [#276](https://github.com/d3servelabs/namefi-resources/issues/276), [#278](https://github.com/d3servelabs/namefi-resources/pull/278), companion [namefi-astra#5525](https://github.com/d3servelabs/namefi-astra/pull/5525)).

- **464 of 491** en+de TLD/glossary files changed (27 already had no boilerplate-matching keywords, e.g. brand TLDs like `.abbott` whose keywords never happened to collide with the template phrasing).
- Nothing changes about what actually renders — this only moves already-duplicated boilerplate out of each file and into the shared registry.

## Solution

**Scope — en + de only, by design.** `content/keyword-templates.json` currently only has `en`/`de` phrase patterns. The other 8 locales (`es fr zh-CN ar hi ko ja ta`) have no template coverage yet, so stripping their `keywords:` now would be a real SEO regression with nothing backfilling it — left untouched. `content/blog/**` is out of scope for this whole mechanism.

**Algorithm** (mirrors `toKeywordTermPlaceholder()` / `composeKeywords()` in `namefi-astra`'s `content.ts` exactly):
- TLD: `{tld}` = the file's bare slug (`content/tld/en/abb.md` → `abb`).
- Glossary: `{term}` = the file's `title:`, with any trailing parenthetical stripped (`"DAO (Decentralized Autonomous Organization)"` → `"DAO"`).
- Expand that file's type+locale template list with its placeholder, then remove any `keywords:` entry that **case-insensitively exact-string-matches** an expanded phrase. Everything else stays, in original order.
- **No fuzzy/near-duplicate matching** — e.g. `.ac top-level domain` (extra) vs. the template's `.ac TLD` (removed) are treated as distinct; only true exact matches were stripped, same as the pilot.

Migrated with a throwaway script (not included in this PR) that performed raw-text surgery on just the `keywords:` field per file — preserving each file's original array style (flow `[...]` vs. block `- item`) and quoting, rather than round-tripping the whole frontmatter through a YAML serializer.

A handful of files ended up with an intentionally-empty `keywords: []` — expected per the repo convention (soft warning only, not an error; no filler keywords added).

## Test plan

- [x] `bun data:validate` — 0 errors, same 26 pre-existing warnings as before this change (none from files touched here).
- [x] `bun lint:mdx` — clean.
- [x] `bun .agents/skills/cross-link/link-audit.ts content/tld/en content/tld/de content/glossary/en content/glossary/de` — 0 broken, 0 missing-locale, 0 locale-mismatch, 0 relationship-mismatch.
- [x] Verified the already-migrated pilot files from #278 (`abb.md`, `dns.md`, `tld.md`, `icann.md`, …) are unaffected — confirms the algorithm is a no-op on them.
- [x] Spot-checked diffs by hand:
  - Brand TLD `content/tld/en/abbott.md` — no boilerplate matches, correctly untouched.
  - Open TLD `content/tld/en/xyz.md` — `what is .xyz` / `.xyz TLD` removed; `.xyz domains` (plural, near-duplicate of template's singular `.xyz domain`) correctly kept.
  - Glossary with parenthetical title `content/glossary/en/dao.md` (`DAO (Decentralized Autonomous Organization)`) and `content/glossary/en/cctld.md` — bare term correctly stripped in both en and de.
  - German TLD `content/tld/de/ac.md` — `.ac TLD` / `was ist .ac` removed; `.ac top-level domain` / `was ist die .ac domain` (near-duplicates, not exact template matches) correctly kept.
- [x] Pre-push hooks (`data_validate`, `links_audit`, `lint_mdx`) all green.

## Claude session summary

- 2026-08-03T07:3X (UTC) — Read `content/keyword-templates.json` and namefi-astra's `toKeywordTermPlaceholder()`/`composeKeywords()` in `apps/resources/src/lib/content.ts` to confirm the exact algorithm to mirror.
- Surveyed `content/tld/{en,de}` and `content/glossary/{en,de}` frontmatter shapes: flow-style `keywords: [...]` (mixed single/double quotes) and block-style `keywords:\n  - item` both present; confirmed pilot-migrated files (`abb.md`, `dns.md`, etc.) as no-op baseline.
- Wrote a throwaway Bun/TS script performing text-level surgery on the `keywords:` field only (case-insensitive exact-match strip against expanded templates), preserving each file's original quoting/array style; ran it across all four target directories (464/491 files changed) and deleted the script before committing.
- Ran `bun data:validate`, `bun lint:mdx`, and the cross-link audit — all clean; spot-checked brand/open TLD and parenthetical-title glossary diffs by hand.
- Branched off freshly-fetched `origin/main`, committed, pushed — pre-push hooks green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/d3servelabs/codesmith/namefi-resources/pr/279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788335385&installation_model_id=1368&pr_number=279&repository=d3servelabs%2Fnamefi-resources&return_to=https%3A%2F%2Fgithub.com%2Fd3servelabs%2Fnamefi-resources%2Fpull%2F279&signature=a6a1f41690337f213fc9adaa4509b3fad21cb8765baac7d19ad940a51addb435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only frontmatter cleanup with no runtime code here; risk is low if template expansion in namefi-astra matches the migration algorithm (already validated in the PR).
> 
> **Overview**
> Finishes the **en + de** keyword migration for glossary pages (alongside TLD pages in the same PR): frontmatter `keywords:` no longer repeats phrases that **`content/keyword-templates.json`** expands at render time in namefi-astra.
> 
> Each touched glossary entry drops **case-insensitive exact matches** to the locale template (e.g. the term title, `what is {term}`, acronym-only duplicates). **Non-matching extras stay** in the same order—synonyms, related acronyms, and near-duplicates that are not identical to a template string.
> 
> **Rendered SEO keywords are unchanged** (template output + page extras, deduped). Other locales and blog content are untouched because templates exist only for en/de today.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 884c339139da9605c6b4a0975ea9681157de4551. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->