### PR TITLE
fix(tld): correct facts and citation quality

### DIFF
--- a/content/tld/en/art.md
+++ b/content/tld/en/art.md
@@ -57,7 +57,9 @@ The **.art domain** is a generic top-level domain built for the global creative 
 
 .art is a [generic top-level domain](/en/glossary/tld) (gTLD), not a country-code extension, so it carries no geographic association. Its registry, **UK Creative Ideas Limited**, entered into a **Base, Non-Sponsored** registry agreement with ICANN on **24 March 2016** — you can confirm the operator and agreement details on the [ICANN Registry Agreement for .art](https://www.icann.org/en/registry-agreements/details/art) and the delegation record on the [IANA root-zone entry for .art](https://www.iana.org/domains/root/db/art.html), which lists a registration date of 2016-06-09 and delegation date of 2016-06-22.
 
-Because .art is generic rather than geographic, [Google treats any TLD resolving through the IANA DNS root zone as a gTLD unless ICANN specifically lists it as a ccTLD](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites), so a .art site is not geo-targeted to any single country by default.
+Because .art is generic rather than geographic, [Google treats any TLD resolving through the IANA DNS root zone as a gTLD unless ICANN specifically lists it as a ccTLD](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en), so a .art site is not geo-targeted to any single country by default.
+
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
 
 ## History of .art
 
@@ -171,3 +173,13 @@ Yes. Major institutions including the Louvre and Tate have registered .art domai
 - [How to name your project](/en/blog/how-to-name-your-project)
 - Glossary: [registrar](/en/glossary/registrar), [ICANN](/en/glossary/icann), [NFT](/en/glossary/nft), [registry](/en/glossary/registry)
 - Compare TLDs: [.com](/en/tld/com), [.xyz](/en/tld/xyz)
+
+## Sources and further reading
+
+- ICANN — [ICANN Registry Agreement for .art](https://www.icann.org/en/registry-agreements/details/art)
+- IANA — [IANA root-zone entry for .art](https://www.iana.org/domains/root/db/art.html)
+- Google Search Central — [developers.google.com](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- en.wikipedia.org — [Wikipedia's history of the .art TLD](https://en.wikipedia.org/wiki/.art_(top-level_domain))
+- art.art — [UK Creative Ideas Limited](https://www.art.art/about)
+- aam-us.org — [American Alliance of Museums](https://www.aam-us.org/member-benefit-claim-a-complimentary-art-domain/)

--- a/content/tld/en/au.md
+++ b/content/tld/en/au.md
@@ -57,7 +57,7 @@ The **.au domain** is Australia's official [country-code top-level domain](/en/g
 
 **.au** is the [ccTLD](/en/glossary/cctld/) delegated to Australia under the ISO 3166-1 country-code system used by [IANA](https://www.iana.org/domains/root/db/au.html). Unlike a generic top-level domain such as [.com](/en/tld/com/), it has no [ICANN](/en/glossary/icann/) Registry Agreement — ccTLDs are governed by the national manager's own rules. IANA lists **.au Domain Administration (auDA)** as the ccTLD manager: a not-for-profit, industry self-regulatory body endorsed by the Australian government. auDA does not run the technical registry itself; **Identity Digital Australia** (formerly Afilias Australia) has held the operator contract since a 2017 tender, reappointed after a 2023 Request for Tender, with the current agreement running from July 1, 2024.
 
-Because .au functions as a genuine national namespace, Google treats it as country-targeted rather than generic: it is absent from [Google Search Central's short list of ccTLDs treated as generic](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites), unlike vanity extensions such as [.tv](/en/tld/tv/) or [.me](/en/tld/me/).
+Because .au functions as a genuine national namespace, Google treats it as country-targeted rather than generic: it is absent from [Google Search Central's short list of ccTLDs treated as generic](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en), unlike vanity extensions such as [.tv](/en/tld/tv/) or [.me](/en/tld/me/).
 
 ## History of .au
 
@@ -133,13 +133,12 @@ Because .au requires a verified Australian Presence for every registration, the 
 - **Use the Australian signal on purpose** — .au is a strong local-trust cue; lean into it if your audience is Australia-first.
 - **Mind the exact-match trade mark rule** — if qualifying via a trade mark, the domain name must match that mark exactly, which constrains creative spelling.
 
-## How to register a .au domain at Namefi
+## How to register a .au domain
 
 1. **Search** for your desired `.au` or `.com.au` name to check availability.
 2. **Confirm eligibility** under the Australian Presence requirement — citizenship/residency, ABN/ACN, or an exact-match Australian trade mark.
 3. **Register** and configure [DNS](/en/glossary/dns) to point your site or email.
 
-[Namefi](https://namefi.io) is an [ICANN](/en/glossary/icann)-accredited registrar that bridges Web2 and Web3. Beyond standard registration, you can optionally [tokenize your domain](/en/blog/what-are-tokenized-domains) — turning it into a blockchain asset you own outright, with easier transfers and added security — all with transparent pricing and fast DNS.
 
 ## Frequently asked questions
 
@@ -167,3 +166,9 @@ auDA (.au Domain Administration) is the industry self-regulatory body that sets 
 - [Top TLDs to secure for your e-commerce store](/en/blog/top-tlds-to-secure-for-your-ecommerce-store)
 - Glossary: [ccTLD](/en/glossary/cctld), [registrar](/en/glossary/registrar), [ICANN](/en/glossary/icann), [registry](/en/glossary/registry), [DNS](/en/glossary/dns)
 - Compare TLDs: [.com](/en/tld/com), [.ca](/en/tld/ca), [.br](/en/tld/br), [.mx](/en/tld/mx)
+
+## Sources and further reading
+
+- IANA — [.au Domain Administration (auDA)](https://www.iana.org/domains/root/db/au.html)
+- Google Search Central — [Google Search Central's short list of ccTLDs treated as generic](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en)
+- auda.org.au — [.au Domain Administration Rules: Licensing](https://www.auda.org.au/au-domain-names/au-rules-and-policies/au-domain-administration-rules-licensing-2/)

--- a/content/tld/en/best.md
+++ b/content/tld/en/best.md
@@ -55,7 +55,9 @@ The **.best domain** turns a single superlative word into a top-level domain, le
 
 .best is a [generic top-level domain](/en/glossary/tld), not a country-code extension, so it carries no geographic meaning. The string itself is the ordinary English superlative "best," which makes it one of the more directly usable words in the new gTLD expansion — a name reads naturally when the word "best" completes it, the way `hosting.best` reads as "hosting, best" or "best hosting."
 
-Because it is a generic gTLD, Google treats .best like any other new extension: no automatic ranking advantage or penalty, and no geo-targeting applied, per [Google Search Central's guidance on generic vs. country-targeted domains](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=more%20generic%20than%20country-targeted). You can confirm the delegation record and current operator on the [IANA root-zone entry for .best](https://www.iana.org/domains/root/db/best.html).
+Because it is a generic gTLD, Google treats .best like any other new extension: no automatic ranking advantage or penalty, and no geo-targeting applied, per [Google Search Central's guidance on generic vs. country-targeted domains](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=more%20generic%20than%20country-targeted). You can confirm the delegation record and current operator on the [IANA root-zone entry for .best](https://www.iana.org/domains/root/db/best.html).
+
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
 
 ## History of .best
 
@@ -162,3 +164,12 @@ It suits businesses and products built around a superlative domain hack, such as
 - [What makes a domain valuable?](/en/blog/what-makes-a-domain-valuable)
 - Glossary: [TLD](/en/glossary/tld), [registrar](/en/glossary/registrar), [ICANN](/en/glossary/icann), [premium domain](/en/glossary/premium-domain)
 - Compare TLDs: [.com](/en/tld/com), [.top](/en/tld/top), [.sbs](/en/tld/sbs), [.xyz](/en/tld/xyz)
+
+## Sources and further reading
+
+- Google Search Central — [Google Search Central's guidance on generic vs. country-targeted domains](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=more%20generic%20than%20country-targeted)
+- IANA — [IANA root-zone entry for .best](https://www.iana.org/domains/root/db/best.html)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- ICANN — [ICANN Registry Agreement for .best](https://www.icann.org/en/registry-agreements/details/best)
+- GoDaddy — [GoDaddy's .best domain policy summary](https://www.godaddy.com/help/about-best-domains-12451)
+- interisle.net — [Cybercrime Supply Chain 2025 research](https://interisle.net/insights/cybercrimesupplychain2025#:~:text=though%20they%20hold%20just%2012%25%20of%20the%20market%2C%20they%20accounted%20for%20nearly%20half%20of%20all%20cybercrime%20domains%20reported)

--- a/content/tld/en/bond.md
+++ b/content/tld/en/bond.md
@@ -57,6 +57,8 @@ The **.bond domain** started as an Australian university's unused dot-brand and 
 
 .bond is a [generic top-level domain](/en/glossary/tld) with no country tie. The string evokes both a **financial bond** (a debt instrument) and, informally, the **James Bond** film franchise — associations ShortDot's marketing leans on, though neither is licensed or official. As a generic extension, Google treats .bond like any other gTLD: no automatic ranking boost or penalty and no geo-targeting bias. You can verify the delegation record directly in the [IANA root-zone entry for .bond](https://www.iana.org/domains/root/db/bond.html).
 
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
+
 ## History of .bond
 
 .bond's ownership history is unusual even among ShortDot's portfolio of acquired strings:
@@ -121,7 +123,7 @@ A trademark sunrise period ran ahead of general availability in 2019, so today r
 
 ## Reputation and email deliverability
 
-This is the section every prospective .bond buyer should read carefully. As the churn statistics above show, Spamhaus's analysts have flagged .bond by name across three consecutive reports, not just by statistic — and the extension also appears among the top TLDs by absolute count of domains listed as malicious or suspicious in its current report. The prior six-month report (October 2023–March 2024) told the same story: .bond ranked #1 among all gTLDs for "percentage of zone newly observed" at over 210%, meaning more domains were newly registered in that period than the entire zone's steady-state size.
+This is the section every prospective .bond buyer should read carefully. The [current Spamhaus report, covering October 2025–March 2026](https://content.spamhaus.org/4d83c22f-84c5-4f82-95ab-4e6b39f73db5.pdf), ranks `.bond` **#1 among gTLDs by share of the zone newly observed**, at **98.57%** (1,130,779 new domains out of a 1,147,185-domain zone). It also ranks `.bond` **#4 by malicious or suspicious domain count** with 59,271, and **#8 by share of zone listed** at 5.17%.
 
 Practically, that means .bond traffic draws real scrutiny from mail providers and security tools, independent of any individual site's actual content. **Mitigation:** configure SPF, DKIM, and DMARC properly for any email sent from a .bond domain, warm up sending volume gradually, keep content clean, and for anything trust-sensitive, weigh whether a more established extension serves you better.
 
@@ -170,3 +172,16 @@ It suits finance-adjacent branding, short domain hacks, and budget projects that
 - [Avoiding domain sale scams](/en/blog/avoiding-domain-sale-scams)
 - Glossary: [registrar](/en/glossary/registrar), [ICANN](/en/glossary/icann), [new gTLD](/en/glossary/new-gtld), [phishing](/en/glossary/phishing)
 - Compare TLDs: [.com](/en/tld/com), [.sbs](/en/tld/sbs), [.icu](/en/tld/icu), [.cyou](/en/tld/cyou)
+
+## Sources and further reading
+
+- spamhaus.org — [Spamhaus](https://www.spamhaus.org/)
+- shortdot.bond — [ShortDot SA](https://shortdot.bond/)
+- IANA — [IANA root-zone entry for .bond](https://www.iana.org/domains/root/db/bond.html)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- bond.edu.au — [Bond University](https://bond.edu.au/)
+- ICANN — [ICANN Registry Agreement on 5 June 2014](https://www.icann.org/en/registry-agreements/details/bond)
+- domainincite.com — [Domain Incite reported](https://domainincite.com/24277-dot-brand-bond-has-been-acquired-and-will-relaunch-as-a-generic-this-july)
+- prnewswire.com — [ShortDot's own launch announcement](https://www.prnewswire.com/news-releases/shortdot-to-launch-bond-domain-extension-on-october-17-to-trademark-holders-and-to-all-end-users-on-november-18-300925429.html)
+- ntldstats.com — [ntldstats.com](https://ntldstats.com/tld/bond)
+- Spamhaus — [Domain Reputation Update for October 2025–March 2026](https://content.spamhaus.org/4d83c22f-84c5-4f82-95ab-4e6b39f73db5.pdf)

--- a/content/tld/en/bot.md
+++ b/content/tld/en/bot.md
@@ -56,7 +56,9 @@ The **.bot domain** is a generic top-level domain that says exactly what it is: 
 
 .bot is a [generic top-level domain](/en/glossary/tld) (gTLD), not a country-code extension, so it carries no geographic association. Its registry operator is **Amazon Registry Services, Inc.**, under a **Base, Non-Sponsored** registry agreement with ICANN signed **18 December 2014** — confirmed on the [ICANN Registry Agreement for .bot](https://www.icann.org/en/registry-agreements/details/bot). The [IANA root-zone entry for .bot](https://www.iana.org/domains/root/db/bot.html) lists a registration date of 2015-11-12 and delegation date of 2015-12-02, with Nominet UK handling back-end technical operations.
 
-Because it is generic rather than geographic, [Google treats any TLD resolving through the IANA DNS root zone as a gTLD unless ICANN lists it as a ccTLD](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites), so a .bot site carries no automatic geo-targeting.
+Because it is generic rather than geographic, [Google treats any TLD resolving through the IANA DNS root zone as a gTLD unless ICANN lists it as a ccTLD](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en), so a .bot site carries no automatic geo-targeting.
+
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
 
 ## History of .bot
 
@@ -164,3 +166,13 @@ No. From its 2017 launch until October 2023, Amazon required registrants to demo
 - [How to register a domain with your AI agent](/en/blog/ai-agent-register)
 - Glossary: [registrar](/en/glossary/registrar), [ICANN](/en/glossary/icann), [AI agent](/en/glossary/ai-agent), [MCP](/en/glossary/mcp)
 - Compare TLDs: [.ai](/en/tld/ai), [.app](/en/tld/app)
+
+## Sources and further reading
+
+- ICANN — [ICANN Registry Agreement for .bot](https://www.icann.org/en/registry-agreements/details/bot)
+- IANA — [IANA root-zone entry for .bot](https://www.iana.org/domains/root/db/bot.html)
+- Google Search Central — [developers.google.com](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- newgtlds.icann.org — [.bot sunrise and claims period record](https://newgtlds.icann.org/en/program-status/sunrise-claims-periods/bot)
+- domainnamewire.com — [Domain Name Wire](https://domainnamewire.com/2023/11/01/amazon-makes-bot-domain-names-easier-to-register/)
+- m.media-amazon.com — [.bot Registration Policy (last updated June 20, 2024)](https://m.media-amazon.com/images/G/01/arsi/documents/2024.06.20_.BOT_GA_Registration_Policy_-_FINAL.pdf)

--- a/content/tld/en/br.md
+++ b/content/tld/en/br.md
@@ -56,7 +56,7 @@ The **.br domain** is Brazil's official [country-code top-level domain](/en/glos
 
 **.br** is the [ccTLD](/en/glossary/cctld/) assigned to Brazil under the ISO 3166-1 country-code system used by [IANA](https://www.iana.org/domains/root/db/br.html). Like other ccTLDs, it has no [ICANN](/en/glossary/icann/) Registry Agreement — the governing rules come from Brazil's own internet-governance structure instead. Policy authority sits with the **Comitê Gestor da Internet no Brasil (CGI.br)**, the multistakeholder Brazilian Internet Steering Committee; its executive arm, **Núcleo de Informação e Coordenação do Ponto BR (NIC.br)**, handles both administrative and operational duties, and its **Registro.br** department is the operational registry that IANA lists as the ccTLD manager.
 
-Because .br functions as a genuine national namespace, Google treats it as country-targeted rather than generic — it does not appear on [Google Search Central's short list of ccTLDs treated as generic](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites), unlike vanity extensions such as [.tv](/en/tld/tv/) or [.me](/en/tld/me/).
+Because .br functions as a genuine national namespace, Google treats it as country-targeted rather than generic — it does not appear on [Google Search Central's short list of ccTLDs treated as generic](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en), unlike vanity extensions such as [.tv](/en/tld/tv/) or [.me](/en/tld/me/).
 
 ## History of .br
 
@@ -129,13 +129,12 @@ Because every .br registration requires a verified CPF or CNPJ (or the documente
 - **Keep foreign-registration paperwork in mind early.** If you're a non-Brazilian company, budget time for the notarized, consular-legalized documentation process before you need the domain live.
 - **Consider direct `.br` only deliberately.** It exists and is shorter, but `.com.br` remains the namespace most Brazilian users recognize by default.
 
-## How to register a .br domain at Namefi
+## How to register a .br domain
 
 1. **Search** for your desired `.br` or `.com.br` name to check availability.
 2. **Confirm eligibility** — a valid CPF or CNPJ, or the documented foreign-company representative process.
 3. **Register** and configure [DNS](/en/glossary/dns) to point your site or email.
 
-[Namefi](https://namefi.io) is an [ICANN](/en/glossary/icann)-accredited registrar that bridges Web2 and Web3. Beyond standard registration, you can optionally [tokenize your domain](/en/blog/what-are-tokenized-domains) — turning it into a blockchain asset you own outright, with easier transfers and added security — all with transparent pricing and fast DNS.
 
 ## Frequently asked questions
 
@@ -163,3 +162,10 @@ The Brazilian Internet Steering Committee (CGI.br) sets policy for .br. Its exec
 - [Top TLDs to secure for your business](/en/blog/top-tlds-to-secure-for-your-business)
 - Glossary: [ccTLD](/en/glossary/cctld), [registrar](/en/glossary/registrar), [ICANN](/en/glossary/icann), [registry](/en/glossary/registry), [IDN](/en/glossary/idn)
 - Compare TLDs: [.com](/en/tld/com), [.mx](/en/tld/mx), [.ca](/en/tld/ca), [.au](/en/tld/au)
+
+## Sources and further reading
+
+- IANA — [Comitê Gestor da Internet no Brasil (CGI.br)](https://www.iana.org/domains/root/db/br.html)
+- Google Search Central — [Google Search Central's short list of ccTLDs treated as generic](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en)
+- registro.br — [Registro.br's domain rules](https://registro.br/dominio/regras/)
+- registro.br — [rules for foreign companies](https://registro.br/dominio/regras/empresas-estrangeiras)

--- a/content/tld/en/ca.md
+++ b/content/tld/en/ca.md
@@ -58,7 +58,7 @@ This page covers what .ca is, who is eligible to register one, its history, and 
 
 **.ca** is the [ccTLD](/en/glossary/cctld/) assigned to Canada under the ISO 3166-1 two-letter country-code system that [IANA](https://www.iana.org/domains/root/db/ca.html) uses to delegate national domains. Unlike a generic top-level domain such as [.com](/en/tld/com/), .ca has no [ICANN](/en/glossary/icann/) Registry Agreement at all — governing rules come from the national registry itself.
 
-That registry is the **Canadian Internet Registration Authority (CIRA)**, a member-based non-profit that IANA lists as the ccTLD manager. Because .ca genuinely functions as a national namespace, Google treats it as country-targeted rather than generic: it is absent from [Google Search Central's short list of ccTLDs treated as generic](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites), a list that includes vanity extensions like [.tv](/en/tld/tv/) and [.me](/en/tld/me/). A .ca site sends a genuine "this is for Canada" signal — an asset for Canada-focused projects, a constraint for anyone chasing a global audience.
+That registry is the **Canadian Internet Registration Authority (CIRA)**, a member-based non-profit that IANA lists as the ccTLD manager. Because .ca genuinely functions as a national namespace, Google treats it as country-targeted rather than generic: it is absent from [Google Search Central's short list of ccTLDs treated as generic](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en), a list that includes vanity extensions like [.tv](/en/tld/tv/) and [.me](/en/tld/me/). A .ca site sends a genuine "this is for Canada" signal — an asset for Canada-focused projects, a constraint for anyone chasing a global audience.
 
 ## History of .ca
 
@@ -111,7 +111,7 @@ Pick .com for a global, non-geographic brand; pick .ca when a Canadian identity 
 
 ## Who can register a .ca domain?
 
-**Registration restrictions: gated by the Canadian Presence Requirements (CPR).** Every registrant must select one of roughly 18 defined categories at registration, administered by [CIRA](https://www.cira.ca/en/resources/documents/domains/canadian-presence-requirements-registrants/). The main categories include:
+**Registration restrictions: gated by the Canadian Presence Requirements (CPR).** Every registrant must select one of 18 defined categories under CIRA's official [Canadian Presence Requirements for Registrants](https://www.cira.ca/uploads/2019/04/canadian-presence-requirements-for-registrants.pdf). The main categories include:
 
 - **Canadian citizens** of the age of majority.
 - **Permanent residents** who are "ordinarily resident in Canada" — defined as residing in Canada more than 183 days in the twelve months before applying, and in every twelve-month period thereafter.
@@ -119,7 +119,7 @@ Pick .com for a global, non-geographic brand; pick .ca when a Canadian identity 
 - **Educational institutions, libraries, hospitals, Indigenous governing bodies, and government entities** located in Canada.
 - **Trademark holders** — a narrower allowance for owners of a trademark registered under Canada's *Trade-marks Act*, limited to the exact word component of that mark, even without otherwise meeting the CPR.
 
-Foreign companies without one of these qualifying ties generally cannot register a .ca name directly. IDN registrations (French accented characters) are supported, [DNSSEC](/en/glossary/dnssec) has been available since 2013, and CIRA offers WHOIS privacy protection for individual registrants by default. The authoritative rules live in CIRA's [Canadian Presence Requirements for Registrants](https://www.cira.ca/en/resources/documents/domains/canadian-presence-requirements-registrants/) policy document.
+Foreign companies without one of these qualifying ties generally cannot register a .ca name directly. IDN registrations (French accented characters) are supported, [DNSSEC](/en/glossary/dnssec) has been available since 2013, and CIRA offers WHOIS privacy protection for individual registrants by default. The authoritative rules live in CIRA's [Canadian Presence Requirements for Registrants](https://www.cira.ca/uploads/2019/04/canadian-presence-requirements-for-registrants.pdf) policy document.
 
 ## .ca pricing and value
 
@@ -170,3 +170,10 @@ The Canadian Presence Requirements (CPR) are CIRA's eligibility rules for .ca. R
 - [Top TLDs to secure for your business](/en/blog/top-tlds-to-secure-for-your-business)
 - Glossary: [ccTLD](/en/glossary/cctld), [registrar](/en/glossary/registrar), [ICANN](/en/glossary/icann), [registry](/en/glossary/registry), [DNS](/en/glossary/dns)
 - Compare TLDs: [.com](/en/tld/com), [.us](/en/tld/us), [.au](/en/tld/au), [.br](/en/tld/br), [.mx](/en/tld/mx)
+
+## Sources and further reading
+
+- IANA — [Canadian Internet Registration Authority (CIRA)](https://www.iana.org/domains/root/db/ca.html)
+- Google Search Central — [Google Search Central's short list of ccTLDs treated as generic](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en)
+- IANA — [IANA redelegation report](https://www.iana.org/reports/2000/ca-report-01dec00.html)
+- CIRA — [Canadian Presence Requirements for Registrants](https://www.cira.ca/uploads/2019/04/canadian-presence-requirements-for-registrants.pdf)

--- a/content/tld/en/cfd.md
+++ b/content/tld/en/cfd.md
@@ -55,7 +55,9 @@ The **.cfd domain** carries two entirely different meanings depending on who reg
 
 ## What is .cfd?
 
-.cfd is a [generic top-level domain](/en/glossary/tld) with no country tie. Under its current registry, ShortDot markets the string as **"Clothing & Fashion Design"** — but "CFD" is also the standard abbreviation for **contracts for difference**, a leveraged derivative product that financial regulators including the UK's [FCA](https://www.fca.org.uk/) and the [North American Securities Administrators Association](https://www.nasaa.org/52192/informed-investor-advisory-contracts-for-difference/) have repeatedly warned carries a high risk of losses for retail investors. As a generic extension, Google treats .cfd like any other gTLD: no automatic ranking boost or penalty and no geo-targeting bias. You can verify the delegation record directly in the [IANA root-zone entry for .cfd](https://www.iana.org/domains/root/db/cfd.html).
+.cfd is a [generic top-level domain](/en/glossary/tld) with no country tie. Under its current registry, ShortDot markets the string as **"Clothing & Fashion Design"** — but "CFD" is also the standard abbreviation for **contracts for difference**, a leveraged derivative product that the UK's Financial Conduct Authority describes as [high-risk and unsuitable for some retail consumers](https://www.fca.org.uk/firms/contract-for-differences#:~:text=CFDs%20are%20high%2Drisk%20products%2C%20which%20are%20not%20suitable%20for%20all%20retail%20consumers). As a generic extension, Google treats .cfd like any other gTLD: no automatic ranking boost or penalty and no geo-targeting bias. You can verify the delegation record directly in the [IANA root-zone entry for .cfd](https://www.iana.org/domains/root/db/cfd.html).
+
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
 
 ## History of .cfd
 
@@ -65,8 +67,6 @@ The **.cfd domain** carries two entirely different meanings depending on who reg
 - **Five unused years:** [Domain Incite reported](https://domainincite.com/26256-shortdot-adds-fourth-gtld-to-its-stable-plans-march-launch) that .cfd sat in the DNS root for roughly five years without properly launching or selling a single domain.
 - **Acquisition and rebrand (2021):** ShortDot acquired .cfd from DotCFD in early 2021. Its COO Kevin Kopas told Domain Incite: "We're branding .cfd for the Clothing & Fashion Design industry and will be marketing it to entrepreneurs, bloggers, vloggers and others that are on the cutting edge of the fashion industry."
 - **Relaunch dates:** Per [ShortDot's launch announcement](https://www.prnewswire.com/news-releases/shortdot-is-all-set-to-launch-the-cfd-domain-extension---tailored-for-the-future-of-clothing--fashion-design-301225057.html), sunrise ran 10 March–12 April 2021, followed by a seven-day Early Access Program, with general availability on 13 April 2021.
-- **Where it stands now:** [ntldstats.com](https://ntldstats.com/tld/cfd) reports .cfd at roughly 1.05 million registered domains, with about 544,000 — just over half — live in the zone file.
-
 Despite the fashion rebrand, the original financial meaning never went away — and, as the reputation section below shows, it is very much alive among abusive registrants.
 
 ## How people use .cfd
@@ -171,3 +171,14 @@ It suits fashion, apparel, and design brands drawn to ShortDot's intended brandi
 - [Avoiding domain sale scams](/en/blog/avoiding-domain-sale-scams)
 - Glossary: [registrar](/en/glossary/registrar), [ICANN](/en/glossary/icann), [new gTLD](/en/glossary/new-gtld), [phishing](/en/glossary/phishing)
 - Compare TLDs: [.com](/en/tld/com), [.sbs](/en/tld/sbs), [.icu](/en/tld/icu), [.bond](/en/tld/bond)
+
+## Sources and further reading
+
+- Financial Conduct Authority — [CFDs are high-risk products](https://www.fca.org.uk/firms/contract-for-differences#:~:text=CFDs%20are%20high%2Drisk%20products%2C%20which%20are%20not%20suitable%20for%20all%20retail%20consumers)
+- IANA — [IANA root-zone entry for .cfd](https://www.iana.org/domains/root/db/cfd.html)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- ICANN — [ICANN Registry Agreement signed 11 December 2014](https://www.icann.org/en/registry-agreements/details/cfd)
+- domainincite.com — [Domain Incite reported](https://domainincite.com/26256-shortdot-adds-fourth-gtld-to-its-stable-plans-march-launch)
+- prnewswire.com — [ShortDot's launch announcement](https://www.prnewswire.com/news-releases/shortdot-is-all-set-to-launch-the-cfd-domain-extension---tailored-for-the-future-of-clothing--fashion-design-301225057.html)
+- Spamhaus — [Domain Reputation Update for October 2025–March 2026](https://content.spamhaus.org/4d83c22f-84c5-4f82-95ab-4e6b39f73db5.pdf)
+- domainnamewire.com — [Interisle's Phishing Landscape 2025 report](https://domainnamewire.com/2025/09/11/report-names-commonly-used-tlds-for-phishing-attacks/)

--- a/content/tld/en/ch.md
+++ b/content/tld/en/ch.md
@@ -58,7 +58,7 @@ This page covers what .ch is, where the two-letter code comes from, its history 
 
 **.ch** is the [ccTLD](/en/glossary/cctld/) assigned to Switzerland, and the two letters stand for **Confoederatio Helvetica** — the Latin name for the Swiss Confederation. Switzerland deliberately chose the Latin form for its country code, per the [IANA root-zone entry for .ch](https://www.iana.org/domains/root/db/ch.html), rather than a code drawn from any one of its four official languages (German, French, Italian, Romansh), keeping the abbreviation linguistically neutral — a very Swiss solution to a very Swiss problem.
 
-.ch does not appear on Google's short list of ccTLDs treated as generic (a list that includes strings like [.io](/en/tld/io) and [.co](/en/tld/co)), so [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs) treats .ch as genuinely country-targeted, even though registration itself is open worldwide. That combination — open eligibility, but a real geo-signal — is unusual and worth understanding before you register.
+.ch does not appear on Google's short list of ccTLDs treated as generic (a list that includes strings like [.io](/en/tld/io) and [.co](/en/tld/co)), so [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs) treats .ch as genuinely country-targeted, even though registration itself is open worldwide. That combination — open eligibility, but a real geo-signal — is unusual and worth understanding before you register.
 
 ## History of .ch
 
@@ -119,7 +119,7 @@ Registration runs through accredited [registrars](/en/glossary/registrar/) rathe
 
 ## .ch pricing and value
 
-.ch pricing follows the same shape as most ccTLDs rather than any single quoted figure. **First-year and renewal pricing typically differ** — introductory rates are often promotional, while the standing renewal rate is what a brand pays long-term. Registrars may apply **premium classifications** to short, dictionary, or high-demand names, carrying higher registration and sometimes renewal costs. Name length, desirability, and registrar margin on top of SWITCH's wholesale rate are the other main drivers. This page intentionally quotes no figures — check current rates with an accredited registrar at the point of purchase.
+.ch registrations are sold through accredited registrars, and SWITCH states that [the cost depends on the registrar you choose](https://www.nic.ch/support/general/#:~:text=The%20cost%20of%20registering%20a%20domain%20name%20ending%20in%20.ch%20depends%20on%20the%20registrar%20you%20choose.). Registrars may bundle hosting or offer introductory discounts, so compare first-year and renewal fees. A concise `.ch` name already owned by someone else may have a higher **aftermarket** asking price, but that is separate from registry registration and renewal pricing.
 
 ## Reputation and email deliverability
 
@@ -169,3 +169,13 @@ The letters CH stand for "Confoederatio Helvetica," the Latin name for the Swiss
 - [Domain hacks explained](/en/blog/domain-hacks-explained)
 - [Domain terminology guide](/en/blog/domain-terminology-guide)
 - Glossary: [ccTLD](/en/glossary/cctld), [DNSSEC](/en/glossary/dnssec), [WHOIS privacy](/en/glossary/whois-privacy), [registrar](/en/glossary/registrar)
+
+## Sources and further reading
+
+- IANA — [SWITCH](https://www.iana.org/domains/root/db/ch.html)
+- Google Search Central — [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs)
+- admin.ch — [admin.ch](https://www.admin.ch/)
+- nzz.ch — [nzz.ch](https://www.nzz.ch/)
+- srf.ch — [srf.ch](https://www.srf.ch/)
+- nic.ch — [SWITCH's own registration FAQ](https://www.nic.ch/support/general/#:~:text=Do%20I%20have%20to%20be%20Swiss%20to%20register%20.ch%20domain%20names)
+- bakom.admin.ch — [OFCOM](https://www.bakom.admin.ch/en/ch-internet-domain-names)

--- a/content/tld/en/cn.md
+++ b/content/tld/en/cn.md
@@ -56,7 +56,7 @@ The **.cn domain** is the official [country-code top-level domain](/en/glossary/
 
 .cn is the [ccTLD](/en/glossary/cctld/) assigned to China under ISO 3166-1 (country code CN), delegated through the [IANA root-zone database](https://www.iana.org/domains/root/db/cn.html), which lists CNNIC as both the registry operator and sponsoring organization. Unlike a borderless [gTLD](/en/glossary/gtld/) such as [.com](/en/tld/com/), .cn is administered under Chinese domain-name policy rather than a standard ICANN registry agreement — the norm for every ccTLD.
 
-Google does **not** treat .cn as one of the small set of ccTLDs it re-classifies as generic (that list — .ad, .ai, .as, .bz, .cc, .cd, .co, .dj, .fm, .io, .la, .me, .ms, .nu, .sc, .sr, .su, .tv, .tk, .ws — is published in [Google Search Central's guidance on managing multi-regional sites](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs)). .cn is absent from it, so it is treated as a country-targeted signal for China — useful when that is exactly your audience, less useful otherwise.
+Google does **not** treat .cn as one of the small set of ccTLDs it re-classifies as generic (that list — .ad, .ai, .as, .bz, .cc, .cd, .co, .dj, .fm, .io, .la, .me, .ms, .nu, .sc, .sr, .su, .tv, .tk, .ws — is published in [Google Search Central's guidance on managing multi-regional sites](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs)). .cn is absent from it, so it is treated as a country-targeted signal for China — useful when that is exactly your audience, less useful otherwise.
 
 ## History of .cn
 
@@ -166,3 +166,14 @@ The China Internet Network Information Center (CNNIC) is the registry operator f
 - [Domain terminology guide](/en/blog/domain-terminology-guide/)
 - Glossary: [ccTLD](/en/glossary/cctld/), [IDN](/en/glossary/idn/), [registrar](/en/glossary/registrar/), [ICANN](/en/glossary/icann/), [DNSSEC](/en/glossary/dnssec/)
 - Compare TLDs: [.com](/en/tld/com/), [.jp](/en/tld/jp/), [.kr](/en/tld/kr/), [.in](/en/tld/in/)
+
+## Sources and further reading
+
+- IANA — [China Internet Network Information Center (CNNIC)](https://www.iana.org/domains/root/db/cn.html)
+- IANA — [.中国](https://www.iana.org/domains/root/db/xn--fiqs8s.html)
+- Google Search Central — [Google Search Central's guidance on managing multi-regional sites](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs)
+- cnnic.com.cn — [Implementing Rules of Domain Name Registration](https://www.cnnic.com.cn/PublicS/fwzxxgzcfg/201907/t20190726_70776.htm)
+- sina.com.cn — [sina.com.cn](https://www.sina.com.cn/)
+- en.wikipedia.org — [people.com.cn](https://en.wikipedia.org/wiki/People%27s_Daily)
+- gov.cn — [gov.cn](https://www.gov.cn/)
+- news.gandi.net — [Gandi](https://news.gandi.net/en/2021/11/new-cn-verification-rules-starting-january-1-2022-what-impact-will-it-have-on-your-domain-names/)

--- a/content/tld/en/cyou.md
+++ b/content/tld/en/cyou.md
@@ -57,6 +57,8 @@ The **.cyou domain** is a short, budget generic top-level domain that [ShortDot 
 
 .cyou is a [generic top-level domain](/en/glossary/tld) with no country tie. ShortDot markets the string as **"See You,"** pitched at creators, influencers, and younger, digital-native brands. As a generic extension, Google treats .cyou like any other gTLD — no automatic ranking boost or penalty and no geo-targeting bias. You can verify the delegation record directly in the [IANA root-zone entry for .cyou](https://www.iana.org/domains/root/db/cyou.html).
 
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
+
 ## History of .cyou
 
 .cyou's history is one of the stranger stories among new gTLDs:
@@ -169,3 +171,14 @@ It suits creators, influencers, and youth-oriented brands drawn to the short, ca
 - [Avoiding domain sale scams](/en/blog/avoiding-domain-sale-scams)
 - Glossary: [registrar](/en/glossary/registrar), [ICANN](/en/glossary/icann), [new gTLD](/en/glossary/new-gtld), [phishing](/en/glossary/phishing)
 - Compare TLDs: [.com](/en/tld/com), [.sbs](/en/tld/sbs), [.icu](/en/tld/icu), [.bond](/en/tld/bond)
+
+## Sources and further reading
+
+- shortdot.bond — [ShortDot SA](https://shortdot.bond/)
+- IANA — [IANA root-zone entry for .cyou](https://www.iana.org/domains/root/db/cyou.html)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- ICANN — [ICANN Registry Agreement was signed 22 January 2015](https://www.icann.org/en/registry-agreements/details/cyou)
+- domainincite.com — [Domain Incite's coverage of the deal](https://domainincite.com/25221-possibly-the-strangest-new-gtld-acquisition-yet)
+- prnewswire.com — [ShortDot reported](https://www.prnewswire.com/news-releases/more-than-30-000-gen-z-brands-and-individuals-from-across-the-globe-have-selected-a-cyou-domain-301159177.html)
+- ntldstats.com — [ntldstats.com](https://ntldstats.com/tld/cyou)
+- Spamhaus — [Domain Reputation Update for October 2025–March 2026](https://content.spamhaus.org/4d83c22f-84c5-4f82-95ab-4e6b39f73db5.pdf)

--- a/content/tld/en/de.md
+++ b/content/tld/en/de.md
@@ -56,7 +56,7 @@ The **.de domain** is the official [country-code top-level domain](/en/glossary/
 
 .de is Germany's [ccTLD](/en/glossary/cctld/), delegated under the ISO 3166-1 country code for Germany. Its delegation record is public in the [IANA root-zone database](https://www.iana.org/domains/root/db/de.html), which lists **DENIC eG** as the sponsoring organization. Unlike a generic [TLD](/en/glossary/tld/) such as [.com](/en/tld/com/), .de is administered under DENIC's own German-law contract rather than a standard ICANN registry agreement — ccTLDs are outside ICANN's registry-agreement framework entirely.
 
-For search visibility, Google's own guidance on [managing multi-regional sites](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=tied%20to%20a%20specific%20country%20%28for%20example%20.de%20for%20Germany) names .de explicitly as an example of a ccTLD "tied to a specific country" — Google does not treat .de as one of its generic vanity ccTLDs (a short list that includes .co, .io, and .tv). A .de site sends a real, explicit signal that the content targets German users.
+For search visibility, Google's own guidance on [managing multi-regional sites](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=tied%20to%20a%20specific%20country%20%28for%20example%20.de%20for%20Germany) names .de explicitly as an example of a ccTLD "tied to a specific country" — Google does not treat .de as one of its generic vanity ccTLDs (a short list that includes .co, .io, and .tv). A .de site sends a real, explicit signal that the content targets German users.
 
 ## History of .de
 
@@ -111,7 +111,7 @@ There is one conditional obligation worth knowing about. Under **§3(4) of DENIC
 
 ## .de pricing and value
 
-.de pricing dynamics follow the pattern common across mature TLDs: **premium names** exist for short, dictionary, or high-demand strings, and **first-year promotional pricing typically differs from the standing renewal rate**, so budget for the renewal rather than an introductory offer. Because the namespace is heavily registered, expect the aftermarket for concise, brandable .de names to carry a real premium over registering a fresh string. This page intentionally quotes no specific figures — check current rates at the point of registration.
+.de retail pricing depends on the provider and service bundle. DENICdirect publishes a [standard annual domain-management fee](https://www.denic.de/preisliste/#:~:text=Domainverwaltung%20f%C3%BCr%20ein%20Jahr%20inkl.%20Domainregistrierung) rather than a label-based registry premium schedule. A registrar may still offer introductory discounts, and an already registered short or dictionary name can command a higher **aftermarket** price from its owner; neither should be described as registry premium registration or renewal pricing. Compare the registrar's first-year and renewal fees before buying.
 
 ## Reputation and email deliverability
 
@@ -127,7 +127,7 @@ There is one conditional obligation worth knowing about. Under **§3(4) of DENIC
 ## How to register a .de domain at Namefi
 
 1. **Search** your desired `.de` name to check availability.
-2. **Review** whether the name is standard or premium-priced.
+2. **Review** the registrar's first-year and renewal fees, and distinguish a new registration from an aftermarket purchase.
 3. **Register** and configure [DNS](/en/glossary/dns) for your site or email.
 
 [Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and [Web3](/en/glossary/web3/), with transparent pricing, fast DNS management, and the option to [tokenize your domain](/en/blog/what-are-tokenized-domains) into a blockchain-backed asset for easier transfers and provable ownership.
@@ -157,3 +157,13 @@ Yes. DENIC supports internationalized domain names (IDNs) for .de, so registrant
 - [How TLD affects domain value](/en/blog/how-tld-affects-domain-value)
 - Glossary: [ccTLD](/en/glossary/cctld), [registrar](/en/glossary/registrar), [DNSSEC](/en/glossary/dnssec)
 - Compare TLDs: [.com](/en/tld/com), [.eu](/en/tld/eu), [.co](/en/tld/co), [.uk](/en/tld/uk)
+
+## Sources and further reading
+
+- denic.de — [DENIC eG](https://www.denic.de/en/about-us/who-we-are/)
+- IANA — [IANA root-zone database](https://www.iana.org/domains/root/db/de.html)
+- Google Search Central — [managing multi-regional sites](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=tied%20to%20a%20specific%20country%20%28for%20example%20.de%20for%20Germany)
+- denic.de — [25th-anniversary retrospective](https://www.denic.de/en/news/press-releases-archive/article/de-turns-twenty-five/)
+- denic.de — [registration page](https://www.denic.de/en/products/de-domains/registration/#:~:text=Open%20to%20everyone)
+- denic.de — [Domain Terms and Conditions](https://www.denic.de/en/domain-terms-and-conditions/)
+- denic.de — [standard annual domain-management fee](https://www.denic.de/preisliste/#:~:text=Domainverwaltung%20f%C3%BCr%20ein%20Jahr%20inkl.%20Domainregistrierung)

--- a/content/tld/en/design.md
+++ b/content/tld/en/design.md
@@ -57,6 +57,8 @@ The **.design domain** is an open generic top-level domain purpose-built for one
 
 Because it is a plain generic extension, Google Search Central treats [new gTLDs](/en/glossary/new-gtld) like .design the same as legacy generics such as [.com](/en/tld/com): there is no automatic ranking benefit or penalty tied to the suffix, and no geo-targeting signal is applied.
 
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
+
 ## History of .design
 
 - **Founded by designers, for designers (2014–2015).** [Top Level Design](https://en.wikipedia.org/wiki/.design), a Portland, Oregon-based company led by CEO Ray King, won the right to operate .design in a private auction against six other applicants in September 2014. IANA's delegation report shows the domain was formally delegated to Top Level Design, LLC on **2015-01-20**; general availability opened **May 12, 2015**, with more than 5,200 .design domains registered on that first day alone. The underlying [ICANN Registry Agreement for .design was signed on 7 November 2014](https://www.icann.org/en/registry-agreements/details/design).
@@ -159,3 +161,12 @@ Generally no. The suffix signals design work specifically, so a company outside 
 - [How to name your project](/en/blog/how-to-name-your-project)
 - Glossary: [gTLD](/en/glossary/gtld), [new gTLD](/en/glossary/new-gtld), [ICANN](/en/glossary/icann), [brandable domain](/en/glossary/brandable-domain)
 - Compare TLDs: [.com](/en/tld/com), [.studio](/en/tld/studio), [.group](/en/tld/group)
+
+## Sources and further reading
+
+- IANA — [IANA root-zone entry for .design](https://www.iana.org/domains/root/db/design.html)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- en.wikipedia.org — [Top Level Design](https://en.wikipedia.org/wiki/.design)
+- ICANN — [ICANN Registry Agreement for .design was signed on 7 November 2014](https://www.icann.org/en/registry-agreements/details/design)
+- prnewswire.com — [GoDaddy Registry announced it was acquiring the .club and .design domain extensions](https://www.prnewswire.com/news-releases/godaddy-registry-agrees-to-acquire-club-design-and-minds--machines-tlds-to-offer-more-choice-and-value-in-digital-name-options-301264501.html)
+- atlassian.design — [atlassian.design](https://atlassian.design)

--- a/content/tld/en/digital.md
+++ b/content/tld/en/digital.md
@@ -57,6 +57,8 @@ The **.digital domain** is an open generic top-level domain aimed squarely at th
 
 Because it's a generic string, Google applies no geo-targeting rule to .digital — it's evaluated like any other gTLD. You can confirm the delegation record directly in the [IANA root-zone entry for .digital](https://www.iana.org/domains/root/db/digital.html).
 
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
+
 ## History of .digital
 
 - **Delegation (2014):** .digital was delegated to the root zone on **May 2, 2014** (registration date April 17, 2014), initially assigned to **Dash Park, LLC** — one of the single-purpose entities Donuts Inc. used to file its 2012-round gTLD applications (the same pattern used for sibling strings like .media, filed under "Grand Glen, LLC"). The underlying [ICANN Registry Agreement for .digital](https://www.icann.org/en/registry-agreements/details/digital) was signed **March 6, 2014**.
@@ -158,3 +160,10 @@ Identity Digital, the company that runs the .digital registry through its Binky 
 - [From Facebook.com to Meta.com](/en/blog/from-facebook-com-to-meta-com/)
 - Glossary: [registrar](/en/glossary/registrar/), [ICANN](/en/glossary/icann/), [registry](/en/glossary/registry/), [DNS](/en/glossary/dns/)
 - Compare TLDs: [.com](/en/tld/com/), [.tech](/en/tld/tech/), [.agency](/en/tld/agency/)
+
+## Sources and further reading
+
+- identity.digital — [Identity Digital](https://www.identity.digital/)
+- IANA — [IANA root-zone entry for .digital](https://www.iana.org/domains/root/db/digital.html)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- ICANN — [ICANN Registry Agreement for .digital](https://www.icann.org/en/registry-agreements/details/digital)

--- a/content/tld/en/es.md
+++ b/content/tld/en/es.md
@@ -58,7 +58,7 @@ This page covers what .es is, how its eligibility rules loosened over time, its 
 
 **.es** is the [ccTLD](/en/glossary/cctld/) assigned to Spain under the ISO 3166-1 country code standard, recorded in the [IANA root-zone entry for .es](https://www.iana.org/domains/root/db/es.html). Unlike a generic [gTLD](/en/glossary/tld/) such as [.com](/en/tld/com), .es represents a single nation's namespace and is administered under Spanish public policy rather than a standard ICANN registry agreement.
 
-.es does not appear on Google's short list of ccTLDs treated as generic (a list that includes strings like [.io](/en/tld/io) and [.co](/en/tld/co)), so [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs) treats .es as genuinely country-targeted. A .es site signals a Spanish audience, which is an advantage for local relevance and a constraint for anyone chasing a global, non-Spanish audience.
+.es does not appear on Google's short list of ccTLDs treated as generic (a list that includes strings like [.io](/en/tld/io) and [.co](/en/tld/co)), so [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs) treats .es as genuinely country-targeted. A .es site signals a Spanish audience, which is an advantage for local relevance and a constraint for anyone chasing a global, non-Spanish audience.
 
 ## History of .es
 
@@ -118,7 +118,7 @@ Choose **.com** for a globally neutral default with no eligibility test. Choose 
 
 ## .es pricing and value
 
-.es pricing follows the same shape as most ccTLDs rather than any single quoted figure. **First-year and renewal pricing typically differ** — introductory rates are often promotional, while the standing renewal rate is what a brand pays long-term. Registrars may apply **premium classifications** to short, dictionary, or high-demand names, carrying higher registration and sometimes renewal costs. Name length, desirability, and registrar margin on top of Red.es's wholesale rate are the other main drivers. This page intentionally quotes no figures — check current rates with an accredited registrar at the point of purchase.
+Dominios.es publishes standard registry tariffs for assignment and renewal, including a [single annual rate for second-level names submitted through an accredited registrar](https://www.dominios.es/es/sobre-dominios/normativa/instruccion-director-general-tarifas-aplicables#:~:text=Tarifa%20cuarta.%20Asignaci%C3%B3n%20anual%20inicial%20o%20renovaci%C3%B3n%20anual%20de%20nombres%20de%20dominio%20de%20segundo%20nivel). Registrars set the customer-facing package and may offer promotions. A registered short name may carry an **aftermarket** asking price, but this is separate from registry registration and renewal fees; do not assume an available `.es` label has a registry premium tier.
 
 ## Reputation and email deliverability
 
@@ -133,14 +133,13 @@ For email deliverability, the suffix itself rarely decides outcomes — modern s
 - **Use accents deliberately.** IDN support means Spanish accented forms and ñ are registrable directly — verify your audience can type and display them correctly before committing a brand to one.
 - **Avoid reserved-term collisions.** Check Red.es's prohibited and reserved lists before finalizing a name tied to institutions or territorial names.
 
-## How to register a .es domain at Namefi
+## How to register a .es domain
 
 1. **Confirm** you have a genuine interest or link to Spain (residency, business target market, or Spain-related content all qualify).
 2. **Search** for your desired name under the .es extension, or the relevant `com.es` / `org.es` / `nom.es` category.
 3. **Choose** an available name and review any reserved-term restrictions.
 4. **Register** and configure [DNS](/en/glossary/dns) to point your site or email.
 
-[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and [Web3](/en/glossary/web3/), with transparent pricing, fast DNS management, and the option to hold eligible domains as a [tokenized domain](/en/glossary/tokenized-domain/) for easier transfer and provable ownership. New to how extensions work? Start with [what is a domain](/en/blog/what-is-domain/) and the broader [domain terminology guide](/en/blog/domain-terminology-guide/).
 
 ## Frequently asked questions
 
@@ -169,3 +168,13 @@ A .es domain registers directly at the second level (yourname.es). Third-level v
 - [Domain terminology guide](/en/blog/domain-terminology-guide)
 - [Top TLDs to secure for your business](/en/blog/top-tlds-to-secure-for-your-business)
 - Glossary: [ccTLD](/en/glossary/cctld), [DNSSEC](/en/glossary/dnssec), [IDN](/en/glossary/idn), [registrar](/en/glossary/registrar)
+
+## Sources and further reading
+
+- IANA — [Red.es](https://www.iana.org/domains/root/db/es.html)
+- Google Search Central — [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs)
+- elmundo.es — [elmundo.es](https://www.elmundo.es/)
+- rtve.es — [rtve.es](https://www.rtve.es/)
+- dominios.es — [Red.es's official Naming Policy Instruction](https://www.dominios.es/es/sobre-dominios/normativa/instruccion-director-general-red#:~:text=tengan%20intereses%20o%20mantengan%20v%C3%ADnculos%20con%20Espa%C3%B1a)
+- dominios.es — [Red.es](https://www.dominios.es/en)
+- dominios.es — [single annual rate for second-level names submitted through an accredited registrar](https://www.dominios.es/es/sobre-dominios/normativa/instruccion-director-general-tarifas-aplicables#:~:text=Tarifa%20cuarta.%20Asignaci%C3%B3n%20anual%20inicial%20o%20renovaci%C3%B3n%20anual%20de%20nombres%20de%20dominio%20de%20segundo%20nivel)

--- a/content/tld/en/eu.md
+++ b/content/tld/en/eu.md
@@ -56,7 +56,7 @@ The **.eu domain** is the regional top-level domain for the **European Union**, 
 
 .eu is a **generic regional top-level domain**, not a national ccTLD — its [IANA root-zone record](https://www.iana.org/domains/root/db/eu.html) lists **EURid vzw**, a Belgium-based non-profit, as the sponsoring organization. EURid was itself founded on 8 April 2003 by the national registries of Belgium, Italy, and Sweden, and the European Commission designated it to run .eu shortly after.
 
-.eu's Google treatment is genuinely unusual among region-associated extensions. Google's own [multi-regional sites guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=Generic%20regional%20top-level%20domains) places .eu in a specific category — **"generic regional top-level domains"** — stating that although these domains are associated with a geographical region, "they are generally treated as generic top-level domains (much like .com or .org)." So unlike .de or .uk, a .eu site does not automatically read to Google as targeting a single country.
+.eu's Google treatment is genuinely unusual among region-associated extensions. Google's own [multi-regional sites guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Generic%20regional%20top-level%20domains) places .eu in a specific category — **"generic regional top-level domains"** — stating that although these domains are associated with a geographical region, "they are generally treated as generic top-level domains (much like .com or .org)." So unlike .de or .uk, a .eu site does not automatically read to Google as targeting a single country.
 
 ## History of .eu
 
@@ -157,3 +157,12 @@ Yes. Alongside the standard Latin-script .eu, EURid operates a Cyrillic-script v
 - [Domain terminology guide](/en/blog/domain-terminology-guide)
 - Glossary: [ccTLD](/en/glossary/cctld), [ICANN](/en/glossary/icann), [IDN](/en/glossary/idn)
 - Compare TLDs: [.com](/en/tld/com), [.de](/en/tld/de), [.uk](/en/tld/uk), [.nl](/en/tld/nl)
+
+## Sources and further reading
+
+- eurid.eu — [EURid](https://eurid.eu/)
+- IANA — [IANA root-zone record](https://www.iana.org/domains/root/db/eu.html)
+- Google Search Central — [multi-regional sites guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Generic%20regional%20top-level%20domains)
+- eurid.eu — [company timeline](https://eurid.eu/en/about-eurid/timeline/)
+- eurid.eu — [10 February 2021 update](https://eurid.eu/en/news/update-on-brexit-related-domain-names/)
+- eurid.eu — [Rules for domain names](https://eurid.eu/en/knowledge-centre/rules-for-eu-domains/#:~:text=Eligibility%20criteria)

--- a/content/tld/en/fm.md
+++ b/content/tld/en/fm.md
@@ -60,7 +60,7 @@ This page covers who operates .fm, its unusual history, which real brands use it
 
 In practice, almost nobody registers a .fm name to signal Micronesia. The letters spell the **FM radio band**, and the [registry](/en/glossary/registry/) leaned into that reading decades ago: **dotFM**, a division of San Francisco-based BRS Media, markets .fm worldwide to broadcasters, podcasters, and streaming services — the "repurposed ccTLD" pattern that also gave the world [.io](/en/tld/io), [.tv](/en/tld/tv), and [.ai](/en/tld/ai).
 
-Search engines have caught up with reality. Google's multi-regional documentation places .fm on its short list of ccTLDs it [treats as generic domains rather than country-targeted ones](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=more%20generic%20than%20country%2Dtargeted), alongside .io, .tv, .me, and .co — because users and site owners see these extensions as generic. A .fm site can therefore rank for audiences anywhere, with no built-in geographic bias.
+Search engines have caught up with reality. Google's multi-regional documentation places .fm on its short list of ccTLDs it [treats as generic domains rather than country-targeted ones](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=more%20generic%20than%20country%2Dtargeted), alongside .io, .tv, .me, and .co — because users and site owners see these extensions as generic. A .fm site can therefore rank for audiences anywhere, with no built-in geographic bias.
 
 ## History of .fm
 
@@ -177,3 +177,14 @@ It suits podcasts, radio stations, streaming and music services, and audio-first
 - [What are tokenized domains?](/en/blog/what-are-tokenized-domains/)
 - Glossary: [ccTLD](/en/glossary/cctld/), [registry](/en/glossary/registry/), [registrar](/en/glossary/registrar/), [UDRP](/en/glossary/udrp/), [WHOIS privacy](/en/glossary/whois-privacy/)
 - Compare TLDs: [.tv](/en/tld/tv), [.am](/en/tld/am), [.io](/en/tld/io), [.ai](/en/tld/ai), [.gg](/en/tld/gg), [.sh](/en/tld/sh), [.ly](/en/tld/ly), [.to](/en/tld/to)
+
+## Sources and further reading
+
+- IANA — [IANA root-zone entry for .fm](https://www.iana.org/domains/root/db/fm.html)
+- Google Search Central — [treats as generic domains rather than country-targeted ones](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=more%20generic%20than%20country%2Dtargeted)
+- brsmedia.com — [signed a new agreement in November 2024](https://brsmedia.com/30yrs/)
+- last.fm — [Last.fm](https://www.last.fm/about)
+- transistor.fm — [Transistor.fm](https://transistor.fm/)
+- overcast.fm — [Overcast.fm](https://overcast.fm/)
+- dot.fm — [dotFM registration policy](https://dot.fm/policy.cfm#:~:text=first%20come%2C%20first%20served)
+- dot.fm — [the registry offers emoji domains](https://dot.fm/)

--- a/content/tld/en/fr.md
+++ b/content/tld/en/fr.md
@@ -58,7 +58,7 @@ This page covers what .fr is, its winding history from a research-institute proj
 
 **.fr** is the [ccTLD](/en/glossary/cctld/) assigned to France under the ISO 3166-1 country code standard, the same delegation system the [Internet Assigned Numbers Authority (IANA) tracks in its .fr root-zone entry](https://www.iana.org/domains/root/db/fr.html). Unlike a generic [gTLD](/en/glossary/tld/) such as [.com](/en/tld/com), .fr represents a single nation's namespace and is administered under French and EU policy rather than a standard ICANN registry agreement.
 
-Because .fr does not appear on Google's short list of ccTLDs it treats as generic — a list that includes strings like [.io](/en/tld/io) and [.co](/en/tld/co) — [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs) treats .fr as a genuinely country-targeted domain. A .fr site sends a clear signal that its audience is France (and, by extension, French-speaking Europe), which is an asset for local relevance and a constraint for anyone chasing a global audience.
+Because .fr does not appear on Google's short list of ccTLDs it treats as generic — a list that includes strings like [.io](/en/tld/io) and [.co](/en/tld/co) — [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs) treats .fr as a genuinely country-targeted domain. A .fr site sends a clear signal that its audience is France (and, by extension, French-speaking Europe), which is an asset for local relevance and a constraint for anyone chasing a global audience.
 
 ## History of .fr
 
@@ -85,7 +85,7 @@ Real, specific niches where .fr shows up:
 
 ## Notable sites using .fr
 
-- **[leboncoin.fr](https://www.leboncoin.fr/)** — France's dominant classifieds marketplace and one of the most-visited websites in the country, founded in 2006.
+- **`leboncoin.fr`** — France's dominant classifieds marketplace and one of the most-visited websites in the country, founded in 2006.
 - **[lemonde.fr](https://www.lemonde.fr/)** — the website of *Le Monde*, one of France's newspapers of record.
 - **service-public.fr** and the `gouv.fr` family — the French government's official public-service portals, reinforcing .fr as the credible "official French" namespace.
 
@@ -116,13 +116,13 @@ Choose **.com** when you want a globally neutral default with no eligibility hur
 
 ## Who can register a .fr domain?
 
-**Registration restrictions: EU/EEA/Swiss nexus.** Per Afnic's [official FAQ](https://www.afnic.fr/en/domain-names-and-support/faq-the-answers-to-your-questions/#:~:text=resident%20in%20one%20of%20the%20Member%20States%20of%20the%20European%20Union), a private individual must be **resident in an EU member state, Switzerland, Liechtenstein, Norway, or Iceland**; an organization must have its **registered office or main place of business** in one of those countries. This is place of residence or establishment, not nationality — a non-French citizen living in Paris qualifies, and a French citizen living outside the EU/EEA/Switzerland generally does not, without an eligible entity to register through.
+**Registration restrictions: EU/EEA/Swiss nexus.** Per Afnic's [official FAQ](https://www.afnic.fr/en/domain-names-and-support/faq-the-answers-to-your-questions/#:~:text=As%20a%20private%20individual%2C%20do%20I%20have%20the%20right%20to%20register%20a%20domain%20name%20under%20the%20TLDs%20managed%20by%20Afnic%3F), a private individual must be **resident in an EU member state, Switzerland, Liechtenstein, Norway, or Iceland**; an organization must have its **registered office or main place of business** in one of those countries. This is place of residence or establishment, not nationality — a non-French citizen living in Paris qualifies, and a French citizen living outside the EU/EEA/Switzerland generally does not, without an eligible entity to register through.
 
 The same eligibility rule applies uniformly across all six Afnic-managed TLDs: .fr plus the five French overseas-territory extensions **.re** (Réunion), **.pm** (Saint Pierre and Miquelon), **.tf** (French Southern and Antarctic Lands), **.wf** (Wallis and Futuna), and **.yt** (Mayotte). Afnic performs verification checks — legal existence and EU establishment for organizations, residential address for individuals — and failure to pass them can lead to suspension or deletion. [DNSSEC](/en/glossary/dnssec/) has been supported since September 2010, and [internationalized domain names (IDN)](/en/glossary/idn/) with accented characters have been available since May 2012. The binding rules are published in [Afnic's current Naming Policy](https://www.afnic.fr/wp-media/uploads/2026/07/afnic-naming-policy-2026-07-06.pdf).
 
 ## .fr pricing and value
 
-.fr pricing dynamics follow the same shape as most ccTLDs rather than any single quoted figure. **First-year and renewal pricing typically differ** — introductory rates are often promotional, while the standing renewal rate is what a brand pays long-term, so budget for the renewal rather than the teaser. Afnic and registrars may also apply **premium classifications** to short, dictionary, or high-demand names, which can carry higher registration and renewal costs. Registrar margin, on top of Afnic's wholesale rate, is the other variable. This page intentionally quotes no figures — check current rates with an accredited registrar at the point of purchase.
+.fr registrations are sold through accredited registrars: Afnic says it [does not accept registration or renewal requests directly](https://www.afnic.fr/en/domain-names-and-support/faq-the-answers-to-your-questions/#:~:text=Why%20can%E2%80%99t%20I%20register%20my%20domain%20name%20directly%20with%20Afnic%3F). The registrar sets the retail package and may offer introductory discounts, so compare its first-year and renewal fees. A short `.fr` name already held by someone else may carry a higher **aftermarket** asking price, but this page found no authoritative basis for describing ordinary available `.fr` labels as registry premium registrations with premium renewal tiers.
 
 ## Reputation and email deliverability
 
@@ -173,3 +173,13 @@ Yes. Since May 3, 2012, Afnic has supported internationalized domain names (IDN)
 - [Domain hacks explained](/en/blog/domain-hacks-explained)
 - [Domain terminology guide](/en/blog/domain-terminology-guide)
 - Glossary: [ccTLD](/en/glossary/cctld), [DNSSEC](/en/glossary/dnssec), [IDN](/en/glossary/idn), [registrar](/en/glossary/registrar)
+
+## Sources and further reading
+
+- afnic.fr — [Afnic](https://www.afnic.fr/en/)
+- IANA — [Afnic](https://www.iana.org/domains/root/db/fr.html)
+- Google Search Central — [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs)
+- afnic.fr — [Afnic published an updated Naming Policy for .fr](https://www.afnic.fr/en/observatory-and-resources/news/afnic-launches-the-new-naming-policy-applicable-to-the-fr-tld/)
+- lemonde.fr — [lemonde.fr](https://www.lemonde.fr/)
+- afnic.fr — [FAQ](https://www.afnic.fr/en/domain-names-and-support/faq-the-answers-to-your-questions/)
+- afnic.fr — [Afnic's current Naming Policy](https://www.afnic.fr/wp-media/uploads/2026/07/afnic-naming-policy-2026-07-06.pdf)

--- a/content/tld/en/gg.md
+++ b/content/tld/en/gg.md
@@ -60,7 +60,7 @@ This page covers what .gg actually is, who runs it, why gaming claimed it, the r
 
 Unlike a [gTLD](/en/glossary/tld/), a ccTLD has no ICANN registry agreement; its rules are set by the national manager. For .gg that is the **Channel Isles registry** operated by Island Networks, which [was founded in August 1996 by Nigel Roberts and Laurie Brown](https://channelisles.net/#:~:text=founded%20in%20August%201996) to run both .gg and .je, the ccTLD of neighbouring Jersey — two islands, one registry.
 
-One SEO nuance deserves precision. Google maintains a published list of ccTLDs it treats as generic (non-geo-targeted), and [.gg is not on that list](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=Google%20treats%20some%20ccTLDs) — the documented generic set includes .io, .tv, .me, .co, and .fm, but not .gg. By Google's own documentation, then, .gg is country-targeted to Guernsey. In practice, globally successful .gg platforms show that content and links dominate the suffix signal — but if worldwide organic search is mission-critical, know this fact rather than assume it away.
+One SEO nuance deserves precision. Google maintains a published list of ccTLDs it treats as generic (non-geo-targeted), and [.gg is not on that list](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Google%20treats%20some%20ccTLDs) — the documented generic set includes .io, .tv, .me, .co, and .fm, but not .gg. By Google's own documentation, then, .gg is country-targeted to Guernsey. In practice, globally successful .gg platforms show that content and links dominate the suffix signal — but if worldwide organic search is mission-critical, know this fact rather than assume it away.
 
 ## History of .gg
 
@@ -171,3 +171,10 @@ The .gg registry is operated by Island Networks, founded in August 1996 by Nigel
 - [Domain terminology guide](/en/blog/domain-terminology-guide/)
 - Glossary: [ccTLD](/en/glossary/cctld/), [domain hack](/en/glossary/domain-hack/), [registry](/en/glossary/registry/), [DNSSEC](/en/glossary/dnssec/)
 - Compare TLDs: [.io](/en/tld/io/), [.tv](/en/tld/tv/), [.us](/en/tld/us/), [.com](/en/tld/com/)
+
+## Sources and further reading
+
+- IANA — [IANA root-database entry for .gg](https://www.iana.org/domains/root/db/gg.html)
+- channelisles.net — [was founded in August 1996 by Nigel Roberts and Laurie Brown](https://channelisles.net/#:~:text=founded%20in%20August%201996)
+- Google Search Central — [.gg is not on that list](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Google%20treats%20some%20ccTLDs)
+- channelisles.net — ["in general, there are no restrictions whatsoever"](https://www.channelisles.net/legal/terms-and-conditions-1#:~:text=no%20restrictions%20whatsoever)

--- a/content/tld/en/group.md
+++ b/content/tld/en/group.md
@@ -57,6 +57,8 @@ The **.group domain** is an open, unrestricted generic top-level domain built fo
 
 Because it is a plain generic extension, Google Search Central treats [new gTLDs](/en/glossary/new-gtld) like .group the same as legacy generics such as [.com](/en/tld/com): there is no automatic ranking benefit or penalty tied to the suffix itself, and no geo-targeting signal is applied.
 
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
+
 ## History of .group
 
 - **Contested string, private auction (2014).** Multiple applicants sought the .group string during ICANN's New gTLD Program; the rights were won by **Donuts Inc.** through a private auction among the competing applicants in July 2014. Donuts signed the underlying [ICANN Registry Agreement for .group on 15 August 2014](https://www.icann.org/en/registry-agreements/details/group).
@@ -160,3 +162,10 @@ Generally no. The word "group" implies plurality and organization, so it reads o
 - [Top TLDs to secure for your startup](/en/blog/top-tlds-to-secure-for-your-startup)
 - Glossary: [gTLD](/en/glossary/gtld), [new gTLD](/en/glossary/new-gtld), [ICANN](/en/glossary/icann), [registrar](/en/glossary/registrar)
 - Compare TLDs: [.com](/en/tld/com), [.company](/en/tld/company), [.design](/en/tld/design), [.studio](/en/tld/studio)
+
+## Sources and further reading
+
+- IANA — [IANA root-zone entry for .group](https://www.iana.org/domains/root/db/group.html)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- ICANN — [ICANN Registry Agreement for .group on 15 August 2014](https://www.icann.org/en/registry-agreements/details/group)
+- identity.digital — [domain policies](https://identity.digital/policies)

--- a/content/tld/en/icu.md
+++ b/content/tld/en/icu.md
@@ -55,7 +55,9 @@ The **.icu domain** is one of the cheapest and, at its 2019 peak, one of the lar
 
 ## What is .icu?
 
-.icu is a [generic top-level domain](/en/glossary/tld) with no country tie. ShortDot markets the three letters as **"I See You,"** though the string also reads naturally as the medical abbreviation for "intensive care unit," a coincidence ShortDot has never tried to hide. As a generic extension, .icu is treated by Google like any other gTLD — no automatic ranking boost, no penalty, and no geo-targeting bias, per [Google Search Central's guidance on generic domains](https://developers.google.com/search/docs/crawling-indexing/special-tags). You can verify the delegation record directly in the [IANA root-zone entry for .icu](https://www.iana.org/domains/root/db/icu.html).
+.icu is a [generic top-level domain](/en/glossary/tld) with no country tie. ShortDot markets the three letters as **"I See You,"** though the string also reads naturally as the medical abbreviation for "intensive care unit," a coincidence ShortDot has never tried to hide. As a generic extension, .icu is treated by Google like any other gTLD — no automatic ranking boost, no penalty, and no geo-targeting bias, per [Google Search Central's guidance on generic domains](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.). You can verify the delegation record directly in the [IANA root-zone entry for .icu](https://www.iana.org/domains/root/db/icu.html).
+
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
 
 ## History of .icu
 
@@ -170,3 +172,14 @@ It suits short-term campaigns, low-budget side projects, and buyers who specific
 - [Avoiding domain sale scams](/en/blog/avoiding-domain-sale-scams)
 - Glossary: [registrar](/en/glossary/registrar), [ICANN](/en/glossary/icann), [new gTLD](/en/glossary/new-gtld), [phishing](/en/glossary/phishing)
 - Compare TLDs: [.com](/en/tld/com), [.sbs](/en/tld/sbs), [.cyou](/en/tld/cyou), [.bond](/en/tld/bond)
+
+## Sources and further reading
+
+- shortdot.bond — [ShortDot SA](https://shortdot.bond/)
+- Google Search Central — [Google Search Central's guidance on generic domains](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- IANA — [IANA root-zone entry for .icu](https://www.iana.org/domains/root/db/icu.html)
+- ICANN — [ICANN Registry Agreement signed 8 January 2015](https://www.icann.org/en/registry-agreements/details/icu)
+- domainincite.com — [industry tracking by Domain Incite](https://domainincite.com/24469-icu-joins-the-million-domains-club-in-one-year-but-spam-triples)
+- domainincite.com — [Domain Incite's 2021 industry analysis](https://domainincite.com/26980-domain-industry-shrinks-again-except-of-course-it-doesnt)
+- ntldstats.com — [ntldstats.com](https://ntldstats.com/tld/icu)
+- Spamhaus — [Domain Reputation Update](https://content.spamhaus.org/4d83c22f-84c5-4f82-95ab-4e6b39f73db5.pdf)

--- a/content/tld/en/im.md
+++ b/content/tld/en/im.md
@@ -55,7 +55,7 @@ The **.im domain** is the country-code top-level domain for the **Isle of Man**,
 
 **.im** is the [ccTLD](/en/glossary/cctld/) assigned to the Isle of Man under the ISO 3166-1 country-code system. The [IANA root-zone database entry for .im](https://www.iana.org/domains/root/db/im.html) lists the **Isle of Man Government** as the ccTLD manager, while day-to-day registry operations are run by **[Domicilium (IOM) Limited](https://www.nic.im/)**, an Isle of Man-based internet services company — a common split for smaller ccTLDs, where the government retains ultimate policy authority and a specialist operator handles the technical and commercial infrastructure.
 
-The Isle of Man itself is a self-governing Crown dependency, constitutionally separate from the United Kingdom, which is why it holds its own ccTLD delegation independent of the UK's `.uk`. For search purposes, Google does not treat .im as generic: it is absent from [Google's explicit list of ccTLDs treated as generic](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=.ad%2C%20.ai%2C%20.as%2C%20.bz%2C%20.cc%2C%20.cd%2C%20.co%2C%20.dj%2C%20.fm%2C%20.io%2C%20.la%2C%20.me%2C%20.ms%2C%20.nu%2C%20.sc%2C%20.sr%2C%20.su%2C%20.tv%2C%20.tk%2C%20.ws), meaning a .im site is geo-targeted toward the Isle of Man by default rather than being read as a borderless "instant messaging" suffix.
+The Isle of Man itself is a self-governing Crown dependency, constitutionally separate from the United Kingdom, which is why it holds its own ccTLD delegation independent of the UK's `.uk`. For search purposes, Google does not treat .im as generic: it is absent from [Google's explicit list of ccTLDs treated as generic](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Google%20treats%20some%20ccTLDs), meaning a .im site is geo-targeted toward the Isle of Man by default rather than being read as a borderless "instant messaging" suffix.
 
 ## History of .im
 
@@ -157,3 +157,12 @@ No. Unlike many modern ccTLDs, .im does not currently support DNSSEC, so registr
 - [Top TLDs to secure for your startup](/en/blog/top-tlds-to-secure-for-your-startup/)
 - Glossary: [ccTLD](/en/glossary/cctld/), [domain hack](/en/glossary/domain-hack/), [registrar](/en/glossary/registrar/), [DNSSEC](/en/glossary/dnssec/)
 - Compare TLDs: [.io](/en/tld/io/), [.me](/en/tld/me/), [.is](/en/tld/is/)
+
+## Sources and further reading
+
+- IANA — [IANA root-zone database entry for .im](https://www.iana.org/domains/root/db/im.html)
+- nic.im — [Domicilium (IOM) Limited](https://www.nic.im/)
+- Google Search Central — [Google's explicit list of ccTLDs treated as generic](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Google%20treats%20some%20ccTLDs)
+- gov.im — [gov.im](https://www.gov.im)
+- ICANN — [ICANN Registry Agreement](https://www.icann.org/en/registry-agreements)
+- nic.im — [domain rules document](https://www.nic.im/pdfs/imrules.pdf)

--- a/content/tld/en/in.md
+++ b/content/tld/en/in.md
@@ -56,7 +56,7 @@ The **.in domain** is the official [country-code top-level domain](/en/glossary/
 
 .in is the [ccTLD](/en/glossary/cctld/) assigned to India under ISO 3166-1 (country code IN), delegated through the [IANA root-zone database](https://www.iana.org/domains/root/db/in.html), which lists NIXI as both registry operator and sponsoring organization. As with any ccTLD, .in operates under Indian domain-name policy rather than a standard ICANN registry agreement.
 
-Google does **not** classify .in among the small set of ccTLDs it treats as generic (that list — .ad, .ai, .as, .bz, .cc, .cd, .co, .dj, .fm, .io, .la, .me, .ms, .nu, .sc, .sr, .su, .tv, .tk, .ws — is published in [Google Search Central's guidance on managing multi-regional sites](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs)). .in is absent from that list, so Google treats it as a genuine India-targeting signal.
+Google does **not** classify .in among the small set of ccTLDs it treats as generic (that list — .ad, .ai, .as, .bz, .cc, .cd, .co, .dj, .fm, .io, .la, .me, .ms, .nu, .sc, .sr, .su, .tv, .tk, .ws — is published in [Google Search Central's guidance on managing multi-regional sites](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs)). .in is absent from that list, so Google treats it as a genuine India-targeting signal.
 
 ## History of .in
 
@@ -159,3 +159,12 @@ The National Internet Exchange of India (NIXI) is the registry operator for .in,
 - [Domain terminology guide](/en/blog/domain-terminology-guide/)
 - Glossary: [ccTLD](/en/glossary/cctld/), [IDN](/en/glossary/idn/), [registrar](/en/glossary/registrar/), [ICANN](/en/glossary/icann/), [DNSSEC](/en/glossary/dnssec/)
 - Compare TLDs: [.com](/en/tld/com/), [.cn](/en/tld/cn/), [.jp](/en/tld/jp/), [.kr](/en/tld/kr/)
+
+## Sources and further reading
+
+- IANA — [National Internet Exchange of India (NIXI)](https://www.iana.org/domains/root/db/in.html)
+- Google Search Central — [Google Search Central's guidance on managing multi-regional sites](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs)
+- registry.in — [about-the-registry page](https://www.registry.in/about-registry)
+- IANA — [.भारत (.bharat, Devanagari script)](https://www.iana.org/reports/2009/in-report-27nov2009.html)
+- en.wikipedia.org — [india.gov.in](https://en.wikipedia.org/wiki/India.gov.in)
+- registry.in — [Internationalized Domain Names program](https://www.registry.in/internationalized-domain-names-idns)

--- a/content/tld/en/inc.md
+++ b/content/tld/en/inc.md
@@ -56,7 +56,9 @@ The **.inc domain** spells out the word most American companies already have in 
 
 ## What is .inc?
 
-.inc is a [generic top-level domain](/en/glossary/gtld) delegated through ICANN's 2012 New gTLD Program. As a generic suffix with no country tie, Google's [multi-regional site guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=Generic%20top-level%20domains%20%28gTLDs%29%20are%20domains%20that%20aren%27t%20associated%20with%20specific%20locations) treats it exactly like any other gTLD — no automatic geo-targeting, and no inherent SEO advantage from the string itself.
+.inc is a [generic top-level domain](/en/glossary/gtld) delegated through ICANN's 2012 New gTLD Program. As a generic suffix with no country tie, Google's [multi-regional site guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Generic%20top-level%20domains%20%28gTLDs%29%20are%20domains%20that%20aren%27t%20associated%20with%20specific%20locations) treats it exactly like any other gTLD — no automatic geo-targeting, and no inherent SEO advantage from the string itself.
+
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
 
 The registry is [Intercap Registry Inc.](https://www.iana.org/domains/root/db/inc.html), a Cayman Islands company that also runs the related [.dealer](https://www.iana.org/domains/root/db/dealer.html) and .box extensions, with CentralNic providing back-end registry infrastructure. You can confirm the current sponsoring organization and delegation record directly in the [IANA root-zone entry for .inc](https://www.iana.org/domains/root/db/inc.html).
 
@@ -170,3 +172,15 @@ Yes. The registry's own published adopter list includes redirect or investor-rel
 - [Brandable vs keyword domains](/en/blog/brandable-vs-keyword-domains)
 - Glossary: [new gTLD](/en/glossary/new-gtld), [ICANN](/en/glossary/icann), [registrar](/en/glossary/registrar), [trademark](/en/glossary/trademark)
 - Compare TLDs: [.com](/en/tld/com), [.llc](/en/tld/llc), [.co](/en/tld/co)
+
+## Sources and further reading
+
+- Google Search Central — [multi-regional site guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Generic%20top-level%20domains%20%28gTLDs%29%20are%20domains%20that%20aren%27t%20associated%20with%20specific%20locations)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- IANA — [Intercap Registry Inc.](https://www.iana.org/domains/root/db/inc.html)
+- IANA — [.dealer](https://www.iana.org/domains/root/db/dealer.html)
+- ICANN — [ICANN Registry Agreement details for .inc](https://www.icann.org/en/registry-agreements/details/inc)
+- globenewswire.com — [launch release](https://www.globenewswire.com/news-release/2019/03/27/1773783/0/en/inc-Launches-as-the-Domain-Ending-that-Means-Business.html)
+- globenewswire.com — [general-availability announcement](https://www.globenewswire.com/news-release/2019/05/07/1818693/0/en/Over-20-Percent-of-Forbes-Most-Valuable-Brands-Have-Purchased-inc-Domains.html)
+- get.inc — [registry itself](https://www.get.inc/companies)
+- domainnamewire.com — [Industry coverage at launch](https://domainnamewire.com/2018/06/12/llc-and-inc-domain-names-are-on-their-way/)

--- a/content/tld/en/ing.md
+++ b/content/tld/en/ing.md
@@ -55,7 +55,9 @@ The **.ing domain** is a generic top-level domain built around a linguistic tric
 
 .ing is a [generic top-level domain](/en/glossary/tld) (gTLD), not a country-code TLD, so it carries no geographic association. Its entire value proposition is wordplay: because so many English words end in "-ing," registering `word.ing` frequently spells out a real term — `go.ing`, `mak.ing`, `adapt.ing`. Google's own registry describes it plainly: build your website "in a single word with .ing." You can confirm the delegation record and operator in the [IANA root-zone database entry for .ing](https://www.iana.org/domains/root/db/ing.html).
 
-Because .ing is a generic extension, [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=Generic%20top-level%20domains%20(gTLDs)%20are%20domains%20that%20aren't%20associated%20with%20specific%20locations.) confirms gTLDs "aren't associated with specific locations," so .ing carries no automatic geo-targeting signal and no inherent ranking boost or penalty.
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
+
+Because .ing is a generic extension, [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Generic%20top-level%20domains%20(gTLDs)%20are%20domains%20that%20aren't%20associated%20with%20specific%20locations.) confirms gTLDs "aren't associated with specific locations," so .ing carries no automatic geo-targeting signal and no inherent ranking boost or penalty.
 
 ## History of .ing
 
@@ -166,3 +168,17 @@ It suits brands, products, and personal sites whose name genuinely ends in "-ing
 - [How TLD affects domain value](/en/blog/how-tld-affects-domain-value)
 - Glossary: [domain hack](/en/glossary/domain-hack), [gTLD](/en/glossary/gtld), [registrar](/en/glossary/registrar)
 - Compare TLDs: [.com](/en/tld/com), [.io](/en/tld/io), [.app](/en/tld/app), [.meme](/en/tld/meme), [.page](/en/tld/page)
+
+## Sources and further reading
+
+- registry.google — [Charleston Road Registry](https://www.registry.google)
+- IANA — [IANA root-zone database entry for .ing](https://www.iana.org/domains/root/db/ing.html)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- Google Search Central — [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Generic%20top-level%20domains%20(gTLDs)%20are%20domains%20that%20aren't%20associated%20with%20specific%20locations.)
+- ICANN — [ICANN Registry Agreement for .ing](https://www.icann.org/en/registry-agreements/details/ing)
+- registry.google — [general availability from December 5, 2023](https://www.registry.google/announcements/launch-details-for-ing-and-meme/)
+- registry.google — [over 20,000 .ing registrations and "thousands of new websites"](https://www.registry.google/announcements/ing-one-year/)
+- get.ing — [get.ing showcase](https://get.ing/)
+- design.ing — [design.ing](https://design.ing)
+- bank.ing — [bank.ing](https://bank.ing)
+- registry.google — [Domain Registration Policy](https://www.registry.google/policies/)

--- a/content/tld/en/is.md
+++ b/content/tld/en/is.md
@@ -55,7 +55,7 @@ The **.is domain** is the country-code top-level domain for **Iceland**, and it 
 
 **.is** is the [ccTLD](/en/glossary/cctld/) assigned to Iceland under the ISO 3166-1 country-code system. It is managed by [**ISNIC — Internet á Íslandi hf.**](https://www.isnic.is/en), a Reykjavík-based company, as confirmed in the [IANA root-zone database entry for .is](https://www.iana.org/domains/root/db/is.html). ISNIC is a for-profit company, not a government agency or nonprofit — it operates the registry under an agreement with IANA/ICANN following RFC 1591 and ICP-1, the standard framework for ccTLD delegations.
 
-Because .is is a ccTLD tied to a specific country, Google's own guidance explains that country-code domains ["provide a strong signal to both users and search engines that your site is explicitly intended for a certain country"](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=These%20are%20tied%20to%20a%20specific%20country). Google maintains a short list of ccTLDs it treats as generic instead — .ad, .ai, .as, .bz, .cc, .cd, .co, .dj, .fm, .io, .la, .me, .ms, .nu, .sc, .sr, .su, .tv, .tk, .ws — and **.is is not on it**. In practice a .is site is geo-targeted toward Iceland by default, which matters for anyone chasing global rankings rather than a wordplay domain used purely for direct traffic.
+Because .is is a ccTLD tied to a specific country, Google's own guidance explains that country-code domains ["provide a strong signal to both users and search engines that your site is explicitly intended for a certain country"](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=These%20are%20tied%20to%20a%20specific%20country). Google maintains a short list of ccTLDs it treats as generic instead — .ad, .ai, .as, .bz, .cc, .cd, .co, .dj, .fm, .io, .la, .me, .ms, .nu, .sc, .sr, .su, .tv, .tk, .ws — and **.is is not on it**. In practice a .is site is geo-targeted toward Iceland by default, which matters for anyone chasing global rankings rather than a wordplay domain used purely for direct traffic.
 
 ## History of .is
 
@@ -128,13 +128,12 @@ For email deliverability specifically, sender reputation, [SPF/DKIM/DMARC authen
 - **Keep the second-level part short.** Domain hacks lose their charm past a handful of characters; the shortest, punchiest options work best.
 - **Check Icelandic character availability separately** if your name could use þ, æ, ö, or ð for a more authentic Icelandic identity.
 
-## How to register a .is domain at Namefi
+## How to register a .is domain
 
 1. **Search** for your desired name and confirm it forms the phrase you want with the .is ending.
 2. **Choose** the exact name and review ISNIC's registration terms.
 3. **Register** and configure [DNS](/en/glossary/dns/) to point your site or email.
 
-[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/registrar/) that bridges Web2 and [Web3](/en/glossary/web3/), with the option to [tokenize your domain](/en/blog/what-are-tokenized-domains/) for provable on-chain ownership and easier transfers — all with transparent pricing and fast DNS management.
 
 ## Frequently asked questions
 
@@ -161,3 +160,12 @@ Yes. ISNIC allows the Icelandic letters á, é, ý, ú, í, ó, þ, æ, ö, and 
 - [What is a domain?](/en/blog/what-is-domain/)
 - Glossary: [ccTLD](/en/glossary/cctld/), [domain hack](/en/glossary/domain-hack/), [registrar](/en/glossary/registrar/), [DNSSEC](/en/glossary/dnssec/)
 - Compare TLDs: [.io](/en/tld/io/), [.co](/en/tld/co/), [.me](/en/tld/me/), [.us](/en/tld/us/)
+
+## Sources and further reading
+
+- who.is — [who.is](https://who.is)
+- this.is — [this.is](https://this.is)
+- isnic.is — [ISNIC — Internet á Íslandi hf.](https://www.isnic.is/en)
+- IANA — [IANA root-zone database entry for .is](https://www.iana.org/domains/root/db/is.html)
+- Google Search Central — [developers.google.com](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=These%20are%20tied%20to%20a%20specific%20country)
+- isnic.is — [official domain rules](https://www.isnic.is/en/domain/rules)

--- a/content/tld/en/it.md
+++ b/content/tld/en/it.md
@@ -58,7 +58,7 @@ This page covers what .it is, its history from a single research-network address
 
 **.it** is the [ccTLD](/en/glossary/cctld/) assigned to Italy under the ISO 3166-1 country code standard, recorded in the [IANA root-zone entry for .it](https://www.iana.org/domains/root/db/it.html). Unlike a generic [gTLD](/en/glossary/tld/) such as [.com](/en/tld/com), .it represents a single nation's namespace and is administered under Italian and European policy rather than a standard ICANN registry agreement.
 
-.it does not appear on Google's short list of ccTLDs treated as generic (a list that includes strings like [.io](/en/tld/io) and [.co](/en/tld/co)), so [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs) treats .it as genuinely country-targeted. A .it site signals an Italian audience, which is an advantage for local relevance and a constraint for anyone chasing a global, non-Italian audience.
+.it does not appear on Google's short list of ccTLDs treated as generic (a list that includes strings like [.io](/en/tld/io) and [.co](/en/tld/co)), so [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs) treats .it as genuinely country-targeted. A .it site signals an Italian audience, which is an advantage for local relevance and a constraint for anyone chasing a global, non-Italian audience.
 
 ## History of .it
 
@@ -113,13 +113,13 @@ Choose **.com** for a globally neutral default with no eligibility gate. Choose 
 
 ## Who can register a .it domain?
 
-**Registration restrictions: EEA nexus.** Per [Registro .it's official FAQ](https://www.nic.it/en/find-your-it/faq#:~:text=adults%20who%20have%20citizenship%2C%20residence%20or%20a%20registered%20office), registration is permitted only to **adults who have citizenship, residence, or a registered office in a country of the European Economic Area, the Vatican City State, the Republic of San Marino, the Swiss Confederation, or the United Kingdom**. Registrants who do not meet this criteria — for example, someone based solely in the United States — typically need to register through a trustee/proxy service offered by some registrars rather than registering directly.
+**Registration restrictions: EEA nexus.** Per [Registro .it's official FAQ](https://www.nic.it/en/find-your-it/faq#:~:text=Who%20can%20register%20a%20.it%20domain%3F), registration is permitted only to **adults who have citizenship, residence, or a registered office in a country of the European Economic Area, the Vatican City State, the Republic of San Marino, the Swiss Confederation, or the United Kingdom**. Registrants who do not meet this criteria — for example, someone based solely in the United States — typically need to register through a trustee/proxy service offered by some registrars rather than registering directly.
 
 Beyond eligibility, registrant contact data is subject to verification under EU NIS 2-driven rules: incomplete or inaccurate information gets flagged and must be corrected, generally within about 75 days, or the domain is at risk. [DNSSEC](/en/glossary/dnssec/) is supported, and [internationalized domain names (IDN)](/en/glossary/idn/) with accented characters have been available since July 2012. The authoritative source for current eligibility and technical rules is [Registro .it](https://www.nic.it/en), the registry operated by IIT-CNR.
 
 ## .it pricing and value
 
-.it pricing follows the same shape as most ccTLDs rather than any single quoted figure. **First-year and renewal pricing typically differ** — introductory rates are often promotional, while the standing renewal rate is what a brand pays long-term. Registrars and the registry may apply **premium classifications** to short, dictionary, or high-demand names, carrying higher registration and sometimes renewal costs. Name length, desirability, and registrar margin on top of the registry's wholesale rate are the other main drivers. This page intentionally quotes no figures — check current rates with an accredited registrar at the point of purchase.
+Registro .it does not sell directly to end users; its registrar guidance says [each registrar independently establishes registration and maintenance costs](https://www.nic.it/en/registrars#:~:text=Each%20Registrar%20independently%20establishes%20the%20costs%20of%20registration%20and%20maintenance). Registrars may bundle other services or offer introductory discounts, so compare first-year and renewal fees. A concise `.it` name already owned by someone else may carry an **aftermarket** asking price, but that is separate from registry registration and renewal pricing.
 
 ## Reputation and email deliverability
 
@@ -170,3 +170,14 @@ Yes. Registro .it has supported internationalized domain names (IDN) with accent
 - [Domain hacks explained](/en/blog/domain-hacks-explained)
 - [Domain terminology guide](/en/blog/domain-terminology-guide)
 - Glossary: [ccTLD](/en/glossary/cctld), [DNSSEC](/en/glossary/dnssec), [IDN](/en/glossary/idn), [registrar](/en/glossary/registrar)
+
+## Sources and further reading
+
+- IANA — [IIT-CNR](https://www.iana.org/domains/root/db/it.html)
+- Google Search Central — [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs)
+- redd.it — [redd.it](https://redd.it)
+- repubblica.it — [repubblica.it](https://www.repubblica.it/)
+- corriere.it — [corriere.it](https://www.corriere.it/)
+- nic.it — [Registro .it's official FAQ](https://www.nic.it/en/find-your-it/faq#:~:text=Who%20can%20register%20a%20.it%20domain%3F)
+- nic.it — [Registro .it](https://www.nic.it/en)
+- nic.it — [each registrar independently establishes registration and maintenance costs](https://www.nic.it/en/registrars#:~:text=Each%20Registrar%20independently%20establishes%20the%20costs%20of%20registration%20and%20maintenance)

--- a/content/tld/en/jp.md
+++ b/content/tld/en/jp.md
@@ -56,7 +56,7 @@ The **.jp domain** is the official [country-code top-level domain](/en/glossary/
 
 .jp is the [ccTLD](/en/glossary/cctld/) assigned to Japan under ISO 3166-1 (country code JP), delegated through the [IANA root-zone database](https://www.iana.org/domains/root/db/jp.html), which lists JPRS as both registry operator and sponsoring organization. As with any ccTLD, .jp sits under Japanese domain-name policy rather than a standard ICANN registry agreement.
 
-Google does **not** classify .jp among the small set of ccTLDs it treats as generic (that list — .ad, .ai, .as, .bz, .cc, .cd, .co, .dj, .fm, .io, .la, .me, .ms, .nu, .sc, .sr, .su, .tv, .tk, .ws — is published in [Google Search Central's guidance on managing multi-regional sites](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs)). .jp is absent from that list, so it functions as a genuine geo-targeting signal for Japan.
+Google does **not** classify .jp among the small set of ccTLDs it treats as generic (that list — .ad, .ai, .as, .bz, .cc, .cd, .co, .dj, .fm, .io, .la, .me, .ms, .nu, .sc, .sr, .su, .tv, .tk, .ws — is published in [Google Search Central's guidance on managing multi-regional sites](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs)). .jp is absent from that list, so it functions as a genuine geo-targeting signal for Japan.
 
 ## History of .jp
 
@@ -126,14 +126,13 @@ DNSSEC is supported, and JPRS's registrar network handles the identity and eligi
 - **Consider a native-script name.** Japanese-script JP domains can strengthen recall and trust with a Japan-based audience.
 - **Plan for one .co.jp only.** If your company operates multiple Japan-facing brands, general-use .jp is the workaround for names beyond the single .co.jp slot.
 
-## How to register a .jp domain at Namefi
+## How to register a .jp domain
 
 1. **Confirm eligibility** — a permanent Japan postal address for general-use .jp, or Japanese corporate registration for .co.jp.
 2. **Search** for your desired name across the JP domain type that fits your entity.
 3. **Register** and complete JPRS's eligibility verification.
 4. **Configure [DNS](/en/glossary/dns/)** to point your site or email.
 
-[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing and the option to hold eligible domains as [tokenized assets](/en/blog/what-are-tokenized-domains/) for provable ownership and easier transfers.
 
 ## Frequently asked questions
 
@@ -161,3 +160,12 @@ Japan Registry Services Co., Ltd. (JPRS) is the registry operator for .jp, liste
 - [Domain hacks explained](/en/blog/domain-hacks-explained/)
 - Glossary: [ccTLD](/en/glossary/cctld/), [IDN](/en/glossary/idn/), [registrar](/en/glossary/registrar/), [ICANN](/en/glossary/icann/), [DNSSEC](/en/glossary/dnssec/)
 - Compare TLDs: [.com](/en/tld/com/), [.cn](/en/tld/cn/), [.kr](/en/tld/kr/), [.in](/en/tld/in/)
+
+## Sources and further reading
+
+- IANA — [Japan Registry Services Co., Ltd. (JPRS)](https://www.iana.org/domains/root/db/jp.html)
+- Google Search Central — [Google Search Central's guidance on managing multi-regional sites](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs)
+- jprs.co.jp — [.JP Q&A](https://jprs.co.jp/en/regist.html)
+- jprs.co.jp — [Guide to JP Domain Name](https://jprs.co.jp/en/jpdomain.html)
+- sony.co.jp — [sony.co.jp](https://www.sony.co.jp/en/index.html)
+- toyota.co.jp — [toyota.co.jp](https://www.toyota.co.jp/)

--- a/content/tld/en/kr.md
+++ b/content/tld/en/kr.md
@@ -56,7 +56,7 @@ The **.kr domain** is the official [country-code top-level domain](/en/glossary/
 
 .kr is the [ccTLD](/en/glossary/cctld/) assigned to South Korea under ISO 3166-1 (country code KR), delegated through the [IANA root-zone database](https://www.iana.org/domains/root/db/kr.html), which lists KISA as registry operator and the Korea Network Information Center (KRNIC) — KISA's domain-registry function — as sponsoring organization. As a ccTLD, .kr operates under Korean domain-name policy rather than a standard ICANN registry agreement.
 
-Google does **not** treat .kr as one of the ccTLDs it re-classifies as generic (that list — .ad, .ai, .as, .bz, .cc, .cd, .co, .dj, .fm, .io, .la, .me, .ms, .nu, .sc, .sr, .su, .tv, .tk, .ws — is published in [Google Search Central's guidance on managing multi-regional sites](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs)). .kr is absent from it, so Google reads a .kr site as targeted at South Korea specifically.
+Google does **not** treat .kr as one of the ccTLDs it re-classifies as generic (that list — .ad, .ai, .as, .bz, .cc, .cd, .co, .dj, .fm, .io, .la, .me, .ms, .nu, .sc, .sr, .su, .tv, .tk, .ws — is published in [Google Search Central's guidance on managing multi-regional sites](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs)). .kr is absent from it, so Google reads a .kr site as targeted at South Korea specifically.
 
 ## History of .kr
 
@@ -126,14 +126,13 @@ DNSSEC is supported at the registry level. Because .kr is a nationally governed 
 - **Confirm your Korea address in advance.** Both direct .kr and the category system require it — verify before you fall in love with a specific name.
 - **Decide between .co.kr and direct .kr early.** .co.kr is the long-established default for Korean businesses; direct .kr suits flatter, Hangul-first branding.
 
-## How to register a .kr domain at Namefi
+## How to register a .kr domain
 
 1. **Confirm eligibility** — a Korean address, and the right category if you're registering under .co.kr, .or.kr, .ac.kr, or another second level.
 2. **Search** for your desired name in your chosen category or directly under .kr.
 3. **Register** and complete KISA's eligibility verification.
 4. **Configure [DNS](/en/glossary/dns/)** to point your site or email.
 
-[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and Web3, with transparent pricing and the option to hold eligible domains as [tokenized assets](/en/blog/what-are-tokenized-domains/) for provable ownership and easier transfers.
 
 ## Frequently asked questions
 
@@ -160,3 +159,11 @@ The Korea Internet & Security Agency (KISA) is the registry operator for .kr, wi
 - [Domain terminology guide](/en/blog/domain-terminology-guide/)
 - Glossary: [ccTLD](/en/glossary/cctld/), [IDN](/en/glossary/idn/), [registrar](/en/glossary/registrar/), [ICANN](/en/glossary/icann/), [DNSSEC](/en/glossary/dnssec/)
 - Compare TLDs: [.com](/en/tld/com/), [.cn](/en/tld/cn/), [.jp](/en/tld/jp/), [.in](/en/tld/in/)
+
+## Sources and further reading
+
+- IANA — [Korea Internet & Security Agency (KISA)](https://www.iana.org/domains/root/db/kr.html)
+- Google Search Central — [Google Search Central's guidance on managing multi-regional sites](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=We%20also%20treat%20some%20vanity%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs)
+- krnic.or.kr — [Domain Name Management Rules](https://krnic.or.kr/jsp/eng/policy/domainNewRules.jsp)
+- korea.kr — [korea.kr](https://www.korea.kr/main.do)
+- lg.co.kr — [lg.co.kr](https://www.lg.co.kr/)

--- a/content/tld/en/life.md
+++ b/content/tld/en/life.md
@@ -55,7 +55,9 @@ The **.life domain** is a plain-English top-level domain aimed at wellness, life
 
 .life is a [generic top-level domain](/en/glossary/tld), not a country-code extension, so it carries no geographic meaning. The string is the ordinary English word for life, which gives it broad, immediately legible use across health, wellness, personal-development, and cause-driven branding without requiring an explanation of what the letters stand for — unlike acronym-based new gTLDs.
 
-Because it is a generic gTLD, Google treats .life like any other new extension: no automatic ranking advantage or penalty, and no geo-targeting applied, per [Google Search Central's guidance on generic vs. country-targeted domains](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=more%20generic%20than%20country-targeted). You can confirm the delegation record and current operator on the [IANA root-zone entry for .life](https://www.iana.org/domains/root/db/life.html).
+Because it is a generic gTLD, Google treats .life like any other new extension: no automatic ranking advantage or penalty, and no geo-targeting applied, per [Google Search Central's guidance on generic vs. country-targeted domains](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=more%20generic%20than%20country-targeted). You can confirm the delegation record and current operator on the [IANA root-zone entry for .life](https://www.iana.org/domains/root/db/life.html).
+
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
 
 ## History of .life
 
@@ -120,7 +122,7 @@ Names can run from 1–63 characters, use letters, numbers, and hyphens (not in 
 
 ## Reputation and email deliverability
 
-Buyers deserve candor here. We could not find a current, fetchable Spamhaus or Interisle report that names .life specifically among its worst- or most-abused TLD lists — if you find one, treat it as more current than this page. What is well documented at the category level: Interisle's [Cybercrime Supply Chain 2025 research](https://interisle.net/insights/cybercrimesupplychain2025#:~:text=though%20they%20hold%20just%2012%25%20of%20the%20market%2C%20they%20accounted%20for%20nearly%20half%20of%20all%20cybercrime%20domains%20reported) (sponsored by APWG, CAUCE, and M3AAWG) found that new gTLDs as a category hold just 12% of the domain market yet accounted for nearly half of all reported cybercrime domains — a reminder that low-cost, easy-to-bulk-register extensions draw disproportionate abuse as a category, even without a .life-specific figure to cite.
+Buyers deserve candor here. The current [Spamhaus Domain Reputation Update for October 2025–March 2026](https://content.spamhaus.org/4d83c22f-84c5-4f82-95ab-4e6b39f73db5.pdf) lists `.life` at **#20 among gTLDs by malicious or suspicious domain count**, with **12,204** listed domains. The same report ranks it **#19 by share of the zone listed**, at **2.99%** (12,204 out of 407,624 domains). Those figures do not mean every `.life` site is risky, but they do show measurable abuse within the zone.
 
 Practically, that means some spam filters and cautious users may apply extra scrutiny to unfamiliar .life links. The extension itself is legitimate and ICANN-accredited, and being operated by an established registry like Identity Digital is a point in its favor — being on .life does not make a site untrustworthy. **Mitigation:** configure SPF, DKIM, and DMARC correctly for any email sent from a .life domain, warm up new sending domains gradually, and keep registrant information clean and verifiable — vital for nonprofit and health-related sites where trust is central.
 
@@ -165,3 +167,12 @@ It suits wellness and health coaches, lifestyle and personal-development brands,
 - [What makes a domain valuable?](/en/blog/what-makes-a-domain-valuable)
 - Glossary: [TLD](/en/glossary/tld), [registrar](/en/glossary/registrar), [ICANN](/en/glossary/icann), [new gTLD](/en/glossary/new-gtld)
 - Compare TLDs: [.com](/en/tld/com), [.today](/en/tld/today)
+
+## Sources and further reading
+
+- Google Search Central — [Google Search Central's guidance on generic vs. country-targeted domains](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=more%20generic%20than%20country-targeted)
+- IANA — [IANA root-zone entry for .life](https://www.iana.org/domains/root/db/life.html)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- ICANN — [ICANN Registry Agreement for .life](https://www.icann.org/en/registry-agreements/details/life)
+- GoDaddy — [GoDaddy's .life domain policy summary](https://www.godaddy.com/help/about-life-domains-12109)
+- Spamhaus — [Spamhaus Domain Reputation Update for October 2025–March 2026](https://content.spamhaus.org/4d83c22f-84c5-4f82-95ab-4e6b39f73db5.pdf)

--- a/content/tld/en/llc.md
+++ b/content/tld/en/llc.md
@@ -55,7 +55,9 @@ The **.llc domain** takes the most common US small-business entity type — the 
 
 ## What is .llc?
 
-.llc is a [generic top-level domain](/en/glossary/gtld) delegated under ICANN's 2012 New gTLD Program. Like any generic suffix, it carries no geographic meaning, so Google's [multi-regional targeting guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=Generic%20top-level%20domains%20%28gTLDs%29%20are%20domains%20that%20aren%27t%20associated%20with%20specific%20locations) treats .llc the same as .com or any other gTLD — there is no automatic ranking effect and no built-in country association.
+.llc is a [generic top-level domain](/en/glossary/gtld) delegated under ICANN's 2012 New gTLD Program. Like any generic suffix, it carries no geographic meaning, so Google's [multi-regional targeting guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Generic%20top-level%20domains%20%28gTLDs%29%20are%20domains%20that%20aren%27t%20associated%20with%20specific%20locations) treats .llc the same as .com or any other gTLD — there is no automatic ranking effect and no built-in country association.
+
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
 
 The registry is Identity Digital Domains Limited, formerly Afilias — one of the industry's larger registry operators, also behind extensions like [.info](/en/tld/info) and [.llc](/en/tld/llc)'s corporate sibling [.ltd](/en/tld/ltd). You can confirm the current operator and delegation date in the [IANA root-zone entry for .llc](https://www.iana.org/domains/root/db/llc.html).
 
@@ -162,3 +164,14 @@ US-style limited liability companies, freelancers planning to incorporate as an 
 - [What is a domain?](/en/blog/what-is-domain)
 - Glossary: [new gTLD](/en/glossary/new-gtld), [gTLD](/en/glossary/gtld), [ICANN](/en/glossary/icann), [registrar](/en/glossary/registrar)
 - Compare TLDs: [.com](/en/tld/com), [.inc](/en/tld/inc), [.co](/en/tld/co)
+
+## Sources and further reading
+
+- Google Search Central — [multi-regional targeting guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Generic%20top-level%20domains%20%28gTLDs%29%20are%20domains%20that%20aren%27t%20associated%20with%20specific%20locations)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- IANA — [IANA root-zone entry for .llc](https://www.iana.org/domains/root/db/llc.html)
+- ICANN — [ICANN Registry Agreement details for .llc](https://www.icann.org/en/registry-agreements/details/llc)
+- afilias.info — [Afilias' official launch announcement](https://afilias.info/news/2018/07/09/new-llc-domain-landrush-period-begins-july-9-general-availability-begins-july-23rd)
+- prnewswire.com — [press release](https://www.prnewswire.com/news-releases/new-llc-domain-landrush-period-begins-july-9-300677484.html)
+- ntldstats.com — [nTLDstats' .llc registry data](https://ntldstats.com/tld/llc)
+- domainnamewire.com — [industry launch coverage](https://domainnamewire.com/2018/06/12/llc-and-inc-domain-names-are-on-their-way/)

--- a/content/tld/en/lol.md
+++ b/content/tld/en/lol.md
@@ -55,7 +55,9 @@ The **.lol domain** takes the internet's most recognizable shorthand — "laugh 
 
 .lol is a [generic top-level domain](/en/glossary/tld) approved through ICANN's 2012-round New gTLD Program, not a country-code extension, so it carries no built-in geographic meaning. The registry positions .lol as "the go-to online destination for everything fun and entertaining," aimed at comedy shows, entertainment venues, meme accounts, and playful URL shortening, according to the [official .lol registry site](https://nic.lol/).
 
-Because it is a generic gTLD, Google treats .lol like any other new extension: there is no automatic ranking advantage or penalty, and no geo-targeting is applied, per [Google Search Central's guidance on multi-regional and generic domains](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=more%20generic%20than%20country-targeted). You can confirm the delegation record and current operator on the [IANA root-zone entry for .lol](https://www.iana.org/domains/root/db/lol.html).
+Because it is a generic gTLD, Google treats .lol like any other new extension: there is no automatic ranking advantage or penalty, and no geo-targeting is applied, per [Google Search Central's guidance on multi-regional and generic domains](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=more%20generic%20than%20country-targeted). You can confirm the delegation record and current operator on the [IANA root-zone entry for .lol](https://www.iana.org/domains/root/db/lol.html).
+
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
 
 ## History of .lol
 
@@ -165,3 +167,14 @@ It suits comedians, meme creators, entertainment brands, and informal community 
 - [The email sender reputation arms race](/en/blog/email-sender-reputation-arms-race)
 - Glossary: [TLD](/en/glossary/tld), [registrar](/en/glossary/registrar), [ICANN](/en/glossary/icann), [new gTLD](/en/glossary/new-gtld)
 - Compare TLDs: [.xyz](/en/tld/xyz), [.fun](/en/tld/fun), [.com](/en/tld/com)
+
+## Sources and further reading
+
+- nic.lol — [official .lol registry site](https://nic.lol/)
+- Google Search Central — [Google Search Central's guidance on multi-regional and generic domains](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=more%20generic%20than%20country-targeted)
+- IANA — [IANA root-zone entry for .lol](https://www.iana.org/domains/root/db/lol.html)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- ICANN — [ICANN Registry Agreement page for .lol](https://www.icann.org/en/registry-agreements/details/lol)
+- ICANN — [ICANN Registry Agreement](https://www.icann.org/en/registry-agreements/details/xyz)
+- GoDaddy — [GoDaddy's .lol domain policy summary](https://www.godaddy.com/help/about-lol-domains-19076)
+- interisle.net — [Cybercrime Supply Chain 2025 research](https://interisle.net/insights/cybercrimesupplychain2025#:~:text=though%20they%20hold%20just%2012%25%20of%20the%20market%2C%20they%20accounted%20for%20nearly%20half%20of%20all%20cybercrime%20domains%20reported)

--- a/content/tld/en/ltd.md
+++ b/content/tld/en/ltd.md
@@ -55,7 +55,7 @@ The **.ltd domain** borrows the company suffix used across the UK, much of the C
 
 ## What is .ltd?
 
-.ltd is a [generic top-level domain](/en/glossary/gtld) delegated under ICANN's 2012 New gTLD Program. As a generic string, it carries no inherent geographic tie in Google's system — per Google's [multi-regional targeting guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Generic%20top-level%20domains%20%28gTLDs%29%20are%20domains%20that%20aren%27t%20associated%20with%20specific%20locations), a gTLD like .ltd needs hreflang, URL structure, or Search Console settings to signal a target country; the suffix itself does not, even though "Ltd." reads as distinctly British in everyday usage.
+.ltd is a [generic top-level domain](/en/glossary/gtld) delegated under ICANN's 2012 New gTLD Program. As a generic string, it carries no inherent geographic tie in Google's system — per Google's [multi-regional targeting guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#targeting-site-content-to-a-specific-country-geotargeting), a gTLD like .ltd needs locale-specific URLs, `hreflang`, or sitemaps to signal a target country; the suffix itself does not, even though "Ltd." reads as distinctly British in everyday usage.
 
 Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
 

--- a/content/tld/en/ltd.md
+++ b/content/tld/en/ltd.md
@@ -55,7 +55,9 @@ The **.ltd domain** borrows the company suffix used across the UK, much of the C
 
 ## What is .ltd?
 
-.ltd is a [generic top-level domain](/en/glossary/gtld) delegated under ICANN's 2012 New gTLD Program. As a generic string, it carries no inherent geographic tie in Google's system — per Google's [multi-regional targeting guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=Generic%20top-level%20domains%20%28gTLDs%29%20are%20domains%20that%20aren%27t%20associated%20with%20specific%20locations), a gTLD like .ltd needs hreflang, URL structure, or Search Console settings to signal a target country; the suffix itself does not, even though "Ltd." reads as distinctly British in everyday usage.
+.ltd is a [generic top-level domain](/en/glossary/gtld) delegated under ICANN's 2012 New gTLD Program. As a generic string, it carries no inherent geographic tie in Google's system — per Google's [multi-regional targeting guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Generic%20top-level%20domains%20%28gTLDs%29%20are%20domains%20that%20aren%27t%20associated%20with%20specific%20locations), a gTLD like .ltd needs hreflang, URL structure, or Search Console settings to signal a target country; the suffix itself does not, even though "Ltd." reads as distinctly British in everyday usage.
+
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
 
 The registry is Binky Moon, LLC, part of the [Identity Digital](https://www.iana.org/domains/root/db/ltd.html) group. You can confirm the current sponsoring organization and delegation record in the [IANA root-zone entry for .ltd](https://www.iana.org/domains/root/db/ltd.html).
 
@@ -161,3 +163,12 @@ The .ltd registry agreement is held by Binky Moon, LLC, the entity that consolid
 - [How TLD affects domain value](/en/blog/how-tld-affects-domain-value)
 - Glossary: [new gTLD](/en/glossary/new-gtld), [gTLD](/en/glossary/gtld), [ICANN](/en/glossary/icann), [registry](/en/glossary/registry)
 - Compare TLDs: [.com](/en/tld/com), [.company](/en/tld/company), [.co](/en/tld/co), [.llc](/en/tld/llc)
+
+## Sources and further reading
+
+- Google Search Central — [multi-regional targeting guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Generic%20top-level%20domains%20%28gTLDs%29%20are%20domains%20that%20aren%27t%20associated%20with%20specific%20locations)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- IANA — [Identity Digital](https://www.iana.org/domains/root/db/ltd.html)
+- ICANN — [ICANN Registry Agreement details for .ltd](https://www.icann.org/en/registry-agreements/details/ltd)
+- domainincite.com — [scrapped roughly 200 individual applicant shell companies](https://domainincite.com/22675-donuts-scraps-200-companies-consolidates-under-binky-moon)
+- ntldstats.com — [nTLDstats' .ltd registry data](https://ntldstats.com/tld/ltd)

--- a/content/tld/en/ly.md
+++ b/content/tld/en/ly.md
@@ -57,7 +57,7 @@ The **.ly domain** is the [country-code top-level domain](/en/glossary/cctld/) (
 
 Outside Libya, almost nobody registers .ly for its geography. Its appeal is linguistic: "-ly" is the standard English adverb ending, so `bit.ly`-style names read as single words with the dot hidden inside — putting .ly in the first wave of ccTLDs repurposed for global branding, alongside [.io](/en/tld/io/), [.tv](/en/tld/tv/), [.me](/en/tld/me/), [.fm](/en/tld/fm/), and [.gg](/en/tld/gg/).
 
-One nuance separates .ly from most of that club: Google's Search Central keeps a published list of ccTLDs it [treats as generic rather than country-targeted](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=Google%20treats%20some%20ccTLDs) — .ai, .co, .io, .fm, .tv, .me, and others — and **.ly is not on it**. By default, then, search engines can read a .ly site as targeted at Libya — an honest asterisk for SEO-sensitive projects, though global .ly brands rank fine on links and reputation.
+One nuance separates .ly from most of that club: Google's Search Central keeps a published list of ccTLDs it [treats as generic rather than country-targeted](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Google%20treats%20some%20ccTLDs) — .ai, .co, .io, .fm, .tv, .me, and others — and **.ly is not on it**. By default, then, search engines can read a .ly site as targeted at Libya — an honest asterisk for SEO-sensitive projects, though global .ly brands rank fine on links and reputation.
 
 ## History of .ly
 
@@ -113,7 +113,7 @@ Pick .ly when your name genuinely ends in "-ly" and your content is uncontrovers
 **Registration restrictions: content-restricted, plus a length rule.** Three layers to know:
 
 1. **Content and morality rules.** The registry's regulations state that a name [must not be "obscene, scandalous, indecent, or contrary to Libyan law or Islamic morality"](https://www.nic.ly/regulations.php#:~:text=Islamic%20morality), and registrar-facing policy extends this to names insulting religion or politics and names [related to gambling and the lottery industry](https://my.register.ly/knowledgebase/2/Which-.ly-domain-names-that-are-NOT-allowed-for-registration.html). Applicants certify the domain is not registered for activities Libyan law does not permit — and the vb.ly case showed the rules reach *site content*, not just the name.
-2. **The four-character rule.** Direct second-level names of **four or more characters are open to registrants worldwide** — no Libyan presence needed. Strings **shorter than four characters** are registered **only through Libya Telecom and Technology, to guarantee local presence** — famous short names like `bit.ly` predate this rule.
+2. **The four-character rule.** Direct second-level names of **four or more characters are open to registrants worldwide**. NIC.LY's current help page says that names [shorter than four characters require local presence in Libya](https://www.nic.ly/help.php#:~:text=for%20those%20less%20than%204%20characters%20long%20in%20the%20top%20level%20must%20have%20local%20presence%20in%20Libya); famous short names such as `bit.ly` predate this rule.
 3. **Third-level zones.** A structured hierarchy — `com.ly`, `net.ly`, `org.ly`, `edu.ly`, `sch.ly`, `med.ly`, `gov.ly`, `plc.ly`, `id.ly` — serves specific registrant categories, with government and institutional zones reserved.
 
 Technically, .ly is [DNSSEC](/en/glossary/dnssec/)-signed in the root zone, with RDAP at `rdap.nic.ly`; [WHOIS privacy](/en/glossary/whois-privacy/) handling varies by [registrar](/en/glossary/registrar/). ccTLD policy is set nationally — check the current NIC.LY regulations before building a brand on the suffix.
@@ -133,13 +133,12 @@ Technically, .ly is [DNSSEC](/en/glossary/dnssec/)-signed in the root zone, with
 - **Screen your name and content against the rules.** For .ly this is real diligence, not boilerplate — check the NIC.LY restrictions above before committing.
 - **Mind the four-character floor.** New two- and three-character registrations require Libyan presence, so plan on a four-plus-character name.
 
-## How to register a .ly domain at Namefi
+## How to register a .ly domain
 
 1. **Search** for your desired "-ly" name (four or more characters) and check availability.
 2. **Screen** the name and your planned content against NIC.LY's restrictions.
 3. **Register** and configure [DNS](/en/glossary/dns/) for your site and email.
 
-[Namefi](https://namefi.io) is an [ICANN](/en/glossary/icann/)-accredited registrar bridging Web2 and Web3, with transparent pricing, fast DNS, and the option to hold your name as a [tokenized domain](/en/blog/what-are-tokenized-domains/) for provable, transferable ownership. New to extensions? Start with [what is a TLD](/en/blog/what-is-a-tld/).
 
 ## Frequently asked questions
 
@@ -167,3 +166,14 @@ Since 2025 the .ly registry has been managed by the General Authority of Communi
 - [What are tokenized domains?](/en/blog/what-are-tokenized-domains/)
 - Glossary: [ccTLD](/en/glossary/cctld/), [domain hack](/en/glossary/domain-hack/), [registry](/en/glossary/registry/), [DNSSEC](/en/glossary/dnssec/)
 - Compare TLDs: [.io](/en/tld/io/), [.fm](/en/tld/fm/), [.gg](/en/tld/gg/), [.tv](/en/tld/tv/), [.me](/en/tld/me/), [.us](/en/tld/us/)
+
+## Sources and further reading
+
+- IANA — [IANA root database entry for .ly](https://www.iana.org/domains/root/db/ly.html)
+- Google Search Central — [treats as generic rather than country-targeted](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Google%20treats%20some%20ccTLDs)
+- techcrunch.com — ["Trouble in clever domain land"](https://techcrunch.com/2010/10/06/trouble-in-clever-domain-land-bit-ly-and-others-risk-losing-theirs-swift-ly)
+- circleid.com — [seized vb.ly](https://circleid.com/posts/libyan_government_has_seized_vbly_domain/)
+- IANA — [transfer of .ly to the General Authority of Communications and Informatics](https://www.iana.org/reports/2025/ly-report-20251030.html)
+- NIC.LY — [must not be "obscene, scandalous, indecent, or contrary to Libyan law or Islamic morality"](https://www.nic.ly/regulations.php#:~:text=Islamic%20morality)
+- my.register.ly — [related to gambling and the lottery industry](https://my.register.ly/knowledgebase/2/Which-.ly-domain-names-that-are-NOT-allowed-for-registration.html)
+- NIC.LY — [shorter than four characters require local presence in Libya](https://www.nic.ly/help.php#:~:text=for%20those%20less%20than%204%20characters%20long%20in%20the%20top%20level%20must%20have%20local%20presence%20in%20Libya)

--- a/content/tld/en/ly.md
+++ b/content/tld/en/ly.md
@@ -135,7 +135,7 @@ Technically, .ly is [DNSSEC](/en/glossary/dnssec/)-signed in the root zone, with
 
 ## How to register a .ly domain
 
-1. **Search** for your desired "-ly" name (four or more characters) and check availability.
+1. **Search** for your desired "-ly" name and check availability; if it is shorter than four characters, confirm that you can satisfy the local-presence route.
 2. **Screen** the name and your planned content against NIC.LY's restrictions.
 3. **Register** and configure [DNS](/en/glossary/dns/) for your site and email.
 

--- a/content/tld/en/media.md
+++ b/content/tld/en/media.md
@@ -57,6 +57,8 @@ The **.media domain** is an open generic top-level domain built for exactly what
 
 Because it is a generic string, Google has no special geo-targeting rule for .media — it is evaluated like any other gTLD. You can confirm the delegation record directly in the [IANA root-zone entry for .media](https://www.iana.org/domains/root/db/media.html), the authoritative source for any delegated TLD's operator and status.
 
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
+
 ## History of .media
 
 - **Delegation (2014):** .media was delegated to the root zone on **April 9, 2014** (registration date April 3, 2014), initially assigned to **Grand Glen, LLC** — one of the many single-purpose entities that Donuts Inc. used to file its 2012-round gTLD applications. The underlying [ICANN Registry Agreement for .media](https://www.icann.org/en/registry-agreements/details/media) was signed **March 6, 2014**.
@@ -161,3 +163,11 @@ It can be, and several real publishers use it, but the string reads as broad "me
 - [What are tokenized domains?](/en/blog/what-are-tokenized-domains/)
 - Glossary: [registrar](/en/glossary/registrar/), [ICANN](/en/glossary/icann/), [registry](/en/glossary/registry/), [DNS](/en/glossary/dns/)
 - Compare TLDs: [.com](/en/tld/com/), [.tv](/en/tld/tv/), [.news](/en/tld/news/)
+
+## Sources and further reading
+
+- identity.digital — [Identity Digital](https://www.identity.digital/)
+- IANA — [IANA root-zone entry for .media](https://www.iana.org/domains/root/db/media.html)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- ICANN — [ICANN Registry Agreement for .media](https://www.icann.org/en/registry-agreements/details/media)
+- en.wikipedia.org — [PA Media](https://en.wikipedia.org/wiki/PA_Media)

--- a/content/tld/en/meme.md
+++ b/content/tld/en/meme.md
@@ -55,7 +55,9 @@ The **.meme domain** is Google Registry's generic top-level domain built for int
 
 .meme is a [generic top-level domain](/en/glossary/tld) (gTLD), not a country-code TLD, so it carries no geographic association. Its string is the plainest possible signal of intent: a site built on memes, internet humor, and shareable culture. Google Registry's own positioning is direct — ".meme is for the culture," meant to help brands "spread humor, ideas, style, and culture." You can confirm the delegation record and operator in the [IANA root-zone database entry for .meme](https://www.iana.org/domains/root/db/meme.html).
 
-Because .meme is a generic extension, [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=Generic%20top-level%20domains%20(gTLDs)%20are%20domains%20that%20aren't%20associated%20with%20specific%20locations.) confirms gTLDs "aren't associated with specific locations," so it carries no automatic geo-targeting signal, and no inherent ranking boost or penalty.
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
+
+Because .meme is a generic extension, [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Generic%20top-level%20domains%20(gTLDs)%20are%20domains%20that%20aren't%20associated%20with%20specific%20locations.) confirms gTLDs "aren't associated with specific locations," so it carries no automatic geo-targeting signal, and no inherent ranking boost or penalty.
 
 ## History of .meme
 
@@ -166,3 +168,15 @@ It suits meme databases, internet-culture brands, entertainment and media pages,
 - [What makes a domain valuable?](/en/blog/what-makes-a-domain-valuable)
 - Glossary: [brandable domain](/en/glossary/brandable-domain), [gTLD](/en/glossary/gtld), [registrar](/en/glossary/registrar)
 - Compare TLDs: [.com](/en/tld/com), [.xyz](/en/tld/xyz), [.fun](/en/tld/fun), [.ing](/en/tld/ing), [.page](/en/tld/page)
+
+## Sources and further reading
+
+- registry.google — [Charleston Road Registry](https://www.registry.google)
+- IANA — [IANA root-zone database entry for .meme](https://www.iana.org/domains/root/db/meme.html)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- Google Search Central — [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Generic%20top-level%20domains%20(gTLDs)%20are%20domains%20that%20aren't%20associated%20with%20specific%20locations.)
+- ICANN — [ICANN Registry Agreement for .meme](https://www.icann.org/en/registry-agreements/details/meme)
+- registry.google — [general availability from December 5, 2023](https://www.registry.google/announcements/launch-details-for-ing-and-meme/)
+- get.meme — [get.meme showcase](https://get.meme/)
+- knowyour.meme — [knowyour.meme](https://knowyour.meme)
+- registry.google — [Domain Registration Policy](https://www.registry.google/policies/)

--- a/content/tld/en/music.md
+++ b/content/tld/en/music.md
@@ -10,13 +10,13 @@ description: 'The .music domain is a community-gated gTLD for the music industry
 keywords: ['.music domain eligibility', 'DotMusic Limited registry', 'id.MUSIC verification', 'music community domain', '.music domain restrictions']
 faqs:
   - question: 'Can anyone register a .music domain?'
-    answer: 'Not without qualifying. .music is a community-restricted gTLD operated by DotMusic Limited. You must self-attest that you are a verifiable member of the global music community — an artist, band, songwriter, label, venue, radio station, or similar — and then complete identity verification through id.MUSIC after registration.'
+    answer: 'No. .music is a community-restricted gTLD operated by DotMusic Limited. Registration and use are exclusive to verified members of the global music community, and registrants must complete the current identity-verification process.'
   - question: 'Does a .music domain affect SEO?'
     answer: 'No. Google treats .music as a generic top-level domain with no geographic bias and no built-in ranking boost or penalty. Its community restriction affects who can register it, not how Google ranks it.'
   - question: 'Who should register a .music domain?'
-    answer: 'Musicians, bands, songwriters, record labels, music publishers, venues, radio stations, recording studios, promoters, and other genuine music-industry participants who can pass the id.MUSIC verification process.'
+    answer: 'Music artists, creators, songwriters, industry professionals, organizations, and brands that can complete the registry''s identity-verification process.'
   - question: 'What happens if I do not complete .music identity verification?'
-    answer: 'As of the current registry policy, you have up to one year from registration to complete verification at id.MUSIC. Domains that remain unverified past that period may be suspended, locked, or ultimately cancelled by the registry.'
+    answer: 'Identity verification is mandatory. The public registry materials cited on this page do not specify a universal deadline or fixed enforcement sequence, so follow the current instructions from your registrar and id.MUSIC and complete verification promptly.'
 relatedArticles:
   - /en/blog/what-is-a-tld/
   - /en/blog/what-is-domain/
@@ -56,7 +56,9 @@ The **.music domain** is one of the few new gTLDs where the extension itself is 
 
 .music is a [generic top-level domain](/en/glossary/tld) (gTLD) with an ICANN **Community designation (Specification 12)** attached to its registry agreement — a status only a small number of new gTLDs hold. The [ICANN Registry Agreement for .music](https://www.icann.org/en/registry-agreements/details/music) confirms the operator as **DotMusic Limited**, agreement date **4 May 2021**, type "Base, Community (Spec 12), Non-Sponsored." The [IANA root-zone entry for .music](https://www.iana.org/domains/root/db/music.html) lists a registration date of 2021-10-14 and delegation date of 2021-10-29.
 
-Because it is a generic gTLD rather than a country-code extension, [Google treats any TLD resolving through the IANA DNS root zone as a gTLD unless ICANN lists it as a ccTLD](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites), so .music carries no geo-targeting bias — its restriction is about *who* can register, not how it ranks.
+Because it is a generic gTLD rather than a country-code extension, [Google treats any TLD resolving through the IANA DNS root zone as a gTLD unless ICANN lists it as a ccTLD](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en), so .music carries no geo-targeting bias — its restriction is about *who* can register, not how it ranks.
+
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
 
 ## History of .music
 
@@ -105,16 +107,15 @@ Pick .com for a music-adjacent business that doesn't want a registration gate; p
 
 ## Things to consider
 
-- **You must qualify — and prove it.** This is the central trade-off: .music is not available to the general public, and the verification step is mandatory, not optional.
-- **Ongoing compliance risk.** The registry can audit eligibility at any time during a domain's life, not just at registration.
+- **You must qualify — and prove it.** This is the central trade-off: .music is reserved for verified members of the global music community, so identity verification is mandatory.
+- **Verification adds onboarding work.** Follow the current instructions from your registrar and the registry's identity provider before relying on the domain for a launch.
 - **New and unproven for general recognition.** With general availability only since October 2024, .music has not yet built mainstream familiarity the way legacy extensions have.
-- **Not for domain investing.** The registry's anti-warehousing policy explicitly targets bulk speculative registration, which rules out a common gTLD use case.
 
 ## Who can register a .music domain?
 
-**Registration restrictions: community-restricted.** Unlike most new gTLDs, .music is not open to the general public. Per the registry's own [.music domain policy](https://support.enom.com/support/solutions/articles/201000081248--music-domain-policy), eligible registrants include musicians and artists, bands and creators, music-industry professionals, and music-related companies, associations, and organizations — listed in more detail by the registry as artists, radio stations, recording studios, songwriters, influencers, music publishers, bands, promoters, venues, music websites, and live-sound professionals, per [getadotmusicdomain.com](https://getadotmusicdomain.com/).
+**Registration restrictions: community-restricted.** Unlike most new gTLDs, `.music` is not open to the general public. The registry's launch announcement says registration and use are [exclusive to verified members of the global music community](https://www.registry.music/press/global-music-industry-launches-its-verified-music-domain-name-and-musicid#:~:text=The%20registration%20and%20use%20of%20.MUSIC%20is%20exclusive%20to%20verified%20members%20of%20the%20global%20music%20community), including music artists, creators, songwriters, industry professionals, organizations, and brands.
 
-Registration is a **two-step process**: applicants self-attest eligibility at registration, then complete identity verification through [id.MUSIC](https://id.music/), the namespace's dedicated non-profit identity-verification service. Registrants currently have **up to one year from registration** to complete verification; unverified domains past that window may be suspended, server-locked, or cancelled — a change from the registry's earlier approach of holding domains immediately until verification finished. The registry may also audit eligibility at any point in a domain's lifecycle. The binding contractual basis is the [ICANN Registry Agreement for .music](https://www.icann.org/en/registry-agreements/details/music), which carries the Community (Specification 12) designation.
+Applicants register through a certified registrar and then follow the registry's identity-verification process through [id.MUSIC](https://id.music/). The registry describes id.MUSIC as the exclusive identity provider and says that [identity verification is mandatory for `.music` registrants](https://www.registry.music/press/global-music-industry-launches-its-verified-music-domain-name-and-musicid#:~:text=By%20mandating%20identity%20verification%20for%20.MUSIC%20registrants). Because the publicly accessible registry materials cited here do not specify a universal verification deadline or automatic enforcement sequence, follow the current instructions presented by the registrar and identity provider. The binding contractual basis is the [ICANN Registry Agreement for .music](https://www.icann.org/en/registry-agreements/details/music), which carries the Community (Specification 12) designation.
 
 DNSSEC is supported; IDN support varies by registrar, so confirm availability before registering a non-ASCII name. [WHOIS privacy](/en/glossary/whois-privacy/) availability also varies by registrar.
 
@@ -124,20 +125,19 @@ DNSSEC is supported; IDN support varies by registrar, so confirm availability be
 
 ## Reputation and email deliverability
 
-Because .music requires verified community membership rather than open self-service registration, it does not carry the bulk-abuse reputation risk associated with cheap, unrestricted new gTLDs — the registry's anti-warehousing and identity-verification policies work against the mass, disposable-registration pattern that typically draws spam-filter scrutiny. Being new to general availability, long-term deliverability data is still limited. Standard **SPF, DKIM, and DMARC** configuration remains good practice for any domain used for email, .music included.
+Because `.music` only reached general availability in October 2024, long-term independent abuse and deliverability data remains limited. Its mandatory identity-verification model is designed to discourage anonymous, disposable registrations, but it is not evidence that every `.music` sender or site is trustworthy. Standard **SPF, DKIM, and DMARC** configuration remains good practice for any domain used for email.
 
 ## Branding and naming tips
 
 - **Lean into the credibility signal.** Because not everyone can register .music, using it well can itself communicate "verified music professional" to an informed audience.
 - **Match the name to your verifiable identity.** Since eligibility ties to your actual music-industry role, names that clearly match your artist, band, or company identity are the safest choice.
 - **Plan for the verification step.** Budget time after registration to complete id.MUSIC identity verification — don't treat it as optional paperwork.
-- **Don't buy speculatively.** The registry's anti-warehousing policy means .music is a poor fit for a portfolio of names you don't intend to use.
 
 ## How to register a .music domain at Namefi
 
 1. **Search** for your desired `.music` name to check availability.
 2. **Choose** the exact name and confirm you meet the music-community eligibility criteria.
-3. **Register**, then complete identity verification at id.MUSIC and configure [DNS](/en/glossary/dns) to point your site or email.
+3. **Register**, follow the current identity-verification instructions provided during checkout, and configure [DNS](/en/glossary/dns) for your site or email.
 
 [Namefi](https://namefi.io) is an [ICANN](/en/glossary/icann)-accredited registrar that bridges Web2 and [Web3](/en/glossary/web3/). Beyond standard registration, you can optionally [tokenize your domain](/en/blog/what-are-tokenized-domains) — turning it into a [blockchain](/en/glossary/blockchain/) asset you own outright, with easier transfers and added security — all with transparent pricing and fast DNS.
 
@@ -145,7 +145,7 @@ Because .music requires verified community membership rather than open self-serv
 
 ### Can anyone register a .music domain?
 
-Not without qualifying. .music is a community-restricted gTLD operated by DotMusic Limited. You must self-attest that you are a verifiable member of the global music community — an artist, band, songwriter, label, venue, radio station, or similar — and then complete identity verification through id.MUSIC after registration.
+No. `.music` is a community-restricted gTLD operated by DotMusic Limited. Registration and use are exclusive to verified members of the global music community, and registrants must complete the current identity-verification process.
 
 ### Does a .music domain affect SEO?
 
@@ -153,11 +153,11 @@ No. Google treats .music as a generic top-level domain with no geographic bias a
 
 ### Who should register a .music domain?
 
-Musicians, bands, songwriters, record labels, music publishers, venues, radio stations, recording studios, promoters, and other genuine music-industry participants who can pass the id.MUSIC verification process.
+Music artists, creators, songwriters, industry professionals, organizations, and brands that can complete the registry's identity-verification process.
 
 ### What happens if I do not complete .music identity verification?
 
-As of the current registry policy, you have up to one year from registration to complete verification at id.MUSIC. Domains that remain unverified past that period may be suspended, locked, or ultimately cancelled by the registry.
+Identity verification is mandatory. The public registry materials cited on this page do not specify a universal deadline or fixed enforcement sequence, so follow the current instructions from your registrar and id.MUSIC and complete verification promptly.
 
 ## Related resources
 
@@ -167,3 +167,15 @@ As of the current registry policy, you have up to one year from registration to 
 - [Domain name terminology guide](/en/blog/domain-terminology-guide)
 - Glossary: [registrar](/en/glossary/registrar), [ICANN](/en/glossary/icann), [registry](/en/glossary/registry), [trademark](/en/glossary/trademark)
 - Compare TLDs: [.com](/en/tld/com), [.live](/en/tld/live)
+
+## Sources and further reading
+
+- ICANN — [ICANN Registry Agreement for .music](https://www.icann.org/en/registry-agreements/details/music)
+- IANA — [IANA root-zone entry for .music](https://www.iana.org/domains/root/db/music.html)
+- Google Search Central — [developers.google.com](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- en.wikipedia.org — [Wikipedia history](https://en.wikipedia.org/wiki/.music)
+- newgtlds.icann.org — [ICANN's official .music launch phase record](https://newgtlds.icann.org/en/program-status/sunrise-claims-periods/music)
+- domainincite.com — [Domain Incite reported](https://domainincite.com/30373-moment-of-truth-as-music-domains-finally-go-on-sale)
+- .MUSIC Registry — [exclusive to verified members of the global music community](https://www.registry.music/press/global-music-industry-launches-its-verified-music-domain-name-and-musicid#:~:text=The%20registration%20and%20use%20of%20.MUSIC%20is%20exclusive%20to%20verified%20members%20of%20the%20global%20music%20community)
+- id.music — [id.MUSIC](https://id.music/)

--- a/content/tld/en/music.md
+++ b/content/tld/en/music.md
@@ -10,13 +10,13 @@ description: 'The .music domain is a community-gated gTLD for the music industry
 keywords: ['.music domain eligibility', 'DotMusic Limited registry', 'id.MUSIC verification', 'music community domain', '.music domain restrictions']
 faqs:
   - question: 'Can anyone register a .music domain?'
-    answer: 'No. .music is a community-restricted gTLD operated by DotMusic Limited. Registration and use are exclusive to verified members of the global music community, and registrants must complete the current identity-verification process.'
+    answer: 'No. .music is a community-restricted gTLD operated by DotMusic Limited. Eligible music-community applicants can register a domain, which is activated immediately, but they must complete identity verification within the registry verification period to keep it active.'
   - question: 'Does a .music domain affect SEO?'
     answer: 'No. Google treats .music as a generic top-level domain with no geographic bias and no built-in ranking boost or penalty. Its community restriction affects who can register it, not how Google ranks it.'
   - question: 'Who should register a .music domain?'
     answer: 'Music artists, creators, songwriters, industry professionals, organizations, and brands that can complete the registry''s identity-verification process.'
   - question: 'What happens if I do not complete .music identity verification?'
-    answer: 'Identity verification is mandatory. The public registry materials cited on this page do not specify a universal deadline or fixed enforcement sequence, so follow the current instructions from your registrar and id.MUSIC and complete verification promptly.'
+    answer: 'Identity verification is mandatory. id.MUSIC says domains are activated upon registration but may be suspended if they remain unverified after the registry verification period.'
 relatedArticles:
   - /en/blog/what-is-a-tld/
   - /en/blog/what-is-domain/
@@ -37,7 +37,7 @@ relatedGlossary:
   - /en/glossary/trademark/
 ---
 
-The **.music domain** is one of the few new gTLDs where the extension itself is the gate: only verified members of the global music community can register one. Operated by **DotMusic Limited** after one of the longest, most contested ICANN community applications on record, .music finally reached general availability in October 2024 — nearly two decades after the initiative began. This page explains who qualifies, how id.MUSIC verification works, and whether it fits your project.
+The **.music domain** is one of the few new gTLDs where the extension itself is the gate: applicants must belong to the global music community and complete identity verification to keep the domain active. Operated by **DotMusic Limited** after one of the longest, most contested ICANN community applications on record, .music finally reached general availability in October 2024 — nearly two decades after the initiative began. This page explains who qualifies, how id.MUSIC verification works, and whether it fits your project.
 
 ## .music at a glance
 
@@ -107,15 +107,15 @@ Pick .com for a music-adjacent business that doesn't want a registration gate; p
 
 ## Things to consider
 
-- **You must qualify — and prove it.** This is the central trade-off: .music is reserved for verified members of the global music community, so identity verification is mandatory.
-- **Verification adds onboarding work.** Follow the current instructions from your registrar and the registry's identity provider before relying on the domain for a launch.
+- **You must qualify — and prove it.** This is the central trade-off: .music is reserved for members of the global music community, so identity verification is mandatory even though the domain is activated when registered.
+- **Verification adds onboarding work.** Complete identity verification within the registry verification period; id.MUSIC says an unverified domain may otherwise be suspended.
 - **New and unproven for general recognition.** With general availability only since October 2024, .music has not yet built mainstream familiarity the way legacy extensions have.
 
 ## Who can register a .music domain?
 
 **Registration restrictions: community-restricted.** Unlike most new gTLDs, `.music` is not open to the general public. The registry's launch announcement says registration and use are [exclusive to verified members of the global music community](https://www.registry.music/press/global-music-industry-launches-its-verified-music-domain-name-and-musicid#:~:text=The%20registration%20and%20use%20of%20.MUSIC%20is%20exclusive%20to%20verified%20members%20of%20the%20global%20music%20community), including music artists, creators, songwriters, industry professionals, organizations, and brands.
 
-Applicants register through a certified registrar and then follow the registry's identity-verification process through [id.MUSIC](https://id.music/). The registry describes id.MUSIC as the exclusive identity provider and says that [identity verification is mandatory for `.music` registrants](https://www.registry.music/press/global-music-industry-launches-its-verified-music-domain-name-and-musicid#:~:text=By%20mandating%20identity%20verification%20for%20.MUSIC%20registrants). Because the publicly accessible registry materials cited here do not specify a universal verification deadline or automatic enforcement sequence, follow the current instructions presented by the registrar and identity provider. The binding contractual basis is the [ICANN Registry Agreement for .music](https://www.icann.org/en/registry-agreements/details/music), which carries the Community (Specification 12) designation.
+Applicants register through a certified registrar and then follow the registry's identity-verification process through id.MUSIC. The identity provider says [all `.music` domains are activated upon registration and must be verified within the registry verification period](https://www.id.music/#:~:text=All%20.MUSIC%20domains%20are%20now%20automatically%20activated%20upon%20registration.,This%20process%20helps%20ensure%20that%20every%20.MUSIC%20domain%20is%20backed%20by%20a%20real%20person); domains left unverified after that period [may be suspended](https://www.id.music/#:~:text=Domains%20that%20remain%20unverified%20past%20this%20period%20may%20be%20subject%20to%20suspension.). The registry separately describes id.MUSIC as the exclusive identity provider and says that [identity verification is mandatory for `.music` registrants](https://www.registry.music/press/global-music-industry-launches-its-verified-music-domain-name-and-musicid#:~:text=By%20mandating%20identity%20verification%20for%20.MUSIC%20registrants). The binding contractual basis is the [ICANN Registry Agreement for .music](https://www.icann.org/en/registry-agreements/details/music), which carries the Community (Specification 12) designation.
 
 DNSSEC is supported; IDN support varies by registrar, so confirm availability before registering a non-ASCII name. [WHOIS privacy](/en/glossary/whois-privacy/) availability also varies by registrar.
 
@@ -137,7 +137,7 @@ Because `.music` only reached general availability in October 2024, long-term in
 
 1. **Search** for your desired `.music` name to check availability.
 2. **Choose** the exact name and confirm you meet the music-community eligibility criteria.
-3. **Register**, follow the current identity-verification instructions provided during checkout, and configure [DNS](/en/glossary/dns) for your site or email.
+3. **Register**, then complete identity verification within the registry verification period to keep the activated domain in good standing, and configure [DNS](/en/glossary/dns) for your site or email.
 
 [Namefi](https://namefi.io) is an [ICANN](/en/glossary/icann)-accredited registrar that bridges Web2 and [Web3](/en/glossary/web3/). Beyond standard registration, you can optionally [tokenize your domain](/en/blog/what-are-tokenized-domains) — turning it into a [blockchain](/en/glossary/blockchain/) asset you own outright, with easier transfers and added security — all with transparent pricing and fast DNS.
 
@@ -145,7 +145,7 @@ Because `.music` only reached general availability in October 2024, long-term in
 
 ### Can anyone register a .music domain?
 
-No. `.music` is a community-restricted gTLD operated by DotMusic Limited. Registration and use are exclusive to verified members of the global music community, and registrants must complete the current identity-verification process.
+No. `.music` is a community-restricted gTLD operated by DotMusic Limited. Eligible music-community applicants can register a domain, which is activated immediately, but they must complete identity verification within the registry verification period to keep it active.
 
 ### Does a .music domain affect SEO?
 
@@ -157,7 +157,7 @@ Music artists, creators, songwriters, industry professionals, organizations, and
 
 ### What happens if I do not complete .music identity verification?
 
-Identity verification is mandatory. The public registry materials cited on this page do not specify a universal deadline or fixed enforcement sequence, so follow the current instructions from your registrar and id.MUSIC and complete verification promptly.
+Identity verification is mandatory. id.MUSIC says domains are activated upon registration but may be suspended if they remain unverified after the registry verification period.
 
 ## Related resources
 
@@ -172,6 +172,7 @@ Identity verification is mandatory. The public registry materials cited on this 
 
 - ICANN — [ICANN Registry Agreement for .music](https://www.icann.org/en/registry-agreements/details/music)
 - IANA — [IANA root-zone entry for .music](https://www.iana.org/domains/root/db/music.html)
+- id.MUSIC — [activation and identity-verification requirements](https://www.id.music/)
 - Google Search Central — [developers.google.com](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en)
 - Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
 - en.wikipedia.org — [Wikipedia history](https://en.wikipedia.org/wiki/.music)

--- a/content/tld/en/mx.md
+++ b/content/tld/en/mx.md
@@ -56,7 +56,7 @@ The **.mx domain** is Mexico's official [country-code top-level domain](/en/glos
 
 **.mx** is the [ccTLD](/en/glossary/cctld/) assigned to Mexico under the ISO 3166-1 country-code system used by [IANA](https://www.iana.org/domains/root/db/mx.html). As with other ccTLDs, .mx has no [ICANN](/en/glossary/icann/) Registry Agreement — governance comes from the national registry's own policy. That registry, **Network Information Center Mexico, S.A. de C.V.**, trades as **Registry .MX** and operates under a delegation originally granted to **ITESM** (Instituto Tecnológico y de Estudios Superiores de Monterrey), Mexico's leading technical university, in November 2003.
 
-What sets .mx apart from most major national ccTLDs is its open eligibility policy: unlike [.ca](/en/tld/ca/), [.au](/en/tld/au/), or [.br](/en/tld/br/), registering `.mx` or `.com.mx` does **not** require Mexican citizenship, residency, or a local presence. Even so, because .mx functions as a genuine national namespace, Google treats it as country-targeted rather than generic — it does not appear on [Google Search Central's short list of ccTLDs treated as generic](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites), unlike vanity extensions such as [.tv](/en/tld/tv/) or [.me](/en/tld/me/).
+What sets .mx apart from most major national ccTLDs is its open eligibility policy: unlike [.ca](/en/tld/ca/), [.au](/en/tld/au/), or [.br](/en/tld/br/), registering `.mx` or `.com.mx` does **not** require Mexican citizenship, residency, or a local presence. Even so, because .mx functions as a genuine national namespace, Google treats it as country-targeted rather than generic — it does not appear on [Google Search Central's short list of ccTLDs treated as generic](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en), unlike vanity extensions such as [.tv](/en/tld/tv/) or [.me](/en/tld/me/).
 
 ## History of .mx
 
@@ -160,3 +160,9 @@ Network Information Center Mexico, S.A. de C.V. ("Registry .MX") operates the re
 - [Top TLDs to secure for your startup](/en/blog/top-tlds-to-secure-for-your-startup)
 - Glossary: [ccTLD](/en/glossary/cctld), [registrar](/en/glossary/registrar), [ICANN](/en/glossary/icann), [registry](/en/glossary/registry), [DNSSEC](/en/glossary/dnssec)
 - Compare TLDs: [.com](/en/tld/com), [.br](/en/tld/br), [.ca](/en/tld/ca), [.au](/en/tld/au)
+
+## Sources and further reading
+
+- IANA — [NIC-Mexico / Registry .MX](https://www.iana.org/domains/root/db/mx.html)
+- Google Search Central — [Google Search Central's short list of ccTLDs treated as generic](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en)
+- beta.dominios.nic.mx — [Registry .MX's own policy documentation](https://beta.dominios.nic.mx/policies/)

--- a/content/tld/en/news.md
+++ b/content/tld/en/news.md
@@ -57,6 +57,8 @@ The **.news domain** is an open generic top-level domain built specifically for 
 
 Because it's a generic string, Google applies no geo-targeting rule to .news — it's evaluated like any other gTLD. You can confirm the delegation record directly in the [IANA root-zone entry for .news](https://www.iana.org/domains/root/db/news.html).
 
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
+
 ## History of .news
 
 - **Delegation (2015):** .news was delegated to the root zone on **March 16, 2015** (registration date March 12, 2015), initially assigned to **United TLD Holdco, Ltd** — a Donuts Inc. entity from the same 2012-round application wave that later became known through the Rightside/Donuts registry brand. The underlying [ICANN Registry Agreement for .news](https://www.icann.org/en/registry-agreements/details/news) was signed **December 18, 2014**.
@@ -159,3 +161,10 @@ Publishers, independent journalists, newsletters, news aggregators, and any outl
 - [Domain terminology guide](/en/blog/domain-terminology-guide/)
 - Glossary: [registrar](/en/glossary/registrar/), [ICANN](/en/glossary/icann/), [registry](/en/glossary/registry/), [DNS](/en/glossary/dns/)
 - Compare TLDs: [.com](/en/tld/com/), [.media](/en/tld/media/), [.blog](/en/tld/blog/)
+
+## Sources and further reading
+
+- identity.digital — [Identity Digital](https://www.identity.digital/)
+- IANA — [IANA root-zone entry for .news](https://www.iana.org/domains/root/db/news.html)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- ICANN — [ICANN Registry Agreement for .news](https://www.icann.org/en/registry-agreements/details/news)

--- a/content/tld/en/nl.md
+++ b/content/tld/en/nl.md
@@ -56,7 +56,7 @@ The **.nl domain** is the official [country-code top-level domain](/en/glossary/
 
 .nl is the Netherlands' [ccTLD](/en/glossary/cctld/), and its [IANA root-zone record](https://www.iana.org/domains/root/db/nl.html) lists SIDN as the registry manager. As a ccTLD it sits outside ICANN's standard registry-agreement system, governed instead by SIDN's own [registration terms](https://www.sidn.nl/en/nl-domain-name/registering-a-domain-name).
 
-For search visibility, Google's own [multi-regional sites guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites) treats ccTLDs as country-targeted signals by default, and .nl is not on Google's short list of ccTLDs (such as .co or .io) that it treats as generic. A .nl site sends Google — and Dutch users — a genuine signal that the content is meant for the Netherlands.
+For search visibility, Google's own [multi-regional sites guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en) treats ccTLDs as country-targeted signals by default, and .nl is not on Google's short list of ccTLDs (such as .co or .io) that it treats as generic. A .nl site sends Google — and Dutch users — a genuine signal that the content is meant for the Netherlands.
 
 ## History of .nl
 
@@ -111,7 +111,7 @@ One administrative detail is worth knowing: under SIDN's [domicile address proce
 
 ## .nl pricing and value
 
-.nl pricing follows familiar TLD dynamics: **premium names** — short, dictionary, or high-demand strings — typically carry higher registration and renewal costs, and **first-year promotional pricing commonly differs from the standing renewal rate**. Because the namespace has been open since 1986 and grew rapidly after 2003, exact-match short Dutch words are largely taken, pushing more of the market toward compound or brandable names. This page intentionally quotes no specific prices — check current rates at the point of registration.
+SIDN publishes a basic wholesale price for every `.nl` registration and explains that [each registrar or reseller is free to decide what to charge customers](https://www.sidn.nl/en/our-prices#:~:text=Each%20registrar%20and%20reseller%20is%20free%20to%20decide%20what%20to%20charge%20their%20customers.). Registrars may package hosting or offer introductory discounts. Because many concise Dutch terms are already registered, buyers may encounter higher **aftermarket** asking prices from existing owners; that is not a registry premium registration or renewal tier. Compare the registrar's first-year and renewal fees before purchase.
 
 ## Reputation and email deliverability
 
@@ -127,7 +127,7 @@ One administrative detail is worth knowing: under SIDN's [domicile address proce
 ## How to register a .nl domain at Namefi
 
 1. **Search** for your desired `.nl` name to check availability.
-2. **Review** whether the name is standard or premium-priced.
+2. **Review** the registrar's first-year and renewal fees, and distinguish a new registration from an aftermarket purchase.
 3. **Register** and configure [DNS](/en/glossary/dns) for your site or email.
 
 [Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and [Web3](/en/glossary/web3/), with transparent pricing, fast DNS management, and the option to [tokenize your domain](/en/blog/what-are-tokenized-domains) into a blockchain-backed asset for easier transfers and provable ownership.
@@ -157,3 +157,15 @@ No. Under SIDN's technical requirements, .nl domain names may only use the lette
 - [ccTLD market share by registration volume](/en/blog/cctld-market-share-by-registration-volume)
 - Glossary: [ccTLD](/en/glossary/cctld), [registrar](/en/glossary/registrar), [WHOIS privacy](/en/glossary/whois-privacy)
 - Compare TLDs: [.com](/en/tld/com), [.de](/en/tld/de), [.eu](/en/tld/eu)
+
+## Sources and further reading
+
+- sidn.nl — [SIDN](https://www.sidn.nl/)
+- IANA — [IANA root-zone record](https://www.iana.org/domains/root/db/nl.html)
+- sidn.nl — [registration terms](https://www.sidn.nl/en/nl-domain-name/registering-a-domain-name)
+- Google Search Central — [multi-regional sites guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en)
+- sidn.nl — [40th-anniversary retrospective](https://www.sidn.nl/en/news-and-blogs/40-years-of-the-nl-domain)
+- stats.sidnlabs.nl — [SIDN Labs](https://stats.sidnlabs.nl/en/)
+- sidn.nl — [domicile address procedure](https://www.sidn.nl/en/nl-domain-name/domicile-address)
+- sidn.nl — [technical requirements](https://www.sidn.nl/en/nl-domain-name/technical-requirements-for-the-registration-and-use-of-nl-domain-names)
+- sidn.nl — [each registrar or reseller is free to decide what to charge customers](https://www.sidn.nl/en/our-prices#:~:text=Each%20registrar%20and%20reseller%20is%20free%20to%20decide%20what%20to%20charge%20their%20customers.)

--- a/content/tld/en/page.md
+++ b/content/tld/en/page.md
@@ -55,7 +55,9 @@ The **.page domain** is Google's generic top-level domain for exactly what it so
 
 .page is a [generic top-level domain](/en/glossary/tld) (gTLD), not a country-code TLD, so it carries no geographic association. The string is deliberately plain-spoken: Google Registry describes it as fitting anyone building "a simple, more secure online presence," from a business launching a site to "an author telling your story." You can confirm the delegation record and operator in the [IANA root-zone database entry for .page](https://www.iana.org/domains/root/db/page.html).
 
-Because .page is a generic extension, [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=Generic%20top-level%20domains%20(gTLDs)%20are%20domains%20that%20aren't%20associated%20with%20specific%20locations.) confirms gTLDs "aren't associated with specific locations," so .page carries no automatic geo-targeting signal, and no inherent ranking boost or penalty from the extension itself.
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
+
+Because .page is a generic extension, [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Generic%20top-level%20domains%20(gTLDs)%20are%20domains%20that%20aren't%20associated%20with%20specific%20locations.) confirms gTLDs "aren't associated with specific locations," so .page carries no automatic geo-targeting signal, and no inherent ranking boost or penalty from the extension itself.
 
 ## History of .page
 
@@ -164,3 +166,15 @@ It suits personal portfolios, writers and publishers, landing pages, documentati
 - [How to name your project](/en/blog/how-to-name-your-project)
 - Glossary: [domain landing page](/en/glossary/domain-landing-page), [gTLD](/en/glossary/gtld), [registrar](/en/glossary/registrar)
 - Compare TLDs: [.com](/en/tld/com), [.site](/en/tld/site), [.blog](/en/tld/blog), [.ing](/en/tld/ing), [.meme](/en/tld/meme)
+
+## Sources and further reading
+
+- registry.google — [Charleston Road Registry](https://www.registry.google)
+- IANA — [IANA root-zone database entry for .page](https://www.iana.org/domains/root/db/page.html)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- Google Search Central — [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Generic%20top-level%20domains%20(gTLDs)%20are%20domains%20that%20aren't%20associated%20with%20specific%20locations.)
+- ICANN — [ICANN Registry Agreement for .page](https://www.icann.org/en/registry-agreements/details/page)
+- registry.google — [general availability began October 9, 2018](https://www.registry.google/announcements/launch-details-for-page/)
+- get.page — [get.page showcase](https://get.page/)
+- mmm.page — [mmm.page](https://mmm.page)
+- registry.google — [Domain Registration Policy](https://www.registry.google/policies/)

--- a/content/tld/en/pro.md
+++ b/content/tld/en/pro.md
@@ -56,7 +56,9 @@ The **.pro domain** has the most unusual biography of any top-level domain cover
 
 ## What is .pro?
 
-.pro is a [generic top-level domain](/en/glossary/gtld), short for "professional." It carries no geographic meaning, so Google's [multi-regional targeting guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=Generic%20top-level%20domains%20%28gTLDs%29%20are%20domains%20that%20aren%27t%20associated%20with%20specific%20locations) treats it like any other generic suffix — you'd need hreflang, URL structure, or Search Console geo-targeting to signal a specific country, the domain itself does not do that for you.
+.pro is a [generic top-level domain](/en/glossary/gtld), short for "professional." It carries no geographic meaning, so Google's [multi-regional targeting guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Generic%20top-level%20domains%20%28gTLDs%29%20are%20domains%20that%20aren%27t%20associated%20with%20specific%20locations) treats it like any other generic suffix — you'd need hreflang, URL structure, or Search Console geo-targeting to signal a specific country, the domain itself does not do that for you.
+
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
 
 What sets .pro apart from same-era peers like [.biz](/en/tld/biz) or [.info](/en/tld/info) is that it wasn't approved in the 2012 New gTLD Program at all. It belongs to ICANN's much earlier **2000-round expansion**, the first set of new TLDs approved after .com, .net, and .org — a cohort that also produced .biz, .info, .name, .coop, .museum, and .aero. You can confirm the delegation record, current sponsoring organization, and IANA's category label for .pro directly in the [IANA root-zone database entry for .pro](https://www.iana.org/domains/root/db/pro.html).
 
@@ -120,7 +122,7 @@ There is no trademark sunrise currently running (the 2015 policy change was a re
 
 ## Reputation and email deliverability
 
-.pro carries a comparatively clean reputation among gTLDs. Because it launched as a gated, professional-only namespace and only opened in 2015, it did not accumulate the bulk-registration spam history that some budget new gTLDs (like [.sbs](/en/tld/sbs)) picked up during rapid open launches. That said, since 2015 it is registered the same way any open gTLD is, so ordinary email-deliverability hygiene still applies: configure SPF, DKIM, and DMARC correctly, and warm up new sending domains gradually regardless of suffix.
+.pro's professional origin should not be mistaken for a current reputation guarantee. The [Spamhaus Domain Reputation Update for October 2025–March 2026](https://content.spamhaus.org/4d83c22f-84c5-4f82-95ab-4e6b39f73db5.pdf) lists **17,005 malicious or suspicious `.pro` domains**, #16 among gTLDs by absolute count. It also records **349,498 newly observed `.pro` domains**, equal to **31.45%** of the 1,111,213-domain zone and #14 among gTLDs by newly observed share. These aggregate figures do not judge an individual site, but they mean `.pro` should not be described as categorically clean. Configure SPF, DKIM, and DMARC correctly, and warm up new sending domains gradually regardless of suffix.
 
 ## Branding and naming tips
 
@@ -167,3 +169,12 @@ IANA's root-zone database still classifies .pro under its original registration-
 - [Domain terminology guide](/en/blog/domain-terminology-guide)
 - Glossary: [gTLD](/en/glossary/gtld), [ICANN](/en/glossary/icann), [registrar](/en/glossary/registrar), [TMCH](/en/glossary/tmch)
 - Compare TLDs: [.com](/en/tld/com), [.attorney](/en/tld/attorney), [.law](/en/tld/law), [.cpa](/en/tld/cpa)
+
+## Sources and further reading
+
+- Google Search Central — [multi-regional targeting guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Generic%20top-level%20domains%20%28gTLDs%29%20are%20domains%20that%20aren%27t%20associated%20with%20specific%20locations)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- IANA — [IANA root-zone database entry for .pro](https://www.iana.org/domains/root/db/pro.html)
+- ICANN — [archived 3 May 2002 agreement](https://www.icann.org/en/registry-agreements/pro/pro-registry-agreement-signed-3-may-2002-3-5-2002-en)
+- ICANN — [ICANN Registry Agreement for .pro](https://www.icann.org/en/registry-agreements/details/pro)
+- Spamhaus — [Spamhaus Domain Reputation Update for October 2025–March 2026](https://content.spamhaus.org/4d83c22f-84c5-4f82-95ab-4e6b39f73db5.pdf)

--- a/content/tld/en/sh.md
+++ b/content/tld/en/sh.md
@@ -58,7 +58,7 @@ The **.sh domain** is the [country-code top-level domain](/en/glossary/cctld/) (
 
 Its cultural meaning, though, has little to do with the island. In Unix and Linux, `sh` is the Bourne shell and `.sh` the conventional extension for shell scripts — so a .sh domain reads to any developer like an executable command. That coincidence turned a tiny-territory ccTLD into a niche favorite for command-line tools, the repurposing path also taken by [.io](/en/tld/io/) ("input/output") and [.ai](/en/tld/ai/) ("artificial intelligence").
 
-One nuance separates .sh from those neighbors: **Google's published list of ccTLDs it treats as generic** — which includes .io, [.co](/en/tld/co/), [.me](/en/tld/me/), [.tv](/en/tld/tv/), and [.fm](/en/tld/fm/) — [does not include .sh](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=Google%20treats%20some%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs). By default, then, .sh can be read as geo-targeted to Saint Helena rather than globally neutral (more under "Things to consider").
+One nuance separates .sh from those neighbors: **Google's published list of ccTLDs it treats as generic** — which includes .io, [.co](/en/tld/co/), [.me](/en/tld/me/), [.tv](/en/tld/tv/), and [.fm](/en/tld/fm/) — [does not include .sh](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Google%20treats%20some%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs). By default, then, .sh can be read as geo-targeted to Saint Helena rather than globally neutral (more under "Things to consider").
 
 ## History of .sh
 
@@ -170,3 +170,15 @@ Because .sh is also the file extension for Unix shell scripts, the suffix reads 
 - [Domain terminology guide](/en/blog/domain-terminology-guide/)
 - Glossary: [ccTLD](/en/glossary/cctld/), [domain hack](/en/glossary/domain-hack/), [registry](/en/glossary/registry/), [DNSSEC](/en/glossary/dnssec/)
 - Compare TLDs: [.io](/en/tld/io/), [.dev](/en/tld/dev/), [.ai](/en/tld/ai/), [.gg](/en/tld/gg/), [.fm](/en/tld/fm/)
+
+## Sources and further reading
+
+- IANA — [IANA root-zone entry for .sh](https://www.iana.org/domains/root/db/sh.html)
+- Google Search Central — [does not include .sh](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Google%20treats%20some%20ccTLDs%20%28such%20as%20.tv%20and%20.me%29%20as%20gTLDs)
+- domainincite.com — [paid $70.17 million in cash](https://domainincite.com/23650-afilias-bought-io-for-70-million#:~:text=%2470.17%20million%20cash)
+- identity.digital — [rebranded as Identity Digital](https://identity.digital/company)
+- brew.sh — [brew.sh](https://brew.sh/)
+- ohmyz.sh — [ohmyz.sh](https://ohmyz.sh/)
+- bun.sh — [bun.sh](https://bun.sh/)
+- nic.sh — [NIC.SH registration rules](https://www.nic.sh/rules.htm#:~:text=An%20applicant%20may%20reside%20in%20any%20legal%20jurisdiction)
+- nic.sh — [free of charge to Saint Helena residents and companies](https://www.nic.sh/free-domain-for-saint-helena-residents.htm)

--- a/content/tld/en/so.md
+++ b/content/tld/en/so.md
@@ -55,7 +55,7 @@ The **.so domain** is the country-code top-level domain for **Somalia**, and it 
 
 **.so** is the [ccTLD](/en/glossary/cctld/) assigned to Somalia under the ISO 3166-1 country-code system. The [IANA root-zone database entry for .so](https://www.iana.org/domains/root/db/so.html) lists Somalia's **Ministry of Post and Telecommunications** as the sponsoring organization, though on-the-ground operational authority has shifted repeatedly, most recently to Somalia's **National Communications Authority (NCA)**.
 
-Because .so is a ccTLD, not a gTLD, it carries no ICANN registry agreement of the kind that governs `.com` or new gTLDs. And despite its popularity in tech branding, Google does not treat .so as generic: it is absent from [Google's explicit list of ccTLDs treated as generic](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=.ad%2C%20.ai%2C%20.as%2C%20.bz%2C%20.cc%2C%20.cd%2C%20.co%2C%20.dj%2C%20.fm%2C%20.io%2C%20.la%2C%20.me%2C%20.ms%2C%20.nu%2C%20.sc%2C%20.sr%2C%20.su%2C%20.tv%2C%20.tk%2C%20.ws) (which includes lookalike vanity ccTLDs like .cc, .co, and .tv), meaning a .so site is geo-targeted toward Somalia by default rather than being read as a neutral "so" suffix.
+Because .so is a ccTLD, not a gTLD, it carries no ICANN registry agreement of the kind that governs `.com` or new gTLDs. And despite its popularity in tech branding, Google does not treat .so as generic: it is absent from [Google's explicit list of ccTLDs treated as generic](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Google%20treats%20some%20ccTLDs) (which includes lookalike vanity ccTLDs like .cc, .co, and .tv), meaning a .so site is geo-targeted toward Somalia by default rather than being read as a neutral "so" suffix.
 
 ## History of .so
 
@@ -72,7 +72,7 @@ Through all of this, .so's international reputation grew from an unrelated direc
 
 Real, specific niches where .so shows up:
 
-- **Developer tools and platforms whose name ends in "so,"** such as [Hiro](https://hiro.so), a Bitcoin-layer developer tools company that markets itself on `hiro.so`.
+- **Developer tools and platforms whose name ends in "so,"** such as [Hiro](https://www.hiro.so/), a Bitcoin-layer developer tools company that markets itself on `hiro.so`.
 - **Startups seeking a short, sentence-completing domain hack** in the tradition Notion popularized, even after Notion's own move to `.com`.
 - **Somalia-connected institutions and organizations**, the suffix's original and continuing use case, with second-level structures such as `.com.so`, `.org.so`, `.edu.so`, and `.gov.so`.
 
@@ -80,7 +80,7 @@ Real, specific niches where .so shows up:
 
 ## Notable sites using .so
 
-- **[hiro.so](https://hiro.so)** — Hiro Systems PBC's live site for its Bitcoin-layer developer tools (Chainhook, the Hiro Platform, the Stacks Blockchain API), actively maintained with 2026 blog activity and a public status page at `status.hiro.so`.
+- **[hiro.so](https://www.hiro.so/)** — Hiro Systems PBC's live site for its Bitcoin-layer developer tools (Chainhook, the Hiro Platform, the Stacks Blockchain API), actively maintained with 2026 blog activity and a public status page at `status.hiro.so`.
 - **notion.so** — for years the definitive .so brand hack, home to workspace tool Notion. As of **June 3, 2026**, Notion completed a move to `notion.com` — an acquisition its co-founder said had been in motion since 2018 — and `notion.so` now **redirects (HTTP 307) to notion.com**. It is the clearest cautionary tale in the ccTLD-hack world: even the flagship "so" brand eventually traded the wordplay for a `.com`.
 
 ## .so vs other domains
@@ -110,7 +110,7 @@ Choose **.io** or **.co** when you want a hack-friendly ccTLD with a stable regi
 
 ## Who can register a .so domain?
 
-**Registration restrictions: confirm before you commit.** Current registrar documentation from major providers, including GoDaddy's and Rebel.com's help centers, reports that .so registration today has **no residency, citizenship, or local-presence requirement** and runs first-come, first-served. This is not how the registry has always operated: from **2015 to 2018**, operator SONIC restricted registration to "institutions and organizations in Somalia, residents of Somalia, and others who have a legitimate, clear and provable connection to Somalia," causing several international registrars to pause .so sales. Since the **National Communications Authority (NCA)** took control in March 2018, the open policy in current registrar materials has held — but given this track record, verify current eligibility with your registrar or the [IANA-listed sponsoring authority](https://www.iana.org/domains/root/db/so.html) before building a brand on `.so`.
+**Registration restrictions: confirm before you commit.** 101domain's current .so registration page says [the extension is open to any individual or entity worldwide](https://www.101domain.com/so.htm#:~:text=The%20.so%20domain%20is%20open%20for%20registration%20by%20any%20individual%20or%20entity%20worldwide). This is not how the registry has always operated: from **2015 to 2018**, operator SONIC restricted registration to institutions, residents, and others with a provable connection to Somalia, causing several international registrars to pause .so sales. The namespace later reopened globally, but given this track record, verify the current rule with your registrar before building a long-term brand on `.so`; the [IANA record](https://www.iana.org/domains/root/db/so.html) can confirm the sponsoring organization but not registrant eligibility.
 
 Domain names generally run **3 to 63 alphanumeric characters or hyphens**; [IDN](/en/glossary/idn/) registrations are **not supported**. Reserved second-level structures include `.com.so`, `.org.so`, `.net.so`, `.edu.so`, and `.gov.so`. Because .so is a ccTLD, it is not governed by a standard [ICANN Registry Agreement](https://www.icann.org/en/registry-agreements) — the sponsoring authority remains Somalia's Ministry of Post and Telecommunications per IANA, with the NCA holding current operational control.
 
@@ -162,3 +162,12 @@ It suits developer tools and brands whose name naturally ends in "so," following
 - [Top TLDs to secure for your startup](/en/blog/top-tlds-to-secure-for-your-startup/)
 - Glossary: [ccTLD](/en/glossary/cctld/), [domain hack](/en/glossary/domain-hack/), [registrar](/en/glossary/registrar/), [registry](/en/glossary/registry/)
 - Compare TLDs: [.io](/en/tld/io/), [.co](/en/tld/co/), [.is](/en/tld/is/)
+
+## Sources and further reading
+
+- notion.com — [Notion](https://www.notion.com)
+- IANA — [IANA root-zone database entry for .so](https://www.iana.org/domains/root/db/so.html)
+- Google Search Central — [Google's explicit list of ccTLDs treated as generic](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Google%20treats%20some%20ccTLDs)
+- hiro.so — [Hiro](https://www.hiro.so/)
+- 101domain — [the extension is open to any individual or entity worldwide](https://www.101domain.com/so.htm#:~:text=The%20.so%20domain%20is%20open%20for%20registration%20by%20any%20individual%20or%20entity%20worldwide)
+- ICANN — [ICANN Registry Agreement](https://www.icann.org/en/registry-agreements)

--- a/content/tld/en/studio.md
+++ b/content/tld/en/studio.md
@@ -57,6 +57,8 @@ The **.studio domain** is an open generic top-level domain built for anyone runn
 
 Because it is a plain generic extension, Google Search Central treats [new gTLDs](/en/glossary/new-gtld) like .studio the same as legacy generics such as [.com](/en/tld/com): there is no automatic ranking benefit or penalty tied to the suffix, and no geo-targeting signal is applied.
 
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
+
 ## History of .studio
 
 - **Original launch under Rightside (2015).** IANA's delegation report shows .studio was delegated to **United TLD Holdco, Ltd.** — the registry-services arm of **Rightside Group** — on **2015-07-06**. The underlying [ICANN Registry Agreement for .studio was signed on 11 February 2015](https://www.icann.org/en/registry-agreements/details/studio). A trademark [sunrise period ran from August 18 to October 17, 2015](https://www.americaregistry.com/domains/studio-domain-registration), followed by a landrush phase from October 21–28, before **general availability opened on October 28, 2015**.
@@ -160,3 +162,12 @@ It can still work if the business is fundamentally creative or production-based,
 - [How to name your project](/en/blog/how-to-name-your-project)
 - Glossary: [gTLD](/en/glossary/gtld), [new gTLD](/en/glossary/new-gtld), [ICANN](/en/glossary/icann), [registrar](/en/glossary/registrar)
 - Compare TLDs: [.com](/en/tld/com), [.design](/en/tld/design), [.group](/en/tld/group)
+
+## Sources and further reading
+
+- IANA — [IANA root-zone entry for .studio](https://www.iana.org/domains/root/db/studio.html)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- ICANN — [ICANN Registry Agreement for .studio was signed on 11 February 2015](https://www.icann.org/en/registry-agreements/details/studio)
+- americaregistry.com — [sunrise period ran from August 18 to October 17, 2015](https://www.americaregistry.com/domains/studio-domain-registration)
+- globenewswire.com — [globenewswire.com](https://www.globenewswire.com/news-release/2017/06/14/1018714/0/en/Rightside-and-Donuts-Announce-Definitive-Merger-Agreement.html)
+- identity.digital — [domain policies](https://identity.digital/policies)

--- a/content/tld/en/to.md
+++ b/content/tld/en/to.md
@@ -59,7 +59,7 @@ This page covers what .to is, its unusually early open-registration history, its
 
 In practice, though, .to has behaved like a global extension for nearly its entire life. Registrations are made directly at the second level (`yourname.to`), there is no residency requirement, and Tonic's [FAQ describes .to as "the first country code to be offered globally through an automated registry"](https://www.tonic.to/faq.htm#:~:text=first%20country%20code%20to%20be%20offered%20globally%20through%20an%20automated%20registry), running since June 1997.
 
-One important SEO nuance: Google maintains a published list of ccTLDs it treats as generic (not geo-targeted), and [.to is not on that list](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites) — the roster includes .ai, .co, .fm, .io, .me, and .tv, but not .to. Many .to sites still rank globally, but unlike [.io](/en/tld/io/) or [.co](/en/tld/co/), you cannot point to Google's documentation for a generic-treatment guarantee.
+One important SEO nuance: Google maintains a published list of ccTLDs it treats as generic (not geo-targeted), and [.to is not on that list](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en) — the roster includes .ai, .co, .fm, .io, .me, and .tv, but not .to. Many .to sites still rank globally, but unlike [.io](/en/tld/io/) or [.co](/en/tld/co/), you cannot point to Google's documentation for a generic-treatment guarantee.
 
 ## History of .to
 
@@ -183,3 +183,11 @@ Because "to" is a common English preposition, names like amzn.to read as natural
 - [What are tokenized domains?](/en/blog/what-are-tokenized-domains/)
 - Glossary: [ccTLD](/en/glossary/cctld/), [domain hack](/en/glossary/domain-hack/), [WHOIS](/en/glossary/whois/), [registry](/en/glossary/registry/), [DNSSEC](/en/glossary/dnssec/)
 - Compare TLDs: [.io](/en/tld/io/), [.co](/en/tld/co/), [.tv](/en/tld/tv/), [.me](/en/tld/me/), [.ly](/en/tld/ly/), [.us](/en/tld/us/)
+
+## Sources and further reading
+
+- IANA — [IANA delegation record](https://www.iana.org/domains/root/db/to.html)
+- tonic.to — [Tonic](https://www.tonic.to/)
+- tonic.to — [tonic.to](https://www.tonic.to/faq.htm#:~:text=first%20country%20code%20to%20be%20offered%20globally%20through%20an%20automated%20registry)
+- Google Search Central — [.to is not on that list](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en)
+- en.wikipedia.org — [history recorded on Wikipedia](https://en.wikipedia.org/wiki/.to)

--- a/content/tld/en/uk.md
+++ b/content/tld/en/uk.md
@@ -105,7 +105,7 @@ Choose **.com** for a globally neutral default, **.uk** (or the still-dominant .
 
 ## Who can register a .uk domain?
 
-**Registration restrictions: open for the general namespaces.** Nominet's current [.UK Registration Policy](https://registrars.nominet.uk/registry/dot-uk/policies/#:~:text=This%20.UK%20Registration%20Policy%20(Policy)%20governs%20the%20registration%20of%20Domains%20in%20the%20.UK%20namespace) contains no citizenship or residency requirement for direct `.uk`, `.co.uk`, or `.org.uk` registrations. It does set explicit category rules for specialist sub-namespaces such as `.ltd.uk`, `.plc.uk`, `.net.uk`, and `.sch.uk`, so those should not be described as unrestricted. [DNSSEC](/en/glossary/dnssec/) is supported registry-wide, and disputes over UK domains run through Nominet's own Dispute Resolution Service rather than the generic [UDRP](/en/glossary/udrp/).
+**Registration restrictions: open for the general namespaces.** Current registrar guidance lists [non-UK individuals, corporations, and other entities as accepted registrant types](https://registrars.nominet.uk/uk-namespace/registration-and-domain-management/field-definitions-and-registrant-types/#:~:text=FIND,Non%2DUK%20Entity%20that%20does%20not%20fit%20into%20any%20of%20the%20above), so direct `.uk`, `.co.uk`, and `.org.uk` registrations do not require UK citizenship or residency. Nominet's current registrar documentation links to the [legacy registration rules](https://nominet.uk/wp-content/uploads/2018/05/22141819/dotUK-Rules-of-Registration.pdf#page=3), under which specialist sub-namespaces such as `.ltd.uk`, `.plc.uk`, `.net.uk`, and `.sch.uk` have category-specific eligibility rules and should not be described as unrestricted. [DNSSEC](/en/glossary/dnssec/) is supported registry-wide, and disputes over UK domains run through Nominet's own Dispute Resolution Service rather than the generic [UDRP](/en/glossary/udrp/).
 
 ## .uk pricing and value
 
@@ -158,7 +158,8 @@ It suits UK-based businesses, brands, and organizations that want an unambiguous
 ## Sources and further reading
 
 - IANA — [IANA root-zone record](https://www.iana.org/domains/root/db/uk.html)
-- registrars.nominet.uk — [.UK policies](https://registrars.nominet.uk/registry/dot-uk/policies/#:~:text=This%20.UK%20Registration%20Policy%20(Policy)%20governs%20the%20registration%20of%20Domains%20in%20the%20.UK%20namespace)
+- registrars.nominet.uk — [current legacy-platform registrant types](https://registrars.nominet.uk/uk-namespace/registration-and-domain-management/field-definitions-and-registrant-types/#:~:text=FIND,Non%2DUK%20Entity%20that%20does%20not%20fit%20into%20any%20of%20the%20above)
+- Nominet — [legacy .uk registration rules](https://nominet.uk/wp-content/uploads/2018/05/22141819/dotUK-Rules-of-Registration.pdf#page=3)
 - Google Search Central — [multi-regional sites guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en)
 - Namecheap — [ended at 06:00 BST on 25 June 2019](https://www.namecheap.com/support/knowledgebase/article.aspx/251/36/uk-domain-registration-requirements/#:~:text=The%20deadline%20to%20claim%20reserved%20.UK%20domain%20names%20ended%20at%206am%20BST%20(UTC%2B1)%20on%20the%2025th%20of%20June%202019.)
 - registrars.nominet.uk — [.UK pricing schedule](https://registrars.nominet.uk/uk-namespace/managing-account/payments/fee-schedule/#:~:text=Domain%20name%20registration%20and%20renewal%20fee%20payable%20by%20Nominet%20Registrars)

--- a/content/tld/en/uk.md
+++ b/content/tld/en/uk.md
@@ -38,14 +38,14 @@ relatedGlossary:
   - /en/glossary/second-level-domain/
 ---
 
-The **.uk domain** is the official [country-code top-level domain](/en/glossary/cctld/) (ccTLD) for the **United Kingdom**, operated by the registry [Nominet](https://nominet.uk). It is also one of the internet's oldest ccTLDs, registered just seven months after the first generic domains went live. For decades, "having a .uk domain" in practice meant a third-level name like `example.co.uk` — direct second-level registration only opened in 2014. This guide covers that history, who can register today, and the honest trade-offs between the shorter .uk and the still-dominant .co.uk.
+The **.uk domain** is the official [country-code top-level domain](/en/glossary/cctld/) (ccTLD) for the **United Kingdom**, operated by the registry Nominet. It is also one of the internet's oldest ccTLDs, registered just seven months after the first generic domains went live. For decades, "having a .uk domain" in practice meant a third-level name like `example.co.uk` — direct second-level registration only opened in 2014. This guide covers that history, who can register today, and the honest trade-offs between the shorter .uk and the still-dominant .co.uk.
 
 ## .uk at a glance
 
 | Fact | Detail |
 | --- | --- |
 | TLD type | Country-code top-level domain (ccTLD) for the United Kingdom |
-| Registry operator | [Nominet UK](https://nominet.uk), based in Oxford |
+| Registry operator | Nominet UK, based in Oxford |
 | Year launched | Delegated by IANA on 24 July 1985 |
 | IDN support | No — .uk names are restricted to ASCII letters, numbers, and hyphens |
 | DNSSEC | Supported |
@@ -54,15 +54,15 @@ The **.uk domain** is the official [country-code top-level domain](/en/glossary/
 
 ## What is .uk?
 
-.uk is the United Kingdom's [ccTLD](/en/glossary/cctld/), and its [IANA root-zone record](https://www.iana.org/domains/root/db/uk.html) lists Nominet as the sponsoring organization. It is administered under Nominet's own [.UK Policy](https://nominet.uk/uk-registry/uk-policy/) framework rather than a standard ICANN registry agreement, since ccTLDs sit outside ICANN's registry-agreement system entirely.
+.uk is the United Kingdom's [ccTLD](/en/glossary/cctld/), and its [IANA root-zone record](https://www.iana.org/domains/root/db/uk.html) lists Nominet as the sponsoring organization. It is administered under Nominet's publicly accessible [.UK policies](https://registrars.nominet.uk/registry/dot-uk/policies/#:~:text=This%20.UK%20Registration%20Policy%20(Policy)%20governs%20the%20registration%20of%20Domains%20in%20the%20.UK%20namespace) rather than a standard ICANN registry agreement, since ccTLDs sit outside ICANN's registry-agreement system.
 
-.uk was actually meant to be **.gb**, following the same two-letter ISO 3166 scheme most countries use. But the UK academic network's own naming scheme had already settled on "UK" months earlier, and .uk went live first — so .gb was reserved but never put into general use. For SEO, Google's own [multi-regional sites guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites) treats most ccTLDs, including .uk, as country-targeted signals by default; .uk is not on Google's short list of ccTLDs (like .co or .io) that it treats as generic.
+.uk was actually meant to be **.gb**, following the same two-letter ISO 3166 scheme most countries use. But the UK academic network's own naming scheme had already settled on "UK" months earlier, and .uk went live first — so .gb was reserved but never put into general use. For SEO, Google's own [multi-regional sites guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en) treats most ccTLDs, including .uk, as country-targeted signals by default; .uk is not on Google's short list of ccTLDs (like .co or .io) that it treats as generic.
 
 ## History of .uk
 
 .uk was registered on **24 July 1985**, the first country-code domain delegated after .us and just seven months behind the original generic domains such as .com. For its first years it was run informally by academic volunteers; **Nominet UK was formed in 1996** as a not-for-profit company to take over administration on a more structured, commercial-grade basis.
 
-The single biggest change to .uk's structure came on **10 June 2014**, when Nominet began accepting direct second-level registrations (`example.uk`) for the first time — before that date, a .uk presence was only possible as a third-level name such as `example.co.uk` or `example.org.uk`. To manage the transition fairly, Nominet ran a five-year **"Right of Registration"** reservation: anyone who held a matching `.co.uk`, `.org.uk`, `.me.uk`, `.net.uk`, `.ltd.uk`, or `.plc.uk` name before **23:59 UTC on 28 October 2013** had the right to claim the equivalent `.uk` name first. That right expired at **06:00 BST on 25 June 2019**, as confirmed on [Nominet's own FAQ page](https://nominet.uk/reserved-uk-rights-faqs/#:~:text=When%20exactly%20did%20the%20rights%20expire). By the close of that window, over **8 million of the original 10 million** eligible rights had either been exercised or allowed to lapse; unclaimed names were released to the public in staged batches through July 2019.
+The single biggest change to .uk's structure came on **10 June 2014**, when Nominet began accepting direct second-level registrations (`example.uk`) for the first time — before that date, a .uk presence was only possible as a third-level name such as `example.co.uk` or `example.org.uk`. To manage the transition, Nominet ran a five-year **"Right of Registration"** reservation for holders of matching legacy third-level names. Namecheap's registrar guidance records that the reservation [ended at 06:00 BST on 25 June 2019](https://www.namecheap.com/support/knowledgebase/article.aspx/251/36/uk-domain-registration-requirements/#:~:text=The%20deadline%20to%20claim%20reserved%20.UK%20domain%20names%20ended%20at%206am%20BST%20(UTC%2B1)%20on%20the%2025th%20of%20June%202019.), after which unclaimed names moved toward general availability.
 
 ## How people use .uk
 
@@ -105,11 +105,11 @@ Choose **.com** for a globally neutral default, **.uk** (or the still-dominant .
 
 ## Who can register a .uk domain?
 
-**Registration restrictions: open to all.** Nominet operates .uk with no general citizenship, residency, or business-registration requirement — registrations are accepted worldwide on a first-come, first-served basis, governed by Nominet's [.UK Policy](https://nominet.uk/uk-registry/uk-policy/) and Terms & Conditions of Domain Name Registration. A handful of specific sub-namespaces carry their own rules — for example `.sch.uk` is reserved for schools under Nominet's Schools Domain Name Rules — but the general `.uk` and `.co.uk`/`.org.uk` namespaces are unrestricted. [DNSSEC](/en/glossary/dnssec/) is supported registry-wide, and disputes over UK domains run through Nominet's own Dispute Resolution Service rather than the generic [UDRP](/en/glossary/udrp/).
+**Registration restrictions: open for the general namespaces.** Nominet's current [.UK Registration Policy](https://registrars.nominet.uk/registry/dot-uk/policies/#:~:text=This%20.UK%20Registration%20Policy%20(Policy)%20governs%20the%20registration%20of%20Domains%20in%20the%20.UK%20namespace) contains no citizenship or residency requirement for direct `.uk`, `.co.uk`, or `.org.uk` registrations. It does set explicit category rules for specialist sub-namespaces such as `.ltd.uk`, `.plc.uk`, `.net.uk`, and `.sch.uk`, so those should not be described as unrestricted. [DNSSEC](/en/glossary/dnssec/) is supported registry-wide, and disputes over UK domains run through Nominet's own Dispute Resolution Service rather than the generic [UDRP](/en/glossary/udrp/).
 
 ## .uk pricing and value
 
-.uk pricing follows familiar TLD dynamics rather than any fixed figure: **premium names** — short, dictionary, or high-demand strings — typically carry higher registration and renewal costs, and **first-year promotional pricing commonly differs from the standing renewal rate**. Because the shorter direct `.uk` namespace only opened in 2014, well-formed short names can still be found more easily there than in the much older `.co.uk` zone. This page intentionally quotes no specific prices — check current rates at the point of registration.
+Nominet's published [.UK pricing schedule](https://registrars.nominet.uk/uk-namespace/managing-account/payments/fee-schedule/#:~:text=Domain%20name%20registration%20and%20renewal%20fee%20payable%20by%20Nominet%20Registrars) sets standard registry fees by term and registrar membership, not by the desirability of the label. Registrars set the retail package and may offer promotions. An already registered short `.uk` name may also carry an aftermarket asking price from its owner, but that is separate from registry registration and renewal pricing. Check the registrar's first-year and renewal fees before purchase.
 
 ## Reputation and email deliverability
 
@@ -122,13 +122,12 @@ Choose **.com** for a globally neutral default, **.uk** (or the still-dominant .
 - **Keep it ASCII.** No accented or IDN characters are supported, so plan names accordingly.
 - **Lean into "UK" as a trust cue.** For UK-facing services, finance, or government-adjacent work, the ccTLD itself communicates legitimacy.
 
-## How to register a .uk domain at Namefi
+## How to register a .uk domain
 
 1. **Search** for your desired `.uk` name, and check the `.co.uk` equivalent too.
-2. **Review** whether the name is standard or premium-priced.
+2. **Review** the registrar's first-year and renewal fees, and distinguish a new registration from an aftermarket purchase.
 3. **Register** and configure [DNS](/en/glossary/dns) for your site or email.
 
-[Namefi](https://namefi.io) is an [ICANN-accredited registrar](/en/glossary/accredited-registrar/) that bridges Web2 and [Web3](/en/glossary/web3/), with transparent pricing, fast DNS management, and the option to [tokenize your domain](/en/blog/what-are-tokenized-domains) into a blockchain-backed asset for easier transfers and provable ownership.
 
 ## Frequently asked questions
 
@@ -155,3 +154,11 @@ It suits UK-based businesses, brands, and organizations that want an unambiguous
 - [Domain hacks explained](/en/blog/domain-hacks-explained)
 - Glossary: [ccTLD](/en/glossary/cctld), [registrar](/en/glossary/registrar), [ICANN](/en/glossary/icann)
 - Compare TLDs: [.com](/en/tld/com), [.eu](/en/tld/eu), [.io](/en/tld/io), [.de](/en/tld/de)
+
+## Sources and further reading
+
+- IANA — [IANA root-zone record](https://www.iana.org/domains/root/db/uk.html)
+- registrars.nominet.uk — [.UK policies](https://registrars.nominet.uk/registry/dot-uk/policies/#:~:text=This%20.UK%20Registration%20Policy%20(Policy)%20governs%20the%20registration%20of%20Domains%20in%20the%20.UK%20namespace)
+- Google Search Central — [multi-regional sites guidance](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en)
+- Namecheap — [ended at 06:00 BST on 25 June 2019](https://www.namecheap.com/support/knowledgebase/article.aspx/251/36/uk-domain-registration-requirements/#:~:text=The%20deadline%20to%20claim%20reserved%20.UK%20domain%20names%20ended%20at%206am%20BST%20(UTC%2B1)%20on%20the%2025th%20of%20June%202019.)
+- registrars.nominet.uk — [.UK pricing schedule](https://registrars.nominet.uk/uk-namespace/managing-account/payments/fee-schedule/#:~:text=Domain%20name%20registration%20and%20renewal%20fee%20payable%20by%20Nominet%20Registrars)

--- a/content/tld/en/vc.md
+++ b/content/tld/en/vc.md
@@ -55,7 +55,7 @@ The **.vc domain** is the country-code top-level domain for **Saint Vincent and 
 
 **.vc** is the [ccTLD](/en/glossary/cctld/) assigned to Saint Vincent and the Grenadines under the ISO 3166-1 country-code system. The [IANA root-zone database entry for .vc](https://www.iana.org/domains/root/db/vc.html) lists the **Ministry of Telecommunications, Science, Technology and Industry** as the sponsoring organization, with technical and WHOIS services run through **Identity Digital Inc.** (the company formerly known as Afilias), reflecting the common ccTLD pattern where a small nation's government retains policy authority while a specialist registry-services company runs the day-to-day infrastructure.
 
-Because .vc is a ccTLD rather than a [gTLD](/en/glossary/tld/), it is not covered by an ICANN registry agreement the way `.com` or new gTLDs are. And despite its popularity as a venture-capital brand element, Google does not treat .vc as generic: it is absent from [Google's explicit list of ccTLDs treated as generic](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=.ad%2C%20.ai%2C%20.as%2C%20.bz%2C%20.cc%2C%20.cd%2C%20.co%2C%20.dj%2C%20.fm%2C%20.io%2C%20.la%2C%20.me%2C%20.ms%2C%20.nu%2C%20.sc%2C%20.sr%2C%20.su%2C%20.tv%2C%20.tk%2C%20.ws) (.ad, .ai, .as, .bz, .cc, .cd, .co, .dj, .fm, .io, .la, .me, .ms, .nu, .sc, .sr, .su, .tv, .tk, .ws). By default, then, Google reads a .vc site as targeting Saint Vincent and the Grenadines specifically, not as a borderless "venture capital" suffix.
+Because .vc is a ccTLD rather than a [gTLD](/en/glossary/tld/), it is not covered by an ICANN registry agreement the way `.com` or new gTLDs are. And despite its popularity as a venture-capital brand element, Google does not treat .vc as generic: it is absent from [Google's explicit list of ccTLDs treated as generic](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Google%20treats%20some%20ccTLDs) (.ad, .ai, .as, .bz, .cc, .cd, .co, .dj, .fm, .io, .la, .me, .ms, .nu, .sc, .sr, .su, .tv, .tk, .ws). By default, then, Google reads a .vc site as targeting Saint Vincent and the Grenadines specifically, not as a borderless "venture capital" suffix.
 
 ## History of .vc
 
@@ -107,7 +107,7 @@ Choose **.com** when the exact name is available and global neutrality matters m
 
 ## Who can register a .vc domain?
 
-**Registration restrictions: open to all.** Registrar documentation for .vc consistently reports no eligibility limits tied to residency, citizenship, or company registration — individuals and organizations worldwide can register. The only standard restrictions are the usual prohibitions on names that infringe third-party trademark rights or relate to illegal activity.
+**Registration restrictions: open to all.** GoDaddy's current .vc registration guide states that [anyone can register a .vc domain](https://www.godaddy.com/en/help/about-vc-domains-41605#:~:text=Anyone%20can%20register%20.vc%20domain%20names.), with no residency, citizenship, or company-registration test. Registrants still have to follow the registrar and registry terms, including rules against unlawful use and infringement.
 
 Domain names can run from roughly 2 to 63 characters, and registrants can choose either direct second-level registration (`yourname.vc`) or a categorized structure such as `.com.vc`, `.org.vc`, or `.net.vc`. Because .vc is a ccTLD, it is not governed by a standard [ICANN Registry Agreement](https://www.icann.org/en/registry-agreements) the way gTLDs are; the sponsoring authority is the **Ministry of Telecommunications, Science, Technology and Industry** of Saint Vincent and the Grenadines, per the [IANA delegation record for .vc](https://www.iana.org/domains/root/db/vc.html), with Identity Digital handling registry operations and WHOIS. Confirm current DNSSEC and IDN support directly with your chosen [registrar](/en/glossary/registrar/), since neither is independently documented on the registry's own public materials.
 
@@ -159,3 +159,11 @@ Alongside direct second-level registration (yourname.vc), the registry also supp
 - [Top TLDs to secure for your startup](/en/blog/top-tlds-to-secure-for-your-startup/)
 - Glossary: [ccTLD](/en/glossary/cctld/), [domain hack](/en/glossary/domain-hack/), [registrar](/en/glossary/registrar/), [registry](/en/glossary/registry/)
 - Compare TLDs: [.io](/en/tld/io/), [.co](/en/tld/co/), [.is](/en/tld/is/)
+
+## Sources and further reading
+
+- hustlefund.vc — [Hustle Fund](https://www.hustlefund.vc)
+- IANA — [IANA root-zone database entry for .vc](https://www.iana.org/domains/root/db/vc.html)
+- Google Search Central — [Google's explicit list of ccTLDs treated as generic](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Google%20treats%20some%20ccTLDs)
+- GoDaddy — [anyone can register a .vc domain](https://www.godaddy.com/en/help/about-vc-domains-41605#:~:text=Anyone%20can%20register%20.vc%20domain%20names.)
+- ICANN — [ICANN Registry Agreement](https://www.icann.org/en/registry-agreements)

--- a/content/tld/en/work.md
+++ b/content/tld/en/work.md
@@ -55,7 +55,9 @@ The **.work domain** is a plain-English top-level domain built for jobs, recruit
 
 .work is a [generic top-level domain](/en/glossary/tld), not a country-code extension, so it carries no geographic meaning. The string is the ordinary English word for employment or labor, which makes it directly legible for job boards, recruiters, and career-focused brands — and a natural fit for the domain-hack pattern where the suffix completes the word, as in `frame.work`.
 
-Because it is a generic gTLD, Google treats .work like any other new extension: no automatic ranking advantage or penalty, and no geo-targeting applied, per [Google Search Central's guidance on generic vs. country-targeted domains](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=more%20generic%20than%20country-targeted). You can confirm the delegation record and current operator on the [IANA root-zone entry for .work](https://www.iana.org/domains/root/db/work.html).
+Because it is a generic gTLD, Google treats .work like any other new extension: no automatic ranking advantage or penalty, and no geo-targeting applied, per [Google Search Central's guidance on generic vs. country-targeted domains](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=more%20generic%20than%20country-targeted). You can confirm the delegation record and current operator on the [IANA root-zone entry for .work](https://www.iana.org/domains/root/db/work.html).
+
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
 
 ## History of .work
 
@@ -73,14 +75,14 @@ Real, specific niches where .work shows up:
 - **Recruiting and HR** — agencies and internal talent-acquisition teams building a career-portal domain distinct from the corporate main site.
 - **Job boards and freelance marketplaces** — platforms connecting employers and workers, where the suffix reinforces the site's purpose.
 - **Career coaching and professional-development brands** — consultants and coaches whose services are literally about work.
-- **The "[word].work" domain hack** — the clearest real example is laptop maker **Framework Computer**, which runs its primary site at [frame.work](https://frame.work) rather than a .com.
+- **The "[word].work" domain hack** — the clearest real example is laptop maker **Framework Computer**, which runs its primary site at `frame.work` rather than a .com.
 - **Short, brandable names** — the .work namespace still has real availability for concise strings long gone on legacy zones.
 
 **Who it's not ideal for:** consumer brands, e-commerce stores, and other businesses with no career, employment, or literal "work" angle — the meaning is specific enough that it reads oddly outside that context.
 
 ## Notable sites using .work
 
-The clearest verifiable example is **[frame.work](https://frame.work)**, the primary domain for Framework Computer, the modular and repairable laptop and desktop maker — a genuine domain hack where "frame" plus ".work" spells the company's name. Beyond that flagship case, .work's visible footprint mostly consists of recruiting portals, job boards, and small career-services sites rather than a broad roster of major consumer brands.
+The clearest verifiable example is **`frame.work`**, the primary domain for Framework Computer, the modular and repairable laptop and desktop maker — a genuine domain hack where "frame" plus ".work" spells the company's name. Beyond that flagship case, .work's visible footprint mostly consists of recruiting portals, job boards, and small career-services sites rather than a broad roster of major consumer brands.
 
 ## .work vs other domains
 
@@ -165,3 +167,13 @@ It suits recruiters, HR departments, job boards, freelancers, and career-coachin
 - [How to name your project](/en/blog/how-to-name-your-project)
 - Glossary: [TLD](/en/glossary/tld), [registrar](/en/glossary/registrar), [ICANN](/en/glossary/icann), [domain hack](/en/glossary/domain-hack)
 - Compare TLDs: [.com](/en/tld/com), [.xyz](/en/tld/xyz)
+
+## Sources and further reading
+
+- Google Search Central — [Google Search Central's guidance on generic vs. country-targeted domains](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=more%20generic%20than%20country-targeted)
+- IANA — [IANA root-zone entry for .work](https://www.iana.org/domains/root/db/work.html)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- ICANN — [ICANN Registry Agreement for .work](https://www.icann.org/en/registry-agreements/details/work)
+- GoDaddy — [GoDaddy's .work domain policy summary](https://www.godaddy.com/help/about-work-domains-12354)
+- dig.watch — [Spamhaus reported](https://dig.watch/updates/spamhaus-lists-top-10-worst-tlds-terms-spam#:~:text=According%20to%20this%20list%2C%20.diet%2C%20.click%2C%20.download%2C%20.review%2C%20.work%2C%20and%20.tokyo%20are%20the%20five%20TLDs%20with%20more%20than%20%2050%25%20%E2%80%98bad%20domains%E2%80%99%20each)
+- interisle.net — [Cybercrime Supply Chain 2025 research](https://interisle.net/insights/cybercrimesupplychain2025#:~:text=though%20they%20hold%20just%2012%25%20of%20the%20market%2C%20they%20accounted%20for%20nearly%20half%20of%20all%20cybercrime%20domains%20reported)

--- a/content/tld/en/zip.md
+++ b/content/tld/en/zip.md
@@ -55,7 +55,9 @@ The **.zip domain** is a generic top-level domain from Google Registry that beca
 
 .zip is a [generic top-level domain](/en/glossary/tld) (gTLD), not a country-code TLD, so it carries no geographic association. Google Registry's own positioning leans into the technical, developer-facing meaning of the string: ".zip is for tying things together or moving really fast." You can confirm the delegation record and operator in the [IANA root-zone database entry for .zip](https://www.iana.org/domains/root/db/zip.html).
 
-Because .zip is a generic extension, [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites#:~:text=Generic%20top-level%20domains%20(gTLDs)%20are%20domains%20that%20aren't%20associated%20with%20specific%20locations.) confirms gTLDs "aren't associated with specific locations," so .zip carries no automatic geo-targeting signal and no inherent SEO boost or penalty. What .zip does carry — uniquely among these extensions — is a real, documented file-extension collision.
+Google also states that [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.), so the extension itself receives no inherent ranking boost or penalty.
+
+Because .zip is a generic extension, [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Generic%20top-level%20domains%20(gTLDs)%20are%20domains%20that%20aren't%20associated%20with%20specific%20locations.) confirms gTLDs "aren't associated with specific locations," so .zip carries no automatic geo-targeting signal and no inherent SEO boost or penalty. What .zip does carry — uniquely among these extensions — is a real, documented file-extension collision.
 
 ## History of .zip
 
@@ -78,7 +80,7 @@ Real, specific niches where .zip shows up:
 
 Google Registry's own [developer-focused showcase](https://registry.google) (covering .zip alongside .foo, .dev, .app, and .mov) lists real, currently active adopters:
 
-- **[download.zip](https://download.zip)** — creator David Imel's monthly curated-download newsletter, "Unzip the internet."
+- **`download.zip`** — a domain previously used by creator David Imel for a curated-download newsletter, "Unzip the internet." The site was not reachable during this review, so do not treat it as a current live-use example.
 - **hadi.zip** — Android developer Hadi Tok's personal site.
 
 Beyond Google's own examples, [BleepingComputer](https://www.bleepingcomputer.com/news/security/clever-file-archiver-in-the-browser-phishing-trick-uses-zip-domains/) and [Talos Intelligence](https://blog.talosintelligence.com/zip-tld-information-leak/) documented .zip domains actively used in phishing campaigns shortly after launch — the honest counterpoint to any showcase of legitimate use.
@@ -165,3 +167,16 @@ It suits developers, file-sharing tools, and technical audiences who understand 
 - [Avoiding domain sale scams](/en/blog/avoiding-domain-sale-scams)
 - Glossary: [phishing](/en/glossary/phishing), [gTLD](/en/glossary/gtld), [registrar](/en/glossary/registrar)
 - Compare TLDs: [.com](/en/tld/com), [.app](/en/tld/app), [.dev](/en/tld/dev), [.ing](/en/tld/ing), [.meme](/en/tld/meme)
+
+## Sources and further reading
+
+- IANA — [IANA root-zone database entry for .zip](https://www.iana.org/domains/root/db/zip.html)
+- Google Search Central — [keywords in a TLD do not give any advantage or disadvantage in search](https://developers.google.com/search/blog/2015/07/googles-handling-of-new-top-level?hl=en#:~:text=Keywords%20in%20a%20TLD%20do%20not%20give%20any%20advantage%20or%20disadvantage%20in%20search.)
+- Google Search Central — [Google Search Central](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites?hl=en#:~:text=Generic%20top-level%20domains%20(gTLDs)%20are%20domains%20that%20aren't%20associated%20with%20specific%20locations.)
+- ICANN — [ICANN Registry Agreement for .zip](https://www.icann.org/en/registry-agreements/details/zip)
+- bleepingcomputer.com — [BleepingComputer's coverage of the launch debate](https://www.bleepingcomputer.com/news/security/new-zip-domains-spark-debate-among-cybersecurity-experts/)
+- bleepingcomputer.com — [published a proof-of-concept](https://www.bleepingcomputer.com/news/security/clever-file-archiver-in-the-browser-phishing-trick-uses-zip-domains/)
+- registry.google — [developer-focused showcase](https://registry.google)
+- blog.talosintelligence.com — [Talos Intelligence](https://blog.talosintelligence.com/zip-tld-information-leak/)
+- thehackernews.com — [The Hacker News](https://thehackernews.com/2023/05/dont-click-that-zip-file-phishers.html)
+- registry.google — [Domain Name Abuse Policy](https://www.registry.google/policies/)


### PR DESCRIPTION
## Summary

This follow-up addresses the post-merge quality findings from #284, #285, #286, #287, and #288 across all 50 English TLD pages.

## Solution

- remove Namefi registration claims and CTAs for TLDs the public availability API does not support (`.ly`, `.is`, `.uk`, `.es`, `.au`, `.jp`, `.kr`, and `.br`)
- correct registry eligibility, pricing, reputation, abuse-statistics, and verification claims, including `.vc`, `.so`, `.uk`, `.life`, `.pro`, `.bond`, and `.music`
- distinguish ccTLD registry/registrar pricing from aftermarket pricing
- pin multilingual Google sources to English and replace mismatched text fragments with verified fragment URLs
- replace blocked, stale, or misattributed sources with accessible registry, regulator, or registrar material
- add a deduplicated `Sources and further reading` section to each of the 50 pages

## Test plan

- [x] `TMPDIR=/private/tmp bun run data:validate`
- [x] `TMPDIR=/private/tmp bun run lint:mdx`
- [x] changed-file cross-link audit: 50 files, 0 broken, 0 missing-locale, 0 locale-mismatch, 0 relationship-mismatch
- [x] citation audit: 50 source sections, 269 unique external URLs, 44 text-fragment URLs
- [x] real-browser verification for dynamic/anti-bot sources and high-priority fragments (Google Search Central, Nominet, Afnic, Registro .it, GoDaddy, 101domain, KRNIC, nTLDStats)
- [x] Namefi public API recheck for all 50 TLDs

## Session summary

- Start: 2026-08-06T05:20:00Z
- End: 2026-08-06T06:32:16Z
- Agent: Codex
- Redaction: no credentials, tokens, personal data, or private source content included
- Result: audited the merged content, corrected factual and attribution issues, verified citation targets/fragments, ran repository checks, and prepared this follow-up PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/d3servelabs/codesmith/namefi-resources/pr/291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788590006&installation_model_id=1368&pr_number=291&repository=d3servelabs%2Fnamefi-resources&return_to=https%3A%2F%2Fgithub.com%2Fd3servelabs%2Fnamefi-resources%2Fpull%2F291&signature=af8c7c6b6f63a2a0f2371485f349f51f6a972591256f6515d2433fd31ea9eddc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only content in `content/tld/en/` with no application or auth changes; risk is limited to occasional copy errors or bad links in docs.
> 
> **Overview**
> Follow-up editorial pass across **50 English TLD guides** to fix post-merge accuracy and attribution issues.
> 
> **Citations and SEO guidance:** Google Search Central links now use **`?hl=en`** (and verified text fragments where needed). Many gTLD pages add Google’s explicit note that **keywords in a TLD do not help or hurt rankings**. Each page gains a **Sources and further reading** section with deduplicated registry, regulator, and reputation links.
> 
> **Facts and tone:** Registry-specific fixes include **Spamhaus-backed abuse stats** for `.bond` and `.life`, **FCA sourcing** for `.cfd`, **CIRA PDF** eligibility links for `.ca`, and **pricing/eligibility** copy grounded in DENIC, SWITCH, Red.es, Afnic, Registro .it, and similar authorities (with **aftermarket vs registry pricing** called out). Vague reputation claims are replaced or removed where sources were weak (e.g. `.cfd` ntldstats blurb).
> 
> **Product accuracy:** **Namefi-specific registration sections and CTAs are removed or neutralized** on TLDs the public API does not support (e.g. `.au`, `.br`, `.es`, `.is`, `.jp`, `.kr`), retitled to generic “How to register” where those blocks remain. Minor example fixes (e.g. `.fr` notable site formatting).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b06ca164c2cf599a0f7273f5de091bcc0f435325. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated dozens of TLD articles with current Google Search Central guidance and clarified that TLD keywords do not inherently improve or harm search rankings.
  - Added “Sources and further reading” sections with authoritative registry, policy, historical, and reputation references.
  - Refreshed registration eligibility, pricing, geographic-targeting, verification, and policy information.
  - Removed outdated, unsupported, promotional, or provider-specific guidance.
  - Corrected example-domain availability and improved source-link accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->