### PR TITLE
fix(content): clarify site TLD copy

### DIFF
--- a/content/tld/en/site.md
+++ b/content/tld/en/site.md
@@ -58,7 +58,7 @@ For founders, indie developers, and brand owners who find their ideal name alrea
 
 .site is a generic top-level domain delegated to the DNS root in 2015 as part of [ICANN's New gTLD Program](https://newgtlds.icann.org/), the 2012-round expansion that added hundreds of new endings to the namespace. Unlike a country-code TLD such as [.io](/en/tld/io/) or .de, .site has no geographic meaning — it is fully generic and globally targeted.
 
-That distinction matters for international projects. According to [Google Search Central](https://developers.google.com/search/docs/crawling-indexing/managing-multi-regional-sites), generic new TLDs like .site are treated as global by default, so a .site site is not geo-locked to any single country the way a [ccTLD](/en/glossary/cctld/) often is. The [IANA root-zone record for .site](https://www.iana.org/domains/root/db/site.html) lists Radix as the current operator and shows its delegation history.
+That distinction matters for international projects. According to [Google Search Central](https://developers.google.com/search/docs/crawling-indexing/managing-multi-regional-sites), generic new TLDs like .site are treated as global by default, so a .site website is not geo-locked to any single country the way a [ccTLD](/en/glossary/cctld/) often is. The [IANA root-zone record for .site](https://www.iana.org/domains/root/db/site.html) lists Radix as the current operator and shows its delegation history.
 
 ## History of .site
 


### PR DESCRIPTION
## Summary

The `.site` TLD page used the awkward phrase “a .site site.”

## Solution

Use “a .site website” so the sentence is clearer without changing its factual claim.

## Test plan

- `TMPDIR=/tmp bun data:validate`
- `bun lint:mdx`
- `bun .agents/skills/cross-link/link-audit.ts content/tld/en/site.md`
- full pre-push data validation and link audit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/d3servelabs/codesmith/namefi-resources/pr/298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789642563&installation_model_id=1368&pr_number=298&repository=d3servelabs%2Fnamefi-resources&return_to=https%3A%2F%2Fgithub.com%2Fd3servelabs%2Fnamefi-resources%2Fpull%2F298&signature=41fcae8ef74295811d1ff87a3c0abe25c92b99fd6cbdd73b0211effd95caf9c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->