### PR TITLE
fix(ci): resolve requested resources ref

### DIFF
--- a/.github/workflows/dispatch-to-astra.yml
+++ b/.github/workflows/dispatch-to-astra.yml
@@ -11,11 +11,24 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+
 jobs:
   dispatch:
     name: Dispatch resources update
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout requested Resources ref
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.inputs.ref || github.sha }}
+
+      - name: Resolve requested Resources commit
+        id: target
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Create NameFi bot token
         id: app-token
         uses: actions/create-github-app-token@v2
@@ -29,7 +42,7 @@ jobs:
       - name: Trigger Astra sync workflow
         env:
           TARGET_REF: ${{ github.event.inputs.ref || github.ref_name }}
-          TARGET_SHA: ${{ github.sha }}
+          TARGET_SHA: ${{ steps.target.outputs.sha }}
           DISPATCH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -66,4 +66,7 @@ aliasesByLocale:    # per-locale non-canonical variants to normalise away
 ## Automation
 
 - On every push to `main`, a workflow dispatches a `resources-updated` event to `namefi-astra`.
+- A manual dispatch checks out the requested Resources ref and sends its exact
+  resolved commit to Astra, so recovery runs cannot accidentally sync the
+  workflow branch instead of the selected ref.
 - The main repo then updates the `apps/resources/data` submodule, runs validation, and opens a PR with the new content and merges if all checks succeed.


### PR DESCRIPTION
## Summary

- check out the Resources ref selected by a manual dispatch
- resolve and send that checkout exact commit SHA to Astra
- explicitly limit the workflow token to contents-read access

## Why

github.sha identifies the workflow run revision, not necessarily the optional ref input. Manual recovery could therefore claim to sync one ref while dispatching another commit.

## Validation

- actionlint on the changed workflow
- repository pre-push data validation and link audit

## Documentation impact

The root README automation section was updated to document exact-ref manual recovery.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/d3servelabs/codesmith/namefi-resources/pr/297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789639189&installation_model_id=1368&pr_number=297&repository=d3servelabs%2Fnamefi-resources&return_to=https%3A%2F%2Fgithub.com%2Fd3servelabs%2Fnamefi-resources%2Fpull%2F297&signature=90e5aa251e9389d92bb2e01c91ec4324d558dce706027ca60887df58411e2c1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->