### PR TITLE
docs(rules): codify fact-audit methodology after the .now Specification 13 incident

### DIFF
--- a/.agents/skills/content-authoring/SKILL.md
+++ b/.agents/skills/content-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: content-authoring
-description: Draft (write) NEW English Namefi resources content — blog posts, glossary terms, TLD pages — in namefi-resources. Use this whenever authoring new English content, before publishing. To TRANSLATE English content into the other locales (single files or bulk batches, plus translation QA), use the `article-translation` skill instead. Covers the model/scale choices, the en-first drafting playbook, citation verification, frontmatter/taxonomy rules, post-draft QA, and the dev-vs-prod publish cadence. Authoritative rules live in `.claude/rules/content.md`.
+description: Draft (write) NEW English Namefi resources content, AND fact-audit/re-verify EXISTING English content (TLD pages, glossary terms, blog posts) against authoritative sources — in namefi-resources. Use this whenever authoring new English content before publishing, OR when asked to fact-check, audit, or correct already-published content (including a reader/customer/vendor-reported error). To TRANSLATE English content into the other locales (single files or bulk batches, plus translation QA), use the `article-translation` skill instead. Covers the model/scale choices, the en-first drafting playbook, citation verification (see `article-writing`'s "Auditing existing content" rules — same bar for a re-audit as for a new draft), frontmatter/taxonomy rules, post-draft QA, and the dev-vs-prod publish cadence. Authoritative rules live in `.claude/rules/content.md`.
 ---
 
 # content-authoring

--- a/.claude/rules/content.md
+++ b/.claude/rules/content.md
@@ -34,6 +34,40 @@ older plan/GOAL doc, **this file wins** — update the plan, not the rule.
 - **Only act on Cursor Bugbot** in PR review. **Ignore CodeRabbit** entirely.
 - **Never force-push** a shared branch without explicit approval.
 
+## Fact-auditing existing content
+
+Triggered whenever you fact-check, audit, or correct **already-published** content — a
+scheduled sweep, or a reader/customer/vendor-reported error. Same skill as drafting
+(`content-authoring` → `article-writing`'s "Auditing existing content" rules), same bar, no
+exceptions found in a real incident:
+
+- **Route each claim to the source type that can actually answer it.** A registry/database
+  record (e.g. IANA root-zone data) answers "who operates this / is it delegated" — it does
+  **not** answer a legal/contractual status (e.g. registration-restriction, dot-brand /
+  Specification 13 status), which only the actual registry agreement, a regulator, or the
+  operator's own current public statement can confirm. Checking the wrong source and finding
+  it "consistent" verifies nothing about a claim that source doesn't cover.
+- **A 403/paywall/login-wall/timeout is zero evidence, never a pass-through.** It does not back
+  a claim and it does not clear one. Escalate to a real browser render (a page that 403s a bot
+  fetch often loads fine in an actual browser — try before giving up) or a different source
+  that can answer the same question. If nothing reachable confirms it, say so explicitly —
+  **UNVERIFIED**, not silently kept as-is, not reported as "checked."
+- **A re-audit means every claim gets checked, not a sample.** Delegating for coverage/speed
+  (parallel subagents) is fine; delegating *trust* is not — a subagent's or a prior pass's
+  "clean" verdict is a lead to personally follow up on, not a result to forward as your own
+  finding. Only say a claim was fact-checked if you personally opened the primary source.
+- **Writing quality is not a correctness signal.** Confident, well-hedged, internally
+  consistent prose and a fabricated claim read identically from the outside. Judge only
+  whether a primary source, actually opened, contains the claim — never let tone raise or
+  lower your confidence.
+
+(Root incident: a TLD page asserted a Specification 13 "closed dot-brand" registration
+restriction, citing the correct ICANN registry agreement URL — nobody had opened that
+document, which contains no Specification 13 at all; a customer was misinformed as a direct
+result. A parallel audit of 63 sibling pages marked the page "clean" because it checked IANA,
+which cannot answer that claim, and the checker's ICANN fetch 403'd and was dropped instead of
+escalated.)
+
 ## Translations
 
 - **Translate with Claude** (one focused pass per locale), **not** a Gemini batch


### PR DESCRIPTION
## Summary

Process-only follow-up to #277 (the TLD fact-audit work). No content pages
touched here — this codifies the methodology fix so the next fact-audit
starts from the corrected process instead of re-discovering it.

## Solution

A TLD page (`now.md`) shipped a false "Specification 13 closed dot-brand"
claim, cited to the correct ICANN registry agreement URL — nobody had
actually opened that document, which contains no Specification 13 at all.
A parallel 63-page audit re-marked the page "clean" because it checked
IANA (which can't answer a registration-restriction claim) and the one
fetch that could have caught it (`icann.org`, 403'd) was dropped instead
of escalated.

- **`.claude/rules/content.md`** — new "Fact-auditing existing content"
  section: route each claim to the source type that can actually answer
  it (a registry database proves operator/date, not legal restriction
  status); a blocked fetch is zero evidence, never a pass-through —
  escalate to a real browser render before giving up; a re-audit checks
  every claim, not a sample; writing tone/confidence is never a
  correctness signal. Includes the root incident as a concrete example.
- **`.agents/skills/content-authoring/SKILL.md`** — broadened the
  trigger description so a fact-audit/re-verify task (not just drafting
  new content) reliably loads this skill, cross-referencing
  `article-writing`'s parallel "Auditing existing content" rules.

Companion fixes to the `article-writing` and `repo-codereview` skills
(outside this repo, in `~/dotfiles/opc/skills/`) were made in the same
session and tracked separately — they don't live in this repo.

## Test plan

- [x] `node ~/.claude/skills/deslop/scripts/scan-slop.mjs` on both files —
      density 0.0 on both.
- [x] Diffed against a freshly-fetched `origin/main` before committing to
      confirm no unrelated content was reverted (an earlier draft of this
      change, based on a stale worktree, would have deleted the
      "Keyword templates" section added by #276 — caught and fixed
      before this push).
- [x] Files are outside `content/**`, so the content QA gates
      (`data:validate`/`lint:mdx`/`link-audit`) don't apply; ran them
      anyway as part of the pre-push hook with no unexpected findings.

## Claude session summary

- 2026-08-02 — Edited these two files in the same worktree as PR #277,
  but held them back from that PR since they're a process change, not a
  content fix. Copied the changes into a fresh worktree off
  `origin/main`, discovered the fresh main had since gained a new
  "Keyword templates" section (#276) that a naive file-copy would have
  deleted — reverted and re-applied only the intended addition. Ran QA,
  committed, pushed, opened this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/d3servelabs/codesmith/namefi-resources/pr/283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788356734&installation_model_id=1368&pr_number=283&repository=d3servelabs%2Fnamefi-resources&return_to=https%3A%2F%2Fgithub.com%2Fd3servelabs%2Fnamefi-resources%2Fpull%2F283&signature=0446afb8b2baae5e20530412ed2b4fea820de73e166375e2155790a5ffe6ca10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent-skill guidance only; no runtime, auth, or published content changes.
> 
> **Overview**
> Process-only follow-up to the TLD fact-audit work: **no content pages change** — this locks in how future audits must run after a false Specification 13 claim on a TLD page and a parallel sweep that marked it clean.
> 
> **`.claude/rules/content.md`** adds a **Fact-auditing existing content** section: match each claim to a source that can actually answer it (e.g. IANA for delegation, not legal restriction status); treat 403/paywall/timeouts as **no evidence** and escalate (browser render or alternate source) or mark **UNVERIFIED**; re-audits require checking every claim with personal verification of primary sources, not sampling or trusting subagent “clean” verdicts; prose quality is not a correctness signal. The `.now` / ICANN / IANA incident is spelled out as the motivating example.
> 
> **`.agents/skills/content-authoring/SKILL.md`** widens the skill description so fact-check, audit, and correction of **existing** English content (including vendor-reported errors) loads the same playbook and points at `article-writing`’s auditing rules at the same bar as new drafts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 164e1ec2db67dfede8addb60ebd62c076991e5cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded content-authoring guidance to cover auditing and re-verifying existing English Namefi resources against authoritative sources.
  - Added requirements for claim-by-claim fact checking, handling inaccessible sources, personal verification, and separating writing quality from factual accuracy.
  - Clarified that translation work remains covered by separate translation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->