### PR TITLE
content(tld): dedupe keywords against keyword-template boilerplate (5 pages)

### DIFF
--- a/content/tld/en/digital.md
+++ b/content/tld/en/digital.md
@@ -7,7 +7,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .digital domain is an open new gTLD run by Binky Moon (Identity Digital) for digital agencies and transformation-era brands. Learn its origin and value.'
-keywords: ['.digital domain meaning', 'digital tld', 'Binky Moon .digital', 'Dash Park .digital', '.digital for agencies']
+keywords: ['.digital domain meaning', 'Binky Moon .digital', 'Dash Park .digital', '.digital for agencies']
 faqs:
   - question: 'Can anyone register a .digital domain?'
     answer: 'Yes. .digital is an open, unrestricted generic top-level domain operated by Binky Moon, LLC. There is no credential, membership, or local-presence requirement, so any individual or organization worldwide can register a .digital name through an accredited registrar.'

--- a/content/tld/en/media.md
+++ b/content/tld/en/media.md
@@ -7,7 +7,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .media domain is an open new gTLD run by Binky Moon (Identity Digital) for journalists, broadcasters, and creators. Learn its origin, real users, and value.'
-keywords: ['.media domain meaning', 'media tld', 'Binky Moon .media', 'Grand Glen .media', '.media for journalists']
+keywords: ['.media domain meaning', 'Binky Moon .media', 'Grand Glen .media', '.media for journalists']
 faqs:
   - question: 'Can anyone register a .media domain?'
     answer: 'Yes. .media is an open, unrestricted generic top-level domain operated by Binky Moon, LLC. There is no credential, membership, or local-presence requirement, so any individual or organization worldwide can register a .media name through an accredited registrar.'

--- a/content/tld/en/meme.md
+++ b/content/tld/en/meme.md
@@ -7,7 +7,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: '.meme is Google Registry''s internet-culture gTLD, home to Know Your Meme and Grumpy Cat. Learn its launch history, real adopters, and if it fits your brand.'
-keywords: ['.meme domain', 'Charleston Road Registry .meme', 'internet culture domain', 'meme brand domain']
+keywords: ['knowyour.meme domain hack', 'Charleston Road Registry .meme', 'internet culture domain', 'meme brand domain']
 faqs:
   - question: 'Can anyone register a .meme domain?'
     answer: 'Yes, today. .meme launched with a temporary limited-registration phase reserved for meme content-creation platforms, but that restriction ended before general availability, and .meme has been an open, unrestricted generic top-level domain since December 5, 2023, registerable by anyone through an accredited registrar.'

--- a/content/tld/en/news.md
+++ b/content/tld/en/news.md
@@ -7,7 +7,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: 'The .news domain is an open new gTLD run by Dog Beach (Identity Digital), used by Apple News, Ground News, and Puck. Learn its origin, users, and reputation.'
-keywords: ['.news domain meaning', 'news tld', 'Dog Beach .news', 'Rightside Donuts .news', 'does .news mean real news']
+keywords: ['.news domain meaning', 'Dog Beach .news', 'Rightside Donuts .news', 'does .news mean real news']
 faqs:
   - question: 'Can anyone register a .news domain?'
     answer: 'Yes. .news is an open, unrestricted generic top-level domain operated by Dog Beach, LLC. There is no credential, membership, journalistic-standards, or local-presence requirement, so any individual or organization worldwide can register a .news name through an accredited registrar.'

--- a/content/tld/en/page.md
+++ b/content/tld/en/page.md
@@ -7,7 +7,7 @@ authors: ['aileen-wright']
 editors: ['victor-zhou']
 draft: false
 description: '.page is Google Registry''s HSTS-secured gTLD for personal sites, portfolios, and landing pages, launched in 2018. Learn its history, real adopters, and fit.'
-keywords: ['.page domain', 'Charleston Road Registry .page', 'personal landing page domain', 'HTTPS-only domain']
+keywords: ['.page HSTS preload', 'Charleston Road Registry .page', 'personal landing page domain', 'HTTPS-only domain']
 faqs:
   - question: 'Can anyone register a .page domain?'
     answer: 'Yes. .page is an open, unrestricted generic top-level domain operated by Charleston Road Registry, a Google subsidiary. There are no credential, membership, or local-presence requirements, so anyone worldwide can register a .page name through an accredited registrar.'


### PR DESCRIPTION
## Summary

A keywords audit of the 50 TLD pages added in PRs #284–#288 (all live and rendering correctly on namefi.io) found 5 pages whose own `keywords:` list overlaps the `content/keyword-templates.json` boilerplate that astra merges in at render time. Per the keyword-template rule in `.claude/rules/content.md`, a page's own list should carry only keywords genuinely unique to that page.

## Solution

- **meme.md / page.md** — `'.meme domain'` / `'.page domain'` exactly duplicate the template's `.{tld} domain` expansion (dedupe collapses them live, but they waste a unique-keyword slot). Replaced with page-unique keywords grounded in each page's body: `'knowyour.meme domain hack'` (Know Your Meme is a featured adopter) and `'.page HSTS preload'` (the page's core security differentiator).
- **digital.md / media.md / news.md** — dropped the dot-less `'digital tld'` / `'media tld'` / `'news tld'` variants, which near-duplicate the template's `.{tld} TLD` expansion (differing only by the missing dot) and survive the exact-match dedupe as redundant chips.

Each page keeps 4 unique keywords, within the 2–5 rule; the template continues to supply `what is .{tld}`, `.{tld} domain`, `.{tld} TLD`.

## Test plan

- [x] `bun data:validate` — passed (0 blocking errors; 37 pre-existing warnings)
- [x] `bun lint:mdx` — passed (exit 0)
- [x] `bun .agents/skills/cross-link/link-audit.ts` on the 5 changed files — 0 broken, 0 locale-mismatch
- [x] Replacement keywords verified against page bodies (knowyour.meme appears in meme.md's adopter list; HSTS preload is cited in page.md with source link)

## Claude session summary (redacted)

- 2026-08-25T01:30Z–01:45Z — audited `keywords:` frontmatter of all 50 TLD pages from PRs #284–#288 in-repo; fetched all 50 live pages' `<meta name="keywords">` to confirm the keyword-template merge + case-insensitive dedupe behave as documented (50/50 present and correct).
- 2026-08-25T01:50Z–02:00Z — flagged 2 exact template duplicates (meme, page) and 3 dot-less near-duplicates (digital, media, news); user approved a cleanup PR.
- 2026-08-25T02:00Z–02:06Z — fresh worktree off origin/main, applied the 5 one-line edits, ran the three validators (all green), pushed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/d3servelabs/codesmith/namefi-resources/pr/300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790215605&installation_model_id=1368&pr_number=300&repository=d3servelabs%2Fnamefi-resources&return_to=https%3A%2F%2Fgithub.com%2Fd3servelabs%2Fnamefi-resources%2Fpull%2F300&signature=8b42b39626f08fc7bf3d88f967a0ba3fd7453bdd086255e6a7f68f2c038d7419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontmatter-only SEO keyword edits on static content with no runtime, auth, or data-model impact.
> 
> **Overview**
> **Trims redundant `keywords:` frontmatter** on five English TLD articles so each page keeps only terms that are not already supplied by `content/keyword-templates.json` at render time.
> 
> On **digital**, **media**, and **news**, the dot-less `'digital tld'` / `'media tld'` / `'news tld'` entries are removed because they largely repeat the template’s `.{tld} TLD` expansion. On **meme** and **page**, `'.meme domain'` and `'.page domain'` are swapped for page-specific phrases—`'knowyour.meme domain hack'` and `'.page HSTS preload'`—that match content in the article bodies instead of duplicating the template’s `.{tld} domain` slot.
> 
> Each file still lists four unique keywords; article body and other frontmatter are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d88c87552a5ca1c1c1923b4e78085fb68d5e5500. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SEO keywords for the `.digital`, `.media`, `.meme`, `.news`, and `.page` articles.
  * Refined search terms to better reflect relevant domain uses, branding, security, HTTPS, and landing-page use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->