### PR TITLE
fix(content): correct French ally keyword

### DIFF
--- a/content/tld/fr/ally.md
+++ b/content/tld/fr/ally.md
@@ -8,7 +8,7 @@ editors: ['victor-zhou']
 translators: ['alan-machin']
 draft: false
 description: "Découvrez tout sur l'extension de domaine .ally : ses avantages, ses usages et pourquoi c'est le choix parfait pour votre marque. Enregistrez-le sur Namefi."
-keywords: ['.ally', 'domaines .ally', 'TLD .ally', 'qu''est-ce que .ally', 'pourquoi choisir .ally', 'investir dans les domaines', 'domaines blockchain', 'extension de domaine', 'domaine web3', 'achat nom de domaine', 'signification .ally', 'registar namefi', 'tld top level domain', 'domaine pour alliance', 'domaine inclusif']
+keywords: ['.ally', 'domaines .ally', 'TLD .ally', 'qu''est-ce que .ally', 'pourquoi choisir .ally', 'investir dans les domaines', 'domaines blockchain', 'extension de domaine', 'domaine web3', 'achat nom de domaine', 'signification .ally', 'registrar namefi', 'tld top level domain', 'domaine pour alliance', 'domaine inclusif']
 relatedArticles:
   - /fr/blog/what-are-tokenized-domains/
   - /fr/blog/what-is-a-tld/


### PR DESCRIPTION
## Summary

Correct the misspelled `registrar` SEO keyword on the French `.ally` page. This is also a focused production ISR verification change.

## Solution

Replace `registar namefi` with `registrar namefi` in the existing frontmatter.

## Test plan

- `TMPDIR=/tmp bun data:validate`
- `bun lint:mdx`
- `bun .agents/skills/cross-link/link-audit.ts content/tld/fr/ally.md`
- Verify the merged content reaches production through the existing ISR workflow without a new Vercel deployment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/d3servelabs/codesmith/namefi-resources/pr/299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789645088&installation_model_id=1368&pr_number=299&repository=d3servelabs%2Fnamefi-resources&return_to=https%3A%2F%2Fgithub.com%2Fd3servelabs%2Fnamefi-resources%2Fpull%2F299&signature=db2bc395f9601fa8feb25693329819adf124a9eea1c1e745b216dd911a23c977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->