### PR TITLE
docs: clarify ICANN's role for domain owners

### DIFF
--- a/content/glossary/en/icann.md
+++ b/content/glossary/en/icann.md
@@ -38,6 +38,8 @@ relatedGlossary:
 
 **ICANN (Internet Corporation for Assigned Names and Numbers)**, also known as the **Internet Corporation for Assigned Names and Numbers**, is a nonprofit, multi-stakeholder organization incorporated under California law in 1998. It is responsible for coordinating the technical policies and databases that make the global internet function as a single, unified network. Specifically, ICANN manages the allocation of [IP addresses](/en/glossary/ip-address/), the assignment of [DNS](/en/glossary/dns/) names, and the distribution of protocol identifiers — tasks collectively known as the [IANA functions](/en/glossary/iana/). Without this coordination, the global [DNS](/en/glossary/dns/) would fragment, making web addresses unresolvable across networks.
 
+For domain owners, ICANN's role is usually indirect. Its contracts and consensus policies shape how accredited registrars and registries handle registrations, transfers, registration data, and disputes, while customer accounts and individual domain transactions remain with those service providers.
+
 ## What ICANN does
 
 ICANN's mandate covers three main areas:


### PR DESCRIPTION
## Summary

- add one neutral explanatory paragraph near the top of the English ICANN glossary entry
- clarify how ICANN policies affect domain owners indirectly through registrars and registries
- keep the change strictly body-only: frontmatter, metadata, links, and MDX behavior are unchanged

## Solution

The new paragraph gives readers a practical explanation without promoting a product or changing the entry's glossary contract. It is intentionally limited to the ISR canary file so merging this PR can demonstrate the new content-only dev → production publication workflow without a Resources application rebuild.

The wording is supported by ICANN's [Consensus Policies](https://www.icann.org/en/contracted-parties/consensus-policies), [Agreements & Policies](https://www.icann.org/en/contracted-parties/accredited-registrars/resources/agreements-and-policies), and [About Registrars](https://www.icann.org/resources/pages/what-2013-05-03-en) documentation.

## Test plan

- `TMPDIR=/tmp bun run data:validate` — passed with the repository's existing warnings
- `bun run lint:mdx` — passed
- `bun .agents/skills/cross-link/link-audit.ts content/glossary/en/icann.md` — passed with 0 broken and 0 locale-mismatched links
- pre-push data validation, full link audit, and MDX lint — passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/d3servelabs/codesmith/namefi-resources/pr/295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789563712&installation_model_id=1368&pr_number=295&repository=d3servelabs%2Fnamefi-resources&return_to=https%3A%2F%2Fgithub.com%2Fd3servelabs%2Fnamefi-resources%2Fpull%2F295&signature=00a4d80b8cab22391d355f6a2a75de7d28d9a0acfbc0b6b06a532650915abe06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->