### PR TITLE
fix(content): validate Tamil and Careers

### DIFF
--- a/.claude/rules/content.md
+++ b/.claude/rules/content.md
@@ -27,8 +27,9 @@ older plan/GOAL doc, **this file wins** — update the plan, not the rule.
 ## Golden rules
 
 - **English is the source of truth.** Author in `en` first; translate from
-  English, never chain language→language. Every collection is English-first, then
-  translated to all 8 locales (`en ar de es fr hi zh ko`).
+  English, never chain language→language. Every collection is English-first,
+  then translated across the 10 supported locales (`en es de fr zh-CN ar hi ko
+  ja ta`).
 - **Validate before you push:** `bun data:validate` + `bun lint:mdx` +
   cross-link audit (0 broken).
 - **Only act on Cursor Bugbot** in PR review. **Ignore CodeRabbit** entirely.
@@ -182,9 +183,10 @@ escalated.)
    to green, address real findings, then merge (non-author approval or admin
    override per repo policy).
 4. **Publish:** merging to `main` auto-dispatches an `apps/resources/data`
-   submodule bump to **astra dev**. Production is a **deliberate** release
-   (`release-resources` workflow) — verify the release tag pins your merged
-   resources `HEAD` before trusting prod (watch for the release-race).
+   submodule bump. Astra waits for that exact pointer to merge, then publishes
+   supported data-only changes to dev followed by production through full-page
+   ISR. Unsupported content changes require the normal `release-resources`
+   application release.
 
 ## Tooling (run from repo root)
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # NameFi Resources Content
 
-This repository holds the content that powers the resources site (blog posts, glossary, partners, authors, and TLDs). It is consumed as a git submodule at `apps/resources/data` inside [`d3servelabs/namefi-astra`](https://github.com/d3servelabs/namefi-astra).
+This repository holds the content that powers the resources site (blog posts, glossary, partners, authors, careers, and TLDs). It is consumed as a git submodule at `apps/resources/data` inside [`d3servelabs/namefi-astra`](https://github.com/d3servelabs/namefi-astra).
 
 All content lives under the `content/` directory (e.g., `content/blog/en/...`).
 
 ## Editing content
 
-- Keep the existing folder structure: `authors/`, `blog/`, `glossary/`, `partners/`, and `tld/`, each with language subfolders inside `content/`.
+- Keep the existing folder structure: `authors/`, `blog/`, `careers/`, `glossary/`, `partners/`, and `tld/`, each with language subfolders inside `content/`.
 - Add or edit Markdown/MDX files directly.
 - Open a PR to `main` once your changes are ready and merge it.
 
 ## Validation
 
 - Run `bun install` once, then:
-  - `bun data:validate` to check frontmatter, dates, and the same-locale internal-link invariant.
+  - `bun data:validate` to check frontmatter and dates across every supported locale and collection, plus the same-locale internal-link invariant.
   - `bun lint:mdx` to lint markdown/MDX frontmatter and formatting.
   - `bun links:locale` for the focused locale-route and related-metadata check (`--fix` repairs prefixes and restores English-source relationship routes).
   - `bun links:audit` for the full broken-link, missing-locale, and locale-prefix audit.

--- a/scripts/validate-data.ts
+++ b/scripts/validate-data.ts
@@ -4,10 +4,27 @@ import { readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import matter from 'gray-matter';
 
-const locales = ['en', 'es', 'de', 'fr', 'zh-CN', 'ar', 'hi', 'ko', 'ja'] as const;
+const locales = [
+  'en',
+  'es',
+  'de',
+  'fr',
+  'zh-CN',
+  'ar',
+  'hi',
+  'ko',
+  'ja',
+  'ta',
+] as const;
 type Locale = (typeof locales)[number];
 
-type Collection = 'blog' | 'tld' | 'partners' | 'glossary' | 'authors';
+type Collection =
+  | 'blog'
+  | 'tld'
+  | 'partners'
+  | 'glossary'
+  | 'authors'
+  | 'careers';
 
 const TOPIC_SLUGS = new Set([
   'domain-tokenization',
@@ -52,6 +69,7 @@ const COLLECTION_ROOTS: Record<Collection, string> = {
   partners: path.join(DATA_ROOT, 'partners'),
   glossary: path.join(DATA_ROOT, 'glossary'),
   authors: path.join(DATA_ROOT, 'authors'),
+  careers: path.join(DATA_ROOT, 'careers'),
 };
 
 function toRelative(filePath: string) {
@@ -507,6 +525,7 @@ async function main() {
     'partners',
     'glossary',
     'authors',
+    'careers',
   ];
 
   let filesChecked = 0;


### PR DESCRIPTION
## Summary
- validate Tamil (`ta`) content alongside the other supported locales
- validate Careers content alongside blog, TLD, partner, and glossary content
- update the content-maintenance guidance to describe the complete coverage

## Root cause
The hard-coded validator locale and collection lists omitted `ta` and `careers`, so those files could skip the same frontmatter and date checks applied elsewhere.

## Impact
Tamil and Careers content now use the existing validation path. This does not change rendered application behavior.

## Validation
- `bun scripts/validate-data.ts` — passed with 37 existing content warnings and no errors
- locale/relationship link audit — 3,963 files, 0 mismatches
- FAQ sync — 1,633 FAQs across 10 locales, passed
- repository pre-push hooks — passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/d3servelabs/codesmith/namefi-resources/pr/296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789629078&installation_model_id=1368&pr_number=296&repository=d3servelabs%2Fnamefi-resources&return_to=https%3A%2F%2Fgithub.com%2Fd3servelabs%2Fnamefi-resources%2Fpull%2F296&signature=a5bd7dced5c1a7f412660d89bfc77c6c39f1d97b63e0e71748dd3e89b4eb7a8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->